### PR TITLE
docs(readme): clarify migration language in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 > [!NOTE]
-> This project is in early development. Some links (website, documentation, demo, repositories) are not yet active and will come online as infrastructure is set up.
-
-> [!NOTE]
-> Grimmory is the successor of booklore.
+> Grimmory is an independent community fork of Booklore.
 
 
 Grimmory is a self-hosted application for managing your entire book collection in one place.
@@ -93,7 +90,7 @@ MYSQL_DATABASE=grimmory
 Stable images are published from semantic-release tags on `main` as `vX.Y.Z` plus `latest`. Nightly images are built from `develop` and tagged `nightly`.
 
 > [!NOTE]
-> Upgrading from an existing Booklore container? Keep your current service name, `container_name`, database name/user, ports, and mounted volumes exactly as they are and replace only the `image:` line with `grimmory/grimmory:<tag>` or `ghcr.io/grimmory-tools/grimmory:<tag>`.
+> Migrating from an existing Booklore container? You can keep your current service name, `container_name`, database name and user, ports, and mounted volumes the same. Replace only the `image:` line with `grimmory/grimmory:<tag>` or `ghcr.io/grimmory-tools/grimmory:<tag>`.
 
 ```yaml
 services:


### PR DESCRIPTION
## Description

Updates the README migration note for existing Booklore users to make the upgrade path clearer and reduce ambiguity around the project's relationship.

## Changes

- Modified the project description to reduce ambiguity around succession/the relationship to Booklore
- Modified the migration instructions for ambiguity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project positioning to clarify the project's independent status as a community fork
  * Improved Docker migration guidance for users transitioning from Booklore installations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->