### PR TITLE
fix(i18n): changed hardcoded translation strings, translation reactivity

### DIFF
--- a/booklore-ui/src/app/features/author-browser/components/author-browser/author-browser.component.ts
+++ b/booklore-ui/src/app/features/author-browser/components/author-browser/author-browser.component.ts
@@ -227,6 +227,29 @@ export class AuthorBrowserComponent implements OnInit, OnDestroy {
       })
     );
 
+    this.subscriptions.push(
+      this.t.langChanges$.subscribe(() => {
+        this.pageTitle.setPageTitle(this.t.translate('authorBrowser.pageTitle'));
+
+        this.sortOptions = [
+          {label: this.t.translate('authorBrowser.sort.name'), value: 'name'},
+          {label: this.t.translate('authorBrowser.sort.bookCount'), value: 'book-count'},
+          {label: this.t.translate('authorBrowser.sort.matched'), value: 'matched'},
+          {label: this.t.translate('authorBrowser.sort.recentlyAdded'), value: 'recently-added'},
+          {label: this.t.translate('authorBrowser.sort.recentlyRead'), value: 'recently-read'},
+          {label: this.t.translate('authorBrowser.sort.readingProgress'), value: 'reading-progress'},
+          {label: this.t.translate('authorBrowser.sort.avgRating'), value: 'avg-rating'},
+          {label: this.t.translate('authorBrowser.sort.photo'), value: 'photo'},
+          {label: this.t.translate('authorBrowser.sort.seriesCount'), value: 'series-count'}
+        ];
+
+        const enriched = this.enrichedAuthors$.value;
+        if (enriched.length > 0) {
+          this.updateDynamicFilterOptions(enriched);
+        }
+      })
+    );
+
     this.setupScrollPositionTracking();
   }
 

--- a/booklore-ui/src/app/features/author-browser/components/author-editor/author-editor.component.html
+++ b/booklore-ui/src/app/features/author-browser/components/author-editor/author-editor.component.html
@@ -24,6 +24,7 @@
         <p-fileupload
           [chooseStyleClass]="'p-button-sm p-button-outlined p-button-danger'"
           [pTooltip]="t('uploadPhotoTooltip')"
+          [chooseLabel]="t('uploadPhotoTooltip')"
           tooltipPosition="top"
           [disabled]="form.get('photoLocked')?.value"
           name="file"

--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.html
@@ -18,7 +18,7 @@
               } @else if (entityType === EntityType.UNSHELVED) {
                 {{ (isFilterActive || hasSearchTerm) ? t('labels.unshelvedBooksFiltered') : t('labels.unshelvedBooks') }}
               } @else {
-                {{ entityType }}: {{ (entity$ | async)?.name }}{{ (isFilterActive || hasSearchTerm) ? ' ' + t('labels.filteredSuffix') : '' }}
+                {{ t('entityTypes.' + entityType) }}: {{ (entity$ | async)?.name }}{{ (isFilterActive || hasSearchTerm) ? ' ' + t('labels.filteredSuffix') : '' }}
               }
             </p>
             @if (seriesCollapseFilter.isSeriesCollapsed && (bookState$ | async)?.books; as books) {

--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -61,11 +61,11 @@ import {SortService} from '../../service/sort.service';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 
 export enum EntityType {
-  LIBRARY = 'Library',
-  SHELF = 'Shelf',
-  MAGIC_SHELF = 'Magic Shelf',
-  ALL_BOOKS = 'All Books',
-  UNSHELVED = 'Unshelved Books',
+  LIBRARY = 'library',
+  SHELF = 'shelf',
+  MAGIC_SHELF = 'magicShelf',
+  ALL_BOOKS = 'allBooks',
+  UNSHELVED = 'unshelved',
 }
 
 @Component({

--- a/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -257,7 +257,7 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
 
     if (filterEntries.length === 1) {
       const [filterType, values] = filterEntries[0];
-      const filterName = FilterLabelHelper.getFilterTypeName(filterType);
+      const filterName = this.t.translate(`book.filter.labels.${filterType}`);
 
       if (values.length === 1) {
         const displayValue = FilterLabelHelper.getFilterDisplayValue(filterType, values[0]);
@@ -268,7 +268,7 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     const filterSummary = filterEntries
-      .map(([type, values]) => `${FilterLabelHelper.getFilterTypeName(type)} (${values.length})`)
+      .map(([type, values]) => `${this.t.translate(`book.filter.labels.${type}`)} (${values.length})`)
       .join(', ');
 
     return filterSummary.length > 50
@@ -307,6 +307,33 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
     this.setupSearchTermSubscription();
     this.setupScrollPositionTracking();
     this.setupSelectionSubscription();
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        setTimeout(() => {
+          if (this.bookTableComponent) {
+            this.visibleColumns = this.visibleColumns.map(col => {
+              const updated = this.bookTableComponent.allColumns.find(c => c.field === col.field);
+              return updated ?? col;
+            });
+          }
+          
+          if (this.entity) {
+            this.entityOptions = this.entityService.isLibrary(this.entity)
+              ? this.libraryShelfMenuService.initializeLibraryMenuItems(this.entity)
+              : this.entityService.isMagicShelf(this.entity)
+                ? this.libraryShelfMenuService.initializeMagicShelfMenuItems(this.entity)
+                : this.libraryShelfMenuService.initializeShelfMenuItems(this.entity);
+          }
+          
+          if (this.isFilterActive) {
+            this.currentFilterLabel = this.computedFilterLabel;
+          }
+
+          this.cdr.detectChanges();
+        });
+      });
   }
 
   ngAfterViewInit(): void {

--- a/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -137,6 +137,16 @@ export class BookCardComponent implements OnInit, OnChanges, OnDestroy {
         this.cdr.markForCheck();
       });
     }
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.computeAllMemoizedValues();
+        if (this.menuInitialized) {
+          this.initMenu();
+          this.cdr.markForCheck();
+        }
+      });
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/book-table/book-table.component.ts
@@ -57,30 +57,7 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
   private metadataCenterViewMode: 'route' | 'dialog' = 'route';
   private destroy$ = new Subject<void>();
 
-  readonly allColumns: { field: string; header: string }[] = [
-    {field: 'readStatus', header: this.t.translate('book.columnPref.columns.readStatus')},
-    {field: 'title', header: this.t.translate('book.columnPref.columns.title')},
-    {field: 'authors', header: this.t.translate('book.columnPref.columns.authors')},
-    {field: 'publisher', header: this.t.translate('book.columnPref.columns.publisher')},
-    {field: 'seriesName', header: this.t.translate('book.columnPref.columns.seriesName')},
-    {field: 'seriesNumber', header: this.t.translate('book.columnPref.columns.seriesNumber')},
-    {field: 'categories', header: this.t.translate('book.columnPref.columns.categories')},
-    {field: 'publishedDate', header: this.t.translate('book.columnPref.columns.publishedDate')},
-    {field: 'lastReadTime', header: this.t.translate('book.columnPref.columns.lastReadTime')},
-    {field: 'addedOn', header: this.t.translate('book.columnPref.columns.addedOn')},
-    {field: 'fileName', header: this.t.translate('book.columnPref.columns.fileName')},
-    {field: 'fileSizeKb', header: this.t.translate('book.columnPref.columns.fileSizeKb')},
-    {field: 'language', header: this.t.translate('book.columnPref.columns.language')},
-    {field: 'isbn', header: this.t.translate('book.columnPref.columns.isbn')},
-    {field: 'pageCount', header: this.t.translate('book.columnPref.columns.pageCount')},
-    {field: 'amazonRating', header: this.t.translate('book.columnPref.columns.amazonRating')},
-    {field: 'amazonReviewCount', header: this.t.translate('book.columnPref.columns.amazonReviewCount')},
-    {field: 'goodreadsRating', header: this.t.translate('book.columnPref.columns.goodreadsRating')},
-    {field: 'goodreadsReviewCount', header: this.t.translate('book.columnPref.columns.goodreadsReviewCount')},
-    {field: 'hardcoverRating', header: this.t.translate('book.columnPref.columns.hardcoverRating')},
-    {field: 'hardcoverReviewCount', header: this.t.translate('book.columnPref.columns.hardcoverReviewCount')},
-    {field: 'ranobedbRating', header: this.t.translate('book.columnPref.columns.ranobedbRating')},
-  ];
+  allColumns: { field: string; header: string }[] = this.buildAllColumns();
 
   scrollHeight = 'calc(100dvh - 160px)';
 
@@ -99,6 +76,12 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
     this.selectedBooks = this.bookService.getBooksByIdsFromState([...this.selectedBookIds]);
     this.setScrollHeight();
     window.addEventListener('resize', this.setScrollHeight.bind(this));
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.allColumns = this.buildAllColumns();
+      });
   }
 
   setScrollHeight() {
@@ -350,5 +333,32 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
     this.destroy$.next();
     this.destroy$.complete();
     window.removeEventListener('resize', this.setScrollHeight.bind(this));
+  }
+
+  private buildAllColumns(): { field: string; header: string }[] {
+    return [
+      {field: 'readStatus', header: this.t.translate('book.columnPref.columns.readStatus')},
+      {field: 'title', header: this.t.translate('book.columnPref.columns.title')},
+      {field: 'authors', header: this.t.translate('book.columnPref.columns.authors')},
+      {field: 'publisher', header: this.t.translate('book.columnPref.columns.publisher')},
+      {field: 'seriesName', header: this.t.translate('book.columnPref.columns.seriesName')},
+      {field: 'seriesNumber', header: this.t.translate('book.columnPref.columns.seriesNumber')},
+      {field: 'categories', header: this.t.translate('book.columnPref.columns.categories')},
+      {field: 'publishedDate', header: this.t.translate('book.columnPref.columns.publishedDate')},
+      {field: 'lastReadTime', header: this.t.translate('book.columnPref.columns.lastReadTime')},
+      {field: 'addedOn', header: this.t.translate('book.columnPref.columns.addedOn')},
+      {field: 'fileName', header: this.t.translate('book.columnPref.columns.fileName')},
+      {field: 'fileSizeKb', header: this.t.translate('book.columnPref.columns.fileSizeKb')},
+      {field: 'language', header: this.t.translate('book.columnPref.columns.language')},
+      {field: 'isbn', header: this.t.translate('book.columnPref.columns.isbn')},
+      {field: 'pageCount', header: this.t.translate('book.columnPref.columns.pageCount')},
+      {field: 'amazonRating', header: this.t.translate('book.columnPref.columns.amazonRating')},
+      {field: 'amazonReviewCount', header: this.t.translate('book.columnPref.columns.amazonReviewCount')},
+      {field: 'goodreadsRating', header: this.t.translate('book.columnPref.columns.goodreadsRating')},
+      {field: 'goodreadsReviewCount', header: this.t.translate('book.columnPref.columns.goodreadsReviewCount')},
+      {field: 'hardcoverRating', header: this.t.translate('book.columnPref.columns.hardcoverRating')},
+      {field: 'hardcoverReviewCount', header: this.t.translate('book.columnPref.columns.hardcoverReviewCount')},
+      {field: 'ranobedbRating', header: this.t.translate('book.columnPref.columns.ranobedbRating')},
+    ];
   }
 }

--- a/booklore-ui/src/app/features/book/components/book-browser/filter-label.helper.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/filter-label.helper.ts
@@ -1,31 +1,7 @@
 import {fileSizeRanges, matchScoreRanges, pageCountRanges, ratingOptions10, ratingRanges} from './book-filter/book-filter.config';
 
 export class FilterLabelHelper {
-  private static readonly FILTER_TYPE_MAP: Record<string, string> = {
-    author: 'Author',
-    category: 'Genre',
-    series: 'Series',
-    publisher: 'Publisher',
-    readStatus: 'Read Status',
-    personalRating: 'Personal Rating',
-    publishedDate: 'Year Published',
-    matchScore: 'Metadata Match Score',
-    language: 'Language',
-    bookType: 'Book Type',
-    shelfStatus: 'Shelf Status',
-    fileSize: 'File Size',
-    pageCount: 'Page Count',
-    amazonRating: 'Amazon Rating',
-    goodreadsRating: 'Goodreads Rating',
-    hardcoverRating: 'Hardcover Rating',
-    ranobedbRating: 'Ranobedb Rating',
-    mood: 'Mood',
-    tag: 'Tag',
-  };
 
-  static getFilterTypeName(filterType: string): string {
-    return this.FILTER_TYPE_MAP[filterType] || this.capitalize(filterType);
-  }
 
   static getFilterDisplayValue(filterType: string, value: string | number): string {
     const numericValue = typeof value === 'string' ? Number(value) : value;
@@ -68,7 +44,4 @@ export class FilterLabelHelper {
     }
   }
 
-  private static capitalize(str: string): string {
-    return str.charAt(0).toUpperCase() + str.slice(1);
-  }
 }

