### PR TITLE
perf(ui): captures some low hanging fruit around excessive re-renders in the app

### DIFF
--- a/booklore-ui/src/app/features/book/components/book-browser/sorting/multi-sort-popover/multi-sort-popover.component.ts
+++ b/booklore-ui/src/app/features/book/components/book-browser/sorting/multi-sort-popover/multi-sort-popover.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, inject, Input, Output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, EventEmitter, inject, Input, Output} from '@angular/core';
 import {SortDirection, SortOption} from '../../../../model/sort.model';
 import {CdkDrag, CdkDragDrop, CdkDragHandle, CdkDropList, moveItemInArray} from '@angular/cdk/drag-drop';
 import {Select} from 'primeng/select';
@@ -10,6 +10,7 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 @Component({
   selector: 'app-multi-sort-popover',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     CdkDropList,
     CdkDrag,

--- a/booklore-ui/src/app/features/book/components/book-card-lite/book-card-lite-component.ts
+++ b/booklore-ui/src/app/features/book/components/book-card-lite/book-card-lite-component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, inject, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, inject, Input} from '@angular/core';
 import {Book} from '../../model/book.model';
 import {UrlHelperService} from '../../../../shared/service/url-helper.service';
 import {Button} from 'primeng/button';
@@ -10,6 +10,7 @@ import {TooltipModule} from 'primeng/tooltip';
 
 @Component({
   selector: 'app-book-card-lite-component',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     Button,
     NgClass,

--- a/booklore-ui/src/app/features/dashboard/components/dashboard-scroller/dashboard-scroller.component.ts
+++ b/booklore-ui/src/app/features/dashboard/components/dashboard-scroller/dashboard-scroller.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, Input, ViewChild, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, ElementRef, Input, ViewChild, inject} from '@angular/core';
 import {BookCardComponent} from '../../../book/components/book-browser/book-card/book-card.component';
 import {InfiniteScrollDirective} from 'ngx-infinite-scroll';
 import {NgClass} from '@angular/common';
@@ -11,6 +11,7 @@ import {TranslocoDirective, TranslocoPipe} from '@jsverse/transloco';
 
 @Component({
   selector: 'app-dashboard-scroller',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './dashboard-scroller.component.html',
   styleUrls: ['./dashboard-scroller.component.scss'],
   imports: [

--- a/booklore-ui/src/app/features/readers/ebook-reader/shared/icon.component.ts
+++ b/booklore-ui/src/app/features/readers/ebook-reader/shared/icon.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 export type ReaderIconName =
@@ -205,6 +205,7 @@ const ICONS: Record<ReaderIconName, IconPath[]> = {
 @Component({
   selector: 'app-reader-icon',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule],
   template: `
     <svg

--- a/booklore-ui/src/app/features/series-browser/components/series-card/series-card.component.ts
+++ b/booklore-ui/src/app/features/series-browser/components/series-card/series-card.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, inject, Input, Output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, EventEmitter, inject, Input, Output} from '@angular/core';
 import {NgClass} from '@angular/common';
 import {ProgressBar} from 'primeng/progressbar';
 import {Button} from 'primeng/button';
@@ -11,6 +11,7 @@ import {UrlHelperService} from '../../../../shared/service/url-helper.service';
 @Component({
   selector: 'app-series-card',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './series-card.component.html',
   styleUrls: ['./series-card.component.scss'],
   imports: [NgClass, ProgressBar, Button, Tooltip, TranslocoPipe]

--- a/booklore-ui/src/app/features/series-browser/components/series-scroller/series-scroller.component.ts
+++ b/booklore-ui/src/app/features/series-browser/components/series-scroller/series-scroller.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, EventEmitter, Input, Output} from '@angular/core';
 import {TranslocoDirective} from '@jsverse/transloco';
 import {SeriesCardComponent} from '../series-card/series-card.component';
 import {SeriesSummary} from '../../model/series.model';
@@ -6,6 +6,7 @@ import {SeriesSummary} from '../../model/series.model';
 @Component({
   selector: 'app-series-scroller',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './series-scroller.component.html',
   styleUrls: ['./series-scroller.component.scss'],
   imports: [SeriesCardComponent, TranslocoDirective]

--- a/booklore-ui/src/app/features/settings/reader-preferences/settings-application-mode/settings-application-mode.component.ts
+++ b/booklore-ui/src/app/features/settings/reader-preferences/settings-application-mode/settings-application-mode.component.ts
@@ -1,10 +1,11 @@
-import {Component, inject, Input, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject, Input, OnInit} from '@angular/core';
 import {TranslocoDirective} from '@jsverse/transloco';
 import {ReaderPreferencesService} from '../reader-preferences.service';
 import {UserSettings} from '../../user-management/user.service';
 
 @Component({
   selector: 'app-settings-application-mode',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './settings-application-mode.component.html',
   standalone: true,
   styleUrls: ['./settings-application-mode.component.scss'],

--- a/booklore-ui/src/app/shared/components/cover-generator/cover-generator.component.ts
+++ b/booklore-ui/src/app/shared/components/cover-generator/cover-generator.component.ts
@@ -1,7 +1,8 @@
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 
 @Component({
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: ''
 })
 export class CoverGeneratorComponent {

--- a/booklore-ui/src/app/shared/components/empty/empty.component.ts
+++ b/booklore-ui/src/app/shared/components/empty/empty.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'app-empty',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [],
   templateUrl: './empty.component.html',
   styleUrl: './empty.component.scss'

--- a/booklore-ui/src/app/shared/components/external-doc-link/external-doc-link.component.ts
+++ b/booklore-ui/src/app/shared/components/external-doc-link/external-doc-link.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {Tooltip} from 'primeng/tooltip';
 
 export type DocType = 'kobo' | 'opds' | 'metadataManager' | 'koReader' | 'email'
@@ -8,6 +8,7 @@ export type DocType = 'kobo' | 'opds' | 'metadataManager' | 'koReader' | 'email'
 @Component({
   selector: 'app-external-doc-link',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [Tooltip],
   template: `
     <i class="pi pi-external-link external-link-icon"

--- a/booklore-ui/src/app/shared/components/tag/tag.component.ts
+++ b/booklore-ui/src/app/shared/components/tag/tag.component.ts
@@ -1,4 +1,4 @@
-import {Component, input, computed} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, input} from '@angular/core';
 
 export type TagColor =
   | 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'danger'
@@ -14,6 +14,7 @@ export type TagVariant = 'label' | 'pill';
 @Component({
   selector: 'app-tag',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <span
       [class]="tagClasses()"

--- a/booklore-ui/src/app/shared/layout/component/theme-configurator/theme-configurator.component.ts
+++ b/booklore-ui/src/app/shared/layout/component/theme-configurator/theme-configurator.component.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {Component, computed, effect, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, effect, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {ButtonModule} from 'primeng/button';
 import {RadioButtonModule} from 'primeng/radiobutton';
@@ -21,6 +21,7 @@ interface Palette {
 @Component({
   selector: 'app-theme-configurator',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './theme-configurator.component.html',
   host: {
     class: 'config-panel hidden'


### PR DESCRIPTION
## Description

This cleans up some issues I noted in discord around there being a few small performance bugs I noticed when skimming the repo, I'll push the others up over the course of the week but they should all be pretty small like this PR

(AI Generated Description as follows)
Adds `ChangeDetectionStrategy.OnPush` to 12 presentational components identified via Angular DevTools profiler as high-frequency change detection targets. All components were verified to have no unmanaged subscriptions, no internal `BehaviorSubject`/`Subject` state, and no mutations outside of `@Input()` or template-event paths — making them safe for OnPush without `markForCheck()` changes.

Profiled on the current `develop` tip (post-TanStack migration) before and after to isolate the contribution of this change specifically.
Profiler results (develop → this branch)

Metric | Before | After | Delta
-- | -- | -- | --
CD cycles | 395 | 313 | -21%
Total CD time | 2,397ms | 1,750ms | -27%
rAF-triggered cycles | 252 (1,165ms) | 166 (734ms) | -37%
BookCardComponent CD cost | 250ms (4,480 checks) | 27ms (6,025 checks) | -89%
SeriesCardComponent CD cost | 100ms | 0ms | -100%
ThemeConfiguratorComponent CD cost | 45ms | 0ms | -100%
Tooltip lifecycle hooks | 237ms | 79ms | -67%
TieredMenu lifecycle hooks | 103ms | 17ms | -83%

`BookCardComponent`'s check count increasing while its cost drops is expected OnPush behavior — Angular visits the node to decide whether to check it, then skips the subtree when inputs are unchanged.

**Linked Issue:** Fixes #157

## Changes

Component | Reason safe for OnPush
-- | --
SeriesCardComponent | Pure @ Input/@ Output, no subscriptions
SeriesScrollerComponent | Pure @ Input/@ Output, no subscriptions
TagComponent | All Signal inputs + computed()
ThemeConfiguratorComponent | All Signal-based (computed, effect)
BookCardLiteComponent | Signal-based after #117; isHovered set via template events
DashboardScrollerComponent | @ Input-driven; openMenuBookId only mutated by template events
MultiSortPopoverComponent | All mutations via template events, emits via @ Output
ReaderIconComponent | Pure @ Input, static SVG renderer
SettingsApplicationModeComponent | @ Input-driven; scope values set by template events
CoverGeneratorComponent | Pure @ Input, empty template
EmptyComponent | No inputs, no logic
ExternalDocLinkComponent | Pure @ Input, click opens URL


What was intentionally excluded
BookBrowserComponent — internal BehaviorSubject state and ChangeDetectorRef injection; safe migration requires verifying all mutation paths first
AppMenuitemComponent — 4 unmanaged subscriptions; needs cleanup before OnPush
SeriesBrowserComponent — @ HostListener('window:resize') mutates template-bound computed properties
Reader components — deferred per contribution guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized change detection behavior across multiple UI components for improved performance and responsiveness throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->