### PR TITLE
fix(hardcover): add series position decimals and use primary books count

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/HardcoverParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/HardcoverParser.java
@@ -231,7 +231,7 @@ public class HardcoverParser implements BookParser {
 
         if (book.getFeaturedBookSeries() != null && book.getFeaturedBookSeries().getSeries() != null) {
             metadata.setSeriesName(book.getFeaturedBookSeries().getSeries().getName());
-            metadata.setSeriesTotal(book.getFeaturedBookSeries().getSeries().getBooksCount());
+            metadata.setSeriesTotal(book.getFeaturedBookSeries().getSeries().getPrimaryBooksCount());
 
             if (book.getFeaturedBookSeries().getPosition() != null) {
                 try {
@@ -316,7 +316,7 @@ public class HardcoverParser implements BookParser {
         }
         if (doc.getFeaturedSeries().getSeries() != null) {
             metadata.setSeriesName(doc.getFeaturedSeries().getSeries().getName());
-            metadata.setSeriesTotal(doc.getFeaturedSeries().getSeries().getBooksCount());
+            metadata.setSeriesTotal(doc.getFeaturedSeries().getSeries().getPrimaryBooksCount());
         }
         if (doc.getFeaturedSeries().getPosition() != null) {
             try {

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/hardcover/GraphQLResponse.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/hardcover/GraphQLResponse.java
@@ -265,6 +265,8 @@ public class GraphQLResponse {
         private String name;
         @JsonProperty("books_count")
         private Integer booksCount;
+        @JsonProperty("primary_books_count")
+        private Integer primaryBooksCount;
     }
 
     @Getter

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/hardcover/HardcoverBookSearchService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/hardcover/HardcoverBookSearchService.java
@@ -57,6 +57,7 @@ public class HardcoverBookSearchService {
                           series {
                             name
                             books_count
+                            primary_books_count
                           }
                           position
                         }

--- a/booklore-api/src/test/java/org/booklore/service/metadata/parser/HardcoverParserTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/parser/HardcoverParserTest.java
@@ -398,7 +398,7 @@ class HardcoverParserTest {
             assertThat(metadata.getAuthors()).contains("Test Author");
             assertThat(metadata.getSeriesName()).isEqualTo("Test Series");
             assertThat(metadata.getSeriesNumber()).isEqualTo(2.0f);
-            assertThat(metadata.getSeriesTotal()).isEqualTo(5);
+            assertThat(metadata.getSeriesTotal()).isEqualTo(3);
             assertThat(metadata.getIsbn13()).isEqualTo("9781111111113");
             assertThat(metadata.getIsbn10()).isEqualTo("1111111111");
             assertThat(metadata.getProvider()).isEqualTo(MetadataProvider.Hardcover);
@@ -433,7 +433,7 @@ class HardcoverParserTest {
             assertThat(metadata.getAuthors()).contains("Test Author");
             assertThat(metadata.getSeriesName()).isEqualTo("Test Series");
             assertThat(metadata.getSeriesNumber()).isEqualTo(2.0f);
-            assertThat(metadata.getSeriesTotal()).isEqualTo(5);
+            assertThat(metadata.getSeriesTotal()).isEqualTo(3);
             assertThat(metadata.getIsbn13()).isEqualTo("9781234567897");
             assertThat(metadata.getIsbn10()).isEqualTo("123456789X");
             assertThat(metadata.getPublisher()).isEqualTo("Test Publisher");
@@ -767,6 +767,7 @@ class HardcoverParserTest {
         GraphQLResponse.Series series = new GraphQLResponse.Series();
         series.setName("Test Series");
         series.setBooksCount(5);
+        series.setPrimaryBooksCount(3);
 
         GraphQLResponse.FeaturedSeries featuredSeries = new GraphQLResponse.FeaturedSeries();
         featuredSeries.setSeries(series);
@@ -825,6 +826,7 @@ class HardcoverParserTest {
         GraphQLResponse.Series series = new GraphQLResponse.Series();
         series.setName("Test Series");
         series.setBooksCount(5);
+        series.setPrimaryBooksCount(3);
 
         GraphQLResponse.FeaturedSeries featuredSeries = new GraphQLResponse.FeaturedSeries();
         featuredSeries.setSeries(series);


### PR DESCRIPTION
## Description
- Changes the Hardcover Series position to float instead of int, to allow for decimal positions (books between two main volumes)
- Uses primary books count instead of total books count for series

Since both these changes are quite small I included them in the same PR, but can separate them if needed

**Linked Issue:** Fixes #86 also fixes #61 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inaccurate series total counts so book metadata now reflects the correct number of primary books in a series.
  * Improved numeric precision for series positioning to ensure consistent ordering where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->