### PR TITLE
fix(api): handle kobo proxy errors during kobo sync

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboLibrarySyncService.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboLibrarySyncService.java
@@ -135,9 +135,14 @@ public class KoboLibrarySyncService {
         }
 
         if (!shouldContinueSync) {
+            ResponseEntity<JsonNode> koboStoreResponse = null;
             try {
-                ResponseEntity<JsonNode> koboStoreResponse = koboServerProxy.proxyCurrentRequest(null, true);
+                koboStoreResponse = koboServerProxy.proxyCurrentRequest(null, true);
+            } catch (Exception e) {
+                log.warn("Failed to get response from Kobo /v1/library/sync, fallback to noproxy", e);
+            }
 
+            if (koboStoreResponse != null) {
                 entitlements.addAll(getEntitlementsFromKoboStoreResponse(koboStoreResponse));
 
                 String upstreamContinueSyncHeader = koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNC);
@@ -148,8 +153,6 @@ public class KoboLibrarySyncService {
                 }
 
                 shouldContinueSync = "continue".equalsIgnoreCase(upstreamContinueSyncHeader);
-            } catch (Exception e) {
-                log.warn("Failed to get response from Kobo /v1/library/sync, fallback to noproxy", e);
             }
         }
 

--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboLibrarySyncService.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboLibrarySyncService.java
@@ -140,12 +140,14 @@ public class KoboLibrarySyncService {
 
                 entitlements.addAll(getEntitlementsFromKoboStoreResponse(koboStoreResponse));
 
-                shouldContinueSync = "continue".equalsIgnoreCase(
-                        Optional.ofNullable(koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNC)).orElse("")
-                );
+                String upstreamContinueSyncHeader = koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNC);
+                String upstreamKoboSyncTokenHeader = koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNCTOKEN);
 
-                String koboSyncTokenHeader = koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNCTOKEN);
-                syncToken = koboSyncTokenHeader != null ? tokenGenerator.fromBase64(koboSyncTokenHeader) : syncToken;
+                if (upstreamKoboSyncTokenHeader != null) {
+                    syncToken = tokenGenerator.fromBase64(upstreamKoboSyncTokenHeader);
+                }
+
+                shouldContinueSync = "continue".equalsIgnoreCase(upstreamContinueSyncHeader);
             } catch (Exception e) {
                 log.warn("Failed to get response from Kobo /v1/library/sync, fallback to noproxy", e);
             }

