### PR TITLE
fix(book-browser): prevent memory leaks by unsubscribing from observables

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -296,13 +296,14 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit(): void {
     this.pageTitle.setPageTitle('');
-    this.coverScalePreferenceService.scaleChange$.pipe(debounceTime(1000)).subscribe();
+    this.coverScalePreferenceService.scaleChange$.pipe(debounceTime(1000), takeUntil(this.destroy$)).subscribe();
     this.loadMobileColumnsPreference();
 
     this.initializeEntityRouting();
     this.setupRouteChangeHandlers();
     this.setupUserStateSubscription();
     this.setupQueryParamSubscription();
+    this.setupFilterToggleSubscription();
     this.setupSearchTermSubscription();
     this.setupScrollPositionTracking();
     this.setupSelectionSubscription();
@@ -364,7 +365,7 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
       this.entity$ = routeEntityInfo$.pipe(
         switchMap(({entityId, entityType}) => this.entityService.fetchEntity(entityId, entityType))
       );
-      this.entity$.subscribe(entity => this.handleEntityLoaded(entity));
+      this.entity$.pipe(takeUntil(this.destroy$)).subscribe(entity => this.handleEntityLoaded(entity));
     }
   }
 
@@ -384,7 +385,7 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private setupRouteChangeHandlers(): void {
-    this.activatedRoute.paramMap.subscribe(() => {
+    this.activatedRoute.paramMap.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.searchTerm$.next('');
       this.bookTitle = '';
       this.bookSelectionService.deselectAll();
@@ -393,8 +394,10 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private setupUserStateSubscription(): void {
-    this.userService.userState$.pipe(filter(u => !!u?.user && u.loaded))
-      .subscribe(userState => {
+    this.userService.userState$.pipe(
+      filter(u => !!u?.user && u.loaded),
+      takeUntil(this.destroy$)
+    ).subscribe(userState => {
         this.metadataMenuItems = this.bookMenuService.getMetadataMenuItems(
           () => this.autoFetchMetadata(),
           () => this.fetchMetadata(),
@@ -414,7 +417,7 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
       this.entityRouteInfo$,
       this.activatedRoute.queryParamMap,
       this.userService.userState$.pipe(filter(u => !!u?.user && u.loaded))
-    ]).subscribe(([entityInfo, queryParamMap, user]) => {
+    ]).pipe(takeUntil(this.destroy$)).subscribe(([entityInfo, queryParamMap, user]) => {
       const parseResult = this.queryParamsService.parseQueryParams(
         queryParamMap,
         user.user?.userSettings?.entityViewPreferences,
@@ -431,11 +434,6 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
           this.bookFilterComponent.selectedFilterMode = parseResult.filterMode;
         }
       }
-
-      this.sidebarFilterTogglePrefService.showFilter$.subscribe(value => {
-        this.showFilter = value;
-      });
-
 
       this.currentFilterLabel = this.t.translate('book.browser.labels.allBooks');
       const filterParams = queryParamMap.get('filter');
@@ -493,9 +491,17 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private setupSearchTermSubscription(): void {
-    this.searchTerm$.subscribe(term => {
+    this.searchTerm$.pipe(takeUntil(this.destroy$)).subscribe(term => {
       this.hasSearchTerm = !!term && term.trim().length > 0;
     });
+  }
+
+  private setupFilterToggleSubscription(): void {
+    this.sidebarFilterTogglePrefService.showFilter$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(value => {
+        this.showFilter = value;
+      });
   }
 
   private setupSelectionSubscription(): void {


### PR DESCRIPTION
This pull request improves the memory management and subscription handling in the `BookBrowserComponent` by ensuring that all observable subscriptions are properly unsubscribed when the component is destroyed. This reduces the risk of memory leaks and unintended side effects. The main changes involve adding the `takeUntil(this.destroy$)` operator to various subscriptions and refactoring filter toggle handling.

**Subscription lifecycle management improvements:**

* Added `takeUntil(this.destroy$)` to all observable subscriptions in the component, including those for cover scale preference, entity loading, route changes, user state, query parameter parsing, and search term updates, ensuring proper cleanup on component destruction. [[1]](diffhunk://#diff-7ece54e8817b2e9cd8bf6bf3d24269503244a23b36bf78746bee49850c7df170L299-R306) [[2]](diffhunk://#diff-7ece54e8817b2e9cd8bf6bf3d24269503244a23b36bf78746bee49850c7df170L367-R368) [[3]](diffhunk://#diff-7ece54e8817b2e9cd8bf6bf3d24269503244a23b36bf78746bee49850c7df170L387-R388) [[4]](diffhunk://#diff-7ece54e8817b2e9cd8bf6bf3d24269503244a23b36bf78746bee49850c7df170L396-R400) [[5]](diffhunk://#diff-7ece54e8817b2e9cd8bf6bf3d24269503244a23b36bf78746bee49850c7df170L417-R420) [[6]](diffhunk://#diff-7ece54e8817b2e9cd8bf6bf3d24269503244a23b36bf78746bee49850c7df170L496-R506)

**Refactoring filter toggle subscription:**

* Moved the filter toggle subscription logic into a new `setupFilterToggleSubscription` method, replacing the previous inline subscription and ensuring it also uses `takeUntil(this.destroy$)` for cleanup. [[1]](diffhunk://#diff-7ece54e8817b2e9cd8bf6bf3d24269503244a23b36bf78746bee49850c7df170L435-L439) [[2]](diffhunk://#diff-7ece54e8817b2e9cd8bf6bf3d24269503244a23b36bf78746bee49850c7df170L496-R506)

## 📝 Description

<!-- Why is this change needed? Explain in your own words. -->

> **Required for `develop` and `main`.** Your PR title must use Conventional Commit format because maintainers squash-merge with the PR title and stable releases are computed from commit history. Example: `fix(reader): prevent blank pages on chapter jump`

**Linked Issue:** Fixes #<!-- issue number -->

> **Required.** Every PR must reference an approved issue. If no issue exists, [open one](https://github.com/grimmory-tools/grimmory/issues/new) and wait for maintainer approval before submitting a PR. Unsolicited PRs without a linked issue will be closed.

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change (existing functionality affected)
- [ ] Documentation update

## 🔧 Changes

<!-- List the specific modifications made -->
-

## 🧪 Testing (MANDATORY)

> **PRs without this section filled out will be closed.** "Tests pass" or "Tested locally" is not sufficient. You must provide specifics.

**Manual testing steps you performed:**
<!-- Walk through the exact steps you took to verify your change works. Be specific. -->
1.
2.
3.

**Regression testing:**
<!-- How did you verify that existing related features still work after your change? -->
-

**Edge cases covered:**
<!-- What boundary conditions or unusual inputs did you test? -->
-

**Test output:**
<!-- Paste the actual terminal output from running tests. Not "all pass", the real output. -->

<details>
<summary>Backend test output (<code>./gradlew test</code>)</summary>

```
PASTE OUTPUT HERE
```

</details>

<details>
<summary>Frontend test output (<code>ng test</code>)</summary>

```
PASTE OUTPUT HERE
```

</details>

## 📸 Screen Recording / Screenshots (MANDATORY)

> Every PR must include a **screen recording or screenshots** showing the change working end-to-end in a running local instance (both backend and frontend). This means you must have actually built, run, and tested the code yourself. PRs without visual proof will be closed without review.

<!-- Attach screen recording or screenshots here -->

---

## ✅ Pre-Submission Checklist

> **All boxes must be checked before requesting review.** Incomplete PRs will be closed without review. No exceptions.

- [ ] This PR is linked to an approved issue
- [ ] Code follows project [backend and frontend conventions](../CONTRIBUTING.md#backend-conventions)
- [ ] Branch is up to date with `develop` (merge conflicts resolved)
- [ ] I ran the full stack locally (backend + frontend + database) and verified the change works
- [ ] Automated tests added or updated to cover changes (backend **and** frontend)
- [ ] All tests pass locally and output is pasted above
- [ ] Screen recording or screenshots are attached above proving the change works
- [ ] PR is a single focused change (one bug fix OR one feature, not multiple unrelated changes)
- [ ] PR is reasonably scoped (PRs over 1000+ changed lines will be closed, split into smaller PRs)
- [ ] No unsolicited refactors, cleanups, or "improvements" are bundled in
- [ ] Flyway migration versioning is correct _(if schema was modified)_
- [ ] Required documentation updates are included in this repo or the current Grimmory docs surface _(if user-facing changes)_

### 🤖 AI-Assisted Contributions

> **If any part of this PR was generated or assisted by AI tools (Copilot, Claude, ChatGPT, etc.), all items below are mandatory.** You are fully responsible for every line you submit. "The AI wrote it" is not an excuse, and AI-generated PRs that clearly haven't been reviewed are the #1 reason PRs get closed.

- [ ] I have read and understand every line of this PR and can explain any part of it during review
- [ ] I personally ran the code and verified it works (not just trusted the AI's output)
- [ ] PR is scoped to a single logical change, not a dump of everything the AI suggested
- [ ] Tests validate actual behavior, not just coverage (AI-generated tests often assert nothing meaningful)
- [ ] No dead code, placeholder comments, `TODO`s, or unused scaffolding left behind by AI
- [ ] I did not submit refactors, style changes, or "improvements" the AI suggested beyond the scope of the issue

---

## 💬 Additional Context _(optional)_

<!-- Any extra information or discussion points for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource management in the book browser to improve application stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->