--- a/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/booklore-ui/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -224,9 +224,10 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
       switchMap(book =>
         combineLatest([
           this.userService.userState$.pipe(take(1)),
-          this.appSettingsService.appSettings$.pipe(take(1))
+          this.appSettingsService.appSettings$.pipe(take(1)),
+          this.t.langChanges$
         ]).pipe(
-          map(([userState, appSettings]) => {
+          map(([userState, appSettings, _lang]) => {
             const items: MenuItem[] = [];
 
             items.push({
@@ -457,6 +458,15 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
       )
       .subscribe(settings => {
         this.amazonDomain = settings?.metadataProviderSettings?.amazon?.domain ?? 'com';
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.readStatusMenuItems = this.readStatusOptions.map(option => ({
+          label: this.t.translate(option.labelKey),
+          command: () => this.updateReadStatus(option.value)
+        }));
       });
   }
 
@@ -1216,7 +1226,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
   formatDate(dateString: string | undefined): string {
     if (!dateString) return '';
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
+    return date.toLocaleDateString(this.t.getActiveLang(), {
       year: 'numeric',
       month: 'short',
       day: 'numeric'

--- a/booklore-ui/src/app/features/notebook/components/notebook/notebook.component.html
+++ b/booklore-ui/src/app/features/notebook/components/notebook/notebook.component.html
@@ -41,6 +41,8 @@
             (ngModelChange)="onFilterChange()"
             (onFilter)="onBookFilter($event)"
             [placeholder]="t('notebook.filterByBook')"
+            [emptyFilterMessage]="t('notebook.noResults')"
+            [emptyMessage]="t('notebook.noResults')"
             [panelStyle]="{'min-width': '300px'}"
             class="book-select"
           />

--- a/booklore-ui/src/app/features/series-browser/components/series-browser/series-browser.component.ts
+++ b/booklore-ui/src/app/features/series-browser/components/series-browser/series-browser.component.ts
@@ -1,8 +1,8 @@
-import {Component, HostListener, inject, OnInit} from '@angular/core';
+import {Component, HostListener, inject, OnDestroy, OnInit} from '@angular/core';
 import {AsyncPipe, NgStyle} from '@angular/common';
 import {FormsModule} from '@angular/forms';
-import {combineLatest, Observable, BehaviorSubject} from 'rxjs';
-import {map} from 'rxjs/operators';
+import {combineLatest, Observable, BehaviorSubject, Subject} from 'rxjs';
+import {map, takeUntil} from 'rxjs/operators';
 import {ProgressSpinner} from 'primeng/progressspinner';
 import {InputText} from 'primeng/inputtext';
 import {Select} from 'primeng/select';
@@ -48,7 +48,7 @@ interface SortOption {
     VirtualScrollerModule
   ]
 })
-export class SeriesBrowserComponent implements OnInit {
+export class SeriesBrowserComponent implements OnInit, OnDestroy {
 
   private static readonly BASE_WIDTH = 230;
   private static readonly BASE_HEIGHT = 285;
@@ -61,6 +61,8 @@ export class SeriesBrowserComponent implements OnInit {
   private t = inject(TranslocoService);
   private router = inject(Router);
   protected seriesScaleService = inject(SeriesScalePreferenceService);
+
+  private destroy$ = new Subject<void>();
 
   bookState$ = this.bookService.bookState$;
 
@@ -124,6 +126,29 @@ export class SeriesBrowserComponent implements OnInit {
       {label: this.t.translate('seriesBrowser.sort.recentlyAdded'), value: 'recently-added'}
     ];
 
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.pageTitle.setPageTitle(this.t.translate('seriesBrowser.pageTitle'));
+
+        this.filterOptions = [
+          {label: this.t.translate('seriesBrowser.filters.all'), value: 'all'},
+          {label: this.t.translate('seriesBrowser.filters.notStarted'), value: 'not-started'},
+          {label: this.t.translate('seriesBrowser.filters.inProgress'), value: 'in-progress'},
+          {label: this.t.translate('seriesBrowser.filters.completed'), value: 'completed'},
+          {label: this.t.translate('seriesBrowser.filters.abandoned'), value: 'abandoned'}
+        ];
+
+        this.sortOptions = [
+          {label: this.t.translate('seriesBrowser.sort.nameAsc'), value: 'name-asc'},
+          {label: this.t.translate('seriesBrowser.sort.nameDesc'), value: 'name-desc'},
+          {label: this.t.translate('seriesBrowser.sort.bookCount'), value: 'book-count'},
+          {label: this.t.translate('seriesBrowser.sort.progress'), value: 'progress'},
+          {label: this.t.translate('seriesBrowser.sort.recentlyRead'), value: 'recently-read'},
+          {label: this.t.translate('seriesBrowser.sort.recentlyAdded'), value: 'recently-added'}
+        ];
+      });
+
     this.filteredSeries$ = combineLatest([
       this.seriesDataService.allSeries$,
       this.searchTerm$,
@@ -147,6 +172,11 @@ export class SeriesBrowserComponent implements OnInit {
         return result;
       })
     );
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   onSearchChange(value: string): void {

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {BehaviorSubject, EMPTY, Observable, Subject} from 'rxjs';
@@ -47,6 +47,8 @@ const COMPLETION_COLORS = {
   styleUrls: ['./author-universe-chart.component.scss']
 })
 export class AuthorUniverseChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
@@ -86,6 +88,21 @@ export class AuthorUniverseChartComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         this.calculateAndUpdateChart();
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.calculateAndUpdateChart();
+
+        if (this.chartOptions?.scales?.['x']?.title) {
+          (this.chartOptions.scales['x'] as any).title.text = this.t.translate('statsLibrary.authorUniverse.axisBooks');
+        }
+        if (this.chartOptions?.scales?.['y']?.title) {
+          (this.chartOptions.scales['y'] as any).title.text = this.t.translate('statsLibrary.authorUniverse.axisRating');
+        }
+
+        this.chart?.chart?.update();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.scss
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.scss
@@ -2,6 +2,7 @@
 
 .language-chart-container {
   width: 100%;
+  overflow-x: auto;
 }
 
 .language-title-icon {
@@ -13,6 +14,7 @@
   position: relative;
   height: 220px;
   width: 100%;
+  min-width: min(500px, 300%);
 }
 
 @media (max-width: 768px) {

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.ts
@@ -1,7 +1,7 @@
 import {Component, inject, OnDestroy, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
-import {BehaviorSubject, EMPTY, Observable, Subject} from 'rxjs';
+import {BehaviorSubject, combineLatest, EMPTY, Observable, Subject} from 'rxjs';
 import {catchError, filter, first, switchMap, takeUntil} from 'rxjs/operators';
 import {ChartConfiguration, ChartData} from 'chart.js';
 import {LibraryFilterService} from '../../service/library-filter.service';
@@ -37,97 +37,6 @@ const LANGUAGE_COLORS = [
   '#84CC16', // Lime
   '#A855F7'  // Purple-500
 ] as const;
-
-// Common language code to display name mapping
-const LANGUAGE_NAMES: Record<string, string> = {
-  'en': 'English',
-  'eng': 'English',
-  'english': 'English',
-  'es': 'Spanish',
-  'spa': 'Spanish',
-  'spanish': 'Spanish',
-  'fr': 'French',
-  'fra': 'French',
-  'french': 'French',
-  'de': 'German',
-  'deu': 'German',
-  'german': 'German',
-  'it': 'Italian',
-  'ita': 'Italian',
-  'italian': 'Italian',
-  'pt': 'Portuguese',
-  'por': 'Portuguese',
-  'portuguese': 'Portuguese',
-  'ru': 'Russian',
-  'rus': 'Russian',
-  'russian': 'Russian',
-  'zh': 'Chinese',
-  'zho': 'Chinese',
-  'chinese': 'Chinese',
-  'ja': 'Japanese',
-  'jpn': 'Japanese',
-  'japanese': 'Japanese',
-  'ko': 'Korean',
-  'kor': 'Korean',
-  'korean': 'Korean',
-  'pl': 'Polish',
-  'pol': 'Polish',
-  'polish': 'Polish',
-  'nl': 'Dutch',
-  'nld': 'Dutch',
-  'dutch': 'Dutch',
-  'sv': 'Swedish',
-  'swe': 'Swedish',
-  'swedish': 'Swedish',
-  'ar': 'Arabic',
-  'ara': 'Arabic',
-  'arabic': 'Arabic',
-  'hi': 'Hindi',
-  'hin': 'Hindi',
-  'hindi': 'Hindi',
-  'tr': 'Turkish',
-  'tur': 'Turkish',
-  'turkish': 'Turkish',
-  'cs': 'Czech',
-  'ces': 'Czech',
-  'czech': 'Czech',
-  'da': 'Danish',
-  'dan': 'Danish',
-  'danish': 'Danish',
-  'fi': 'Finnish',
-  'fin': 'Finnish',
-  'finnish': 'Finnish',
-  'no': 'Norwegian',
-  'nor': 'Norwegian',
-  'norwegian': 'Norwegian',
-  'uk': 'Ukrainian',
-  'ukr': 'Ukrainian',
-  'ukrainian': 'Ukrainian',
-  'he': 'Hebrew',
-  'heb': 'Hebrew',
-  'hebrew': 'Hebrew',
-  'el': 'Greek',
-  'ell': 'Greek',
-  'greek': 'Greek',
-  'hu': 'Hungarian',
-  'hun': 'Hungarian',
-  'hungarian': 'Hungarian',
-  'ro': 'Romanian',
-  'ron': 'Romanian',
-  'romanian': 'Romanian',
-  'th': 'Thai',
-  'tha': 'Thai',
-  'thai': 'Thai',
-  'vi': 'Vietnamese',
-  'vie': 'Vietnamese',
-  'vietnamese': 'Vietnamese',
-  'id': 'Indonesian',
-  'ind': 'Indonesian',
-  'indonesian': 'Indonesian',
-  'ms': 'Malay',
-  'msa': 'Malay',
-  'malay': 'Malay'
-};
 
 @Component({
   selector: 'app-language-chart',
@@ -206,8 +115,10 @@ export class LanguageChartComponent implements OnInit, OnDestroy {
       .pipe(
         filter(state => state.loaded),
         first(),
-        switchMap(() =>
-          this.libraryFilterService.selectedLibrary$.pipe(
+        switchMap(() => combineLatest([
+          this.libraryFilterService.selectedLibrary$,
+          this.t.langChanges$
+        ]).pipe(
             takeUntil(this.destroy$)
           )
         ),
@@ -277,9 +188,7 @@ export class LanguageChartComponent implements OnInit, OnDestroy {
     books.forEach(book => {
       const language = book.metadata?.language?.trim().toLowerCase();
       if (language) {
-        // Normalize the language to a display name
-        const normalizedKey = this.normalizeLanguage(language);
-        languageCounts.set(normalizedKey, (languageCounts.get(normalizedKey) || 0) + 1);
+        languageCounts.set(language, (languageCounts.get(language) || 0) + 1);
       }
     });
 
@@ -296,22 +205,17 @@ export class LanguageChartComponent implements OnInit, OnDestroy {
       .slice(0, 15); // Show top 15 languages
   }
 
-  private normalizeLanguage(language: string): string {
-    const lower = language.toLowerCase().trim();
-    // Check if it maps to a known language
-    if (LANGUAGE_NAMES[lower]) {
-      return lower;
-    }
-    return lower;
-  }
-
   private getDisplayName(language: string): string {
-    const lower = language.toLowerCase();
-    if (LANGUAGE_NAMES[lower]) {
-      return LANGUAGE_NAMES[lower];
+    try {
+      const displayNames = new Intl.DisplayNames(
+        [this.t.getActiveLang()], 
+        { type: 'language' }
+      );
+      const name = displayNames.of(language) ?? language;
+      return name.charAt(0).toUpperCase() + name.slice(1);
+    } catch {
+      return language.charAt(0).toUpperCase() + language.slice(1);
     }
-    // Capitalize first letter if no mapping found
-    return language.charAt(0).toUpperCase() + language.slice(1);
   }
 
   private updateChartData(stats: LanguageStats[]): void {

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.ts
@@ -128,6 +128,12 @@ export class MetadataScoreChartComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         this.calculateAndUpdateChart();
       });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.calculateAndUpdateChart();
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {BehaviorSubject, EMPTY, Observable, Subject} from 'rxjs';
@@ -43,6 +43,8 @@ const PAGE_RANGES: PageRange[] = [
   styleUrls: ['./page-count-chart.component.scss']
 })
 export class PageCountChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
@@ -155,6 +157,21 @@ export class PageCountChartComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         this.calculateAndUpdateChart();
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.calculateAndUpdateChart();
+
+        if (this.chartOptions?.scales?.['x']?.title) {
+          (this.chartOptions.scales['x'] as any).title.text = this.t.translate('statsLibrary.pageCount.axisPageCount');
+        }
+        if (this.chartOptions?.scales?.['y']?.title) {
+          (this.chartOptions.scales['y'] as any).title.text = this.t.translate('statsLibrary.pageCount.axisBooks');
+        }
+
+        this.chart?.chart?.update();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {BehaviorSubject, EMPTY, Observable, Subject} from 'rxjs';
@@ -60,6 +60,8 @@ const DECADE_COLORS: Record<string, string> = {
   styleUrls: ['./publication-timeline-chart.component.scss']
 })
 export class PublicationTimelineChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
@@ -98,6 +100,18 @@ export class PublicationTimelineChartComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         this.calculateAndUpdateChart();
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.calculateAndUpdateChart();
+
+        if (this.chartOptions?.scales?.['x']?.title) {
+          (this.chartOptions.scales['x'] as any).title.text = this.t.translate('statsLibrary.publicationTimeline.axisNumberOfBooks');
+        }
+
+        this.chart?.chart?.update();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {BehaviorSubject, EMPTY, Observable, Subject} from 'rxjs';
@@ -38,6 +38,8 @@ type TrendChartData = ChartData<'line', number[], string>;
   styleUrls: ['./publication-trend-chart.component.scss']
 })
 export class PublicationTrendChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
@@ -77,6 +79,21 @@ export class PublicationTrendChartComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         this.calculateAndUpdateChart();
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.calculateAndUpdateChart();
+
+        if (this.chartOptions?.scales?.['x']?.title) {
+          (this.chartOptions.scales['x'] as any).title.text = this.t.translate('statsLibrary.publicationTrend.axisPublicationYear');
+        }
+        if (this.chartOptions?.scales?.['y']?.title) {
+          (this.chartOptions.scales['y'] as any).title.text = this.t.translate('statsLibrary.publicationTrend.axisBooks');
+        }
+
+        this.chart?.chart?.update();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.ts
@@ -67,22 +67,26 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.bookService.bookState$
-      .pipe(
-        filter(state => state.loaded),
-        first(),
-        switchMap(() =>
-          this.libraryFilterService.selectedLibrary$.pipe(
-            takeUntil(this.destroy$)
-          )
-        ),
-        catchError((error) => {
-          console.error('Error processing reading journey data:', error);
-          return EMPTY;
-        })
-      )
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
-        this.calculateAndUpdateChart();
+        this.bookService.bookState$
+          .pipe(
+            filter(state => state.loaded),
+            first(),
+            switchMap(() =>
+              this.libraryFilterService.selectedLibrary$.pipe(
+                takeUntil(this.destroy$)
+              )
+            ),
+            catchError((error) => {
+              console.error('Error processing reading journey data:', error);
+              return EMPTY;
+            })
+          )
+          .subscribe(() => {
+            this.calculateAndUpdateChart();
+          });
       });
   }
 
@@ -261,7 +265,6 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
     const monthlyFinished = new Map<string, number>();
 
     for (const book of books) {
-      // Track added dates
       if (book.addedOn) {
         const monthKey = this.getMonthKey(book.addedOn);
         if (monthKey) {
@@ -269,7 +272,6 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
         }
       }
 
-      // Track finished dates
       if (book.dateFinished && book.readStatus === ReadStatus.READ) {
         const monthKey = this.getMonthKey(book.dateFinished);
         if (monthKey) {
@@ -278,7 +280,6 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
       }
     }
 
-    // Get all unique months and sort them
     const allMonths = new Set([...monthlyAdded.keys(), ...monthlyFinished.keys()]);
     const sortedMonths = Array.from(allMonths).sort();
 
@@ -286,7 +287,6 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
       return [];
     }
 
-    // Fill in gaps and calculate cumulative values
     const firstMonth = sortedMonths[0];
     const lastMonth = sortedMonths[sortedMonths.length - 1];
     const allMonthsRange = this.getMonthRange(firstMonth, lastMonth);
@@ -348,8 +348,8 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
 
   private formatMonthLabel(monthKey: string): string {
     const [year, month] = monthKey.split('-');
-    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    return `${monthNames[parseInt(month, 10) - 1]} ${year}`;
+    const formatter = new Intl.DateTimeFormat(this.t.getActiveLang(), {month: 'short'});
+    return `${formatter.format(new Date(parseInt(year), parseInt(month, 10) - 1, 1))} ${year}`;
   }
 
   private calculateInsights(books: Book[], monthlyData: MonthlyData[]): JourneyInsights {
@@ -361,7 +361,6 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
     const currentBacklog = totalAdded - totalFinished;
     const backlogPercent = totalAdded > 0 ? Math.round((currentBacklog / totalAdded) * 100) : 0;
 
-    // Calculate average time to finish
     let totalDaysToFinish = 0;
     let finishedWithBothDates = 0;
 
@@ -383,7 +382,6 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
       ? Math.round(totalDaysToFinish / finishedWithBothDates)
       : 0;
 
-    // Find most productive reading month
     let mostProductiveMonth = 'N/A';
     let mostProductiveCount = 0;
     let busiestAcquisitionMonth = 'N/A';
@@ -400,12 +398,10 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
       }
     }
 
-    // Finish rate (books finished per month on average)
     const finishRate = monthlyData.length > 0
       ? +(totalFinished / monthlyData.length).toFixed(1)
       : 0;
 
-    // Recent activity
     const now = new Date();
     const threeMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 3, 1);
     let recentFinished = 0;
@@ -421,7 +417,6 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
       ? this.t.translate('statsLibrary.readingJourney.recentActivityBooks', {count: recentFinished})
       : this.t.translate('statsLibrary.readingJourney.recentActivityNone');
 
-    // Longest reading streak (consecutive months with finished books)
     let longestStreak = 0;
     let currentStreak = 0;
     for (const data of monthlyData) {

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {BehaviorSubject, EMPTY, Observable, Subject} from 'rxjs';
@@ -44,6 +44,8 @@ type JourneyChartData = ChartData<'line', number[], string>;
   styleUrls: ['./reading-journey-chart.component.scss']
 })
 export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
@@ -87,6 +89,15 @@ export class ReadingJourneyChartComponent implements OnInit, OnDestroy {
           .subscribe(() => {
             this.calculateAndUpdateChart();
           });
+
+        if (this.chartOptions?.scales?.['x']?.title) {
+          (this.chartOptions.scales['x'] as any).title.text = this.t.translate('statsLibrary.readingJourney.axisMonth');
+        }
+        if (this.chartOptions?.scales?.['y']?.title) {
+          (this.chartOptions.scales['y'] as any).title.text = this.t.translate('statsLibrary.readingJourney.axisCumulativeBooks');
+        }
+
+        this.chart?.chart?.update();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {BaseChartDirective} from 'ng2-charts';
@@ -82,6 +82,7 @@ const READ_STATUS_ORDER: ReadStatus[] = [
 })
 export class TopItemsChartComponent implements OnInit, OnDestroy {
   @Input() initialDataType: DataType | null = null;
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
 
   public readonly chartType = 'bar' as const;
   public readonly chartData$: Observable<ItemChartData>;
@@ -142,6 +143,25 @@ export class TopItemsChartComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         this.loadAndProcessData();
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.dataTypeOptions = DATA_TYPE_DEFS.map(def => ({
+          label: this.t.translate(`statsLibrary.topItems.dataTypes.${def.key}`),
+          value: def.value,
+          icon: def.icon,
+          color: def.color
+        }));
+        this.selectedDataType = this.dataTypeOptions.find(o => o.value === this.selectedDataType.value) ?? this.dataTypeOptions[0];
+
+        if (this.chartOptions?.scales?.['x']?.title) {
+          (this.chartOptions.scales['x'] as any).title.text = this.t.translate('statsLibrary.topItems.axisNumberOfBooks');
+        }
+
+        this.chart?.chart?.update();
+        this.processData();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/library-stats/library-stats.component.ts
+++ b/booklore-ui/src/app/features/stats/component/library-stats/library-stats.component.ts
@@ -80,6 +80,26 @@ export class LibraryStatsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.loadLibraryOptions();
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.chartsConfig = this.chartsConfig.map(chart => ({
+          ...chart,
+          name: this.t.translate(`statsLibrary.chartNames.${this.getChartTranslationKey(chart.id)}`)
+        }));
+
+        this.libraryOptions = this.libraryOptions.map(option => ({
+          ...option,
+          name: option.id === null
+            ? this.t.translate('statsLibrary.libraryFilter.allLibraries')
+            : option.name
+        }));
+
+        if (this.selectedLibrary) {
+          this.selectedLibrary = this.libraryOptions.find(o => o.id === this.selectedLibrary!.id) ?? this.selectedLibrary;
+        }
+      });
   }
 
   ngOnDestroy(): void {
@@ -178,6 +198,21 @@ export class LibraryStatsComponent implements OnInit, OnDestroy {
 
   public resetChartOrder(): void {
     this.chartsConfig = this.buildChartsConfig();
+  }
+
+  private getChartTranslationKey(id: string): string {
+    const map: Record<string, string> = {
+      bookFormats: 'bookFormats',
+      languageDistribution: 'languages',
+      metadataScore: 'metadataScore',
+      pageCountDistribution: 'pageCount',
+      publicationTimeline: 'publicationTimeline',
+      readingJourney: 'readingJourney',
+      topItems: 'topItems',
+      authorUniverse: 'authorUniverse',
+      publicationTrend: 'publicationTrend'
+    };
+    return map[id] ?? id;
   }
 
   private buildChartsConfig(): ChartConfig[] {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {Tooltip} from 'primeng/tooltip';
@@ -41,6 +41,8 @@ const PAGE_RANGES = [
   styleUrls: ['./book-length-chart.component.scss']
 })
 export class BookLengthChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly t = inject(TranslocoService);
   private readonly destroy$ = new Subject<void>();
@@ -151,6 +153,21 @@ export class BookLengthChartComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(() => this.processData());
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.processData();
+
+        setTimeout(() => {
+          const chartInstance = this.chart?.chart;
+          if (chartInstance) {
+            (chartInstance.options as any).scales.x.title.text = this.t.translate('statsUser.bookLength.axisPageCount');
+            (chartInstance.options as any).scales.y.title.text = this.t.translate('statsUser.bookLength.axisPersonalRating');
+            chartInstance.update();
+          }
+        });
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {Tooltip} from 'primeng/tooltip';
@@ -32,6 +32,7 @@ const LINE_COLORS = [
 })
 export class CompletionRaceChartComponent implements OnInit, OnDestroy {
   @Input() initialYear: number = new Date().getFullYear();
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
 
   public currentYear: number = new Date().getFullYear();
   public readonly chartType = 'line' as const;
@@ -142,6 +143,20 @@ export class CompletionRaceChartComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.currentYear = this.initialYear;
     this.loadData(this.currentYear);
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if (this.chartOptions?.scales?.['x']?.title) {
+          (this.chartOptions!.scales!['x'] as any).title.text = this.t.translate('statsUser.completionRace.axisDaysSinceFirstSession');
+        }
+        if (this.chartOptions?.scales?.['y']?.title) {
+          (this.chartOptions!.scales!['y'] as any).title.text = this.t.translate('statsUser.completionRace.axisProgress');
+        }
+
+        this.chart?.chart?.update();
+        this.loadData(this.currentYear);
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {ChartConfiguration, ChartData} from 'chart.js';
@@ -18,6 +18,7 @@ type CompletionChartData = ChartData<'bar', number[], string>;
 })
 export class CompletionTimelineChartComponent implements OnInit, OnDestroy {
   @Input() initialYear: number = new Date().getFullYear();
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
 
   public currentYear: number = new Date().getFullYear();
   public readonly chartType = 'bar' as const;
@@ -131,6 +132,15 @@ export class CompletionTimelineChartComponent implements OnInit, OnDestroy {
       .subscribe(locale => {
         const formatter = new Intl.DateTimeFormat(locale, {month: 'short'});
         this.monthNames = [...Array(12)].map((_, i) => formatter.format(new Date(2024, i, 1)));
+
+        if ((this.chartOptions?.scales?.['x'] as any)?.title) {
+          (this.chartOptions!.scales!['x'] as any).title.text = this.t.translate('statsUser.completionTimeline.axisMonth');
+        }
+        if ((this.chartOptions?.scales?.['y'] as any)?.title) {
+          (this.chartOptions!.scales!['y'] as any).title.text = this.t.translate('statsUser.completionTimeline.axisNumberOfBooks');
+        }
+
+        this.chart?.chart?.update();
         this.loadCompletionTimeline(this.currentYear);
       });
   }

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.ts
@@ -29,7 +29,7 @@ export class CompletionTimelineChartComponent implements OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private readonly chartDataSubject: BehaviorSubject<CompletionChartData>;
 
-  private readonly monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  private monthNames: string[] = [];
 
   constructor() {
     this.chartDataSubject = new BehaviorSubject<CompletionChartData>({
@@ -125,7 +125,14 @@ export class CompletionTimelineChartComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.currentYear = this.initialYear;
-    this.loadCompletionTimeline(this.currentYear);
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(locale => {
+        const formatter = new Intl.DateTimeFormat(locale, {month: 'short'});
+        this.monthNames = [...Array(12)].map((_, i) => formatter.format(new Date(2024, i, 1)));
+        this.loadCompletionTimeline(this.currentYear);
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.ts
@@ -29,7 +29,7 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private readonly chartDataSubject: BehaviorSubject<FavoriteDaysChartData>;
 
-  private readonly allDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  private allDays: string[] = [];
 
   public selectedYear: number | null = null;
   public selectedMonth: number | null = null;
@@ -163,11 +163,18 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
         }
       }
     };
-    this.initializeYearOptions();
   }
 
   ngOnInit(): void {
-    this.loadFavoriteDays();
+    this.t.langChanges$
+    .pipe(takeUntil(this.destroy$))
+    .subscribe(() => {
+      const locale = this.t.getActiveLang();
+      const formatter = new Intl.DateTimeFormat(locale, { weekday: 'long' });
+      this.allDays = [...Array(7)].map((_, i) => formatter.format(new Date(2024, 0, 7 + i)));
+      this.initializeYearOptions();
+      this.loadFavoriteDays();
+    });
   }
 
   ngOnDestroy(): void {
@@ -177,14 +184,20 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
 
   private initializeYearOptions(): void {
     const currentYear = new Date().getFullYear();
+    const locale = this.t.getActiveLang();
+    
     this.yearOptions = [{label: this.t.translate('statsUser.favoriteDays.allYears'), value: null}];
     for (let year = currentYear; year >= currentYear - 10; year--) {
       this.yearOptions.push({label: year.toString(), value: year});
     }
-    const monthKeys = ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december'];
+    
+    const monthFormatter = new Intl.DateTimeFormat(locale, { month: 'long' });
     this.monthOptions = [
       {label: this.t.translate('statsUser.favoriteDays.allMonths'), value: null},
-      ...monthKeys.map((key, i) => ({label: this.t.translate(`statsUser.favoriteDays.${key}`), value: i + 1}))
+      ...Array.from({length: 12}, (_, i) => ({
+        label: monthFormatter.format(new Date(2024, i, 1)),
+        value: i + 1
+      }))
     ];
   }
 

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {ChartConfiguration, ChartData} from 'chart.js';
@@ -20,6 +20,8 @@ type FavoriteDaysChartData = ChartData<'bar', number[], string>;
   styleUrls: ['./favorite-days-chart.component.scss']
 })
 export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   public readonly chartType = 'bar' as const;
   public readonly chartData$: Observable<FavoriteDaysChartData>;
   public readonly chartOptions: ChartConfiguration['options'];
@@ -167,14 +169,26 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.t.langChanges$
-    .pipe(takeUntil(this.destroy$))
-    .subscribe(() => {
-      const locale = this.t.getActiveLang();
-      const formatter = new Intl.DateTimeFormat(locale, { weekday: 'long' });
-      this.allDays = [...Array(7)].map((_, i) => formatter.format(new Date(2024, 0, 7 + i)));
-      this.initializeYearOptions();
-      this.loadFavoriteDays();
-    });
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        const locale = this.t.getActiveLang();
+        const formatter = new Intl.DateTimeFormat(locale, {weekday: 'long'});
+        this.allDays = [...Array(7)].map((_, i) => formatter.format(new Date(2024, 0, 7 + i)));
+        this.initializeYearOptions();
+
+        if ((this.chartOptions?.scales?.['x'] as any)?.title) {
+          (this.chartOptions!.scales!['x'] as any).title.text = this.t.translate('statsUser.favoriteDays.axisDayOfWeek');
+        }
+        if ((this.chartOptions?.scales?.['y'] as any)?.title) {
+          (this.chartOptions!.scales!['y'] as any).title.text = this.t.translate('statsUser.favoriteDays.axisNumberOfSessions');
+        }
+        if ((this.chartOptions?.scales?.['y1'] as any)?.title) {
+          (this.chartOptions!.scales!['y1'] as any).title.text = this.t.translate('statsUser.favoriteDays.axisDurationHours');
+        }
+
+        this.chart?.chart?.update();
+        this.loadFavoriteDays();
+      });
   }
 
   ngOnDestroy(): void {
@@ -191,7 +205,7 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
       this.yearOptions.push({label: year.toString(), value: year});
     }
     
-    const monthFormatter = new Intl.DateTimeFormat(locale, { month: 'long' });
+    const monthFormatter = new Intl.DateTimeFormat(locale, {month: 'long'});
     this.monthOptions = [
       {label: this.t.translate('statsUser.favoriteDays.allMonths'), value: null},
       ...Array.from({length: 12}, (_, i) => ({

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/genre-stats-chart/genre-stats-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/genre-stats-chart/genre-stats-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {ChartConfiguration, ChartData} from 'chart.js';
@@ -19,6 +19,7 @@ type GenreChartData = ChartData<'bar', number[], string>;
 })
 export class GenreStatsChartComponent implements OnInit, OnDestroy {
   @Input() maxGenres: number = 35;
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
 
   public readonly chartType = 'bar' as const;
   public readonly chartData$: Observable<GenreChartData>;
@@ -159,6 +160,20 @@ export class GenreStatsChartComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.loadGenreStats();
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if ((this.chartOptions?.scales as any)?.['x']?.title) {
+          (this.chartOptions!.scales!['x'] as any).title.text = this.t.translate('statsUser.genreStats.axisGenres');
+        }
+        if ((this.chartOptions?.scales?.['y'] as any)?.title) {
+          (this.chartOptions!.scales!['y'] as any).title.text = this.t.translate('statsUser.genreStats.axisTimeRead');
+        }
+
+        this.chart?.chart?.update();
+        this.loadGenreStats();
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {Tooltip} from 'primeng/tooltip';
@@ -18,6 +18,8 @@ type PageTurnerChartData = ChartData<'bar', number[], string>;
   styleUrls: ['./page-turner-chart.component.scss']
 })
 export class PageTurnerChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   public readonly chartType = 'bar' as const;
   public readonly chartData$: Observable<PageTurnerChartData>;
   public readonly chartOptions: ChartConfiguration['options'];
@@ -90,6 +92,17 @@ export class PageTurnerChartComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.loadData();
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if ((this.chartOptions?.scales?.['x'] as any)?.title) {
+          (this.chartOptions!.scales!['x'] as any).title.text = this.t.translate('statsUser.pageTurner.axisGripScore');
+        }
+
+        this.chart?.chart?.update();
+        this.loadData();
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/peak-hours-chart/peak-hours-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/peak-hours-chart/peak-hours-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {ChartConfiguration, ChartData} from 'chart.js';
@@ -20,6 +20,8 @@ type PeakHoursChartData = ChartData<'line', number[], string>;
   styleUrls: ['./peak-hours-chart.component.scss']
 })
 export class PeakHoursChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   public readonly chartType = 'line' as const;
   public readonly chartData$: Observable<PeakHoursChartData>;
   public readonly chartOptions: ChartConfiguration['options'];
@@ -161,11 +163,27 @@ export class PeakHoursChartComponent implements OnInit, OnDestroy {
         }
       }
     };
