### PR TITLE
fix(api): use ASIN when specified for retrieving Amazon / Audible metadata

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 @Service
 @AllArgsConstructor
 public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
-
+    private static final Pattern ASIN_PATTERN = Pattern.compile("([A-Z0-9]{10})");
     private static final Pattern TRAILING_BR_TAGS_PATTERN = Pattern.compile("(\\s*<br\\s*/?>\\s*)+$");
     private static final Pattern LEADING_BR_TAGS_PATTERN = Pattern.compile("^(\\s*<br\\s*/?>\\s*)+");
     private static final Pattern MULTIPLE_BR_TAGS_PATTERN = Pattern.compile("(<br\\s*/?>\\s*){3,}");
@@ -51,7 +51,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     private static final Pattern SERIES_FORMAT_PATTERN = Pattern.compile("Book (\\d+(?:\\.\\d+)?) of (\\d+)");
     private static final Pattern PARENTHESES_WITH_WHITESPACE_PATTERN = Pattern.compile("\\s*\\(.*?\\)");
     private static final Pattern NON_ALPHANUMERIC_PATTERN = Pattern.compile("[^\\p{L}\\p{M}0-9]");
-    private static final Pattern DP_SEPARATOR_PATTERN = Pattern.compile("/dp/");
+    private static final Pattern ASIN_PATH_PATTERN = Pattern.compile("/dp/([A-Z0-9]{10})");
     private static final Pattern REVIEWED_IN_ON_PATTERN = Pattern.compile("(?i)(?:Reviewed in|Rezension aus|Beoordeeld in|Recensie uit|Commenté en|Recensito in|Revisado en)\\s+(.+?)\\s+(?:on|vom|op|le|il|el)\\s+(.+)");
     private static final Pattern JAPANESE_REVIEW_DATE_PATTERN = Pattern.compile("(\\d{4}年\\d{1,2}月\\d{1,2}日).+");
     private static final String[] TITLE_SELECTORS = {"#productTitle", "#ebooksProductTitle", "h1#title", "span#productTitle"};
@@ -96,17 +96,17 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     @Override
     public BookMetadata fetchTopMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
-        LinkedList<String> amazonBookIds = getAmazonBookIds(book, fetchMetadataRequest);
-        if (amazonBookIds == null || amazonBookIds.isEmpty()) {
+        String amazonBookId = getTopAmazonBookId(book, fetchMetadataRequest);
+        if (amazonBookId == null) {
             return null;
         }
-        return getBookMetadata(amazonBookIds.getFirst());
+        return getBookMetadata(amazonBookId);
     }
 
     @Override
     public List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
-        LinkedList<String> amazonBookIds = getAmazonBookIds(book, fetchMetadataRequest);
-        if (amazonBookIds == null || amazonBookIds.isEmpty()) {
+        List<String> amazonBookIds = getAmazonBookIds(book, fetchMetadataRequest);
+        if (amazonBookIds.isEmpty()) {
             return Collections.emptyList();
         }
         List<BookMetadata> results = new ArrayList<>();
@@ -134,11 +134,47 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         return getBookMetadata(asin);
     }
 
