### PR TITLE
ci: apt update before installing libarchive

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -59,6 +59,7 @@ jobs:
       # Needed for NightCompress
       - name: Install libarchive
         run: |
+          sudo apt-get update 
           sudo apt-get install libarchive-dev --yes
 
           # Place libarchive somewhere that java looks for it.


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
For whatever reason, libarchive is not in the apt cache correctly.  This works around the issue.

**Linked Issue:** Fixes #374<!-- issue number leave empty if none -->

## Changes

Add update to test CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve test suite reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->