### PR TITLE
ci(lint): set LINT_ERROR_THRESHOLD to zero

### DIFF
--- a/.github/workflows/angular-lint-threshold.yml
+++ b/.github/workflows/angular-lint-threshold.yml
@@ -21,7 +21,7 @@ jobs:
 
     env:
       LINT_WARNING_THRESHOLD: 0
-      LINT_ERROR_THRESHOLD: 721
+      LINT_ERROR_THRESHOLD: 0
       BUILD_WARNING_THRESHOLD: 24
 
     steps:


### PR DESCRIPTION
## Description

Since all the lint issue are solved, we need set the threshold to zero.

**Linked Issue:** #133 

## Changes

This pull request makes a small configuration change to the linting workflow. The error threshold for linting has been set to zero, which means any lint error will now cause the workflow to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened the lint quality gate to enforce stricter error thresholds in the build pipeline. This ensures higher code quality standards are maintained across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->