### PR TITLE
refactor(api): use `Path` for FileUtils.getBookFullPath

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/book/BookDownloadService.java
+++ b/booklore-api/src/main/java/org/booklore/service/book/BookDownloadService.java
@@ -59,7 +59,7 @@ public class BookDownloadService {
             if (primaryFile == null) {
                 throw ApiError.FAILED_TO_DOWNLOAD_FILE.createException(bookId);
             }
-            Path file = Paths.get(FileUtils.getBookFullPath(bookEntity)).toAbsolutePath().normalize();
+            Path file = FileUtils.getBookFullPath(bookEntity).toAbsolutePath().normalize();
 
             if (!Files.exists(file)) {
                 throw ApiError.FAILED_TO_DOWNLOAD_FILE.createException(bookId);
@@ -258,7 +258,7 @@ public class BookDownloadService {
         int compressionPercentage = koboSettings.getConversionImageCompressionPercentage();
         Path tempDir = null;
         try {
-            File inputFile = new File(FileUtils.getBookFullPath(bookEntity));
+            File inputFile = FileUtils.getBookFullPath(bookEntity).toFile();
             File fileToSend = inputFile;
 
             if (convertCbxToEpub || convertEpubToKepub) {

--- a/booklore-api/src/main/java/org/booklore/service/book/BookService.java
+++ b/booklore-api/src/main/java/org/booklore/service/book/BookService.java
@@ -338,7 +338,7 @@ public class BookService {
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
             filePath = bookFile.getFullFilePath().toString();
         } else {
-            filePath = FileUtils.getBookFullPath(bookEntity);
+            filePath = FileUtils.getBookFullPath(bookEntity).toString();
         }
         File file = new File(filePath);
         if (!file.exists()) {
@@ -362,7 +362,7 @@ public class BookService {
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
             filePath = bookFile.getFullFilePath().toString();
         } else {
-            filePath = FileUtils.getBookFullPath(bookEntity);
+            filePath = FileUtils.getBookFullPath(bookEntity).toString();
         }
 
         Path path = Paths.get(filePath);

--- a/booklore-api/src/main/java/org/booklore/service/email/SendEmailV2Service.java
+++ b/booklore-api/src/main/java/org/booklore/service/email/SendEmailV2Service.java
@@ -96,7 +96,7 @@ public class SendEmailV2Service {
         helper.setTo(recipientEmail);
         helper.setSubject("Your Book from Booklore: " + book.getMetadata().getTitle());
         helper.setText(generateEmailBody(book.getMetadata().getTitle()));
-        File bookFile = new File(FileUtils.getBookFullPath(book, bookFileEntity));
+        File bookFile = FileUtils.getBookFullPath(book, bookFileEntity).toFile();
         helper.addAttachment(bookFile.getName(), bookFile);
         dynamicMailSender.send(message);
         log.info("Book sent successfully to {}", recipientEmail);

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/AudiobookProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/AudiobookProcessor.java
@@ -160,7 +160,7 @@ public class AudiobookProcessor extends AbstractFileProcessor implements BookFil
                     .map(java.nio.file.Path::toFile)
                     .orElse(null);
         } else {
-            return new File(FileUtils.getBookFullPath(bookEntity));
+            return FileUtils.getBookFullPath(bookEntity).toFile();
         }
     }
 

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/Azw3Processor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/Azw3Processor.java
@@ -72,7 +72,7 @@ public class Azw3Processor extends AbstractFileProcessor implements BookFileProc
     @Override
     public boolean generateCover(BookEntity bookEntity, BookFileEntity bookFile) {
         try {
-            File azw3File = new File(FileUtils.getBookFullPath(bookEntity, bookFile));
+            File azw3File = FileUtils.getBookFullPath(bookEntity, bookFile).toFile();
             byte[] coverData = azw3MetadataExtractor.extractCover(azw3File);
 
             if (coverData == null || coverData.length == 0) {

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/CbxProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/CbxProcessor.java
@@ -33,6 +33,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.file.Path;
 import java.io.InputStream;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -65,7 +66,7 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
     @Override
     public BookEntity processNewFile(LibraryFile libraryFile) {
         BookEntity bookEntity = bookCreatorService.createShellBook(libraryFile, BookFileType.CBX);
-        bookEntity.getPrimaryBookFile().setArchiveType(ArchiveUtils.detectArchiveType(new File(FileUtils.getBookFullPath(bookEntity))));
+        bookEntity.getPrimaryBookFile().setArchiveType(ArchiveUtils.detectArchiveType(FileUtils.getBookFullPath(bookEntity).toFile()));
         boolean coverGenerated = generateCover(bookEntity);
         if (!coverGenerated) {
             var folder = getBookFolderForCoverFallback(libraryFile);
@@ -88,7 +89,7 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
 
     @Override
     public boolean generateCover(BookEntity bookEntity, BookFileEntity bookFile) {
-        File file = new File(FileUtils.getBookFullPath(bookEntity, bookFile));
+        File file = FileUtils.getBookFullPath(bookEntity, bookFile).toFile();
         try {
             Optional<BufferedImage> imageOptional = extractImagesFromArchive(file);
             if (imageOptional.isPresent()) {
@@ -251,7 +252,7 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
 
     private void extractAndSetMetadata(BookEntity bookEntity) {
         try {
-            BookMetadata extracted = cbxMetadataExtractor.extractMetadata(new File(FileUtils.getBookFullPath(bookEntity)));
+            BookMetadata extracted = cbxMetadataExtractor.extractMetadata(FileUtils.getBookFullPath(bookEntity).toFile());
             if (extracted == null) {
                 // Fallback to filename-derived title
                 setMetadata(bookEntity);

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/EpubProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/EpubProcessor.java
@@ -73,7 +73,7 @@ public class EpubProcessor extends AbstractFileProcessor implements BookFileProc
     @Override
     public boolean generateCover(BookEntity bookEntity, BookFileEntity bookFile) {
         try {
-            File epubFile = new File(FileUtils.getBookFullPath(bookEntity, bookFile));
+            File epubFile = FileUtils.getBookFullPath(bookEntity, bookFile).toFile();
             byte[] coverData = epubMetadataExtractor.extractCover(epubFile);
 
             if (coverData == null) {

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/Fb2Processor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/Fb2Processor.java
@@ -71,7 +71,7 @@ public class Fb2Processor extends AbstractFileProcessor implements BookFileProce
     @Override
     public boolean generateCover(BookEntity bookEntity, BookFileEntity bookFile) {
         try {
-            File fb2File = new File(FileUtils.getBookFullPath(bookEntity, bookFile));
+            File fb2File = FileUtils.getBookFullPath(bookEntity, bookFile).toFile();
             byte[] coverData = fb2MetadataExtractor.extractCover(fb2File);
 
             if (coverData == null || coverData.length == 0) {

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/MobiProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/MobiProcessor.java
@@ -72,7 +72,7 @@ public class MobiProcessor extends AbstractFileProcessor implements BookFileProc
     @Override
     public boolean generateCover(BookEntity bookEntity, BookFileEntity bookFile) {
         try {
-            File mobiFile = new File(FileUtils.getBookFullPath(bookEntity, bookFile));
+            File mobiFile = FileUtils.getBookFullPath(bookEntity, bookFile).toFile();
             byte[] coverData = mobiMetadataExtractor.extractCover(mobiFile);
 
             if (coverData == null || coverData.length == 0) {

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/PdfProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/PdfProcessor.java
@@ -74,7 +74,7 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
 
     @Override
     public boolean generateCover(BookEntity bookEntity, BookFileEntity bookFile) {
-        File pdfFile = new File(FileUtils.getBookFullPath(bookEntity, bookFile));
+        File pdfFile = FileUtils.getBookFullPath(bookEntity, bookFile).toFile();
         try (RandomAccessReadBufferedFile randomAccessRead = new RandomAccessReadBufferedFile(pdfFile);
              PDDocument pdf = Loader.loadPDF(randomAccessRead)) {
             return generateCoverImageAndSave(bookEntity.getId(), pdf);
@@ -104,7 +104,7 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
 
     private void extractAndSetMetadata(BookEntity bookEntity) {
         try {
-            BookMetadata extracted = pdfMetadataExtractor.extractMetadata(new File(FileUtils.getBookFullPath(bookEntity)));
+            BookMetadata extracted = pdfMetadataExtractor.extractMetadata(FileUtils.getBookFullPath(bookEntity).toFile());
 
             if (StringUtils.isNotBlank(extracted.getTitle())) {
                 bookEntity.getMetadata().setTitle(truncate(extracted.getTitle(), 1000));

--- a/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
@@ -197,7 +197,7 @@ public class BookMetadataService {
             log.info("Unsupported operation for book ID {} - no file or not CBX type", bookId);
             return null;
         }
-        return cbxMetadataExtractor.extractMetadata(new File(FileUtils.getBookFullPath(bookEntity)));
+        return cbxMetadataExtractor.extractMetadata(FileUtils.getBookFullPath(bookEntity).toFile());
     }
 
     public BookMetadata getFileMetadata(long bookId) {
@@ -207,7 +207,7 @@ public class BookMetadataService {
         if (primaryFile == null) {
             throw ApiError.GENERIC_BAD_REQUEST.createException("Book has no file to extract metadata from");
         }
-        return metadataExtractorFactory.extractMetadata(primaryFile.getBookType(), new File(FileUtils.getBookFullPath(bookEntity)));
+        return metadataExtractorFactory.extractMetadata(primaryFile.getBookType(), FileUtils.getBookFullPath(bookEntity).toFile());
     }
 
     @Transactional

--- a/booklore-api/src/main/java/org/booklore/service/reader/CbxReaderService.java
+++ b/booklore-api/src/main/java/org/booklore/service/reader/CbxReaderService.java
@@ -144,8 +144,7 @@ public class CbxReaderService {
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
             return bookFile.getFullFilePath();
         }
-        String bookFullPath = FileUtils.getBookFullPath(bookEntity);
-        return Path.of(bookFullPath);
+        return FileUtils.getBookFullPath(bookEntity);
     }
 
     private void validatePageRequest(Long bookId, int page, List<String> imageEntries) throws FileNotFoundException {

--- a/booklore-api/src/main/java/org/booklore/service/reader/EpubReaderService.java
+++ b/booklore-api/src/main/java/org/booklore/service/reader/EpubReaderService.java
@@ -217,8 +217,7 @@ public class EpubReaderService {
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
             return bookFile.getFullFilePath();
         }
-        String bookFullPath = FileUtils.getBookFullPath(bookEntity);
-        return Path.of(bookFullPath);
+        return FileUtils.getBookFullPath(bookEntity);
     }
 
     private CachedEpubMetadata getCachedMetadata(Path epubPath) throws IOException {

--- a/booklore-api/src/main/java/org/booklore/service/reader/PdfReaderService.java
+++ b/booklore-api/src/main/java/org/booklore/service/reader/PdfReaderService.java
@@ -113,8 +113,7 @@ public class PdfReaderService {
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
             return bookFile.getFullFilePath();
         }
-        String bookFullPath = FileUtils.getBookFullPath(bookEntity);
-        return Path.of(bookFullPath);
+        return FileUtils.getBookFullPath(bookEntity);
     }
 
     private void validatePageRequest(Long bookId, int page, int pageCount) throws FileNotFoundException {

--- a/booklore-api/src/main/java/org/booklore/util/FileUtils.java
+++ b/booklore-api/src/main/java/org/booklore/util/FileUtils.java
@@ -24,27 +24,18 @@ public class FileUtils {
 
     private final String FILE_NOT_FOUND_MESSAGE = "File does not exist: ";
 
-    public String getBookFullPath(BookEntity bookEntity) {
+    public Path getBookFullPath(BookEntity bookEntity) {
         BookFileEntity bookFile = bookEntity.getPrimaryBookFile();
-        if (bookFile == null || bookEntity.getLibraryPath() == null) {
-            return null;
-        }
-
-        return Path.of(bookEntity.getLibraryPath().getPath(), bookFile.getFileSubPath(), bookFile.getFileName())
-                .normalize()
-                .toString()
-                .replace("\\", "/");
+        return getBookFullPath(bookEntity, bookFile);
     }
 
-    public String getBookFullPath(BookEntity bookEntity, BookFileEntity bookFile) {
+    public Path getBookFullPath(BookEntity bookEntity, BookFileEntity bookFile) {
         if (bookFile == null || bookEntity.getLibraryPath() == null) {
             return null;
         }
 
         return Path.of(bookEntity.getLibraryPath().getPath(), bookFile.getFileSubPath(), bookFile.getFileName())
-                .normalize()
-                .toString()
-                .replace("\\", "/");
+                .normalize();
     }
 
     public String getBookFullPath(Book book) {
@@ -60,7 +51,7 @@ public class FileUtils {
     }
 
     public Long getFileSizeInKb(BookEntity bookEntity) {
-        Path filePath = Path.of(getBookFullPath(bookEntity));
+        Path filePath = getBookFullPath(bookEntity);
         return getFileSizeInKb(filePath);
     }
 

--- a/booklore-api/src/test/java/org/booklore/service/Rar5FallbackIntegrationTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/Rar5FallbackIntegrationTest.java
@@ -74,7 +74,7 @@ class Rar5FallbackIntegrationTest {
 
         try (var fileUtilsStatic = org.mockito.Mockito.mockStatic(org.booklore.util.FileUtils.class)) {
             fileUtilsStatic.when(() -> org.booklore.util.FileUtils.getBookFullPath(book))
-                    .thenReturn(cbrCopy.toString());
+                    .thenReturn(cbrCopy);
 
             CbxReaderService readerService = new CbxReaderService(mockRepo);
             List<Integer> pages = readerService.getAvailablePages(99L);
@@ -96,7 +96,7 @@ class Rar5FallbackIntegrationTest {
 
         try (var fileUtilsStatic = org.mockito.Mockito.mockStatic(org.booklore.util.FileUtils.class)) {
             fileUtilsStatic.when(() -> org.booklore.util.FileUtils.getBookFullPath(book))
-                    .thenReturn(cbrCopy.toString());
+                    .thenReturn(cbrCopy);
 
             CbxReaderService readerService = new CbxReaderService(mockRepo);
             ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -81,6 +81,9 @@ class BookServiceTest {
 
     private BookLoreUser testUser;
 
+    private Path epubPath;
+    private Path pdfPath;
+
     @BeforeEach
     void setUp() {
         BookLoreUser.UserPermissions perms = new BookLoreUser.UserPermissions();
@@ -90,6 +93,9 @@ class BookServiceTest {
                 .permissions(perms)
                 .assignedLibraries(List.of())
                 .isDefaultPassword(false).build();
+
+        epubPath = Path.of("/tmp/library/book.epub");
+        pdfPath = Path.of("/tmp/library/book.pdf");
     }
 
     @Test
@@ -125,7 +131,7 @@ class BookServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
 
         try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(Path.of("/tmp/library/book.epub"));
+            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(epubPath);
             List<Book> result = bookService.getBooksByIds(Set.of(2L), false);
 
             assertEquals(1, result.size());
@@ -153,7 +159,7 @@ class BookServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
 
         try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(Path.of("/tmp/library/book.pdf"));
+            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(pdfPath);
             Book result = bookService.getBook(3L, true);
             assertEquals(3L, result.getId());
             verify(bookRepository).findByIdWithBookFiles(3L);
@@ -476,12 +482,12 @@ class BookServiceTest {
         // `FileUtils.getBookFullPath` calls `book.getPrimaryBookFile()`.
 
         try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn("/tmp/library/book.epub");
+            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(epubPath);
 
             bookService.streamBookContent(15L, null, request, response);
 
             verify(bookRepository).findByIdWithBookFiles(15L);
-            verify(fileStreamingService).streamWithRangeSupport(eq(Paths.get("/tmp/library/book.epub")), eq("application/epub+zip"), eq(request), eq(response));
+            verify(fileStreamingService).streamWithRangeSupport(eq(epubPath), eq("application/epub+zip"), eq(request), eq(response));
         }
     }
 

--- a/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -125,7 +125,7 @@ class BookServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
 
         try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn("/tmp/library/book.epub");
+            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(Path.of("/tmp/library/book.epub"));
             List<Book> result = bookService.getBooksByIds(Set.of(2L), false);
 
             assertEquals(1, result.size());
@@ -153,7 +153,7 @@ class BookServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
 
         try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn("/tmp/library/book.pdf");
+            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(Path.of("/tmp/library/book.pdf"));
             Book result = bookService.getBook(3L, true);
             assertEquals(3L, result.getId());
             verify(bookRepository).findByIdWithBookFiles(3L);
@@ -329,7 +329,7 @@ class BookServiceTest {
         Path path = Paths.get("/tmp/bookcontent.txt");
         Files.write(path, "hello".getBytes());
         try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(path.toString());
+            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(path);
             ResponseEntity<Resource> response = bookService.getBookContent(10L);
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertArrayEquals("hello".getBytes(), response.getBody().getInputStream().readAllBytes());
@@ -350,7 +350,7 @@ class BookServiceTest {
         entity.setId(12L);
         when(bookRepository.findByIdWithBookFiles(12L)).thenReturn(Optional.of(entity));
         try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn("/tmp/nonexistentfile.txt");
+            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(Path.of("/tmp/nonexistentfile.txt"));
             assertThrows(APIException.class, () -> bookService.getBookContent(12L));
         }
     }

--- a/booklore-api/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -122,7 +123,7 @@ class SendEmailV2ServiceTest {
                     });
 
             try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-                fileUtilsMock.when(() -> FileUtils.getBookFullPath(book)).thenReturn("/library/books/test-book.epub");
+                fileUtilsMock.when(() -> FileUtils.getBookFullPath(book)).thenReturn(Path.of("/library/books/test-book.epub"));
 
                 sendEmailV2Service.emailBookQuick(10L);
 
@@ -192,7 +193,7 @@ class SendEmailV2ServiceTest {
                     });
 
             try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-                fileUtilsMock.when(() -> FileUtils.getBookFullPath(book)).thenReturn("/library/books/test-book.epub");
+                fileUtilsMock.when(() -> FileUtils.getBookFullPath(book)).thenReturn(Path.of("/library/books/test-book.epub"));
 
                 sendEmailV2Service.emailBook(request);
 
@@ -225,7 +226,7 @@ class SendEmailV2ServiceTest {
                     });
 
             try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-                fileUtilsMock.when(() -> FileUtils.getBookFullPath(book)).thenReturn("/library/books/test-book.epub");
+                fileUtilsMock.when(() -> FileUtils.getBookFullPath(book)).thenReturn(Path.of("/library/books/test-book.epub"));
 
                 sendEmailV2Service.emailBook(request);
 

--- a/booklore-api/src/test/java/org/booklore/service/reader/CbxReaderServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/reader/CbxReaderServiceTest.java
@@ -63,7 +63,7 @@ class CbxReaderServiceTest {
     void testGetAvailablePages_CBZ_Success() throws Exception {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath);
 
             ZipArchiveEntry entry1 = new ZipArchiveEntry("1.jpg");
             ZipArchiveEntry entry2 = new ZipArchiveEntry("2.png");
@@ -94,7 +94,7 @@ class CbxReaderServiceTest {
     void testGetAvailablePages_CBZ_Fallback_Success() throws Exception {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath);
 
             // Unicode enabled -> throws Exception
             ZipFile zipFileFail = mock(ZipFile.class);
@@ -141,7 +141,7 @@ class CbxReaderServiceTest {
     void testStreamPageImage_CBZ_Success() throws Exception {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath);
 
             ZipArchiveEntry entry1 = new ZipArchiveEntry("1.jpg");
             Enumeration<ZipArchiveEntry> entries = Collections.enumeration(List.of(entry1));
@@ -180,7 +180,7 @@ class CbxReaderServiceTest {
     void testGetAvailablePages_CB7_Success() throws Exception {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cb7Path.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cb7Path);
 
             SevenZArchiveEntry entry1 = mock(SevenZArchiveEntry.class);
             when(entry1.getName()).thenReturn("1.jpg");
@@ -209,7 +209,7 @@ class CbxReaderServiceTest {
     void testGetAvailablePages_CBR_Success() throws Exception {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbrPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbrPath);
 
             FileHeader header = mock(FileHeader.class);
             when(header.isDirectory()).thenReturn(false);
@@ -232,7 +232,7 @@ class CbxReaderServiceTest {
     void testStreamPageImage_CBR_Success() throws Exception {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbrPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbrPath);
 
             FileHeader header = mock(FileHeader.class);
             when(header.isDirectory()).thenReturn(false);
@@ -261,7 +261,7 @@ class CbxReaderServiceTest {
     void testStreamPageImage_PageOutOfRange_Throws() throws Exception {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath);
 
             ZipArchiveEntry entry1 = new ZipArchiveEntry("1.jpg");
             Enumeration<ZipArchiveEntry> entries = Collections.enumeration(List.of(entry1));
@@ -292,7 +292,7 @@ class CbxReaderServiceTest {
         Files.deleteIfExists(unknownPath);
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(unknownPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(unknownPath);
 
             Files.createFile(unknownPath);
             Files.setLastModifiedTime(unknownPath, FileTime.fromMillis(System.currentTimeMillis()));
@@ -305,7 +305,7 @@ class CbxReaderServiceTest {
     void testStreamPageImage_EntryNotFound_Throws() throws Exception {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(cbzPath);
 
             ZipArchiveEntry entry1 = new ZipArchiveEntry("1.jpg");
             Enumeration<ZipArchiveEntry> entries = Collections.enumeration(List.of(entry1));

--- a/booklore-api/src/test/java/org/booklore/service/reader/EpubReaderServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/reader/EpubReaderServiceTest.java
@@ -110,7 +110,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -149,7 +149,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -177,7 +177,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             byte[] chapterContent = "<html><body>Chapter 1 content</body></html>".getBytes(StandardCharsets.UTF_8);
             ZipFile zipFile = createMockZipFileWithStreamableEntry("OEBPS/chapter1.xhtml", chapterContent);
@@ -212,7 +212,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -238,7 +238,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -264,7 +264,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             byte[] containerContent = CONTAINER_XML.getBytes(StandardCharsets.UTF_8);
             ZipFile zipFile = createMockZipFileWithStreamableEntry("META-INF/container.xml", containerContent);
@@ -299,7 +299,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -325,7 +325,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -353,7 +353,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFileWithSizes();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -375,7 +375,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -396,7 +396,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -424,7 +424,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -453,7 +453,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             ZipFile zipFile = createMockZipFile();
             ZipFile.Builder builder = createMockZipFileBuilder(zipFile);
@@ -494,7 +494,7 @@ class EpubReaderServiceTest {
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
         try (MockedStatic<FileUtils> fileUtilsStatic = mockStatic(FileUtils.class)) {
-            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath.toString());
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(bookEntity)).thenReturn(epubPath);
 
             byte[] chapterContent = "<html><body>Chapter 1 content</body></html>".getBytes(StandardCharsets.UTF_8);
             ZipFile zipFile = createMockZipFileWithStreamableEntry("OEBPS/chapter1.xhtml", chapterContent);

--- a/booklore-api/src/test/java/org/booklore/util/FileUtilsTest.java
+++ b/booklore-api/src/test/java/org/booklore/util/FileUtilsTest.java
@@ -42,10 +42,9 @@ class FileUtilsTest {
 
         BookEntity book = createBookEntity(libraryPath, subPath, fileName);
 
-        String fullPath = FileUtils.getBookFullPath(book);
+        Path fullPath = FileUtils.getBookFullPath(book);
 
-        String expected = libraryPath.resolve(subPath).resolve(fileName)
-                .toString().replace("\\", "/");
+        Path expected = libraryPath.resolve(subPath).resolve(fileName);
 
         assertEquals(expected, fullPath);
     }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

This change passes around a `Path` object instead of a string in `FileUtils.getBookFullPath()`.  In `getBookFullPath` we convert the path to a string, only to (in most cases) convert right back to a path.  The conversion opens up room for error, and it's a heck of a lot simpler to just pass the path back and forth.

For example, even in `FileUtils.getBookFullPath`, we convert backslashes and then in other locations, we ALSO have to convert backslashes.  `Path` handles these under the hood natively.

This was originally part of #113 but I split it out because it seems beneficial on its own & helps with testing and reviewing the nightcompress library.

**Linked Issue:** Related to #29 

## Changes

* updates `FileUtils.getBookFullPath()` to return a `java.nio.file.Path` instead of a `String`
* refactors other code paths to use this `Path`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized internal file-path handling across downloads, streaming, cover extraction, metadata retrieval, and email attachments to improve consistency and reduce path-related errors.
* **Tests**
  * Updated test fixtures and mocks to use the new file-path representation, keeping tests aligned with runtime behavior and validating the refactor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->