### PR TITLE
feat(api-docs): reintroduce API doc generation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,8 @@ Create a dev config at `booklore-api/src/main/resources/application-dev.yml`:
 app:
   path-book: '/path/to/booklore-data/books'
   path-config: '/path/to/booklore-data/config'
+  api-docs:
+    enabled: true
 
 spring:
   datasource:
@@ -208,6 +210,14 @@ just ui dev
 ```
 
 The UI will be available at http://localhost:4200 with hot-reload enabled.
+
+---
+
+## API Reference Docs
+
+When enabled, API documentation is available as both an `openapi.json` and as publicly accessible docs. The endpoints are:
+- Scalar UI is available at `http://localhost:6060/api/docs`
+- OpenAPI JSON is available at `http://localhost:6060/api/openapi.json`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ DATABASE_URL=jdbc:mariadb://mariadb:3306/grimmory
 DB_USER=grimmory
 DB_PASSWORD=ChangeMe_Grimmory_2025!
 
+# Optional: enable API docs + export OpenAPI JSON (defaults to false)
+API_DOCS_ENABLED=false
+
 # Storage: LOCAL (default) or NETWORK (disables file operations; see Network Storage section)
 DISK_TYPE=LOCAL
 
@@ -117,6 +120,7 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - DATABASE_USERNAME=${DB_USER}
       - DATABASE_PASSWORD=${DB_PASSWORD}
+      - API_DOCS_ENABLED=${API_DOCS_ENABLED}
     depends_on:
       mariadb:
         condition: service_healthy
@@ -191,6 +195,14 @@ just test          # Run backend and frontend tests
 just api test      # Run backend tests only
 just ui dev        # Start the frontend dev server
 ```
+
+---
+
+## API Reference Docs
+
+When enabled, API reference documentation is available as both an `openapi.json` and as publicly accessible docs. The endpoints are:
+- API reference docs are available at `http://localhost:6060/api/docs`
+- OpenAPI JSON is available at `http://localhost:6060/api/openapi.json`
 
 ---
 

