### PR TITLE
fix(file): deduplicate book files and protect source library root in FileMoveService

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/file/FileMoveService.java
+++ b/booklore-api/src/main/java/org/booklore/service/file/FileMoveService.java
@@ -10,6 +10,7 @@ import org.booklore.model.dto.FileMoveResult;
 import org.booklore.model.dto.Library;
 import org.booklore.model.dto.request.FileMoveRequest;
 import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.LibraryEntity;
 import org.booklore.model.entity.LibraryPathEntity;
 import org.booklore.model.websocket.Topic;
@@ -124,6 +125,8 @@ public class FileMoveService {
                 return;
             }
 
+            List<BookFileEntity> bookFiles = bookEntity.getBookFiles().stream().distinct().toList();
+
             Path currentPrimaryFilePath = bookEntity.getFullFilePath();
             String pattern = fileMoveHelper.getFileNamingPattern(targetLibrary);
             Path newFilePath = fileMoveHelper.generateNewFilePath(bookEntity, libraryPathEntity, pattern);
@@ -141,7 +144,7 @@ public class FileMoveService {
             }
 
             // Validate all source paths exist before attempting moves
-            for (var bookFile : bookEntity.getBookFiles()) {
+            for (var bookFile : bookFiles) {
                 Path sourcePath = bookFile.getFullFilePath();
                 if (!fileMoveHelper.validateSourceExists(sourcePath, bookFile.isFolderBased())) {
                     log.warn("Source {} not found: bookId={}, path={}",
@@ -150,7 +153,7 @@ public class FileMoveService {
                 }
             }
 
-            for (var bookFile : bookEntity.getBookFiles()) {
+            for (var bookFile : bookFiles) {
                 Path sourcePath = bookFile.getFullFilePath();
                 Path targetPath;
                 if (bookFile.isBook()) {
@@ -186,7 +189,7 @@ public class FileMoveService {
             // Only update database after all file commits succeed
             try {
                 transactionTemplate.executeWithoutResult(status -> {
-                    for (var bookFile : bookEntity.getBookFiles()) {
+                    for (var bookFile : bookFiles) {
                         String newFileName;
                         if (bookFile.isBook()) {
                             Path targetPath = fileMoveHelper.generateNewFilePath(bookEntity, bookFile, libraryPathEntity, pattern);
@@ -216,8 +219,10 @@ public class FileMoveService {
                     .map(Paths::get)
                     .map(Path::toAbsolutePath)
                     .map(Path::normalize)
-                    .collect(Collectors.toSet());
-            
+                    .collect(Collectors.toCollection(HashSet::new));
+            // Also protect the source library root so cleanup doesn't traverse above it
+            libraryRoots.add(Paths.get(bookEntity.getLibraryPath().getPath()).toAbsolutePath().normalize());
+
             for (Path sourceParent : sourceParentsToCleanup) {
                 fileMoveHelper.deleteEmptyParentDirsUpToLibraryFolders(sourceParent, libraryRoots);
             }
@@ -274,6 +279,8 @@ public class FileMoveService {
                 return FileMoveResult.builder().moved(false).build();
             }
 
+            List<BookFileEntity> bookFiles = bookWithFiles.getBookFiles().stream().distinct().toList();
+
             String pattern = fileMoveHelper.getFileNamingPattern(bookWithFiles.getLibraryPath().getLibrary());
             Path currentPrimaryFilePath = bookWithFiles.getFullFilePath();
             Path expectedPrimaryFilePath = fileMoveHelper.generateNewFilePath(bookWithFiles, bookWithFiles.getLibraryPath(), pattern);
@@ -293,7 +300,7 @@ public class FileMoveService {
             }
 
             // Validate all source paths exist before attempting moves
-            for (var bookFile : bookWithFiles.getBookFiles()) {
+            for (var bookFile : bookFiles) {
                 Path sourcePath = bookFile.getFullFilePath();
                 if (!fileMoveHelper.validateSourceExists(sourcePath, bookFile.isFolderBased())) {
                     log.warn("Source {} not found: bookId={}, path={}",
@@ -309,7 +316,7 @@ public class FileMoveService {
             }
 
             // Stage all files to temp locations
-            for (var bookFile : bookWithFiles.getBookFiles()) {
+            for (var bookFile : bookFiles) {
                 Path sourcePath = bookFile.getFullFilePath();
                 Path targetPath;
                 if (bookFile.isBook()) {
@@ -346,7 +353,7 @@ public class FileMoveService {
             BookEntity finalBookWithFiles = bookWithFiles;
             try {
                 transactionTemplate.executeWithoutResult(status -> {
-                    for (var bookFile : finalBookWithFiles.getBookFiles()) {
+                    for (var bookFile : bookFiles) {
                         String newFileName;
                         if (bookFile.isBook()) {
                             Path targetPath = fileMoveHelper.generateNewFilePath(finalBookWithFiles, bookFile, finalBookWithFiles.getLibraryPath(), pattern);
@@ -375,8 +382,10 @@ public class FileMoveService {
                     .map(Paths::get)
                     .map(Path::toAbsolutePath)
                     .map(Path::normalize)
-                    .collect(Collectors.toSet());
-            
+                    .collect(Collectors.toCollection(HashSet::new));
+            // Also protect the source library root so cleanup doesn't traverse above it
+            libraryRoots.add(Paths.get(bookWithFiles.getLibraryPath().getPath()).toAbsolutePath().normalize());
+
             for (Path sourceParent : sourceParentsToCleanup) {
                 fileMoveHelper.deleteEmptyParentDirsUpToLibraryFolders(sourceParent, libraryRoots);
             }


### PR DESCRIPTION
Fixes #293

Changes
FileMoveService

Two bugs fixed in both processSingleMove and moveBookToMatchLibraryPattern:

Duplicate BookFileEntity entries — getBookFiles() can return duplicates from the Hibernate lazy collection. Added .stream().distinct().toList() before iterating, so validation, staging, commit, and DB update loops each see each file exactly once.

libraryRoots missing source library — libraryRoots was built only from the target library's paths. On a cross-library move the source library root was absent, giving deleteEmptyParentDirsUpToLibraryFolders no stop boundary on the source side. Fixed by adding the source library path to the set before cleanup.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file move operations to correctly handle duplicate files through deduplication during validation, staging, and database updates.
  * Enhanced directory cleanup safety to prevent accidental deletion of directories outside the source library by strengthening protected path verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->