-    this.initializeYearOptions();
   }
 
   ngOnInit(): void {
-    this.loadPeakHours();
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.initializeYearOptions();
+
+        if ((this.chartOptions?.scales?.['x'] as any)?.title) {
+          (this.chartOptions!.scales!['x'] as any).title.text = this.t.translate('statsUser.peakHours.axisHourOfDay');
+        }
+        if ((this.chartOptions?.scales?.['y'] as any)?.title) {
+          (this.chartOptions!.scales!['y'] as any).title.text = this.t.translate('statsUser.peakHours.axisNumberOfSessions');
+        }
+        if ((this.chartOptions?.scales?.['y1'] as any)?.title) {
+          (this.chartOptions!.scales!['y1'] as any).title.text = this.t.translate('statsUser.peakHours.axisAvgDuration');
+        }
+
+        this.chart?.chart?.update();
+        this.loadPeakHours();
+      });
   }
 
   ngOnDestroy(): void {
@@ -175,14 +193,20 @@ export class PeakHoursChartComponent implements OnInit, OnDestroy {
 
   private initializeYearOptions(): void {
     const currentYear = new Date().getFullYear();
+    const locale = this.t.getActiveLang();
+
     this.yearOptions = [{label: this.t.translate('statsUser.peakHours.allYears'), value: null}];
     for (let year = currentYear; year >= currentYear - 10; year--) {
       this.yearOptions.push({label: year.toString(), value: year});
     }
-    const monthKeys = ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december'];
+
+    const monthFormatter = new Intl.DateTimeFormat(locale, {month: 'long'});
     this.monthOptions = [
       {label: this.t.translate('statsUser.peakHours.allMonths'), value: null},
-      ...monthKeys.map((key, i) => ({label: this.t.translate(`statsUser.peakHours.${key}`), value: i + 1}))
+      ...Array.from({length: 12}, (_, i) => ({
+        label: monthFormatter.format(new Date(2024, i, 1)),
+        value: i + 1
+      }))
     ];
   }
 
@@ -268,9 +292,7 @@ export class PeakHoursChartComponent implements OnInit, OnDestroy {
   }
 
   private formatHour(hour: number): string {
-    if (hour === 0) return '12 AM';
-    if (hour === 12) return '12 PM';
-    if (hour < 12) return `${hour} AM`;
-    return `${hour - 12} PM`;
+    const date = new Date(2024, 0, 1, hour);
+    return new Intl.DateTimeFormat(this.t.getActiveLang(), {hour: 'numeric', hour12: true}).format(date);
   }
 }

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/personal-rating-chart/personal-rating-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/personal-rating-chart/personal-rating-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {BehaviorSubject, EMPTY, Observable, Subject} from 'rxjs';
@@ -59,6 +59,8 @@ type RatingChartData = ChartData<'bar', number[], string>;
   styleUrls: ['./personal-rating-chart.component.scss']
 })
 export class PersonalRatingChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly t = inject(TranslocoService);
   private readonly destroy$ = new Subject<void>();
