### PR TITLE
fix(api): update sidecar generatedBy field to grimmory

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/sidecar/SidecarMetadata.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/sidecar/SidecarMetadata.java
@@ -18,7 +18,7 @@ public class SidecarMetadata {
     private String version = "1.0";
     private Instant generatedAt;
     @Builder.Default
-    private String generatedBy = "booklore";
+    private String generatedBy = "grimmory";
     private SidecarBookMetadata metadata;
     private SidecarCoverInfo cover;
 }

--- a/booklore-api/src/main/java/org/booklore/service/metadata/sidecar/SidecarMetadataMapper.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/sidecar/SidecarMetadataMapper.java
@@ -58,7 +58,7 @@ public class SidecarMetadataMapper {
         return SidecarMetadata.builder()
                 .version("1.0")
                 .generatedAt(Instant.now())
-                .generatedBy("booklore")
+                .generatedBy("grimmory")
                 .metadata(bookMetadata)
                 .cover(coverInfo)
                 .build();


### PR DESCRIPTION
## Description
Fixes issue where exported sidecar JSON files incorrectly identified their generator as 'booklore' instead of 'grimmory'.

**Linked Issue:** Fixes #282 

## Changes
- Changed `generatedBy` default value
- Changed hardcoded builder value

## Output
```json
{      
  "version": "1.0",      
  "generatedAt": "2026-03-30T19:25:55.931603275Z",      
  "generatedBy": "grimmory",      
  "metadata": {      
    "title": "The Project Gutenberg eBook #29785: First Course in the Theory of Equations",      
    "authors": [      
      "Leonard Eugene Dickson"      
    ],      
    "publishedDate": "2009-08-25",      
    "pageCount": 207,      
    "categories": [      
      "Peter Vachuska",      
      "Andrew D. Hwang",      
      "Dave Morgan",      
      "Project Gutenberg Online Distributed Proofreading Team"      
    ],      
    "moods": [],      
    "tags": [],      
    "identifiers": {},      
    "ratings": {}      
  }      
}      
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the system identifier in generated sidecar metadata from "booklore" to "grimmory".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->