-    private LinkedList<String> getAmazonBookIds(Book book, FetchMetadataRequest request) {
+    private String getExistingAsin(Book book) {
+        if (book == null) {
+            return null;
+        }
+
+        BookMetadata metadata = book.getMetadata();
+        if (metadata == null) {
+            return null;
+        }
+        String asin = metadata.getAsin();
+        if (asin == null) {
+            return null;
+        }
+
+        Matcher matcher = AmazonBookParser.ASIN_PATTERN.matcher(asin);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        return matcher.group(1);
+    }
+
+    private String getTopAmazonBookId(Book book, FetchMetadataRequest request) {
+        String storedBookId = getExistingAsin(book);
+        if (storedBookId != null) {
+            return storedBookId;
+        }
+
+        List<String> amazonBookIds = getAmazonBookIds(book, request);
+        if (!amazonBookIds.isEmpty() && !amazonBookIds.getFirst().isEmpty()) {
+            return amazonBookIds.getFirst();
+        }
+
+        return null;
+    }
+
+    private List<String> getAmazonBookIds(Book book, FetchMetadataRequest request) {
         String queryUrl = buildQueryUrl(request, book);
         if (queryUrl == null) {
             log.error("Query URL is null, cannot proceed.");
-            return null;
+            return Collections.emptyList();
         }
         LinkedList<String> bookIds = new LinkedList<>();
         try {
@@ -146,7 +182,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
             Element searchResults = doc.select("span[data-component-type=s-search-results]").first();
             if (searchResults == null) {
                 log.error("No search results found for query: {}", queryUrl);
-                return null;
+                return Collections.emptyList();
             }
             Elements items = searchResults.select("div[role=listitem][data-index]");
             if (items.isEmpty()) {
@@ -174,12 +210,16 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                         log.debug("Skipping box set item (matched filtered phrase) in title: {}", extractAmazonBookId(item));
                         continue;
                     }
-                    bookIds.add(extractAmazonBookId(item));
+                    String bookId = extractAmazonBookId(item);
+                    if (bookId == null || bookIds.contains(bookId)) {
+                        continue;
+                    }
+                    bookIds.add(bookId);
                 }
             }
         } catch (AmazonAntiScrapingException e) {
             log.debug("Aborting Amazon search due to anti-scraping (503).");
-            return null;
+            return Collections.emptyList();
         } catch (Exception e) {
             log.error("Failed to get asin: {}", e.getMessage(), e);
         }
@@ -196,18 +236,26 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                 break;
             }
         }
+
         if (bookLink != null) {
             return extractAsinFromUrl(bookLink);
-        } else {
-            return item.attr("data-asin");
         }
