### PR TITLE
feat(lint): Additional CI workflow to enforce a threshold of the amount of frontend lint issues

### DIFF
--- a/.github/workflows/angular-lint-threshold.yml
+++ b/.github/workflows/angular-lint-threshold.yml
@@ -93,7 +93,6 @@ jobs:
           echo "LINT_ERROR_COUNT=${LINT_ERROR_COUNT}" >> "$GITHUB_ENV"
 
       - name: Enforce Quality Thresholds
-        working-directory: ./booklore-ui
         run: |
           BUILD_STATUS="PASS"
           LINT_STATUS="PASS"


### PR DESCRIPTION
## Description

We need to get the amount of lint issues down for the frontend. That's why I created this new workflow, so that it's not possible to introduce new lint issues. And when we solve lint issues, we can lower the threshold. It's the idea that this threshold will be worked down to zero. 

**Linked Issue:** #133 

## Changes

This pull request introduces a new GitHub Actions workflow to enforce a lint problem threshold for the frontend codebase. The workflow automatically runs on pull requests and pushes to the main development branches, ensuring that the number of linting issues does not exceed a specified limit.

**Continuous Integration and Lint Enforcement:**

* Added a new workflow file `.github/workflows/angular-lint-threshold.yml` that runs on pull requests and pushes to `develop` and `main` branches, as well as via manual dispatch.
* The workflow installs frontend dependencies, runs Angular lint with JSON output, and checks that the total lint problem count does not exceed the set threshold (`LINT_THRESHOLD`, default 725). If the threshold is exceeded, the workflow fails the check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI check that measures frontend build warnings, lint warnings, and lint errors against configurable thresholds and fails the run if any threshold is exceeded.
  * Runs on pull requests, pushes to main/develop, and via manual trigger; collects counts from build and lint output, writes a markdown summary of results to the job summary, and enforces the quality gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->