@@ -171,6 +173,22 @@ export class PersonalRatingChartComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         const stats = this.calculatePersonalRatingStats();
         this.updateChartData(stats);
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        const stats = this.calculatePersonalRatingStats();
+        this.updateChartData(stats);
+
+        if ((this.chartOptions?.scales?.['x'] as any)?.title) {
+          (this.chartOptions!.scales!['x'] as any).title.text = this.t.translate('statsUser.personalRating.axisPersonalRating');
+        }
+        if ((this.chartOptions?.scales?.['y'] as any)?.title) {
+          (this.chartOptions!.scales!['y'] as any).title.text = this.t.translate('statsUser.personalRating.axisNumberOfBooks');
+        }
+
+        this.chart?.chart?.update();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {Tooltip} from 'primeng/tooltip';
@@ -16,6 +16,8 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
   styleUrls: ['./publication-era-chart.component.scss']
 })
 export class PublicationEraChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly t = inject(TranslocoService);
   private readonly destroy$ = new Subject<void>();
@@ -50,7 +52,7 @@ export class PublicationEraChartComponent implements OnInit, OnDestroy {
         borderColor: '#ffffff', borderWidth: 1, cornerRadius: 6, padding: 10,
         callbacks: {
           label: (ctx) => {
-            return `${ctx.dataset.label}: ${ctx.parsed.y} books`;
+            return `${ctx.dataset.label}: ${ctx.parsed.y} ${this.t.translate('statsUser.publicationEra.books')}`;
           }
         }
       },
