### PR TITLE
fix(auth-interceptor): remove unused Router injection and parameters

### DIFF
--- a/booklore-ui/src/app/core/security/auth-interceptor.service.ts
+++ b/booklore-ui/src/app/core/security/auth-interceptor.service.ts
@@ -45,7 +45,7 @@ function handle401Error(authService: AuthService, request: HttpRequest<unknown>,
       }),
       catchError(err => {
         isRefreshing = false;
-        forceLogout(authService);
+        authService.logout();
         return throwError(() => err);
       })
     );
@@ -60,8 +60,4 @@ function handle401Error(authService: AuthService, request: HttpRequest<unknown>,
       }))
     )
   );
-}
-
-function forceLogout(authService: AuthService): void {
-  authService.logout();
 }


### PR DESCRIPTION
## Description

The router object is not used in the AuthInterceptorService, so therefor removed it. This solves a lint issue. 

**Linked Issue:** #133

## Changes

This pull request simplifies the authentication error handling logic in the `AuthInterceptorService` by removing the dependency on Angular's `Router`. The changes focus on streamlining the handling of 401 Unauthorized errors and the logout process.

Refactoring authentication error handling:

* Removed the injection and usage of the `Router` service from `AuthInterceptorService`, making the interceptor less coupled to routing logic.
* Updated the `handle401Error` and `forceLogout` functions to no longer require or use the `Router` parameter, reflecting the removal of routing logic from authentication error handling. 
* Adjusted the call to `handle401Error` in the interceptor to match the new function signature without the `Router` argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined authentication interceptor to improve token refresh failure handling and session management processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->