### PR TITLE
fix: fix text overflow with attach-to-book flow when dealing with long titles

### DIFF
--- a/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.html
+++ b/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.html
@@ -1,118 +1,95 @@
 <ng-container *transloco="let t; prefix: 'book.fileAttacher'">
-<div class="book-file-attacher-container">
-  <div class="panel-header">
-    <div class="header-icon-wrapper">
-      <i class="pi pi-link header-icon"></i>
+  <div class="book-file-attacher-container">
+    <div class="panel-header">
+      <div class="header-icon-wrapper">
+        <i class="pi pi-link header-icon"></i>
+      </div>
+      <div class="header-text">
+        <h2 class="panel-title">{{ isBulkMode ? t('titleBulk') : t('title') }}</h2>
+        <p class="panel-description">{{ isBulkMode ? t('descriptionBulk') : t('description') }}</p>
+      </div>
+      <p-button icon="pi pi-times" [rounded]="true" [text]="true" severity="secondary" (click)="closeDialog()"
+        class="close-button">
+      </p-button>
     </div>
-    <div class="header-text">
-      <h2 class="panel-title">{{ isBulkMode ? t('titleBulk') : t('title') }}</h2>
-      <p class="panel-description">{{ isBulkMode ? t('descriptionBulk') : t('description') }}</p>
-    </div>
-    <p-button
-      icon="pi pi-times"
-      [rounded]="true"
-      [text]="true"
-      severity="secondary"
-      (click)="closeDialog()"
-      class="close-button">
-    </p-button>
-  </div>
 
-  <div class="dialog-content">
-    <!-- Source Book(s) Info -->
-    <div class="source-info">
-      <h3 class="section-title">{{ isBulkMode ? t('sourceBooksLabel', { count: sourceBooks.length }) : t('sourceBookLabel', { count: sourceBooks.length }) }}</h3>
-      <div class="source-books-list">
-        @for (book of sourceBooks; track book.id) {
+    <div class="dialog-content">
+      <!-- Source Book(s) Info -->
+      <div class="source-info">
+        <h3 class="section-title">{{ isBulkMode ? t('sourceBooksLabel', { count: sourceBooks.length }) :
+          t('sourceBookLabel', { count: sourceBooks.length }) }}</h3>
+        <div class="source-books-list">
+          @for (book of sourceBooks; track book.id) {
           <div class="book-info-card">
             <div class="book-title">{{ book.metadata?.title || t('unknownTitle') }}</div>
             @if (book.metadata?.authors?.length) {
-              <div class="book-authors">{{ book.metadata?.authors?.join(', ') }}</div>
+            <div class="book-authors">{{ book.metadata?.authors?.join(', ') }}</div>
             }
             <div class="file-info">
               <i class="pi pi-file"></i>
               <span>{{ getSourceFileInfo(book) }}</span>
             </div>
           </div>
-        }
+          }
+        </div>
       </div>
-    </div>
 
