### PR TITLE
fix(components): prevent memory leaks by using takeUntil and managing subscriptions

### DIFF
--- a/booklore-ui/src/app/app.component.ts
+++ b/booklore-ui/src/app/app.component.ts
@@ -51,14 +51,14 @@ export class AppComponent implements OnInit, OnDestroy {
     window.addEventListener('online', this.onOnline);
     window.addEventListener('offline', this.onOffline);
 
-    this.authInit.initialized$.subscribe(ready => {
+    this.subscriptions.push(this.authInit.initialized$.subscribe(ready => {
       this.loading = !ready;
       if (ready && !this.subscriptionsInitialized) {
         this.setupWebSocketSubscriptions();
         this.libraryHealthService.initialize();
         this.subscriptionsInitialized = true;
       }
-    });
+    }));
   }
 
   private onOnline = () => {

--- a/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.ts
@@ -56,6 +56,7 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
 
   private metadataCenterViewMode: 'route' | 'dialog' = 'route';
   private destroy$ = new Subject<void>();
+  private boundSetScrollHeight = this.setScrollHeight.bind(this);
 
   readonly allColumns: { field: string; header: string }[] = [
     {field: 'readStatus', header: this.t.translate('book.columnPref.columns.readStatus')},
@@ -98,7 +99,7 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
     this.selectedBookIds = this.preselectedBookIds;
     this.selectedBooks = this.bookService.getBooksByIdsFromState([...this.selectedBookIds]);
     this.setScrollHeight();
-    window.addEventListener('resize', this.setScrollHeight.bind(this));
+    window.addEventListener('resize', this.boundSetScrollHeight);
   }
 
   setScrollHeight() {
@@ -349,6 +350,6 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
-    window.removeEventListener('resize', this.setScrollHeight.bind(this));
+    window.removeEventListener('resize', this.boundSetScrollHeight);
   }
 }

--- a/booklore-ui/src/app/features/dashboard/components/dashboard-settings/dashboard-settings.component.ts
+++ b/booklore-ui/src/app/features/dashboard/components/dashboard-settings/dashboard-settings.component.ts
@@ -66,11 +66,11 @@ export class DashboardSettingsComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.buildTranslatedOptions());
 
