### PR TITLE
chore(api): fix typo on openapi doc for healthcheck

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/HealthcheckController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/HealthcheckController.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/v1/healthcheck")
-@Tag(name = "Healthcheck", description = "Endpoints for checking the healch of the application")
+@Tag(name = "Healthcheck", description = "Endpoints for checking the health of the application")
 public class HealthcheckController {
 
   @Value("${app.version}")


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

noticed typo when looking at healthcheck controller


## Changes

fixes typo on healthcheck - `s/healch/health/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the API documentation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->