### PR TITLE
fix(api): merge processFile() transactions with calling transactions

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/AbstractFileProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/AbstractFileProcessor.java
@@ -53,7 +53,7 @@ public abstract class AbstractFileProcessor implements BookFileProcessor {
         this.sidecarMetadataWriter = sidecarMetadataWriter;
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.REQUIRED)
     @Override
     public FileProcessResult processFile(LibraryFile libraryFile) {
         Path path = libraryFile.getFullPath();


### PR DESCRIPTION
## Description

If processFile was called within an ongoing transaction, it would previously have generated a new transaction, which could leave the database in a state inconsistent with the prior transaction's expectations, causing errors and database corruption. This fixes that so that transactions are merged at the cost of errors propagating upwards. If processFile() throws an uncaught error, it taints the entire transaction and causes a rollback of the entire transaction.

**Linked Issue:** Fixes #261

## Changes

- swaps propagation mode to REQUIRED to merge transactions so that multiple transactions do not modify the same book at the same time and conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file processing to better handle concurrent operations and ensure data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->