### PR TITLE
fix(webmvc): avoid index fallback exception for missing public routes

### DIFF
--- a/booklore-api/src/main/java/org/booklore/config/WebMvcConfig.java
+++ b/booklore-api/src/main/java/org/booklore/config/WebMvcConfig.java
@@ -42,9 +42,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
                     @Override
                     protected Resource getResource(String resourcePath, Resource location) throws IOException {
                         Resource resource = location.createRelative(resourcePath);
-                        return resource.exists() && resource.isReadable()
-                                ? resource
-                                : new ClassPathResource("/static/index.html");
+                        if (resource.exists() && resource.isReadable()) {
+                            return resource;
+                        }
+
+                        Resource index = new ClassPathResource("/static/index.html");
+                        return index.exists() && index.isReadable() ? index : null;
                     }
                 });
     }


### PR DESCRIPTION
## Description

Fixes backend only error handling for unresolved public routes that were falling into static index fallback behaviour, and producing `FileNotFoundException`/500 log paths when `app://-/index.html` is not present. This occurs because `WebMvcConfig` is expecting `index.html` to exist all of the time, when it only exists when the frontend is bundled with the backend. As a result, this could cause 500s on local backend only runs.

This change makes unresolved requests return normal API/web behavior (404/403 as appropriate) instead of attempting to resolve a missing SPA index resource.

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/297

## Changes

- Updated WebMvcConfig static resource fallback behaviour to avoid attempting to resolve a non-existent `index.html`
- Ensures that unresolved backend/API requests fall through cleanly, rather than triggering classpath lookup exceptions
- Preserves normal static resource serving when files are present.
- Verified the system behaviiour both pre- and post- fix, on both a backend only run and and a full build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced static resource handling with improved validation checks to ensure resources exist and are readable before being served. The application now properly manages edge cases where resources may be unavailable or unreadable, preventing potential serving errors and improving reliability for single-page applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->