-    <!-- Target Book Selection -->
-    <div class="target-selection">
-      <h3 class="section-title">{{ t('selectTargetBook') }}</h3>
-      <p-autocomplete
-        [(ngModel)]="targetBook"
-        [suggestions]="filteredBooks"
-        (completeMethod)="filterBooks($event)"
-        (onSelect)="onBookSelect($event)"
-        (onClear)="onBookClear()"
-        optionLabel="metadata.title"
-        [dropdown]="true"
-        [showClear]="true"
-        [placeholder]="t('searchPlaceholder')"
-        fluid
-        [disabled]="isAttaching">
-        <ng-template let-book pTemplate="item">
-          <div class="book-suggestion">
-            <div class="suggestion-title">{{ book.metadata?.title || t('unknownTitle') }}</div>
-            @if (book.metadata?.authors?.length) {
+      <!-- Target Book Selection -->
+      <div class="target-selection" #autocompleteWrapper>
+        <h3 class="section-title">{{ t('selectTargetBook') }}</h3>
+        <p-autocomplete [(ngModel)]="targetBook" [suggestions]="filteredBooks" (completeMethod)="filterBooks($event)"
+          (onSelect)="onBookSelect($event)" (onClear)="onBookClear()" optionLabel="metadata.title" [dropdown]="true"
+          [showClear]="true" [placeholder]="t('searchPlaceholder')" [panelStyle]="autocomplePanelStyle" fluid
+          [disabled]="isAttaching">
+          <ng-template let-book pTemplate="item">
+            <div class="book-suggestion">
+              <div class="suggestion-title">{{ book.metadata?.title || t('unknownTitle') }}</div>
+              @if (book.metadata?.authors?.length) {
               <div class="suggestion-authors">{{ book.metadata.authors.join(', ') }}</div>
-            }
-            @if (book.primaryFile) {
-              <div class="suggestion-format">{{ book.primaryFile.extension?.toUpperCase() || book.primaryFile.bookType }}</div>
-            }
-          </div>
-        </ng-template>
-        <ng-template let-book pTemplate="selectedItem">
-          <span>{{ getBookDisplayName(book) }}</span>
-        </ng-template>
-      </p-autocomplete>
-    </div>
-
-    <!-- Options -->
-    <div class="delete-option">
-      <p-checkbox
-        [(ngModel)]="moveFiles"
-        [binary]="true"
-        inputId="moveFiles"
-        [disabled]="isAttaching">
-      </p-checkbox>
-      <label for="moveFiles" class="delete-label">
-        {{ t('moveFilesLabel') }}
-      </label>
-    </div>
-
-    <!-- Warning Message -->
-    <div class="warning-message">
-      <i class="pi pi-info-circle"></i>
-      <div class="warning-text">
-        @if (moveFiles) {
-          <p>{{ isBulkMode ? t('warningMoveBulk') : t('warningMove') }}</p>
-        } @else {
-          <p>{{ isBulkMode ? t('warningNoMoveBulk') : t('warningNoMove') }}</p>
-        }
-        <p>{{ isBulkMode ? t('warningDeleteBulk') : t('warningDelete') }}</p>
+              }
+              @if (book.primaryFile) {
+              <div class="suggestion-format">{{ book.primaryFile.extension?.toUpperCase() || book.primaryFile.bookType
+                }}</div>
+              }
+            </div>
+          </ng-template>
+          <ng-template let-book pTemplate="selectedItem">
+            <span>{{ getBookDisplayName(book) }}</span>
+          </ng-template>
+        </p-autocomplete>
       </div>
-    </div>
 
-    <!-- Action Buttons -->
-    <div class="action-buttons">
-      <p-button
-        [label]="'common.cancel' | transloco"
-        [outlined]="true"
-        severity="secondary"
-        (click)="closeDialog()"
-        [disabled]="isAttaching">
-      </p-button>
-      <p-button
-        [label]="isBulkMode ? t('attachFilesBulk') : t('attachFile')"
-        icon="pi pi-link"
-        (click)="attach()"
-        [disabled]="!canAttach()"
-        [loading]="isAttaching">
-      </p-button>
+      <!-- Options -->
+      <div class="delete-option">
+        <p-checkbox [(ngModel)]="moveFiles" [binary]="true" inputId="moveFiles" [disabled]="isAttaching">
+        </p-checkbox>
+        <label for="moveFiles" class="delete-label">
+          {{ t('moveFilesLabel') }}
+        </label>
+      </div>
+
+      <!-- Warning Message -->
+      <div class="warning-message">
+        <i class="pi pi-info-circle"></i>
+        <div class="warning-text">
+          @if (moveFiles) {
+          <p>{{ isBulkMode ? t('warningMoveBulk') : t('warningMove') }}</p>
+          } @else {
+          <p>{{ isBulkMode ? t('warningNoMoveBulk') : t('warningNoMove') }}</p>
+          }
+          <p>{{ isBulkMode ? t('warningDeleteBulk') : t('warningDelete') }}</p>
+        </div>
+      </div>
+
+      <!-- Action Buttons -->
+      <div class="action-buttons">
+        <p-button [label]="'common.cancel' | transloco" [outlined]="true" severity="secondary" (click)="closeDialog()"
+          [disabled]="isAttaching">
+        </p-button>
+        <p-button [label]="isBulkMode ? t('attachFilesBulk') : t('attachFile')" icon="pi pi-link" (click)="attach()"
+          [disabled]="!canAttach()" [loading]="isAttaching">
+        </p-button>
+      </div>
     </div>
   </div>
-</div>
 </ng-container>

