### PR TITLE
chore(frontend): add missing auth service mock

### DIFF
--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -15,6 +15,7 @@ import {LibraryService} from './features/book/service/library.service';
 import {LibraryHealthService} from './features/book/service/library-health.service';
 import {LibraryLoadingService} from './features/library-creator/library-loading.service';
 import {TranslocoTestingModule} from '@jsverse/transloco';
+import {AuthService} from './shared/service/auth.service';
 
 describe('AppComponent offline detection', () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -35,6 +36,7 @@ describe('AppComponent offline detection', () => {
         {provide: LibraryService, useValue: {largeLibraryLoading: signal({isLoading: false, expectedCount: 0})}},
         {provide: LibraryHealthService, useValue: {initialize: vi.fn()}},
         {provide: LibraryLoadingService, useValue: {hide: vi.fn()}},
+        {provide: AuthService, useValue: {token: signal(null)}},
       ]
     });
 


### PR DESCRIPTION
Adds missing `AuthService` import to `app.component.spec.ts` which caused a failure when running `just ui test`.

Tests ran after fix and all frontend tests pass. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes internal test infrastructure improvements to ensure reliable component testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->