### PR TITLE
fix(api): support kobo sync without proxy-auth header

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboLibrarySyncService.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboLibrarySyncService.java
@@ -15,6 +15,7 @@ import org.booklore.util.RequestUtils;
 import org.booklore.util.kobo.BookloreSyncTokenGenerator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -109,7 +110,10 @@ public class KoboLibrarySyncService {
             }
         }
 
-        if (!shouldContinueSync) {
+        // If there's no authorization header, the proxy call will for sure fail and will take
+        // the whole sync down with it.  Thus, no authorization header, no proxy call.
+        boolean hasKoboAuth = request.getHeader(HttpHeaders.AUTHORIZATION) != null;
+        if (!shouldContinueSync && hasKoboAuth) {
             ResponseEntity<JsonNode> koboStoreResponse = koboServerProxy.proxyCurrentRequest(null, true);
             Collection<Entitlement> syncResultsKobo = Optional.ofNullable(koboStoreResponse.getBody())
                     .map(body -> {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

the kobo sync call receives an authorization header which it passes along in proxy requests to the kobo store API.  however, when debugging issues with kobo sync this can make it difficult to determine issues as requests without a valid auth header lead to invalid JSON & failing the whole request

## Changes

this turns off the upstream proxy when a request is made against `/v1/library/sync` without the authorization header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kobo synchronization now requires an Authorization header; sync operations (including proxying and response processing) will only run when authorization is present and continuation conditions allow, preventing unauthorized or unnecessary remote calls and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->