### PR TITLE
chore(ui): enforce placeholder aspect ratios

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.scss
@@ -60,7 +60,7 @@
 
 .tooltip-cover-image {
   width: 40rem;
-  height: auto;
+  aspect-ratio: 5 / 7;
 }
 
 .tooltip-cover-title {

--- a/frontend/src/app/features/book/components/book-card-lite/book-card-lite-component.scss
+++ b/frontend/src/app/features/book/components/book-card-lite/book-card-lite-component.scss
@@ -7,6 +7,7 @@
   .book-cover {
     width: 100%;
     aspect-ratio: 5 / 7;
+    object-fit: cover;
     display: block;
     border-radius: 0.5rem;
   }

--- a/frontend/src/app/features/book/components/book-card-lite/book-card-lite-component.scss
+++ b/frontend/src/app/features/book/components/book-card-lite/book-card-lite-component.scss
@@ -6,6 +6,7 @@
 
   .book-cover {
     width: 100%;
+    aspect-ratio: 5 / 7;
     display: block;
     border-radius: 0.5rem;
   }

--- a/frontend/src/app/shared/components/cover-generator/cover-generator.component.ts
+++ b/frontend/src/app/shared/components/cover-generator/cover-generator.component.ts
@@ -51,6 +51,7 @@ export type CoverPlaceholderSize = 'sm' | 'md' | 'lg';
       align-items: center;
       justify-content: center;
       text-align: center;
+      border-radius: inherit;
     }
 
     .placeholder.size-sm { padding: 0.5rem; }


### PR DESCRIPTION
## Description

I noticed a couple areas in the UI (E.g. book details similar books) that weren't correctly enforcing the correct aspect ratio or rounded corners for the new CSS placeholders. 

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes
- Enforced aspect ratios in the book lite cards
- Enforced the placeholder border radius to be inherited by the cards themselves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized book cover visuals by enforcing a consistent 5:7 aspect ratio for cover images in tooltips and card views, improving layout uniformity.
  * Ensured cover images use cropping behavior that preserves focal content for varied image sizes.
  * Enhanced placeholder styling so placeholders inherit parent border-radius, producing smoother corners and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->