--- a/booklore-api/CONTRIBUTING.md
+++ b/booklore-api/CONTRIBUTING.md
@@ -24,6 +24,15 @@ just api run
 just api check
 ```
 
+## API Docs (`API_DOCS_ENABLED`)
+
+- `application.yaml` binds `app.api-docs.enabled` to `API_DOCS_ENABLED` (default `false`).
+- `application.yaml` binds `springdoc.api-docs.enabled` to `app.api-docs.enabled`.
+- `application-dev.yml` enables docs for local dev profile runs by default.
+- For runtime/container profiles, set `API_DOCS_ENABLED=true` to expose:
+  - `/api/openapi.json`
+  - `/api/docs`
+
 ## Backend Conventions
 
 - Use Spring Data JPA repository methods or JPQL. Do not introduce native queries unless a maintainer has explicitly approved them.

--- a/booklore-api/build.gradle.kts
+++ b/booklore-api/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")
 
     // --- API Documentation ---
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:3.0.2")
     implementation("org.apache.commons:commons-compress:1.28.0")
     implementation("org.tukaani:xz:1.12") // Required by commons-compress for 7z support
     implementation("org.apache.commons:commons-text:1.15.0")

--- a/booklore-api/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/booklore-api/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
     private static final String[] COMMON_PUBLIC_ENDPOINTS = {
             "/ws/**",                  // WebSocket connections (auth handled in WebSocketAuthInterceptor)
             "/kobo/**",                // Kobo API requests (auth handled in KoboAuthFilter)
+            "/api/docs",               // API documentation UI
+            "/api/openapi.json",       // OpenAPI spec (used by API documentation UI)
             "/api/v1/auth/**",         // Login and token refresh endpoints (must remain public)
             "/api/v1/public-settings", // Public endpoint for checking OIDC or other app settings
             "/api/v1/setup/**",        // Setup wizard endpoints (must remain accessible before initial setup)

--- a/booklore-api/src/main/java/org/booklore/controller/ScalarController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/ScalarController.java
@@ -1,0 +1,15 @@
+package org.booklore.controller;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@ConditionalOnProperty(name = "app.api-docs.enabled", havingValue = "true", matchIfMissing = false)
+public class ScalarController {
+
+    @GetMapping("/api/docs")
+    public String scalar() {
+        return "forward:/scalar.html";
+    }
+}

--- a/booklore-api/src/main/resources/application.yaml
+++ b/booklore-api/src/main/resources/application.yaml
@@ -2,6 +2,8 @@ app:
   path-config: '/app/data'
   bookdrop-folder: '/bookdrop'
   version: ${APP_VERSION:development}
+  api-docs:
+    enabled: ${API_DOCS_ENABLED:false}
 
   cors:
     # Comma-separated list of allowed CORS origins.
@@ -93,9 +95,8 @@ spring:
 
 springdoc:
   api-docs:
-    enabled: false
-  swagger-ui:
-    enabled: false
+    enabled: ${app.api-docs.enabled:false}
+    path: /api/openapi.json
 
 logging:
   level:

--- a/booklore-api/src/main/resources/static/scalar.html
+++ b/booklore-api/src/main/resources/static/scalar.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Grimmory API Reference</title>
+  <meta charset="UTF-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1"
+  />
+</head>
+<body>
+  <script
+    id="api-reference"
+    data-url="/api/openapi.json"
+    data-configuration='{"theme":"default","hideDownloadButton":false,"telemetry":false}'
+  ></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.49.7/dist/browser/standalone.js"></script>
+</body>
+</html>

--- a/booklore-api/src/test/java/org/booklore/controller/ScalarControllerTest.java
+++ b/booklore-api/src/test/java/org/booklore/controller/ScalarControllerTest.java
@@ -1,0 +1,30 @@
+package org.booklore.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScalarControllerTest {
+
+    private final ScalarController controller = new ScalarController();
+
+    @Test
+    void shouldForwardToStaticScalarPage() {
+        assertThat(controller.scalar()).isEqualTo("forward:/scalar.html");
+    }
+
+    @Test
+    void staticScalarPageShouldDisableTelemetryAndPointToApiDocs() throws IOException {
+        String html = StreamUtils.copyToString(
+                new ClassPathResource("static/scalar.html").getInputStream(),
+                StandardCharsets.UTF_8
+        );
+        assertThat(html).contains("data-url=\"/api/openapi.json\"");
+        assertThat(html).contains("\"telemetry\":false");
+    }
+}


### PR DESCRIPTION
## Description

This PR reintroduces API reference documentation. It does so by introducing a new env variable, `API_DOCS_ENABLED` (default `false`).

When enabled, docs are available publicly at `.../api/docs`, and the JSON spec at `.../api/openapi.json`.

**Linked Issue:** https://github.com/grimmory-tools/grimmory/issues/288

## Changes

- Populates `app.api-docs.enabled` the value of a new env var, `API_DOCS_ENABLED`, or defaults to false
- Populates `springdoc.api-docs.enabled` to use the value of `app.api-docs.enabled`
  - Exports the OpenAPI json to `/api/openapi.json`
- Adds a new `ScalarController` to server Scalar API docs via `/api/docs` (if enabled) using the generated OpenAPI json
  - Includes a new test for the controller
- Adds the routes `/api/openapi.json` and `"/api/docs` to the common public routes list in `SecurityConfig`
- Updates readme/contributor docs w/ new env var + API reference doc access details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API docs UI available at /api/docs and OpenAPI JSON at /api/openapi.json (can be enabled via env flag)

* **Documentation**
  * Added guidance and examples for enabling API docs; updated dev and Docker Compose examples to include the API_DOCS_ENABLED flag and local access URLs

* **Tests**
  * Added tests validating the docs endpoint behavior and static docs page configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->