### PR TITLE
feat: add Unraid community app template

### DIFF
--- a/unraid.xml
+++ b/unraid.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
     <Name>Grimmory</Name>
-    <Repository>grimmory/grimmory:latest</Repository>
-    <Registry>https://hub.docker.com/r/grimmory/grimmory</Registry>
+    <Repository>ghcr.io/grimmory-tools/grimmory:latest</Repository>
+    <Registry>https://github.com/grimmory-tools/grimmory/pkgs/container/grimmory</Registry>
     <TemplateURL>https://github.com/grimmory-tools/grimmory/blob/main/unraid.xml</TemplateURL>
     <MyIP/>
     <Shell>bash</Shell>


### PR DESCRIPTION
## 📝 Description

<!-- Why is this change needed? Explain in your own words. -->

**Linked Issue:** Addresses https://github.com/grimmory-tools/grimmory/issues/20

>[!CAUTION]
>This PR should remain in `Draft` until proper container releases are available!

## 🏷️ Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change (existing functionality affected)
- [ ] Documentation update

## 🔧 Changes

This PR adds an `unraid.xml` template file to the root of the repository, which, when added to the [Unraid](https://unraid.net/) ["Community Applications" (CA) store](https://unraid.net/community/apps#community-apps-iframe), allows easy container installation for Unraid users (generally, the "default" way Unraid handles Docker and containers).

- Adds `unraid.xml`
- Preconfigures required items: port, volume mounts, database env vars, timezone
- Adds advanced config for DISK_TYPE and ALLOWED_ORIGINS
- Adds "Requires" note about MariaDB dependency

## 🧪 Testing (MANDATORY)

> **PRs without this section filled out will be closed.** "Tests pass" or "Tested locally" is not sufficient. You must provide specifics.

**Manual testing steps you performed:**

1. Installed the template on my Unraid server
2. Configured it with a MariaDB instance
3. Verified the web UI loaded
4. Verified database connectivity
5. Tested library scanning

**Regression testing:**

- N/A

**Edge cases covered:**

- Tested advanced ENV worked for `DISK_TYPE` and `ALLOWED_ORIGINS`

**Test output:**

- N/A

## 📸 Screen Recording / Screenshots (MANDATORY)

<img width="412" height="127" alt="grimmory-unraid" src="https://github.com/user-attachments/assets/664f0ff9-87ee-4a06-97a3-e5d744c9287d" />

---

## ✅ Pre-Submission Checklist

> **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.

- [X] This PR is linked to an approved issue
- [X] Code follows project [backend and frontend conventions](../CONTRIBUTING.md#backend-conventions)
- [X] Branch is up to date with `develop` (merge conflicts resolved)
- [X] ~I ran the full stack locally (backend + frontend + database) and verified the change works~
- [X] ~Automated tests added or updated to cover changes (backend **and** frontend)~
- [X] ~All tests pass locally and output is pasted above~
- [X] Screen recording or screenshots are attached above proving the change works
- [X] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [X] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [X] No unsolicited refactors, cleanups, or "improvements" are bundled in
- [X] Flyway migration versioning is correct _(if schema was modified)_
- [X] ~Documentation PR submitted to [booklore-docs](https://github.com/booklore-app/booklore-docs) _(if user-facing changes)_~

### 🤖 AI-Assisted Contributions

> **If any part of this PR was generated or assisted by AI tools (Copilot, Claude, ChatGPT, etc.), all items below are mandatory.** You are fully responsible for every line you submit. "The AI wrote it" is not an excuse, and AI-generated PRs that clearly haven't been reviewed are the #1 reason PRs get closed.

- [X] I have read and understand every line of this PR and can explain any part of it during review
- [X] I personally ran the code and verified it works (not just trusted the AI's output)
- [X] PR is scoped to a single logical change, not a dump of everything the AI suggested
- [X] Tests validate actual behavior, not just coverage (AI-generated tests often assert nothing meaningful)
- [X] No dead code, placeholder comments, `TODO`s, or unused scaffolding left behind by AI
- [X] I did not submit refactors, style changes, or "improvements" the AI suggested beyond the scope of the issue

---

## 💬 Additional Context _(optional)_

This template allows Unraid users to install the Grimmory container directly from the CA store with minimal setup (it pre-fills the necessary ports, volume mappings, and environment variables recommended in the compose). Having it alongside the application code and in this repo makes it easy to change any container-related item and keep it correct/compatible with the latest release. These templates effectively translate to a `docker run` command, which users actually see once they load/save the container from the CA store. Example of what it translates to:

```bash
docker run
  -d
  --name='Grimmory'
  --net='bridge'
  --pids-limit 2048
  -e HOST_OS="Unraid"
  -e HOST_HOSTNAME="unraid-server"
  -e HOST_CONTAINERNAME="Grimmory"
  -e 'DATABASE_URL'='jdbc:mariadb://10.0.0.10:3307/grimmory'
  -e 'DATABASE_USERNAME'='grimmory'
  -e 'DATABASE_PASSWORD'='ChangeMe_Grimmory_2025!'
  -e 'TZ'='America/Los_Angeles'
  -e 'DISK_TYPE'='LOCAL'
  -e 'ALLOWED_ORIGINS'='*'
  -e 'USER_ID'='99'
  -e 'GROUP_ID'='100'
  -l net.unraid.docker.managed=dockerman
  -l net.unraid.docker.webui='http://[IP]:[PORT:6060]/'
  -l net.unraid.docker.icon='https://raw.githubusercontent.com/grimmory-tools/grimmory/main/assets/logo.svg'
  -p '6060:6060/tcp'
  -v '/mnt/user/appdata/grimmory':'/app/data':'rw'
  -v '/mnt/user/data/media/ebooks/':'/data/media/books':'rw'
  -v '/mnt/user/data/media/bookdrop':'/bookdrop':'rw'
  --restart=unless-stopped 'ghcr.io/grimmory-tools/grimmory:latest'
``` 

This translation occurs automatically based on values in the template.

### MariaDB

Unraid CA templates only allow for a singular container to be specified. Unless Grimmory wants to provide an all-in-one (AIO) option (doubtful!), users will also have to install a MariaDB container. _This is very common!_ I've made a call-out in the template that they'll need to install the additional container for this to work.

### Getting Grimmory into the CA Store

In order for this to be available in the CA Store, a maintainer would need to apply to have it added via a [Community Applications submission form](https://form.asana.com/?k=qtIUrf5ydiXvXzPI57BiJw&d=714739274360802). This form is very short and self-explanatory. Usually, a repo is approved within 24-48 hours, though that, too, is a manual process. Despite what it says, you shouldn't need to create a forum thread (there are links to your support outlets as part of the template).

Once accepted, the CA scraper checks the repo frequently for updates (I think it's about every 2 hours).

Alternatively--and I don't think this is the best route for this repo--I maintain a dedicated templates repository ([tritones/unraid-templates](https://github.com/tritones/unraid-templates)) that is already published in the store. If maintainers want to go this route we'd close this PR and open one in my repo.

### Permissions

Unraid's standard user and group are `99` and `100`, respectively, and these are prefilled for users.

### Links and Helpful Info

To understand what this file does or how the formatting works:

- [Submission Process (official docs)](https://docs.unraid.net/unraid-os/using-unraid-to/run-docker-containers/community-applications/#contributing-your-own-applications)
- [Writing a template compatible for Unraid - Selfhosters.net](https://selfhosters.net/docker/templating/templating/)
- [Unraid Forum about XML Schema](https://forums.unraid.net/topic/38619-docker-template-xml-schema/)
- [Unraid Forum about Docker FAQ & XML Syntax](https://forums.unraid.net/topic/57181-real-docker-faq/#comment-566084)