### PR TITLE
fix(deps): primeicons CSS import fix

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,5 +1,5 @@
 @use "sass:meta";
-@import "../node_modules/primeicons/primeicons.css";
+@import "primeicons/primeicons.css";
 @include meta.load-css("assets/styles/reset.scss");
 @include meta.load-css("assets/layout/styles/global.scss");
 


### PR DESCRIPTION
Fixes #219 - Primeicons import error upon container start



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency import configuration for improved build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->