-    this.configService.config$.subscribe(config => {
+    this.configService.config$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(config => {
       this.config = JSON.parse(JSON.stringify(config));
     });
 
-    this.magicShelfService.shelvesState$.subscribe(state => {
+    this.magicShelfService.shelvesState$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(state => {
       this.magicShelvesMap.clear();
       (state.shelves || []).forEach(shelf => {
         if (shelf.id) {

--- a/booklore-ui/src/app/features/dashboard/components/main-dashboard/main-dashboard.component.ts
+++ b/booklore-ui/src/app/features/dashboard/components/main-dashboard/main-dashboard.component.ts
@@ -1,4 +1,5 @@
-import {Component, inject, OnInit} from '@angular/core';
+import {Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DynamicDialogRef} from 'primeng/dynamicdialog';
 import {LibraryService} from '../../../book/service/library.service';
 import {Observable} from 'rxjs';
@@ -50,6 +51,7 @@ export class MainDashboardComponent implements OnInit {
   private sortService = inject(SortService);
   private pageTitle = inject(PageTitleService);
   private readonly t = inject(TranslocoService);
+  private destroyRef = inject(DestroyRef);
 
   bookState$ = this.bookService.bookState$;
   dashboardConfig$ = this.dashboardConfigService.config$;
@@ -65,11 +67,11 @@ export class MainDashboardComponent implements OnInit {
   ngOnInit(): void {
     this.pageTitle.setPageTitle(this.t.translate('dashboard.main.pageTitle'));
 
-    this.dashboardConfig$.subscribe(() => {
+    this.dashboardConfig$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.scrollerBooksCache.clear();
     });
 
-    this.magicShelfService.shelvesState$.subscribe(() => {
+    this.magicShelfService.shelvesState$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.scrollerBooksCache.clear();
     });
   }

--- a/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/booklore-ui/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -174,7 +174,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     this.subscribeToFooterEvents();
     this.subscribeToQuickSettingsEvents();
 
-    this.route.paramMap.subscribe((params) => {
+    this.route.paramMap.pipe(takeUntil(this.destroy$)).subscribe((params) => {
       this.isLoading = true;
       this.bookId = +params.get('bookId')!;
       this.altBookType = this.route.snapshot.queryParamMap.get('bookType') ?? undefined;
@@ -218,7 +218,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
           const pagesObservable = this.cbxReaderService.getAvailablePages(this.bookId, this.altBookType);
 
-          pagesObservable.subscribe({
+          pagesObservable.pipe(takeUntil(this.destroy$)).subscribe({
             next: (pages) => {
               this.pages = pages;
               if (this.bookType === CbxReaderComponent.TYPE_CBX) {

--- a/booklore-ui/src/app/features/readers/ebook-reader/core/event.service.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/core/event.service.ts
@@ -41,6 +41,8 @@ export class ReaderEventService {
   private lastClickZone: 'left' | 'middle' | 'right' | null = null;
   private longHoldTimeout: ReturnType<typeof setTimeout> | null = null;
   private keydownHandler?: (event: KeyboardEvent) => void;
+  private windowMessageHandler?: (event: MessageEvent) => void;
+  private attachedDocCleanups: Array<() => void> = [];
   private clickedDocs = new WeakSet<Document>();
 
   private touchStartX = 0;
@@ -66,6 +68,20 @@ export class ReaderEventService {
       document.removeEventListener('keydown', this.keydownHandler);
       this.keydownHandler = undefined;
     }
+    if (this.windowMessageHandler) {
+      window.removeEventListener('message', this.windowMessageHandler);
+      this.windowMessageHandler = undefined;
+    }
+    this.attachedDocCleanups.forEach(cleanup => cleanup());
+    this.attachedDocCleanups = [];
+    if (this.longHoldTimeout) {
+      clearTimeout(this.longHoldTimeout);
+      this.longHoldTimeout = null;
+    }
+    if (this.selectionChangeTimeout) {
+      clearTimeout(this.selectionChangeTimeout);
+      this.selectionChangeTimeout = null;
+    }
     this.view = null;
     this.viewCallbacks = null;
     this.clickedDocs = new WeakSet<Document>();
@@ -81,9 +97,6 @@ export class ReaderEventService {
     this.view.addEventListener('load', (e: any) => {
       this.eventSubject.next({type: 'load', detail: e.detail});
       if (e.detail?.doc) {
-        if (this.keydownHandler) {
-          e.detail.doc.addEventListener('keydown', this.keydownHandler);
-        }
         this.attachIframeEventHandlers(e.detail.doc);
       }
 
@@ -169,11 +182,12 @@ export class ReaderEventService {
   }
 
   private attachWindowMessageHandler(): void {
-    window.addEventListener('message', (event) => {
+    this.windowMessageHandler = (event: MessageEvent) => {
       if (event.data?.type === 'iframe-click') {
         this.handleIframeClickMessage(event.data);
       }
-    });
+    };
+    window.addEventListener('message', this.windowMessageHandler);
   }
 
   private attachIframeEventHandlers(doc: Document): void {
@@ -182,15 +196,22 @@ export class ReaderEventService {
     }
     this.clickedDocs.add(doc);
 
+    const abortController = new AbortController();
+    const {signal} = abortController;
+
+    if (this.keydownHandler) {
+      doc.addEventListener('keydown', this.keydownHandler, {signal});
+    }
+
     doc.addEventListener('mousedown', () => {
       this.longHoldTimeout = setTimeout(() => {
         this.longHoldTimeout = null;
       }, this.LONG_HOLD_THRESHOLD_MS);
-    }, true);
+    }, {capture: true, signal});
 
     doc.addEventListener('mouseup', () => {
       this.handleSelectionEnd(doc);
-    });
+    }, {signal});
 
     doc.addEventListener('click', (event: MouseEvent) => {
       // Ignore synthesized mouse events that follow touch events
@@ -214,25 +235,26 @@ export class ReaderEventService {
         eventClientX: event.clientX,
         target: (event.target as HTMLElement)?.tagName
       }, '*');
-    }, true);
+    }, {capture: true, signal});
 
     doc.addEventListener('touchstart', (event: TouchEvent) => {
       this.handleTouchStart(event, doc);
-    }, {passive: true});
+    }, {passive: true, signal});
 
     doc.addEventListener('touchmove', (event: TouchEvent) => {
       this.handleTouchMove(event, doc);
-    }, {passive: false});
+    }, {passive: false, signal});
 
     doc.addEventListener('touchend', (event: TouchEvent) => {
       this.handleTouchEnd(event, doc);
-    }, {passive: false});
+    }, {passive: false, signal});
 
     doc.addEventListener('selectionchange', () => {
       this.handleSelectionChange(doc);
-    });
+    }, {signal});
 
     this.injectMobileSelectionStyles(doc);
+    this.attachedDocCleanups.push(() => abortController.abort());
   }
 
   private handleSelectionChange(doc: Document): void {

--- a/booklore-ui/src/app/features/readers/ebook-reader/ebook-reader.component.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/ebook-reader.component.ts
@@ -380,14 +380,11 @@ export class EbookReaderComponent implements OnInit, OnDestroy {
 
   private updateBookmarkIndicator(): void {
     const currentCfi = this.progressService.currentCfi;
-    this.sidebarService.bookmarks$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(bookmarks => {
-        this.isCurrentCfiBookmarked = currentCfi
-          ? bookmarks.some(b => b.cfi === currentCfi)
-          : false;
-        this.headerService.setCurrentCfiBookmarked(this.isCurrentCfiBookmarked);
-      });
+    const bookmarks = this.sidebarService.currentBookmarks;
+    this.isCurrentCfiBookmarked = currentCfi
+      ? bookmarks.some(b => b.cfi === currentCfi)
+      : false;
+    this.headerService.setCurrentCfiBookmarked(this.isCurrentCfiBookmarked);
   }
 
   private applyStyles(): void {

--- a/booklore-ui/src/app/features/readers/ebook-reader/layout/sidebar/sidebar.service.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/layout/sidebar/sidebar.service.ts
@@ -83,6 +83,10 @@ export class ReaderSidebarService {
     return this._activeTab.value;
   }
 
+  get currentBookmarks(): BookMark[] {
+    return this._bookmarks.value;
+  }
+
   initialize(bookId: number, book: Book, destroy$: Subject<void>): void {
     this.bookId = bookId;
     this.destroy$ = destroy$;

--- a/booklore-ui/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/booklore-ui/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -4,7 +4,7 @@ import {NgxExtendedPdfViewerModule, NgxExtendedPdfViewerService, pdfDefaultOptio
 import {PageTitleService} from "../../../shared/service/page-title.service";
 import {BookService} from '../../book/service/book.service';
 import {forkJoin, Subject, Subscription} from 'rxjs';
-import {debounceTime, map, switchMap} from 'rxjs/operators';
+import {debounceTime, map, switchMap, takeUntil} from 'rxjs/operators';
 import {BookSetting} from '../../book/model/book.model';
 import {UserService} from '../../settings/user-management/user.service';
 import {AuthService} from '../../../shared/service/auth.service';
@@ -50,6 +50,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   private annotationSaveSubject = new Subject<void>();
   private annotationSaveSubscription!: Subscription;
   private annotationsLoaded = false;
+  private destroy$ = new Subject<void>();
 
   private bookService = inject(BookService);
   private userService = inject(UserService);
@@ -68,7 +69,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
       .pipe(debounceTime(1500))
       .subscribe(() => this.persistAnnotations());
 
-    this.route.paramMap.subscribe((params) => {
+    this.route.paramMap.pipe(takeUntil(this.destroy$)).subscribe((params) => {
       this.isLoading = true;
       this.bookId = +params.get('bookId')!;
       this.altBookType = this.route.snapshot.queryParamMap.get('bookType') ?? undefined;
@@ -172,6 +173,9 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+
     if (this.readingSessionService.isSessionActive()) {
       const percentage = this.totalPages > 0 ? Math.round((this.page / this.totalPages) * 1000) / 10 : 0;
       this.readingSessionService.endSession(this.page.toString(), percentage);

--- a/booklore-ui/src/app/features/settings/file-naming-pattern/file-naming-pattern.component.ts
+++ b/booklore-ui/src/app/features/settings/file-naming-pattern/file-naming-pattern.component.ts
@@ -1,4 +1,5 @@
-import {Component, inject, OnInit} from '@angular/core';
+import {Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {FormsModule} from '@angular/forms';
 import {Button} from 'primeng/button';
 import {MessageService} from 'primeng/api';
@@ -42,6 +43,7 @@ export class FileNamingPatternComponent implements OnInit {
   private messageService = inject(MessageService);
   private libraryService = inject(LibraryService);
   private t = inject(TranslocoService);
+  private destroyRef = inject(DestroyRef);
 
   appSettings$: Observable<AppSettings | null> = this.appSettingsService.appSettings$;
 
@@ -53,7 +55,10 @@ export class FileNamingPatternComponent implements OnInit {
       });
 
     this.libraryService.libraryState$
-      .pipe(filter(state => state.loaded && !!state.libraries))
+      .pipe(
+        filter(state => state.loaded && !!state.libraries),
+        takeUntilDestroyed(this.destroyRef)
+      )
       .subscribe(state => {
         this.libraries = state.libraries ?? [];
       });

--- a/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.ts
+++ b/booklore-ui/src/app/shared/layout/component/layout-menu/app.menu.component.ts
@@ -1,4 +1,5 @@
-import {Component, inject, OnInit} from '@angular/core';
+import {Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {AppMenuitemComponent} from './app.menuitem.component';
 import {AsyncPipe} from '@angular/common';
 import {MenuModule} from 'primeng/menu';
@@ -52,6 +53,7 @@ export class AppMenuComponent implements OnInit {
   private authorService = inject(AuthorService);
   private t = inject(TranslocoService);
   private localStorageService = inject(LocalStorageService);
+  private destroyRef = inject(DestroyRef);
 
   librarySortField: 'name' | 'id' = 'name';
   librarySortOrder: 'asc' | 'desc' = 'desc';
@@ -72,7 +74,8 @@ export class AppMenuComponent implements OnInit {
     this.authorService.getAllAuthors().subscribe();
 
     this.userService.userState$.pipe(
-      filter(userState => !!userState?.user && userState.loaded))
+      filter(userState => !!userState?.user && userState.loaded),
+      takeUntilDestroyed(this.destroyRef))
       .subscribe(userState => {
         if (userState.user?.userSettings.sidebarLibrarySorting) {
           this.librarySortField = this.validateSortField(userState.user.userSettings.sidebarLibrarySorting.field);


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This PR refactor few component that had potential for memory leaks. 

Main changes are the following:

- Store bound function reference for resize listener so removeEventListener actually works
- Add takeUntilDestroyed / takeUntil(destroy$) to unmanaged observable subscriptions
- Clean up iframe document listeners via AbortController in ebook reader event service
- Clear pending timeouts on service destruction
- Replace reactive subscription with synchronous read in updateBookmarkIndicator to avoid subscription accumulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription lifecycle management across the application to prevent memory leaks. Components now properly unsubscribe from observables when destroyed.
  * Enhanced event listener cleanup with proper reference binding to ensure deterministic removal of handlers.
  * Added automatic cleanup of timers and DOM listeners to prevent resource leaks in reader components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->