@@ -60,13 +62,13 @@ export class PublicationEraChartComponent implements OnInit, OnDestroy {
       x: {
         grid: {color: 'rgba(255, 255, 255, 0.08)'},
         ticks: {color: 'rgba(255, 255, 255, 0.6)', font: {size: 11}},
-        title: {display: true, text: 'Rating Range', color: 'rgba(255, 255, 255, 0.5)', font: {size: 11}}
+        title: {display: true, text: this.t.translate('statsUser.publicationEra.axisRatingRange'), color: 'rgba(255, 255, 255, 0.5)', font: {size: 11}}
       },
       y: {
         beginAtZero: true,
         grid: {color: 'rgba(255, 255, 255, 0.08)'},
         ticks: {color: 'rgba(255, 255, 255, 0.6)', font: {size: 11}, stepSize: 1},
-        title: {display: true, text: 'Books', color: 'rgba(255, 255, 255, 0.5)', font: {size: 11}}
+        title: {display: true, text: this.t.translate('statsUser.publicationEra.axisBooks'), color: 'rgba(255, 255, 255, 0.5)', font: {size: 11}}
       }
     },
     interaction: {mode: 'index', intersect: false}
@@ -76,6 +78,21 @@ export class PublicationEraChartComponent implements OnInit, OnDestroy {
     this.bookService.bookState$
       .pipe(filter(state => state.loaded), first(), catchError(() => EMPTY), takeUntil(this.destroy$))
       .subscribe(() => this.processData());
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.processData();
+
+        setTimeout(() => {
+          const chartInstance = this.chart?.chart;
+          if (chartInstance) {
+            (chartInstance.options as any).scales.x.title.text = this.t.translate('statsUser.publicationEra.axisRatingRange');
+            (chartInstance.options as any).scales.y.title.text = this.t.translate('statsUser.publicationEra.axisBooks');
+            chartInstance.update();
+          }
+        });
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {Tooltip} from 'primeng/tooltip';
@@ -37,6 +37,8 @@ type RatingTasteChartData = ChartData<'scatter', BookDataPoint[], string>;
   styleUrls: ['./rating-taste-chart.component.scss']
 })
 export class RatingTasteChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
@@ -184,6 +186,21 @@ export class RatingTasteChartComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         this.calculateAndUpdateChart();
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.calculateAndUpdateChart();
+
+        if (this.chartOptions?.scales?.['x']?.title) {
+          (this.chartOptions!.scales!['x'] as any).title.text = this.t.translate('statsUser.ratingTaste.axisExternalRating');
+        }
+        if (this.chartOptions?.scales?.['y']?.title) {
+          (this.chartOptions!.scales!['y'] as any).title.text = this.t.translate('statsUser.ratingTaste.axisPersonalRating');
+        }
+
+        this.chart?.chart?.update();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/read-status-chart/read-status-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/read-status-chart/read-status-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {BehaviorSubject, EMPTY, Observable, Subject} from 'rxjs';
@@ -46,6 +46,8 @@ type StatusChartData = ChartData<'doughnut', number[], string>;
   styleUrls: ['./read-status-chart.component.scss']
 })
 export class ReadStatusChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly t = inject(TranslocoService);
   private readonly destroy$ = new Subject<void>();
@@ -130,6 +132,14 @@ export class ReadStatusChartComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         const stats = this.calculateReadingStatusStats();
         this.updateChartData(stats);
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        const stats = this.calculateReadingStatusStats();
+        this.updateChartData(stats);
+        this.chart?.chart?.update();
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.ts
@@ -10,13 +10,6 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 
 type ClockChartData = ChartData<'polarArea', number[], string>;
 
