### PR TITLE
fix(auth): ensure case-insensitivity on reading remote auth headers

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/AuthenticationController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AuthenticationController.java
@@ -17,11 +17,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -73,15 +73,15 @@ public class AuthenticationController {
     })
     @GetMapping("/remote")
     public ResponseEntity<Map<String, String>> loginRemote(
-            @Parameter(description = "Authentication headers") @RequestHeader Map<String, String> headers) {
+            @Parameter(description = "Authentication headers") @RequestHeader HttpHeaders headers) {
         if (!appProperties.getRemoteAuth().isEnabled()) {
             throw ApiError.REMOTE_AUTH_DISABLED.createException();
         }
 
-        String name = headers.get(appProperties.getRemoteAuth().getHeaderName().toLowerCase(Locale.ROOT));
-        String username = headers.get(appProperties.getRemoteAuth().getHeaderUser().toLowerCase(Locale.ROOT));
-        String email = headers.get(appProperties.getRemoteAuth().getHeaderEmail().toLowerCase(Locale.ROOT));
-        String groups = headers.get(appProperties.getRemoteAuth().getHeaderGroups().toLowerCase(Locale.ROOT));
+        String name = headers.getFirst(appProperties.getRemoteAuth().getHeaderName());
+        String username = headers.getFirst(appProperties.getRemoteAuth().getHeaderUser());
+        String email = headers.getFirst(appProperties.getRemoteAuth().getHeaderEmail());
+        String groups = headers.getFirst(appProperties.getRemoteAuth().getHeaderGroups());
         log.debug("Remote-Auth: header values present name: {}, username: {}, email: {}, groups: {}",
                 name != null, username != null, email != null, groups != null);
 


### PR DESCRIPTION
## Description

Ensures that Remote Auth headers read case-insensetive.

**Linked Issue:** Fixes #388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced remote authentication header processing for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->