### PR TITLE
fix(entrypoint): ensure books directory exists and is writable by thetarget user

### DIFF
--- a/packaging/docker/entrypoint.sh
+++ b/packaging/docker/entrypoint.sh
@@ -30,8 +30,8 @@ if ! getent passwd "$USER_ID" >/dev/null 2>&1; then
     adduser -u "$USER_ID" -G "$(getent group "$GROUP_ID" | cut -d: -f1)" -S -D "$APP_USER"
 fi
 
-# Ensure data and bookdrop directories exist and are writable by the target user
-mkdir -p /app/data /bookdrop
-chown "$USER_ID:$GROUP_ID" /app/data /bookdrop 2>/dev/null || true
+# Ensure data, bookdrop, and books directories exist and are writable by the target user
+mkdir -p /app/data /bookdrop /books
+chown "$USER_ID:$GROUP_ID" /app/data /bookdrop /books 2>/dev/null || true
 
 exec su-exec "$USER_ID:$GROUP_ID" "$@"


### PR DESCRIPTION
 
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #115<!-- issue number leave empty if none -->

## Changes

This pull request makes a minor update to the Docker entrypoint script to ensure that the `/books` directory is created and has the correct permissions, in addition to the existing `/app/data` and `/bookdrop` directories. This helps prevent permission issues when the application needs to access or write to the `/books` directory.

- Docker entrypoint improvements:
  * Updated `entrypoint.sh` to create the `/books` directory and set its ownership to the target user and group, ensuring it is writable by the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container initialization to properly establish and configure additional system directories with appropriate access permissions during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->