### PR TITLE
fix(api): skip physical books in metadata manager to prevent NPE

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/MetadataManagementService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/MetadataManagementService.java
@@ -59,6 +59,9 @@ public class MetadataManagementService {
         for (BookMetadataEntity metadata : metadataList) {
             if (metadata.getBook() != null) {
                 BookEntity book = metadata.getBook();
+                if (Boolean.TRUE.equals(book.getIsPhysical())) {
+                    continue;
+                }
                 boolean bookModified = false;
 
                 var primaryFile = book.getPrimaryBookFile();

--- a/booklore-api/src/test/java/org/booklore/service/metadata/MetadataManagementServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/MetadataManagementServiceTest.java
@@ -592,4 +592,35 @@ class MetadataManagementServiceTest {
         verify(metadataWriterFactory, never()).getWriter(any());
         verify(authorRepository).delete(oldAuthor);
     }
+
+    @Test
+    void consolidateAuthors_physicalBook_skipsFileWriteAndDoesNotThrow() {
+        AuthorEntity oldAuthor = AuthorEntity.builder().id(1L).name("Old").build();
+        AuthorEntity targetAuthor = AuthorEntity.builder().id(2L).name("Target").build();
+
+        when(authorRepository.findByNameIgnoreCase("Target")).thenReturn(Optional.of(targetAuthor));
+        when(authorRepository.save(targetAuthor)).thenReturn(targetAuthor);
+        when(authorRepository.findByNameIgnoreCase("Old")).thenReturn(Optional.of(oldAuthor));
+
+        BookEntity physicalBook = BookEntity.builder()
+                .id(1L)
+                .isPhysical(true)
+                .bookFiles(new ArrayList<>())
+                .build();
+        BookMetadataEntity metadata = BookMetadataEntity.builder()
+                .authors(new ArrayList<>(List.of(oldAuthor)))
+                .book(physicalBook)
+                .build();
+        physicalBook.setMetadata(metadata);
+
+        when(bookMetadataRepository.findAllByAuthorsContaining(oldAuthor)).thenReturn(List.of(metadata));
+
+        service.consolidateMetadata(MergeMetadataType.authors, List.of("Target"), List.of("Old"));
+
+        assertThat(metadata.getAuthors()).contains(targetAuthor);
+        assertThat(metadata.getAuthors()).doesNotContain(oldAuthor);
+        verify(metadataWriterFactory, never()).getWriter(any());
+        verify(bookRepository, never()).saveAndFlush(any());
+        verify(authorRepository).delete(oldAuthor);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix NullPointerException when using Metadata Manager to merge/consolidate metadata that includes physical books
- Physical books have no associated file, so `getPrimaryBookFile()` returns null
- The fix skips physical books in `writeMetadataToFile()` since there is no file to write metadata to

## Test plan
- [x] Added unit test `consolidateAuthors_physicalBook_skipsFileWriteAndDoesNotThrow`
- [x] All existing tests pass (`just api test`)
- [ ] Manual test: merge authors that include a physical book in the library

## Reproduction steps (before fix)
1. Have a physical book in your library (marked as physical, no file attached)
2. Have that physical book share an author with digital books
3. Go to Metadata Manager → Authors
4. Try to merge that author with another
5. Observe NullPointerException in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Physical books no longer trigger metadata file writing and associated operations.

* **Tests**
  * Added test coverage verifying metadata handling for physical books skips file operations while still processing author consolidation correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->