### PR TITLE
fix(frontend): Fix series page double-encoded URL causing refresh failure

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -666,8 +666,7 @@ export class BookCardComponent implements OnInit, OnChanges {
   openSeriesInfo(): void {
     const seriesName = this.book?.metadata?.seriesName;
     if (this.isSeriesCollapsed && seriesName) {
-      const encodedSeriesName = encodeURIComponent(seriesName);
-      this.router.navigate(['/series', encodedSeriesName]);
+      this.router.navigate(['/series', seriesName]);
     } else {
       this.openBookInfo(this.book);
     }

--- a/frontend/src/app/features/book/components/series-page/series-page.component.ts
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.ts
@@ -142,7 +142,6 @@ export class SeriesPageComponent implements AfterViewChecked {
 
   private seriesParam = toSignal(this.route.paramMap.pipe(
     map((params) => params.get("seriesName") || ""),
-    map((name) => decodeURIComponent(name))
   ), {initialValue: ""});
 
   filteredBooks = computed(() => {

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -805,8 +805,7 @@ export class MetadataViewerComponent implements OnInit, OnChanges, AfterViewChec
   }
 
   goToSeries(seriesName: string): void {
-    const encodedSeriesName = encodeURIComponent(seriesName);
-    this.router.navigate(['/series', encodedSeriesName]);
+    this.router.navigate(['/series', seriesName]);
   }
 
   goToPublisher(publisher: string): void {

--- a/frontend/src/app/shared/service/url-helper.service.ts
+++ b/frontend/src/app/shared/service/url-helper.service.ts
@@ -156,7 +156,7 @@ export class UrlHelperService {
 
   filterBooksBy(filterKey: string, filterValue: string) {
     if (filterKey === 'series') {
-      return this.router.createUrlTree(['/series', encodeURIComponent(filterValue)])
+      return this.router.createUrlTree(['/series', filterValue])
     }
 
     return this.router.createUrlTree(['/all-books'], {


### PR DESCRIPTION
## Description

Series pages break on refresh (Whitelabel Error) when the series name contains spaces or non-ASCII characters. This is caused by manually calling `encodeURIComponent()` before passing the series name to Angular Router, which already encodes path segments automatically.

**Linked Issue:** Fixes #259 

## Changes

| File | Change |
|------|--------|
| `book-card.component.ts` | Remove `encodeURIComponent()` from `openSeriesInfo()` |
| `metadata-viewer.component.ts` | Remove `encodeURIComponent()` from `goToSeries()` |
| `url-helper.service.ts` | Remove `encodeURIComponent()` from `filterBooksBy()` |
| `series-page.component.ts` | Remove unnecessary `decodeURIComponent()` pipe from `seriesParam` |

## Testing (MANDATORY)

Create a series named `test series` (with a space), then navigate to the series page via each path and press F5:

| # | Path | Before | After |
|---|------|--------|-------|
| 1 | All Books (table view) → series column | ❌ Whitelabel Error | ✅ Refreshes normally |
| 2 | Series Browser → click a series | ✅ Already works | ✅ No change |
| 3 | Book detail → series name link | ❌ Whitelabel Error | ✅ Refreshes normally |
| 4 | Grid view (Series View enabled, Collapse on) → series card | ❌ Whitelabel Error | ✅ Refreshes normally |

## Screen Recording / Screenshots (MANDATORY)
**Before** — Series page with test series: click series link → URL shows %2520 (double-encoded) → F5 → Whitelabel Error

https://github.com/user-attachments/assets/ca646aa4-3527-48ae-97df-ea7f284d5a89

**After** — Same steps: click series link → URL shows %20 (correct) → F5 → page loads normally

https://github.com/user-attachments/assets/c29cc7df-4268-4e12-bf4e-e4f0e7545301

**Test Screenshot**
<img width="283" height="186" alt="화면 캡처 2026-03-29 094452" src="https://github.com/user-attachments/assets/a7c42e6b-cd55-43d1-b5c8-714eca36cf36" />

## Additional Context (optional)
the `decodeURIComponent()` pipe in `series-page.component.ts` L145 has been removed, as it is no longer needed once the double encoding is eliminated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved series name navigation handling across the application to ensure consistent behavior in series browsing and filtering features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->