-const HOUR_LABELS = [
-  '12am', '1am', '2am', '3am', '4am', '5am',
-  '6am', '7am', '8am', '9am', '10am', '11am',
-  '12pm', '1pm', '2pm', '3pm', '4pm', '5pm',
-  '6pm', '7pm', '8pm', '9pm', '10pm', '11pm'
-];
-
 @Component({
   selector: 'app-reading-clock-chart',
   standalone: true,
@@ -34,6 +27,8 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
   public totalHoursRead = 0;
   public readerType = '';
   public hasData = false;
+
+  private lastData: PeakHoursResponse[] = [];
 
   public readonly chartOptions: ChartConfiguration<'polarArea'>['options'] = {
     responsive: true,
@@ -55,7 +50,7 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
         titleFont: {size: 13, weight: 'bold'},
         bodyFont: {size: 12},
         callbacks: {
-          title: (context) => HOUR_LABELS[context[0].dataIndex],
+          title: (context) => this.buildHourLabels()[context[0].dataIndex],
           label: (context) => {
             const minutes = context.parsed.r;
             if (minutes >= 60) {
@@ -98,12 +93,28 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
           return EMPTY;
         })
       )
-      .subscribe((data) => this.processData(data));
+      .subscribe((data) => {
+        this.lastData = data;
+        this.processData(data);
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if (this.lastData.length > 0) {
+          this.processData(this.lastData);
+        }
+      });
   }
 
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private buildHourLabels(): string[] {
+    const formatter = new Intl.DateTimeFormat(this.t.getActiveLang(), {hour: 'numeric', hour12: true});
+    return [...Array(24)].map((_, i) => formatter.format(new Date(2024, 0, 1, i)));
   }
 
   private processData(data: PeakHoursResponse[]): void {
@@ -114,7 +125,8 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
 
     this.hasData = true;
 
-    // Build 24-hour array
+    const hourLabels = this.buildHourLabels();
+
     const hourMinutes = new Array(24).fill(0);
     let totalSeconds = 0;
     let peakIdx = 0;
@@ -130,7 +142,7 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
       }
     }
 
-    this.peakHour = HOUR_LABELS[peakIdx];
+    this.peakHour = hourLabels[peakIdx];
     this.totalHoursRead = Math.round(totalSeconds / 3600);
 
     // Night owl vs early bird
@@ -158,7 +170,7 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
     });
 
     this.chartDataSubject.next({
-      labels: HOUR_LABELS,
+      labels: hourLabels,
       datasets: [{
         data: hourMinutes,
         backgroundColor: colors,

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.ts
@@ -62,9 +62,13 @@ export class ReadingDebtChartComponent implements OnInit, OnDestroy {
   };
 
   ngOnInit(): void {
-    this.bookService.bookState$
-      .pipe(filter(state => state.loaded), first(), catchError(() => EMPTY), takeUntil(this.destroy$))
-      .subscribe(() => this.processData());
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.bookService.bookState$
+          .pipe(filter(state => state.loaded), first(), catchError(() => EMPTY))
+          .subscribe(() => this.processData());
+      });
   }
 
   ngOnDestroy(): void {
@@ -78,17 +82,18 @@ export class ReadingDebtChartComponent implements OnInit, OnDestroy {
     if (!books || books.length === 0) return;
 
     const now = new Date();
+    const locale = this.t.getActiveLang();
     const monthlyAdded = new Map<string, number>();
     const monthlyFinished = new Map<string, number>();
     const months: string[] = [];
     const monthLabels: string[] = [];
-    const monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    const formatter = new Intl.DateTimeFormat(locale, {month: 'short'});
 
     for (let i = 11; i >= 0; i--) {
       const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
       const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
       months.push(key);
-      monthLabels.push(`${monthNames[d.getMonth()]} ${String(d.getFullYear()).slice(2)}`);
+      monthLabels.push(`${formatter.format(d)} ${String(d.getFullYear()).slice(2)}`);
       monthlyAdded.set(key, 0);
       monthlyFinished.set(key, 0);
     }

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.ts
@@ -42,6 +42,9 @@ export class ReadingDNAChartComponent implements OnInit, OnDestroy {
   private readonly t = inject(TranslocoService);
   private readonly destroy$ = new Subject<void>();
 
+  private readonly traitKeys = ['adventurous', 'perfectionist', 'intellectual', 'emotional', 'patient', 'social', 'nostalgic', 'ambitious'];
+  private lastProfile: ReadingDNAProfile | null = null;
+
   public readonly chartType = 'radar' as const;
 
   public readonly chartOptions: ChartConfiguration<'radar'>['options'] = {
@@ -80,9 +83,8 @@ export class ReadingDNAChartComponent implements OnInit, OnDestroy {
           },
           padding: 25,
           callback: (label: string) => {
-            const traitKeys = ['adventurous', 'perfectionist', 'intellectual', 'emotional', 'patient', 'social', 'nostalgic', 'ambitious'];
             const icons = ['🌟', '💎', '🧠', '💖', '🕰️', '👥', '📚', '🚀'];
-            const translatedLabels = traitKeys.map(k => this.t.translate(`statsUser.readingDna.traits.${k}`));
+            const translatedLabels = this.traitKeys.map(k => this.t.translate(`statsUser.readingDna.traits.${k}`));
             const idx = translatedLabels.indexOf(label);
             return [idx >= 0 ? icons[idx] : '', label];
           }
@@ -140,8 +142,6 @@ export class ReadingDNAChartComponent implements OnInit, OnDestroy {
     }
   };
 
-  private readonly traitKeys = ['adventurous', 'perfectionist', 'intellectual', 'emotional', 'patient', 'social', 'nostalgic', 'ambitious'];
-
   private readonly chartDataSubject = new BehaviorSubject<ReadingDNAChartData>({
     labels: [],
     datasets: []
@@ -162,8 +162,14 @@ export class ReadingDNAChartComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(() => {
-        const profile = this.calculateReadingDNAData();
-        this.updateChartData(profile);
+        this.lastProfile = this.calculateReadingDNAData();
+        this.updateChartData(this.lastProfile);
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.updateChartData(this.lastProfile);
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.ts
@@ -43,6 +43,7 @@ export class ReadingHabitsChartComponent implements OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
 
   private readonly habitKeys = ['consistency', 'multitasking', 'completionism', 'exploration', 'organization', 'intensity', 'methodology', 'momentum'];
+  private lastProfile: ReadingHabitsProfile | null = null;
 
   public readonly chartType = 'radar' as const;
 
@@ -161,8 +162,14 @@ export class ReadingHabitsChartComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(() => {
-        const profile = this.calculateReadingHabitsData();
-        this.updateChartData(profile);
+        this.lastProfile = this.calculateReadingHabitsData();
+        this.updateChartData(this.lastProfile);
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.updateChartData(this.lastProfile);
       });
   }
 

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-heatmap-chart/reading-heatmap-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-heatmap-chart/reading-heatmap-chart.component.ts
@@ -22,8 +22,6 @@ interface YearMonthData {
   count: number;
 }
 
-const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
 type HeatmapChartData = ChartData<'matrix', MatrixDataPoint[], string>;
 
 @Component({
@@ -41,6 +39,7 @@ export class ReadingHeatmapChartComponent implements OnInit, OnDestroy {
   public readonly chartType = 'matrix' as const;
 
   private yearLabels: string[] = [];
+  private monthNames: string[] = [];
   private maxBookCount = 1;
 
   public readonly chartOptions: ChartConfiguration['options'] = {
@@ -69,7 +68,7 @@ export class ReadingHeatmapChartComponent implements OnInit, OnDestroy {
           title: (context) => {
             const point = context[0].raw as MatrixDataPoint;
             const year = this.yearLabels[point.y];
-            const month = MONTH_NAMES[point.x];
+            const month = this.monthNames[point.x];
             return `${month} ${year}`;
           },
           label: (context) => {
@@ -96,7 +95,7 @@ export class ReadingHeatmapChartComponent implements OnInit, OnDestroy {
         position: 'bottom',
         ticks: {
           stepSize: 1,
-          callback: (value) => MONTH_NAMES[value as number] || '',
+          callback: (value) => this.monthNames[value as number] || '',
           color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
@@ -133,6 +132,16 @@ export class ReadingHeatmapChartComponent implements OnInit, OnDestroy {
   public readonly chartData$: Observable<HeatmapChartData> = this.chartDataSubject.asObservable();
 
   ngOnInit(): void {
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(locale => {
+        const formatter = new Intl.DateTimeFormat(locale, {month: 'short'});
+        this.monthNames = [...Array(12)].map((_, i) => formatter.format(new Date(2024, i, 1)));
+
+        const stats = this.calculateHeatmapData();
+        this.updateChartData(stats);
+      });
+
     this.bookService.bookState$
       .pipe(
         filter(state => state.loaded),
@@ -247,4 +256,3 @@ export class ReadingHeatmapChartComponent implements OnInit, OnDestroy {
       .sort((a, b) => a.year - b.year || a.month - b.month);
   }
 }
-

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.ts
@@ -9,8 +9,6 @@ import {catchError, takeUntil} from 'rxjs/operators';
 import {ReadingSessionHeatmapResponse, UserStatsService} from '../../../../../settings/user-management/user-stats.service';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 
-const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 interface MatrixDataPoint {
   x: number;
@@ -56,6 +54,8 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private readonly chartDataSubject: BehaviorSubject<SessionHeatmapChartData>;
   private maxSessionCount = 1;
+  private dayNames: string[] = [];
+  private monthNames: string[] = [];
 
   constructor() {
     this.chartDataSubject = new BehaviorSubject<SessionHeatmapChartData>({
@@ -88,7 +88,7 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
             title: (context) => {
               const point = context[0].raw as MatrixDataPoint;
               const date = new Date(point.date);
-              return date.toLocaleDateString('en-US', {
+              return date.toLocaleDateString(this.translocoService.getActiveLang(), {
                 weekday: 'short',
                 year: 'numeric',
                 month: 'short',
@@ -117,7 +117,7 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
               const weekNum = value as number;
               if (weekNum % 4 === 0) {
                 const date = this.getDateFromWeek(this.currentYear, weekNum);
-                return MONTH_NAMES[date.getMonth()];
+                return this.monthNames[date.getMonth()];
               }
               return '';
             },
@@ -135,7 +135,7 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
             stepSize: 1,
             callback: (value) => {
               const dayIndex = value as number;
-              return dayIndex >= 0 && dayIndex <= 6 ? DAY_NAMES[dayIndex] : '';
+              return dayIndex >= 0 && dayIndex <= 6 ? this.dayNames[dayIndex] : '';
             },
             color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11}
@@ -149,8 +149,18 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     Chart.register(...registerables, MatrixController, MatrixElement);
     this.currentYear = this.initialYear;
-    this.loadYearData(this.currentYear);
-    this.loadStreakData();
+
+    this.translocoService.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(locale => {
+        const dayFormatter = new Intl.DateTimeFormat(locale, { weekday: 'short' });
+        const monthFormatter = new Intl.DateTimeFormat(locale, { month: 'short' });
+        this.dayNames = [...Array(7)].map((_, i) => dayFormatter.format(new Date(2024, 0, i + 1)));
+        this.monthNames = [...Array(12)].map((_, i) => monthFormatter.format(new Date(2024, i, 1)));
+
+        this.loadYearData(this.currentYear);
+        this.loadStreakData();
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.ts
@@ -1,7 +1,8 @@
-import {Component, inject, Input, OnInit} from '@angular/core';
+import {Component, inject, Input, OnDestroy, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {catchError} from 'rxjs/operators';
-import {of} from 'rxjs';
+import {of, Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 import {Select} from 'primeng/select';
 import {FormsModule} from '@angular/forms';
 import {Tooltip} from 'primeng/tooltip';
@@ -58,15 +59,16 @@ interface DayTimeline {
   templateUrl: './reading-session-timeline.component.html',
   styleUrls: ['./reading-session-timeline.component.scss']
 })
-export class ReadingSessionTimelineComponent implements OnInit {
+export class ReadingSessionTimelineComponent implements OnInit, OnDestroy {
   @Input() initialYear: number = new Date().getFullYear();
   @Input() weekNumber: number = getISOWeek(new Date());
 
   private userStatsService = inject(UserStatsService);
   private urlHelperService = inject(UrlHelperService);
   private translocoService = inject(TranslocoService);
+  private readonly destroy$ = new Subject<void>();
 
-  public daysOfWeek = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  public daysOfWeek: string[] = [];
   public hourLabels: string[] = [];
   public timelineData: DayTimeline[] = [];
   public currentYear: number = new Date().getFullYear();
@@ -82,9 +84,21 @@ export class ReadingSessionTimelineComponent implements OnInit {
     this.updateDateFromYearAndWeek();
     this.initializeYearOptions();
     this.ensureYearInOptions();
-    this.updateWeekOptions();
-    this.initializeHourLabels();
-    this.loadReadingSessions();
+
+    this.translocoService.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(locale => {
+        const formatter = new Intl.DateTimeFormat(locale, {weekday: 'short'});
+        this.daysOfWeek = [...Array(7)].map((_, i) => formatter.format(new Date(2024, 0, 1 + i)));
+        this.initializeHourLabels();
+        this.updateWeekOptions();
+        this.loadReadingSessions();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   private initializeYearOptions(): void {
@@ -120,11 +134,8 @@ export class ReadingSessionTimelineComponent implements OnInit {
   }
 
   private initializeHourLabels(): void {
-    for (let i = 0; i < 24; i++) {
-      const hour = i === 0 ? 12 : i > 12 ? i - 12 : i;
-      const period = i < 12 ? 'AM' : 'PM';
-      this.hourLabels.push(`${hour} ${period}`);
-    }
+    const formatter = new Intl.DateTimeFormat(this.translocoService.getActiveLang(), {hour: 'numeric', hour12: true});
+    this.hourLabels = [...Array(24)].map((_, i) => formatter.format(new Date(2024, 0, 1, i)));
   }
 
   private loadReadingSessions(): void {
@@ -190,7 +201,7 @@ export class ReadingSessionTimelineComponent implements OnInit {
     const weekEnd = endOfISOWeek(this.currentDate);
 
     const formatDate = (date: Date) => {
-      const month = date.toLocaleDateString('en-US', {month: 'short'});
+      const month = date.toLocaleDateString(this.translocoService.getActiveLang(), {month: 'short'});
       const day = date.getDate();
       return `${month} ${day}`;
     };
@@ -340,10 +351,8 @@ export class ReadingSessionTimelineComponent implements OnInit {
   }
 
   public formatTime(hour: number, minute: number): string {
-    const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
-    const period = hour < 12 ? 'AM' : 'PM';
-    const displayMinute = minute.toString().padStart(2, '0');
-    return `${displayHour}:${displayMinute} ${period}`;
+    const date = new Date(2024, 0, 1, hour, minute);
+    return new Intl.DateTimeFormat(this.translocoService.getActiveLang(), {hour: 'numeric', minute: '2-digit', hour12: true}).format(date);
   }
 
   public formatDuration(minutes: number): string {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {Tooltip} from 'primeng/tooltip';
@@ -22,6 +22,8 @@ const THRESHOLDS = [0, 10, 25, 50, 75, 90, 100];
   styleUrls: ['./reading-survival-chart.component.scss']
 })
 export class ReadingSurvivalChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly t = inject(TranslocoService);
   private readonly destroy$ = new Subject<void>();
@@ -113,6 +115,21 @@ export class ReadingSurvivalChartComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(() => this.calculateSurvivalCurve());
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.calculateSurvivalCurve();
+
+        setTimeout(() => {
+          const chartInstance = this.chart?.chart;
+          if (chartInstance) {
+            (chartInstance.options as any).scales.x.title.text = this.t.translate('statsUser.readingSurvival.axisProgressThreshold');
+            (chartInstance.options as any).scales.y.title.text = this.t.translate('statsUser.readingSurvival.axisBooksSurviving');
+            chartInstance.update();
+          }
+        });
+      });
   }
 
   ngOnDestroy(): void {

--- a/booklore-ui/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.ts
+++ b/booklore-ui/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BaseChartDirective} from 'ng2-charts';
 import {Tooltip} from 'primeng/tooltip';
@@ -49,6 +49,8 @@ type SeriesChartData = ChartData<'bar', number[], string>;
   styleUrls: ['./series-progress-chart.component.scss']
 })
 export class SeriesProgressChartComponent implements OnInit, OnDestroy {
+  @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
+
   private readonly bookService = inject(BookService);
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
@@ -190,6 +192,20 @@ export class SeriesProgressChartComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         this.calculateAndUpdateChart();
+      });
+
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.calculateAndUpdateChart();
+
+        setTimeout(() => {
+          const chartInstance = this.chart?.chart;
+          if (chartInstance) {
+            (chartInstance.options as any).scales.x.title.text = this.t.translate('statsUser.seriesProgress.axisCompletion');
+            chartInstance.update();
+          }
+        });
       });
   }
 

--- a/booklore-ui/src/app/shared/components/file-mover/file-mover-component.html
+++ b/booklore-ui/src/app/shared/components/file-mover/file-mover-component.html
@@ -1,11 +1,12 @@
+<ng-container *transloco="let t">
 <div class="file-mover-container">
   <div class="panel-header">
     <div class="header-icon-wrapper">
       <i class="pi pi-folder-open header-icon"></i>
     </div>
     <div class="header-text">
-      <h2 class="panel-title">Move & Organize Files</h2>
-      <p class="panel-description">{{ books.length }} book{{ books.length !== 1 ? 's' : '' }} selected</p>
+      <h2 class="panel-title">{{ t('shared.fileMover.title') }}</h2>
+      <p class="panel-description">{{ t('shared.fileMover.booksSelected', { count: books.length }) }}</p>
     </div>
     <p-button
       icon="pi pi-times"
@@ -25,17 +26,14 @@
           <i class="pi pi-info-circle"></i>
         </div>
         <div class="banner-content">
-          <span class="banner-text">
-            Preview and organize <strong>{{ filePreviews.length }} file{{ filePreviews.length !== 1 ? 's' : '' }}</strong>.
-            Files will be renamed based on metadata and naming patterns.
-          </span>
+          <span class="banner-text" [innerHTML]="t('shared.fileMover.banner.preview', { count: filePreviews.length })"></span>
           <span class="banner-warning">
             <i class="pi pi-exclamation-triangle"></i>
-            Requires good metadata quality.
+            {{ t('shared.fileMover.banner.metadataWarning') }}
           </span>
         </div>
         <button type="button" class="banner-toggle" (click)="toggleInfoCollapsed()">
-          <span>{{ infoCollapsed ? 'Learn more' : 'Hide' }}</span>
+          <span>{{ infoCollapsed ? t('shared.fileMover.banner.learnMore') : t('shared.fileMover.banner.hide') }}</span>
           <i [class]="infoCollapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up'"></i>
         </button>
       </div>
@@ -44,19 +42,19 @@
         <div class="banner-details">
           <div class="detail-item">
             <i class="pi pi-check-circle"></i>
-            <span>Your files will be automatically renamed, organized, and can be moved between libraries based on your preferences. Check the preview below to see how your files will look.</span>
+            <span>{{ t('shared.fileMover.banner.details.autoOrganize') }}</span>
           </div>
           <div class="detail-item">
             <i class="pi pi-cog"></i>
-            <span>Want to change how files are named? Go to <strong>Settings → File Naming Pattern</strong>. Each library can have its own naming pattern!</span>
+            <span [innerHTML]="t('shared.fileMover.banner.details.changePattern')"></span>
           </div>
           <div class="detail-item warning">
             <i class="pi pi-exclamation-triangle"></i>
-            <span>This will actually move and rename files on your computer across different library folders. Make sure you're happy with the preview first!</span>
+            <span>{{ t('shared.fileMover.banner.details.moveWarning') }}</span>
           </div>
           <div class="detail-item danger">
             <i class="pi pi-shield"></i>
-            <span>This feature relies entirely on your books' metadata. If your metadata is missing or inconsistent, the resulting file names will be incorrect. Only recommended for well-curated libraries.</span>
+            <span>{{ t('shared.fileMover.banner.details.metadataDanger') }}</span>
           </div>
         </div>
       }
@@ -67,7 +65,7 @@
       <button type="button" class="patterns-toggle" (click)="togglePatternsCollapsed()">
         <div class="toggle-content">
           <i class="pi pi-code"></i>
-          <span>Naming Rules</span>
+          <span>{{ t('shared.fileMover.patterns.title') }}</span>
           <span class="patterns-count">{{ libraryPatterns.length }}</span>
         </div>
         <i [class]="patternsCollapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up'"></i>
@@ -79,9 +77,9 @@
             <div class="pattern-card">
               <div class="pattern-header">
                 <span class="pattern-library">{{ pattern.libraryName }}</span>
-                <span class="pattern-badge">{{ pattern.bookCount }} book{{ pattern.bookCount > 1 ? 's' : '' }}</span>
+                <span class="pattern-badge">{{ t('shared.fileMover.patterns.bookCount', { count: pattern.bookCount }) }}</span>
               </div>
-              <code class="pattern-code">{{ pattern.pattern || 'No pattern configured' }}</code>
+              <code class="pattern-code">{{ pattern.pattern || t('shared.fileMover.patterns.noPattern') }}</code>
               <span class="pattern-source">{{ pattern.source }}</span>
             </div>
           }
@@ -93,16 +91,16 @@
     <section class="bulk-section">
       <div class="bulk-header">
         <i class="pi pi-list"></i>
-        <span>Bulk Assignment</span>
+        <span>{{ t('shared.fileMover.bulk.title') }}</span>
       </div>
       <div class="bulk-controls">
-        <label class="bulk-label">Set all files to:</label>
+        <label class="bulk-label">{{ t('shared.fileMover.bulk.setAllTo') }}</label>
         <p-select
           [options]="availableLibraries"
           [(ngModel)]="defaultTargetLibraryId"
           optionLabel="name"
           optionValue="id"
-          placeholder="Select library"
+          [placeholder]="t('shared.fileMover.bulk.selectLibrary')"
           (onChange)="onDefaultLibraryChange()"
           class="select-library"
           size="small"
@@ -114,7 +112,7 @@
             [(ngModel)]="defaultTargetLibraryPathId"
             optionLabel="path"
             optionValue="id"
-            placeholder="Select path"
+            [placeholder]="t('shared.fileMover.bulk.selectPath')"
             (onChange)="onDefaultLibraryPathChange()"
             class="select-path"
             size="small"
@@ -128,7 +126,7 @@
     <section class="table-section">
       <div class="table-header">
         <i class="pi pi-table"></i>
-        <span>File Preview</span>
+        <span>{{ t('shared.fileMover.table.title') }}</span>
       </div>
       <div class="table-container">
         <p-table
@@ -142,12 +140,12 @@
           <ng-template pTemplate="header">
             <tr>
               <th style="width: 50px;"></th>
-              <th style="width: 60px;">ID</th>
-              <th>Current Path</th>
-              <th style="width: 160px;">Target Library</th>
-              <th style="width: 160px;">Library Path</th>
+              <th style="width: 60px;">{{ t('shared.fileMover.table.columns.id') }}</th>
+              <th>{{ t('shared.fileMover.table.columns.currentPath') }}</th>
+              <th style="width: 160px;">{{ t('shared.fileMover.table.columns.targetLibrary') }}</th>
+              <th style="width: 160px;">{{ t('shared.fileMover.table.columns.libraryPath') }}</th>
               <th style="width: 40px;"></th>
-              <th>New Path</th>
+              <th>{{ t('shared.fileMover.table.columns.newPath') }}</th>
             </tr>
           </ng-template>
           <ng-template pTemplate="body" let-preview>
@@ -195,7 +193,7 @@
                     size="small"
                   ></p-select>
                 } @else {
-                  <span class="no-paths">No paths</span>
+                  <span class="no-paths">{{ t('shared.fileMover.table.noPaths') }}</span>
                 }
               </td>
               <td class="arrow-cell">
@@ -218,20 +216,20 @@
     @if (movedFileCount > 0) {
       <div class="success-indicator">
         <i class="pi pi-check-circle"></i>
-        <span>{{ movedFileCount }} file{{ movedFileCount > 1 ? 's' : '' }} successfully moved</span>
+        <span>{{ t('shared.fileMover.footer.successCount', { count: movedFileCount }) }}</span>
       </div>
     }
     <div class="footer-actions">
       @if (movedFileCount === 0) {
         <p-button
-          label="Cancel"
+          label="{{ t('common.cancel') }}"
           icon="pi pi-times"
           severity="secondary"
           [outlined]="true"
           (click)="cancel()"
         ></p-button>
         <p-button
-          [label]="loading ? 'Moving...' : 'Move Files'"
+          [label]="loading ? t('shared.fileMover.footer.moving') : t('shared.fileMover.footer.moveFiles')"
           [icon]="loading ? 'pi pi-spin pi-spinner' : 'pi pi-check'"
           severity="success"
           (click)="saveChanges()"
@@ -239,7 +237,7 @@
         ></p-button>
       } @else {
         <p-button
-          label="Close"
+          label="{{ t('common.close') }}"
           icon="pi pi-check"
           severity="primary"
           (click)="cancel()"
@@ -248,3 +246,4 @@
     </div>
   </div>
 </div>
+</ng-container>

--- a/booklore-ui/src/app/shared/components/file-mover/file-mover-component.ts
+++ b/booklore-ui/src/app/shared/components/file-mover/file-mover-component.ts
@@ -15,6 +15,7 @@ import {AppSettingsService} from '../../service/app-settings.service';
 import {Select} from 'primeng/select';
 import {Library, LibraryPath} from '../../../features/book/model/library.model';
 import {replacePlaceholders} from '../../util/pattern-resolver';
+import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 
 interface FilePreview {
   bookId: number;
@@ -36,7 +37,7 @@ interface FilePreview {
 @Component({
   selector: 'app-file-mover-component',
   standalone: true,
-  imports: [Button, FormsModule, TableModule, Select],
+  imports: [Button, FormsModule, TableModule, Select, TranslocoDirective],
   templateUrl: './file-mover-component.html',
   styleUrl: './file-mover-component.scss'
 })

--- a/booklore-ui/src/app/shared/components/icon-picker/icon-picker-component.html
+++ b/booklore-ui/src/app/shared/components/icon-picker/icon-picker-component.html
@@ -1,3 +1,4 @@
+<ng-container *transloco="let t; prefix: 'shared.iconPicker'">
 <div class="icon-picker">
   <header class="dialog-header">
     <div class="header-content">
@@ -5,8 +6,8 @@
         <i class="pi pi-palette"></i>
       </div>
       <div class="header-text">
-        <h1>Choose an Icon</h1>
-        <p>Select from library or add custom SVGs</p>
+        <h1>{{ t('title') }}</h1>
+        <p>{{ t('subtitle') }}</p>
       </div>
     </div>
     <p-button
@@ -23,16 +24,16 @@
       <p-tablist>
         <p-tab value="0">
           <i class="pi pi-prime"></i>
-          <span>Prime Icons</span>
+          <span>{{ t('primeIcons') }}</span>
         </p-tab>
         <p-tab value="1">
           <i class="pi pi-images"></i>
-          <span>SVG Library</span>
+          <span>{{ t('svgLibrary') }}</span>
         </p-tab>
         @if (canManageIcons) {
           <p-tab value="2">
             <i class="pi pi-plus-circle"></i>
-            <span>Add Custom</span>
+            <span>{{ t('addCustom') }}</span>
           </p-tab>
         }
       </p-tablist>
@@ -46,7 +47,7 @@
               <input
                 type="text"
                 pInputText
-                placeholder="Search Prime icons..."
+                placeholder="{{ t('primeIconsSearch') }}"
                 [(ngModel)]="searchText"
                 class="search-input"
               />
@@ -73,7 +74,7 @@
             @if (isLoadingSvgIcons) {
               <div class="loading-state">
                 <i class="pi pi-spin pi-spinner"></i>
-                <span>Loading icons...</span>
+                <span>{{ t('loadingIcons') }}</span>
               </div>
             } @else if (svgIconsError) {
               <div class="error-state">
@@ -86,7 +87,7 @@
                 <input
                   type="text"
                   pInputText
-                  placeholder="Search SVG icons..."
+                  placeholder="{{ t('svgIconsSearch') }}"
                   [(ngModel)]="svgSearchText"
                   class="search-input"
                 />
@@ -118,7 +119,7 @@
                     (drop)="onTrashDrop($event)"
                   >
                     <i class="pi pi-trash"></i>
-                    <span>Drop here to delete</span>
+                    <span>{{ t('deleteIcon') }}</span>
                   </div>
                 </div>
               }
@@ -133,23 +134,23 @@
               <section class="form-section">
                 <div class="section-header">
                   <i class="pi pi-code"></i>
-                  <span>SVG Input</span>
+                  <span>{{ t('svgInput.title') }}</span>
                 </div>
 
                 <div class="form-fields">
                   <div class="form-field">
-                    <label>Icon Name</label>
+                    <label>{{ t('svgInput.iconName') }}</label>
                     <input
                       type="text"
                       pInputText
                       [(ngModel)]="svgName"
-                      placeholder="e.g., my-custom-icon"
+                      placeholder="{{ t('svgInput.placeholder') }}"
                       class="input-full"
                     />
                   </div>
 
                   <div class="form-field">
-                    <label>SVG Code</label>
+                    <label>{{ t('svgInput.svgCode') }}</label>
                     <textarea
                       pInputTextarea
                       [(ngModel)]="svgContent"
@@ -162,7 +163,7 @@
 
                   @if (svgContent && svgPreview) {
                     <div class="preview-card">
-                      <div class="preview-label">Preview</div>
+                      <div class="preview-label">{{ t('svgInput.preview') }}</div>
                       <div class="preview-content" [innerHTML]="svgPreview"></div>
                     </div>
                   }
@@ -177,7 +178,7 @@
 
                 <div class="form-actions">
                   <p-button
-                    label="Add to Queue"
+                    label="{{ t('svgInput.addToQueue') }}"
                     icon="pi pi-plus"
                     [outlined]="true"
                     [disabled]="!svgContent || !svgName"
@@ -190,11 +191,11 @@
                 <section class="form-section queue-section">
                   <div class="section-header">
                     <i class="pi pi-list"></i>
-                    <span>Queue</span>
+                    <span>{{ t('svgInput.queue') }}</span>
                     <span class="section-badge">{{ svgEntries.length }}</span>
                     <div class="section-actions">
                       <p-button
-                        label="Clear All"
+                        label="{{ t('svgInput.clearAll') }}"
                         icon="pi pi-times"
                         severity="danger"
                         [text]="true"
@@ -230,7 +231,7 @@
 
                   <div class="form-actions">
                     <p-button
-                      label="Save All Icons"
+                      label="{{ t('saveAllIcons') }}"
                       icon="pi pi-save"
                       severity="success"
                       [loading]="isSavingBatch"
@@ -247,3 +248,4 @@
     </p-tabs>
   </div>
 </div>
+</ng-container>

--- a/booklore-ui/src/app/shared/components/icon-picker/icon-picker-component.ts
+++ b/booklore-ui/src/app/shared/components/icon-picker/icon-picker-component.ts
@@ -11,6 +11,7 @@ import {IconCategoriesHelper} from '../../helpers/icon-categories.helper';
 import {Button} from 'primeng/button';
 import {TabsModule} from 'primeng/tabs';
 import {UserService} from '../../../features/settings/user-management/user.service';
+import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 
 interface SvgEntry {
   name: string;
@@ -37,7 +38,8 @@ interface SvgIconBatchResponse {
   imports: [
     FormsModule,
     Button,
-    TabsModule
+    TabsModule,
+    TranslocoDirective
   ],
   templateUrl: './icon-picker-component.html',
   styleUrl: './icon-picker-component.scss'
@@ -67,6 +69,7 @@ export class IconPickerComponent implements OnInit {
   urlHelper = inject(UrlHelperService);
   messageService = inject(MessageService);
   userService = inject(UserService);
+  private readonly t = inject(TranslocoService);
 
   searchText: string = '';
   selectedIcon: string | null = null;

--- a/booklore-ui/src/i18n/en/book.json
+++ b/booklore-ui/src/i18n/en/book.json
@@ -30,6 +30,13 @@
       "deleting": "Deleting {{ count }} book(s)...",
       "unshelving": "Unshelving {{ count }} book(s)..."
     },
+    "entityTypes": {
+      "library": "Library",
+      "shelf": "Shelf",
+      "magicShelf": "Magic Shelf",
+      "allBooks": "All Books",
+      "unshelved": "Unshelved Books"
+    },
     "labels": {
       "allBooks": "All Books",
       "unshelvedBooks": "Unshelved Books",

--- a/booklore-ui/src/i18n/en/shared.json
+++ b/booklore-ui/src/i18n/en/shared.json
@@ -150,5 +150,27 @@
     "toast": {
       "createFailedDefault": "Failed to create admin user. Try again."
     }
+  },
+  "iconPicker": {
+    "title": "Choose an Icon",
+    "subtitle": "Select from library or add custom SVGs",
+    "primeIcons": "Prime Icons",
+    "svgLibrary": "SVG Library",
+    "addCustom": "Add Custom",
+    "primeIconsSearch": "Search Prime icons...",
+    "loadingIcons": "Loading icons...",
+    "svgIconsSearch": "Search SVG icons...",
+    "deleteIcon": "Drop here to delete",
+    "svgInput": {
+      "title": "SVG Input",
+      "iconName": "Icon Name",
+      "placeholder": "e.g., my-custom-icon",
+      "svgCode": "SVG Code",
+      "preview": "Preview",
+      "addToQueue": "Add to Queue",
+      "queue": "Queue",
+      "clearAll": "Clear All",
+      "saveAllIcons": "Save All Icons"
+    }
   }
 }

--- a/booklore-ui/src/i18n/en/shared.json
+++ b/booklore-ui/src/i18n/en/shared.json
@@ -89,6 +89,75 @@
     "foldersWillBeSelected": "{{ count }} folders will be selected",
     "selectDirectoriesBtn": "Select Directories"
   },
+  "fileMover": {
+    "title": "Move & Organize Files",
+    "booksSelected": "{{ count }} book selected",
+    "booksSelected_other": "{{ count }} books selected",
+    "banner": {
+      "preview": "Preview and organize <strong>{{ count }} file</strong>. Files will be renamed based on metadata and naming patterns.",
+      "preview_other": "Preview and organize <strong>{{ count }} files</strong>. Files will be renamed based on metadata and naming patterns.",
+      "metadataWarning": "Requires good metadata quality.",
+      "learnMore": "Learn more",
+      "hide": "Hide",
+      "details": {
+        "autoOrganize": "Your files will be automatically renamed, organized, and can be moved between libraries based on your preferences. Check the preview below to see how your files will look.",
+        "changePattern": "Want to change how files are named? Go to <strong>Settings → File Naming Pattern</strong>. Each library can have its own naming pattern!",
+        "moveWarning": "This will actually move and rename files on your computer across different library folders. Make sure you're happy with the preview first!",
+        "metadataDanger": "This feature relies entirely on your books' metadata. If your metadata is missing or inconsistent, the resulting file names will be incorrect. Only recommended for well-curated libraries."
+      }
+    },
+    "patterns": {
+      "title": "Naming Rules",
+      "bookCount": "{{ count }} book",
+      "bookCount_other": "{{ count }} books",
+      "noPattern": "No pattern configured"
+    },
+    "bulk": {
+      "title": "Bulk Assignment",
+      "setAllTo": "Set all files to:",
+      "selectLibrary": "Select library",
+      "selectPath": "Select path"
+    },
+    "table": {
+      "title": "File Preview",
+      "noPaths": "No paths",
+      "columns": {
+        "id": "ID",
+        "currentPath": "Current Path",
+        "targetLibrary": "Target Library",
+        "libraryPath": "Library Path",
+        "newPath": "New Path"
+      }
+    },
+    "footer": {
+      "successCount": "{{ count }} file successfully moved",
+      "successCount_other": "{{ count }} files successfully moved",
+      "moving": "Moving...",
+      "moveFiles": "Move Files"
+    }
+  },
+  "iconPicker": {
+    "title": "Choose an Icon",
+    "subtitle": "Select from library or add custom SVGs",
+    "primeIcons": "Prime Icons",
+    "svgLibrary": "SVG Library",
+    "addCustom": "Add Custom",
+    "primeIconsSearch": "Search Prime icons...",
+    "loadingIcons": "Loading icons...",
+    "svgIconsSearch": "Search SVG icons...",
+    "deleteIcon": "Drop here to delete",
+    "svgInput": {
+      "title": "SVG Input",
+      "iconName": "Icon Name",
+      "placeholder": "e.g., my-custom-icon",
+      "svgCode": "SVG Code",
+      "preview": "Preview",
+      "addToQueue": "Add to Queue",
+      "queue": "Queue",
+      "clearAll": "Clear All",
+      "saveAllIcons": "Save All Icons"
+    }
+  },
   "liveNotification": {
     "defaultMessage": "No recent notifications..."
   },
@@ -149,28 +218,6 @@
     },
     "toast": {
       "createFailedDefault": "Failed to create admin user. Try again."
-    }
-  },
-  "iconPicker": {
-    "title": "Choose an Icon",
-    "subtitle": "Select from library or add custom SVGs",
-    "primeIcons": "Prime Icons",
-    "svgLibrary": "SVG Library",
-    "addCustom": "Add Custom",
-    "primeIconsSearch": "Search Prime icons...",
-    "loadingIcons": "Loading icons...",
-    "svgIconsSearch": "Search SVG icons...",
-    "deleteIcon": "Drop here to delete",
-    "svgInput": {
-      "title": "SVG Input",
-      "iconName": "Icon Name",
-      "placeholder": "e.g., my-custom-icon",
-      "svgCode": "SVG Code",
-      "preview": "Preview",
-      "addToQueue": "Add to Queue",
-      "queue": "Queue",
-      "clearAll": "Clear All",
-      "saveAllIcons": "Save All Icons"
     }
   }
 }

--- a/booklore-ui/src/i18n/es/book.json
+++ b/booklore-ui/src/i18n/es/book.json
@@ -30,6 +30,13 @@
       "deleting": "Eliminando {{ count }} libro(s)...",
       "unshelving": "Quitando {{ count }} libro(s) del estante..."
     },
+    "entityTypes": {
+      "library": "Biblioteca",
+      "shelf": "Estante",
+      "magicShelf": "Estante Mágico",
+      "allBooks": "Todos los libros",
+      "unshelved": "Libros sin estante"
+    },
     "labels": {
       "allBooks": "Todos los libros",
       "unshelvedBooks": "Libros sin estante",

--- a/booklore-ui/src/i18n/es/shared.json
+++ b/booklore-ui/src/i18n/es/shared.json
@@ -21,7 +21,7 @@
     "filesCount": "{{ uploaded }}/{{ total }} archivos",
     "failedCount": "({{ count }} fallidos)",
     "dragDropTitle": "Arrastra y suelta archivos",
-    "supportedFormats": "",
+    "supportedFormats": "Formatos soportados: <strong>.pdf</strong>, <strong>.epub</strong>, <strong>.cbz</strong>, <strong>.cbr</strong>, <strong>.cb7</strong>, <strong>.fb2</strong>, <strong>.mobi</strong>, <strong>.azw</strong>, <strong>.azw3</strong>, <strong>.m4b</strong>, <strong>.m4a</strong>, <strong>.mp3</strong>, <strong>.opus</strong>",
     "maxFileSize": "Tamaño máximo de archivo: {{ size }} por archivo",
     "fileTooLargeTooltip": "Archivo demasiado grande",
     "uploadFailedTooltip": "Error al subir",
@@ -92,6 +92,75 @@
   "liveNotification": {
     "defaultMessage": "Sin notificaciones recientes..."
   },
+  "fileMover": {
+    "title": "Mover y organizar archivos",
+    "booksSelected": "{{ count }} libro seleccionado",
+    "booksSelected_other": "{{ count }} libros seleccionados",
+    "banner": {
+      "preview": "Previsualiza y organiza <strong>{{ count }} archivo</strong>. Los archivos se renombrarán según los metadatos y los patrones de nombre.",
+      "preview_other": "Previsualiza y organiza <strong>{{ count }} archivos</strong>. Los archivos se renombrarán según los metadatos y los patrones de nombre.",
+      "metadataWarning": "Requiere metadatos de buena calidad.",
+      "learnMore": "Más información",
+      "hide": "Ocultar",
+      "details": {
+        "autoOrganize": "Tus archivos se renombrarán y organizarán automáticamente, y podrán moverse entre bibliotecas según tus preferencias. Revisa la vista previa abajo para ver cómo quedarán.",
+        "changePattern": "¿Quieres cambiar cómo se nombran los archivos? Ve a <strong>Configuración → Patrón de nombres de archivos</strong>. ¡Cada biblioteca puede tener su propio patrón!",
+        "moveWarning": "Esto realmente moverá y renombrará archivos en tu computadora entre diferentes carpetas de biblioteca. ¡Asegúrate de estar conforme con la vista previa primero!",
+        "metadataDanger": "Esta función depende completamente de los metadatos de tus libros. Si los metadatos faltan o son inconsistentes, los nombres resultantes serán incorrectos. Solo recomendado para bibliotecas bien cuidadas."
+      }
+    },
+    "patterns": {
+      "title": "Reglas de nombrado",
+      "bookCount": "{{ count }} libro",
+      "bookCount_other": "{{ count }} libros",
+      "noPattern": "No hay patrón configurado"
+    },
+    "bulk": {
+      "title": "Asignación masiva",
+      "setAllTo": "Establecer todos los archivos a:",
+      "selectLibrary": "Seleccionar biblioteca",
+      "selectPath": "Seleccionar ruta"
+    },
+    "table": {
+      "title": "Vista previa de archivos",
+      "noPaths": "Sin rutas",
+      "columns": {
+        "id": "ID",
+        "currentPath": "Ruta actual",
+        "targetLibrary": "Biblioteca de destino",
+        "libraryPath": "Ruta de la biblioteca",
+        "newPath": "Nueva ruta"
+      }
+    },
+    "footer": {
+      "successCount": "{{ count }} archivo movido correctamente",
+      "successCount_other": "{{ count }} archivos movidos correctamente",
+      "moving": "Moviendo...",
+      "moveFiles": "Mover archivos"
+    }
+  },
+  "iconPicker": {
+    "title": "Escoger un Ícono",
+    "subtitle": "Selecciona desde la biblioteca o agrega SVGs personalizados",
+    "primeIcons": "Íconos Prime",
+    "svgLibrary": "Biblioteca SVG",
+    "addCustom": "Añadir Personalizados",
+    "primeIconsSearch": "Buscar íconos Prime...",
+    "loadingIcons": "Cargando íconos...",
+    "svgIconsSearch": "Buscar iconos SVG...",
+    "deleteIcon": "Suelta aquí para borrar",
+    "svgInput": {
+      "title": "Ingresa SVG",
+      "iconName": "Nombre del Ícono",
+      "placeholder": "e.g., mi-icono-personalizado",
+      "svgCode": "Código SVG",
+      "preview": "Vista Previa",
+      "addToQueue": "Agregar a la Cola",
+      "queue": "Cola",
+      "clearAll": "Limpiar todo",
+      "saveAllIcons": "Guardar todos los íconos"
+    }
+  },
   "metadataProgress": {
     "taskStalled": "Tarea detenida o servidor no disponible",
     "taskCancelled": "Tarea cancelada por el usuario",
@@ -149,28 +218,6 @@
     },
     "toast": {
       "createFailedDefault": "Error al crear el usuario administrador. Inténtalo de nuevo."
-    }
-  },
-  "iconPicker": {
-    "title": "Escoger un Ícono",
-    "subtitle": "Selecciona desde la biblioteca o agrega SVGs personalizados",
-    "primeIcons": "Íconos Prime",
-    "svgLibrary": "Biblioteca SVG",
-    "addCustom": "Añadir Personalizados",
-    "primeIconsSearch": "Buscar íconos Prime...",
-    "loadingIcons": "Cargando íconos...",
-    "svgIconsSearch": "Buscar iconos SVG...",
-    "deleteIcon": "Suelta aquí para borrar",
-    "svgInput": {
-      "title": "Ingresa SVG",
-      "iconName": "Nombre del Ícono",
-      "placeholder": "e.g., mi-icono-personalizado",
-      "svgCode": "Código SVG",
-      "preview": "Vista Previa",
-      "addToQueue": "Agregar a la Cola",
-      "queue": "Cola",
-      "clearAll": "Limpiar todo",
-      "saveAllIcons": "Guardar todos los íconos"
     }
   }
 }

--- a/booklore-ui/src/i18n/es/shared.json
+++ b/booklore-ui/src/i18n/es/shared.json
@@ -150,5 +150,27 @@
     "toast": {
       "createFailedDefault": "Error al crear el usuario administrador. Inténtalo de nuevo."
     }
+  },
+  "iconPicker": {
+    "title": "Escoger un Ícono",
+    "subtitle": "Selecciona desde la biblioteca o agrega SVGs personalizados",
+    "primeIcons": "Íconos Prime",
+    "svgLibrary": "Biblioteca SVG",
+    "addCustom": "Añadir Personalizados",
+    "primeIconsSearch": "Buscar íconos Prime...",
+    "loadingIcons": "Cargando íconos...",
+    "svgIconsSearch": "Buscar iconos SVG...",
+    "deleteIcon": "Suelta aquí para borrar",
+    "svgInput": {
+      "title": "Ingresa SVG",
+      "iconName": "Nombre del Ícono",
+      "placeholder": "e.g., mi-icono-personalizado",
+      "svgCode": "Código SVG",
+      "preview": "Vista Previa",
+      "addToQueue": "Agregar a la Cola",
+      "queue": "Cola",
+      "clearAll": "Limpiar todo",
+      "saveAllIcons": "Guardar todos los íconos"
+    }
   }
 }


### PR DESCRIPTION
fix(i18n): changed hardcoded translation strings, translation reactivity

## Description

First PR in a long time, don't want to mess it up so draft PR while I look for more instances of the bugs in other parts of the UI and make sure it's okay 😅

fix(stats): changed language display names in LibraryStats/LanguageChart
fix(shared): added missing translation strings to the json files
fix(i18n): translation reactivity in parts of the ui

**Linked Issue:** Fixes #103 

## Changes

LanguageChart now uses Intl.DisplayNames
EntityType keys changed for correct translation (was hardcoded to english in the struct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Charts and UI labels now update dynamically when switching languages without requiring a page refresh.
  * File mover and icon picker components now fully support multiple languages.
  * Locale-aware formatting for dates, months, and times adapts to the selected language.

* **Bug Fixes**
  * Entity type labels (Library, Shelf, etc.) now display in the correct language.
  * Filter labels properly translate across the application.

* **Refactor**
  * Improved internal translation handling for better multilingual support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->