### PR TITLE
fix(api): stop using `CBXReaderService.streamEntryFromArchive`

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/reader/CbxReaderService.java
+++ b/booklore-api/src/main/java/org/booklore/service/reader/CbxReaderService.java
@@ -112,7 +112,7 @@ public class CbxReaderService {
             List<CbxPageDimension> dimensions = new ArrayList<>();
             for (int i = 0; i < imageEntries.size(); i++) {
                 String entryName = imageEntries.get(i);
-                CbxPageDimension dim = readEntryDimension(cbxPath, entryName, metadata, i + 1);
+                CbxPageDimension dim = readEntryDimension(cbxPath, entryName, i + 1);
                 dimensions.add(dim);
             }
             return dimensions;
@@ -122,10 +122,10 @@ public class CbxReaderService {
         }
     }
 
-    private CbxPageDimension readEntryDimension(Path cbxPath, String entryName, CachedArchiveMetadata metadata, int pageNumber) {
+    private CbxPageDimension readEntryDimension(Path cbxPath, String entryName, int pageNumber) {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            streamEntryFromArchive(cbxPath, entryName, baos, metadata);
+            archiveService.transferEntryTo(cbxPath, entryName, baos);
             byte[] imageBytes = baos.toByteArray();
             try (ImageInputStream iis = ImageIO.createImageInputStream(new ByteArrayInputStream(imageBytes))) {
                 Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

the `streamEntryFromArchive` helper was replaced with `ArchiveService.transferEntryTo` and during the merge of #113 we had a conflict that was automatically resolved incorrectly

this replaces the erroneous call with the expected to fix the build

**Linked Issue:** Related to #29

## Changes

use `ArchiveService.transferEntryTo` instead of `streamEntryFromArchive` in `CBXReaderService`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of comic book archive file access in the CBX reader service. The mechanism for retrieving page dimension data has been streamlined to use more efficient archive entry access methods, reducing code complexity without affecting user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->