### PR TITLE
fix(api): check legacy tools path for binaries

### DIFF
--- a/booklore-api/src/main/java/org/booklore/util/FileService.java
+++ b/booklore-api/src/main/java/org/booklore/util/FileService.java
@@ -148,15 +148,31 @@ public class FileService {
         return Paths.get(appProperties.getPathConfig(), "bookdrop_temp", bookdropFileId + ".jpg").toString();
     }
 
-    public Path findSystemFile(String filename) {
-        // Search first in the application folder's "local" `tools` / `bin` folders
+    private String getSystemSearchPath() {
+        // Search first in the application folder's "local" `bin`.
+        StringBuilder localPaths = new StringBuilder("bin");
+
+        // Then, check the legacy "tools" path from previous app versions.
+        localPaths.append(File.pathSeparator).append(Path.of(appProperties.getPathConfig(), "tools"));
+
         // If not found in those, then search the system $PATH.
         String systemSearchPath = System.getenv("PATH");
-        String searchPath = systemSearchPath == null ? "bin:tools" : "bin:tools:".concat(systemSearchPath);
-        String[] searchPaths = searchPath.split(":");
+        if (systemSearchPath != null) {
+            localPaths.append(File.pathSeparator).append(systemSearchPath);
+        }
+
+        return localPaths.toString();
+    }
+
+    public Path findSystemFile(String filename) {
+        String[] searchPaths = getSystemSearchPath().split(":");
 
         for (String path : searchPaths) {
-            Path possiblePath = Paths.get(path).resolve(filename).toAbsolutePath();
+            Path possiblePath = Paths
+                    .get(path)
+                    .resolve(filename)
+                    .toAbsolutePath()
+                    .normalize();
 
             if (Files.isRegularFile(possiblePath)) {
                 return possiblePath;

--- a/booklore-api/src/test/java/org/booklore/util/FileServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/util/FileServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -302,6 +303,40 @@ class FileServiceTest {
             void handlesFilenameWithSpaces() {
                 String result = FileService.getBackgroundUrl("my background.jpg", null);
                 assertTrue(result.contains("my background.jpg"));
+            }
+        }
+
+        @Nested
+        @DisplayName("findSystemFile")
+        class FindSystemFileTest {
+            @Test
+            void searchesLocalBinFolderFirst() {
+                Path expected = Path.of("bin/example").toAbsolutePath().normalize();
+
+                try (
+                    MockedStatic<Files> filesMock = mockStatic(Files.class);
+                ) {
+                    filesMock.when(() -> Files.isRegularFile(any())).thenReturn(true);
+
+                    Path actual = fileService.findSystemFile("example");
+
+                    assertEquals(expected, actual);
+                }
+            }
+
+            @Test
+            void searchesAppDataToolsFolder() {
+                Path expected = tempDir.resolve("tools", "example");
+
+                try (
+                        MockedStatic<Files> filesMock = mockStatic(Files.class);
+                ) {
+                    filesMock.when(() -> Files.isRegularFile(any())).thenReturn(false, true);
+
+                    Path actual = fileService.findSystemFile("example");
+
+                    assertEquals(expected, actual);
+                }
             }
         }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

the kepubify / ffprobe binaries may be on disk but they're in the "data"
directory under `tools` rather than under the current directory

in some cases, like proxmox or other manual installs, this helps make the
transition to grimmory easier

## Changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Internal Improvements**
  * Refined how the system search path is built and how candidates are selected; returned file paths are now normalized (may change path formatting).

* **Tests**
  * Added unit tests that simulate filesystem responses to verify primary and fallback search resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->