### PR TITLE
fix(file): update file type and size retrieval to use primaryFile structure

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
+++ b/booklore-api/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
@@ -771,7 +771,7 @@ public class BookRuleEvaluatorService {
             case DATE_FINISHED -> progressJoin.get("dateFinished");
             case LAST_READ_TIME -> progressJoin.get("lastReadTime");
             case PERSONAL_RATING -> progressJoin.get("personalRating");
-            case FILE_SIZE -> root.get("fileSizeKb");
+            case FILE_SIZE -> root.join("bookFiles", JoinType.LEFT).get("fileSizeKb");
             case METADATA_SCORE -> root.get("metadataMatchScore");
             case TITLE -> root.get("metadata").get("title");
             case SUBTITLE -> root.get("metadata").get("subtitle");
@@ -814,7 +814,7 @@ public class BookRuleEvaluatorService {
                 yield cb.function("GREATEST", Float.class, koreader, kobo, pdf, epub, cbx);
             }
             case FILE_TYPE -> cb.function("SUBSTRING_INDEX", String.class,
-                    root.get("fileName"), cb.literal("."), cb.literal(-1));
+                    root.join("bookFiles", JoinType.LEFT).get("fileName"), cb.literal("."), cb.literal(-1));
             default -> null;
         };
     }

--- a/frontend/src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts
+++ b/frontend/src/app/features/magic-shelf/service/book-rule-evaluator.service.spec.ts
@@ -14,11 +14,9 @@ describe('BookRuleEvaluatorService', () => {
 
   const createBook = (overrides: Partial<Book> = {}): Book => ({
     id: 1,
-    bookType: 'EPUB',
+    primaryFile: {id: 1, bookId: 1, bookType: 'EPUB', fileName: 'test.epub', filePath: '/path/to/test.epub', fileSizeKb: 1024},
     libraryId: 1,
     libraryName: 'Test Library',
-    fileName: 'test.epub',
-    filePath: '/path/to/test.epub',
     readStatus: ReadStatus.UNREAD,
     shelves: [],
     metadata: {
@@ -33,7 +31,7 @@ describe('BookRuleEvaluatorService', () => {
 
   describe('fileType filtering', () => {
     it('should filter EPUB books correctly when rule uses "epub"', () => {
-      const book = createBook({bookType: 'EPUB'});
+      const book = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'EPUB'}});
       const group: GroupRule = {
         name: 'test',
         type: 'group',
@@ -52,7 +50,7 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should filter PDF books correctly when rule uses "pdf"', () => {
-      const book = createBook({bookType: 'PDF'});
+      const book = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'PDF'}});
       const group: GroupRule = {
         name: 'test',
         type: 'group',
@@ -71,7 +69,7 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should handle CBX books correctly for cbr, cbz, and cb7 rules', () => {
-      const book = createBook({bookType: 'CBX'});
+      const book = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'CBX'}});
 
       const cbrGroup: GroupRule = {
         name: 'test',
@@ -117,7 +115,7 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should handle not_equals operator correctly', () => {
-      const epubBook = createBook({bookType: 'EPUB'});
+      const epubBook = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'EPUB'}});
       const group: GroupRule = {
         name: 'test',
         type: 'group',
@@ -134,14 +132,14 @@ describe('BookRuleEvaluatorService', () => {
       const result = service.evaluateGroup(epubBook, group);
       expect(result).toBe(true);
 
-      const pdfBook = createBook({bookType: 'PDF'});
+      const pdfBook = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'PDF'}});
       const result2 = service.evaluateGroup(pdfBook, group);
       expect(result2).toBe(false);
     });
 
     it('should filter EPUB books correctly when rule uses "not_equals" with "epub"', () => {
-      const epubBook = createBook({bookType: 'EPUB'});
-      const pdfBook = createBook({bookType: 'PDF'});
+      const epubBook = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'EPUB'}});
+      const pdfBook = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'PDF'}});
 
       const group: GroupRule = {
         name: 'test',
@@ -165,7 +163,7 @@ describe('BookRuleEvaluatorService', () => {
   describe('evaluateGroup', () => {
     it('should evaluate group rules with AND logic', () => {
       const book = createBook({
-        bookType: 'EPUB'
+        primaryFile: {id: 1, bookId: 1, bookType: 'EPUB'}
       });
 
       const group: GroupRule = {
@@ -183,7 +181,7 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should evaluate group rules with OR logic', () => {
-      const book = createBook({bookType: 'PDF'});
+      const book = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'PDF'}});
 
       const group: GroupRule = {
         name: 'test',
@@ -1177,7 +1175,7 @@ describe('BookRuleEvaluatorService', () => {
     });
 
     it('should handle includes_any with fileType mapping', () => {
-      const book = createBook({bookType: 'CBX'});
+      const book = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'CBX'}});
       expect(service.evaluateGroup(book, rule('fileType', 'includes_any', ['cbr', 'pdf']))).toBe(true);
     });
 
@@ -1189,17 +1187,17 @@ describe('BookRuleEvaluatorService', () => {
 
   describe('fileType mapping edge cases', () => {
     it('should map azw to azw3', () => {
-      const book = createBook({bookType: 'AZW3'});
+      const book = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'AZW3'}});
       expect(service.evaluateGroup(book, rule('fileType', 'equals', 'azw'))).toBe(true);
     });
 
     it('should handle MOBI bookType', () => {
-      const book = createBook({bookType: 'MOBI'});
+      const book = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'MOBI'}});
       expect(service.evaluateGroup(book, rule('fileType', 'equals', 'mobi'))).toBe(true);
     });
 
     it('should handle not_equals with fileType cbr mapping', () => {
-      const book = createBook({bookType: 'PDF'});
+      const book = createBook({primaryFile: {id: 1, bookId: 1, bookType: 'PDF'}});
       expect(service.evaluateGroup(book, rule('fileType', 'not_equals', 'cbr'))).toBe(true);
     });
   });

--- a/frontend/src/app/features/magic-shelf/service/book-rule-evaluator.service.ts
+++ b/frontend/src/app/features/magic-shelf/service/book-rule-evaluator.service.ts
@@ -71,7 +71,7 @@ export class BookRuleEvaluatorService {
         case 'readStatus':
           return [String(book.readStatus ?? 'UNSET').toLowerCase()];
         case 'fileType':
-          return [String(book['bookType'] ?? '').toLowerCase()];
+          return [String(book.primaryFile?.bookType ?? '').toLowerCase()];
         case 'library':
           return [String(book.libraryId)];
         case 'shelf':
@@ -275,9 +275,9 @@ export class BookRuleEvaluatorService {
       case 'readStatus':
         return book.readStatus ?? 'UNSET';
       case 'fileType':
-        return (book['bookType'] as string)?.toLowerCase() ?? null;
+        return (book.primaryFile?.bookType as string)?.toLowerCase() ?? null;
       case 'fileSize':
-        return book.fileSizeKb;
+        return book.primaryFile?.fileSizeKb;
       case 'metadataScore':
         return book.metadataMatchScore;
       case 'personalRating':


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes
This pull request updates how file-related attributes are accessed for books, moving from top-level fields like `bookType` and `fileSizeKb` to retrieving these values from the `primaryFile` property on the frontend and from the `bookFiles` relationship on the backend. This change improves consistency with the data model and prepares the codebase for handling books with multiple files. The test suite has also been updated to reflect these changes.

Essentially fixes filetype filters. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File type and file size filtering in book rules now correctly source from associated file data, improving the accuracy of rule-based filtering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->