+
+        String dataAsin = item.attr("data-asin");
+        if (ASIN_PATTERN.matcher(dataAsin).matches()) {
+            return dataAsin;
+        }
+
+        return null;
     }
 
     private String extractAsinFromUrl(String url) {
-        String[] parts = DP_SEPARATOR_PATTERN.split(url);
-        if (parts.length > 1) {
-            String[] asinParts = parts[1].split("/");
-            return asinParts[0];
+        Matcher matcher = ASIN_PATH_PATTERN.matcher(url);
+        if (matcher.find()) {
+            String asin = matcher.group(1);
+            if (asin != null && !asin.isEmpty()) {
+                return asin;
+            }
         }
         return null;
     }

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
@@ -41,7 +41,8 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
     private static final String DEFAULT_DOMAIN = "com";
 
     private static final Pattern NON_ALPHANUMERIC_PATTERN = Pattern.compile("[^\\p{L}\\p{M}0-9]");
-    private static final Pattern ASIN_PATTERN = Pattern.compile("/pd/[^/]+/([A-Z0-9]{10})");
+    private static final Pattern ASIN_PATTERN = Pattern.compile("([A-Z0-9]{10})");
+    private static final Pattern ASIN_PATH_PATTERN = Pattern.compile("/pd/[^/]+/([A-Z0-9]{10})");
     private static final Pattern SERIES_BOOK_PATTERN = Pattern.compile(",?\\s*Book\\s*(\\d+(?:\\.\\d+)?)$");
 
     private static final Map<String, LocaleInfo> DOMAIN_LOCALE_MAP = Map.ofEntries(
@@ -67,17 +68,17 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
 
     @Override
     public BookMetadata fetchTopMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
-        List<String> audibleIds = getAudibleIds(book, fetchMetadataRequest);
-        if (audibleIds == null || audibleIds.isEmpty()) {
+        String audibleId = getTopAudibleId(book, fetchMetadataRequest);
+        if (audibleId == null || audibleId.isEmpty()) {
             return null;
         }
-        return getBookMetadata(audibleIds.getFirst());
+        return getBookMetadata(audibleId);
     }
 
     @Override
     public List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
         List<String> audibleIds = getAudibleIds(book, fetchMetadataRequest);
-        if (audibleIds == null || audibleIds.isEmpty()) {
+        if (audibleIds.isEmpty()) {
             return Collections.emptyList();
         }
         List<BookMetadata> results = new ArrayList<>();
@@ -105,11 +106,47 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
         return getBookMetadata(audibleId);
     }
 
+    private String getExistingAsin(Book book) {
+        if (book == null) {
+            return null;
+        }
+
+        BookMetadata metadata = book.getMetadata();
+        if (metadata == null) {
+            return null;
+        }
+        String asin = metadata.getAsin();
+        if (asin == null) {
+            return null;
+        }
+
+        Matcher matcher = AudibleParser.ASIN_PATTERN.matcher(asin);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        return matcher.group(1);
+    }
+
+    private String getTopAudibleId(Book book, FetchMetadataRequest request) {
+        String storedBookId = getExistingAsin(book);
+        if (storedBookId != null) {
+            return storedBookId;
+        }
+
+        List<String> bookIds = getAudibleIds(book, request);
+        if (!bookIds.isEmpty() && !bookIds.getFirst().isEmpty()) {
+            return bookIds.getFirst();
+        }
+
+        return null;
+    }
+
     private List<String> getAudibleIds(Book book, FetchMetadataRequest request) {
         String queryUrl = buildQueryUrl(request, book);
         if (queryUrl == null) {
             log.error("Query URL is null, cannot proceed with Audible search.");
-            return null;
+            return Collections.emptyList();
         }
 
         List<String> bookIds = new ArrayList<>();
@@ -120,10 +157,10 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
             Elements allLinks = doc.select("a[href*='/pd/']");
             for (Element link : allLinks) {
                 String href = link.attr("href");
-                Matcher matcher = ASIN_PATTERN.matcher(href);
+                Matcher matcher = ASIN_PATH_PATTERN.matcher(href);
                 if (matcher.find()) {
                     String asin = matcher.group(1);
-                    if (!bookIds.contains(asin)) {
+                    if (asin != null && !asin.isEmpty() && !bookIds.contains(asin)) {
                         bookIds.add(asin);
                     }
                 }

--- a/booklore-api/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -1,0 +1,195 @@
+package org.booklore.service.metadata.parser;
+
+
+import org.booklore.model.dto.Book;
+import org.booklore.model.dto.BookMetadata;
+import org.booklore.model.dto.request.FetchMetadataRequest;
+import org.booklore.model.dto.settings.AppSettings;
+import org.booklore.model.dto.settings.MetadataProviderSettings;
+import org.booklore.model.dto.settings.MetadataPublicReviewsSettings;
+import org.booklore.service.appsettings.AppSettingService;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AmazonBookParserTest {
+    @Mock private AppSettingService mockAppSettingService;
+
+    @InjectMocks
+    private AmazonBookParser amazonBookParser;
+
+    private MockedStatic<Jsoup> mockJsoup;
+
+    private AppSettings getAppSettings(String domain) {
+        MetadataProviderSettings.Amazon amazonSettings = new MetadataProviderSettings.Amazon();
+        amazonSettings.setEnabled(true);
+        amazonSettings.setDomain(domain);
+
+        MetadataProviderSettings metadataProviderSettings = new MetadataProviderSettings();
+        metadataProviderSettings.setAmazon(amazonSettings);
+
+        MetadataPublicReviewsSettings publicReviewsSettings = MetadataPublicReviewsSettings.builder()
+                .providers(Collections.emptySet())
+                .build();
+
+        return AppSettings
+                .builder()
+                .metadataPublicReviewsSettings(publicReviewsSettings)
+                .metadataProviderSettings(metadataProviderSettings)
+                .build();
+    }
+
+    private Book getBook(String asin) {
+        BookMetadata bookMetadata = BookMetadata.builder()
+                .asin(asin)
+                .build();
+
+        return Book.builder()
+                .title("Example")
+                .metadata(bookMetadata)
+                .build();
+    }
+
+    private Connection getConnection(Document document) throws IOException {
+        Connection mockConnection = mock(Connection.class);
+
+        Connection.Response mockResponse = mock(Connection.Response.class);
+
+        when(mockConnection.header(any(String.class), any(String.class))).thenReturn(mockConnection);
+        when(mockConnection.method(any(Connection.Method.class))).thenReturn(mockConnection);
+        when(mockConnection.execute()).thenReturn(mockResponse);
+
+        when(mockResponse.parse()).thenReturn(document);
+
+        return mockConnection;
+    }
+
+    private void mockJsoupConnect(String url, String html) throws Exception {
+        Document document = Parser.parse(html, "");
+        Connection connection = getConnection(document);
+
+        mockJsoup.when(() -> Jsoup.connect(url))
+                .thenReturn(connection);
+    }
+
+    private void mockAmazonIDSearch(String keyword) throws Exception {
+        mockJsoupConnect(
+                "https://www.amazon.com/s?k=" + keyword,
+                """
+                <html><body>
+                <span data-component-type="s-search-results">
+                <div div role="listitem" data-index>
+                    <div data-cy="title-recipe">Example</div>
+                    <a href="https://www.amazon.com/dp/SEARCHASIN">Paperback</a>
+                </div>
+                </span>
+                </body></html>
+                """
+        );
+
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings( "com"));
+
+        mockJsoup = mockStatic(Jsoup.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockJsoup.close();
+    }
+
+    @Test
+    public void fetchTopMetadata_usesAsinFromBookWhenAvailable() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_useDomain() throws Exception {
+        mockJsoupConnect("https://www.amazon.co.jp/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings( "co.jp"));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.co.jp/dp/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_removesExtraWhitespace() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+
+        Book book = getBook("  EXAMPLESKU  ");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_removesExtraCharacters() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+
+        Book book = getBook("@EXAMPLESKU!!");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_ignoresInvalidBookASINUsesLink() throws Exception {
+        mockAmazonIDSearch("Example");
+        mockJsoupConnect("https://www.amazon.com/dp/SEARCHASIN", "<html />");
+
+        // Not 10 characters, alpha-numeric.
+        Book book = getBook("bad asin");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().title("Example").build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/SEARCHASIN"));
+    }
+
+    @Test
+    public void fetchTopMetadata_ignoresMissingBookASINUsesLink() throws Exception {
+        mockAmazonIDSearch("Example");
+        mockJsoupConnect("https://www.amazon.com/dp/SEARCHASIN", "<html />");
+
+        Book book = getBook(null);
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().title("Example").build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/SEARCHASIN"));
+    }
+}

--- a/booklore-api/src/test/java/org/booklore/service/metadata/parser/AudibleParserTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/parser/AudibleParserTest.java
@@ -1,0 +1,191 @@
+package org.booklore.service.metadata.parser;
+
+
+import org.booklore.model.dto.Book;
+import org.booklore.model.dto.BookMetadata;
+import org.booklore.model.dto.request.FetchMetadataRequest;
+import org.booklore.model.dto.settings.AppSettings;
+import org.booklore.model.dto.settings.MetadataProviderSettings;
+import org.booklore.model.dto.settings.MetadataPublicReviewsSettings;
+import org.booklore.service.appsettings.AppSettingService;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AudibleParserTest {
+    @Mock private AppSettingService mockAppSettingService;
+
+    @InjectMocks
+    private AudibleParser audibleParser;
+
+    private MockedStatic<Jsoup> mockJsoup;
+
+    private AppSettings getAppSettings(String domain) {
+        MetadataProviderSettings.Audible audibleSettings = new MetadataProviderSettings.Audible();
+        audibleSettings.setEnabled(true);
+        audibleSettings.setDomain(domain);
+
+        MetadataProviderSettings metadataProviderSettings = new MetadataProviderSettings();
+        metadataProviderSettings.setAudible(audibleSettings);
+
+        MetadataPublicReviewsSettings publicReviewsSettings = MetadataPublicReviewsSettings.builder()
+                .providers(Collections.emptySet())
+                .build();
+
+        return AppSettings
+                .builder()
+                .metadataPublicReviewsSettings(publicReviewsSettings)
+                .metadataProviderSettings(metadataProviderSettings)
+                .build();
+    }
+
+    private Book getBook(String asin) {
+        BookMetadata bookMetadata = BookMetadata.builder()
+                .asin(asin)
+                .build();
+
+        return Book.builder()
+                .title("Example")
+                .metadata(bookMetadata)
+                .build();
+    }
+
+    private Connection getConnection(Document document) throws IOException {
+        Connection mockConnection = mock(Connection.class);
+
+        Connection.Response mockResponse = mock(Connection.Response.class);
+
+        when(mockConnection.header(any(String.class), any(String.class))).thenReturn(mockConnection);
+        when(mockConnection.method(any(Connection.Method.class))).thenReturn(mockConnection);
+        when(mockConnection.timeout(anyInt())).thenReturn(mockConnection);
+        when(mockConnection.execute()).thenReturn(mockResponse);
+
+        when(mockResponse.parse()).thenReturn(document);
+
+        return mockConnection;
+    }
+
+    private void mockJsoupConnect(String url, String html) throws Exception {
+        Document document = Parser.parse(html, "");
+        Connection connection = getConnection(document);
+
+        mockJsoup.when(() -> Jsoup.connect(url))
+                .thenReturn(connection);
+    }
+
+    private void mockASINSearch(String keyword) throws Exception {
+        mockJsoupConnect(
+                "https://www.audible.com/search?keywords=" + keyword,
+                """
+                <html><body>
+                <a href="https://www.audible.com/pd/something/SEARCHASIN">Example</a>
+                </body></html>
+                """
+        );
+
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings("com"));
+
+        mockJsoup = mockStatic(Jsoup.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockJsoup.close();
+    }
+
+    @Test
+    public void fetchTopMetadata_usesAsinFromBookWhenAvailable() throws Exception {
+        mockJsoupConnect("https://www.audible.com/pd/EXAMPLESKU", "<html />");
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.audible.com/pd/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_useDomain() throws Exception {
+        mockJsoupConnect("https://www.audible.co.jp/pd/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings( "co.jp"));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.audible.co.jp/pd/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_removesExtraWhitespace() throws Exception {
+        mockJsoupConnect("https://www.audible.com/pd/EXAMPLESKU", "<html />");
+
+        Book book = getBook("  EXAMPLESKU  ");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.audible.com/pd/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_removesExtraCharacters() throws Exception {
+        mockJsoupConnect("https://www.audible.com/pd/EXAMPLESKU", "<html />");
+
+        Book book = getBook("@EXAMPLESKU!!");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.audible.com/pd/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_ignoresInvalidBookASIN() throws Exception {
+        mockASINSearch("Example");
+        mockJsoupConnect("https://www.audible.com/pd/SEARCHASIN", "<html />");
+
+        // Not 10 characters, alpha-numeric.
+        Book book = getBook("bad asin");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().title("Example").build();
+
+        audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.audible.com/pd/SEARCHASIN"));
+    }
+
+    @Test
+    public void fetchTopMetadata_ignoresMissingBookASIN() throws Exception {
+        mockASINSearch("Example");
+        mockJsoupConnect("https://www.audible.com/pd/SEARCHASIN", "<html />");
+
+        Book book = getBook(null);
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().title("Example").build();
+
+        audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.audible.com/pd/SEARCHASIN"));
+    }
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Updates the `AmazonBookParser` and `AudibleParser` to use existing ASIN when fetching top metadata - to match behavior of `GoodReadsParser`

**Linked Issue:** Fixes #366 

## Changes

* updates `AmazonBookParser` to use `List` for return type of `getAmazonBookIds`
* uses the ASIN instead of searching by ISBN / title when available for `AmazonBookParser`
* uses the ASIN instead of searching by ISBN / title when available for `AusibleParser`
* adds minimal test for changes to `AmazonBookParser`
* adds minimal test for changes to `AudibleParser`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * External ID lookups now always return empty lists instead of null and pick a single top ID (preferring a validated stored ID) for metadata fetches.

* **Bug Fixes**
  * Improved ID extraction and validation to skip malformed, duplicate, or empty IDs, normalize inputs, and treat empty-result paths consistently to reduce failed lookups.

* **Tests**
  * Added tests verifying selection, sanitization, domain-aware lookups, and fallback search behavior for external-ID resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->