### PR TITLE
fix(cbx-reader): add GIF and BMP to supported image extensions

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/reader/CbxReaderService.java
+++ b/booklore-api/src/main/java/org/booklore/service/reader/CbxReaderService.java
@@ -39,7 +39,7 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 public class CbxReaderService {
 
-    private static final String[] SUPPORTED_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".avif", ".heic"};
+    private static final String[] SUPPORTED_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".avif", ".heic", ".gif", ".bmp"};
     private static final Charset[] ENCODINGS_TO_TRY = {
             StandardCharsets.UTF_8,
             Charset.forName("Shift_JIS"),


### PR DESCRIPTION
## Description
GIF and BMP images inside CBX archives are not displayed in the web reader. This PR adds support for these formats.

**Linked Issue:** Fixes #165

## Changes
- Added `.gif` and `.bmp` to `SUPPORTED_IMAGE_EXTENSIONS` in `CbxReaderService.java`

## Test Output

```
Environment: Docker gradle:9.3.1-jdk25-alpine (same image as project Dockerfile)

> Task :test
3483 tests, 0 failures, 15 ignored
Duration: 11m 7.38s

BUILD SUCCESSFUL in 20m 34s
6 actionable tasks: 6 executed
```

## Verification

Deployed the build on my server and tested with the following CBZ file:

- `format_test.cbz` — 8 pages, one per format (JPG, JPEG, PNG, WebP, AVIF, HEIC, GIF, BMP)
[format_test.zip](https://github.com/user-attachments/files/26292997/format_test.zip)

<img width="952" height="915" alt="format_test-1" src="https://github.com/user-attachments/assets/7730919a-bac7-41da-869f-bf48745f3d3c" />
<img width="957" height="912" alt="format_test-2" src="https://github.com/user-attachments/assets/79755aac-2446-4d3a-aec8-7b96a58fc8ff" />
<img width="959" height="911" alt="format_test-3" src="https://github.com/user-attachments/assets/641ca114-8f9f-43cf-878d-b4335b77532f" />
<img width="959" height="914" alt="format_test-4" src="https://github.com/user-attachments/assets/3d3f904f-5faf-42cf-ad1f-d3c145593cb0" />
<img width="957" height="912" alt="format_test-5" src="https://github.com/user-attachments/assets/e68abbd1-f4a7-4e5a-b472-f16cfa3744fe" />
<img width="958" height="916" alt="format_test-6" src="https://github.com/user-attachments/assets/2056ae90-6eb4-4a68-beb6-7ce4c8f2c764" />
<img width="957" height="916" alt="format_test-7" src="https://github.com/user-attachments/assets/efe8e3ba-ec1e-4c9b-b7bc-f18908177657" />
<img width="958" height="913" alt="format_test-8" src="https://github.com/user-attachments/assets/46bbc9c3-55d0-4056-af46-73fdfd3c15d0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GIF and BMP image formats in comic book archives. The application now recognizes these formats as valid page images when reading archive files, improving compatibility and expanding the range of image formats that can be used in comic book publications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->