--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboLibrarySyncService.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboLibrarySyncService.java
@@ -39,6 +39,31 @@ public class KoboLibrarySyncService {
     private final ObjectMapper objectMapper;
     private final KoboSettingsService koboSettingsService;
 
+    private Collection<Entitlement> getEntitlementsFromKoboStoreResponse(ResponseEntity<JsonNode> koboStoreResponse) {
+         return Optional.ofNullable(koboStoreResponse.getBody())
+                .map(body -> {
+                    try {
+                        List<Entitlement> results = new ArrayList<>();
+                        if (body.isArray()) {
+                            for (JsonNode node : body) {
+                                if (node.has("NewEntitlement")) {
+                                    results.add(objectMapper.treeToValue(node, NewEntitlement.class));
+                                } else if (node.has("ChangedEntitlement")) {
+                                    results.add(objectMapper.treeToValue(node, ChangedEntitlement.class));
+                                } else {
+                                    log.warn("Unknown entitlement type in Kobo response: {}", node);
+                                }
+                            }
+                        }
+                        return results;
+                    } catch (Exception e) {
+                        log.error("Failed to map Kobo response to Entitlement objects", e);
+                        return Collections.<Entitlement>emptyList();
+                    }
+                })
+                .orElse(Collections.emptyList());
+    }
+
     @Transactional
     public ResponseEntity<?> syncLibrary(BookLoreUser user, String token) {
         HttpServletRequest request = RequestUtils.getCurrentRequest();
@@ -110,38 +135,20 @@ public class KoboLibrarySyncService {
         }
 
         if (!shouldContinueSync) {
-            ResponseEntity<JsonNode> koboStoreResponse = koboServerProxy.proxyCurrentRequest(null, true);
-            Collection<Entitlement> syncResultsKobo = Optional.ofNullable(koboStoreResponse.getBody())
-                    .map(body -> {
-                        try {
-                            List<Entitlement> results = new ArrayList<>();
-                            if (body.isArray()) {
-                                for (JsonNode node : body) {
-                                    if (node.has("NewEntitlement")) {
-                                        results.add(objectMapper.treeToValue(node, NewEntitlement.class));
-                                    } else if (node.has("ChangedEntitlement")) {
-                                        results.add(objectMapper.treeToValue(node, ChangedEntitlement.class));
-                                    } else {
-                                        log.warn("Unknown entitlement type in Kobo response: {}", node);
-                                    }
-                                }
-                            }
-                            return results;
-                        } catch (Exception e) {
-                            log.error("Failed to map Kobo response to Entitlement objects", e);
-                            return Collections.<Entitlement>emptyList();
-                        }
-                    })
-                    .orElse(Collections.emptyList());
+            try {
+                ResponseEntity<JsonNode> koboStoreResponse = koboServerProxy.proxyCurrentRequest(null, true);
 
-            entitlements.addAll(syncResultsKobo);
+                entitlements.addAll(getEntitlementsFromKoboStoreResponse(koboStoreResponse));
 
-            shouldContinueSync = "continue".equalsIgnoreCase(
-                    Optional.ofNullable(koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNC)).orElse("")
-            );
+                shouldContinueSync = "continue".equalsIgnoreCase(
+                        Optional.ofNullable(koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNC)).orElse("")
+                );
 
-            String koboSyncTokenHeader = koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNCTOKEN);
-            syncToken = koboSyncTokenHeader != null ? tokenGenerator.fromBase64(koboSyncTokenHeader) : syncToken;
+                String koboSyncTokenHeader = koboStoreResponse.getHeaders().getFirst(KoboHeaders.X_KOBO_SYNCTOKEN);
+                syncToken = koboSyncTokenHeader != null ? tokenGenerator.fromBase64(koboSyncTokenHeader) : syncToken;
+            } catch (Exception e) {
+                log.warn("Failed to get response from Kobo /v1/library/sync, fallback to noproxy", e);
+            }
         }
 
         if (shouldContinueSync) {

--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboServerProxy.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboServerProxy.java
@@ -41,7 +41,6 @@ public class KoboServerProxy {
             HttpHeaders.AUTHORIZATION.toLowerCase(),
             HttpHeaders.AUTHORIZATION,
             HttpHeaders.USER_AGENT,
-            HttpHeaders.ACCEPT,
             HttpHeaders.ACCEPT_LANGUAGE
     );
 
@@ -105,7 +104,8 @@ public class KoboServerProxy {
                     .uri(uri)
                     .timeout(Duration.ofMinutes(1))
                     .method(request.getMethod(), HttpRequest.BodyPublishers.ofString(bodyString))
-                    .header(HttpHeaders.CONTENT_TYPE, "application/json");
+                    .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                    .header(HttpHeaders.ACCEPT, "application/json");
 
             Collections.list(request.getHeaderNames()).forEach(headerName -> {
                 if (!HEADERS_OUT_EXCLUDE.contains(headerName.toLowerCase()) &&


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Whenever Kobo servers error out the kobo sync fails to process with an HTTP 500.  This is because Kobo servers respond with HTML.  In the sync routes we try to combine the kobo response with our response whcih fails.

This corrects the issue by wrapping the sync code that makes a proxy request in a try / catch & handling JSON parse failures in the kobo proxy requests more gracefully.

**Linked Issue:** Fixes #216 

## Changes

* updates kobo sync to handle failures more gracefully (like the kobo init endpoint)
* tells kobo that we only ever want JSON - including in error messages (otherwise they send HTML and we fail to parse it)

## Testing Strategy

Tested with a Kobo Clara BW to do standard sync operations & file downloading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync is more resilient: remote parsing issues now log and return an empty result so they don't break sync.
  * Proxy errors during sync are caught and logged so they no longer cause incomplete state updates.

* **Refactor**
  * Response and header handling tightened: outbound requests explicitly request JSON; sync-token and continue-sync decisions now update only when upstream headers are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->