--- a/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.scss
+++ b/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.scss
@@ -100,15 +100,22 @@
 
 .book-suggestion {
   padding: 0.25rem 0;
+  overflow: hidden;
 
   .suggestion-title {
     font-weight: 500;
     margin-bottom: 0.125rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .suggestion-authors {
     font-size: 0.875rem;
     color: var(--p-text-muted-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .suggestion-format {
@@ -116,6 +123,9 @@
     color: var(--p-primary-color);
     font-weight: 600;
     margin-top: 0.25rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 

--- a/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.ts
+++ b/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, OnInit, OnDestroy, Signal, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, OnDestroy, AfterViewInit, ElementRef, ViewChild, Signal, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DynamicDialogRef, DynamicDialogConfig } from 'primeng/dynamicdialog';
 import { AutoComplete, AutoCompleteSelectEvent } from 'primeng/autocomplete';
@@ -8,7 +8,7 @@ import { Subject, takeUntil } from 'rxjs';
 import { BookService } from '../../service/book.service';
 import { BookFileService } from '../../service/book-file.service';
 import { Book } from '../../model/book.model';
-import {MessageService, PrimeTemplate} from 'primeng/api';
+import { MessageService, PrimeTemplate } from 'primeng/api';
 import { TranslocoDirective, TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { AppSettingsService } from '../../../../shared/service/app-settings.service';
 
@@ -27,13 +27,16 @@ import { AppSettingsService } from '../../../../shared/service/app-settings.serv
   templateUrl: './book-file-attacher.component.html',
   styleUrls: ['./book-file-attacher.component.scss']
 })
-export class BookFileAttacherComponent implements OnInit, OnDestroy {
+export class BookFileAttacherComponent implements OnInit, AfterViewInit, OnDestroy {
+  @ViewChild('autocompleteWrapper') autocompleteWrapper!: ElementRef;
+
   sourceBooks: Book[] = [];
   targetBook: Book | null = null;
   moveFiles = false;
   isAttaching = false;
   searchQuery = '';
   filteredBooks: Book[] = [];
+  autocomplePanelStyle: Record<string, string> = {};
 
   private destroy$ = new Subject<void>();
   private allBooks: Signal<Book[]> = signal([]);
@@ -45,6 +48,15 @@ export class BookFileAttacherComponent implements OnInit, OnDestroy {
   private bookService = inject(BookService);
   private bookFileService = inject(BookFileService);
   private messageService = inject(MessageService);
+
+  ngAfterViewInit(): void {
+    setTimeout(() => {
+      const width = this.autocompleteWrapper?.nativeElement?.offsetWidth;
+      if (width) {
+        this.autocomplePanelStyle = { 'width': `${width}px`, 'max-width': `${width}px` };
+      }
+    });
+  }
 
   ngOnInit(): void {
     // Support both single book and multiple books
@@ -86,7 +98,7 @@ export class BookFileAttacherComponent implements OnInit, OnDestroy {
     return this.sourceBooks.length > 1;
   }
 
-  filterBooks(event: { query: string }): void {
+  filterBooks(event: { query: string; }): void {
     const query = event.query.toLowerCase().trim();
     const books = this.allBooks();
     if (!query) {


### PR DESCRIPTION
## Description

This PR fixes the annoying issue with overflowing long book titles in the "book merge" modal, described in issue #240 .

I am not an Angular (or frontend) expert, so I definitely used AI tools to help me debug the issue and find a plausible fix.
I did thoroughly test the fix, and after applying it in my local environment, long titles are correctly rendered and truncated, making them selectable without glitches.

See this screenshot and compare it with the video on the linked issue.

<img width="699" height="525" alt="Screenshot 2026-03-29 at 10 36 06" src="https://github.com/user-attachments/assets/afb4be50-0869-42d6-9d29-0b12ae9237cc" />

**Linked Issue:** Fixes #240 

**⚠️ Important:** given all of the above, though I'm quite confident in what the PR does, I'd love it if an Angular expert could review it in depth and suggest any ways in which it could be handled better.

## Changes

* Measure the actual rendered pixel width of the autocomplete wrapper div
* Use the calculated measure to style the component, overriding the PrimeNG default styles
* Add CSS attributes to ensure long titles are truncated with ellipses if they overflow

There are some formatting fixes included too, as my IDE applies them by default. Please let me know if you'd rather me submit an updated version without them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text overflow in book suggestion lists by enforcing single-line truncation for titles, authors, and formats.
  * Improved autocomplete panel width to properly align with the input field, preventing layout misalignment.

* **Style**
  * Enhanced visual presentation of book suggestion items with improved text handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->