### PR TITLE
refactor(config): update configuration to use property setters for association management and lazy initialization

### DIFF
--- a/booklore-api/build.gradle.kts
+++ b/booklore-api/build.gradle.kts
@@ -133,8 +133,8 @@ dependencies {
 
 hibernate {
     enhancement {
-        enableAssociationManagement = false
-        enableLazyInitialization = true
+        enableAssociationManagement.set(false)
+        enableLazyInitialization.set(true)
     }
 }
 


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes
Resolve the following warnings:

```
backend-1   | w: file:///booklore-api/build.gradle.kts:141:9: 'val enableAssociationManagement: Property<Boolean>!' is deprecated. Deprecated in Java.
backend-1   | w: file:///booklore-api/build.gradle.kts:142:9: 'val enableLazyInitialization: Property<Boolean>!' is deprecated. Deprecated in Java.
```

not a functional change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for Hibernate enhancement settings to use Gradle property API, improving build script consistency.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->