### PR TITLE
feat(api): support `Authorization` headers on media/fonts

### DIFF
--- a/booklore-api/src/main/java/org/booklore/config/security/filter/AbstractMediaJwtFilter.java
+++ b/booklore-api/src/main/java/org/booklore/config/security/filter/AbstractMediaJwtFilter.java
@@ -19,16 +19,26 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
 @AllArgsConstructor
-public abstract class AbstractQueryParameterJwtFilter extends OncePerRequestFilter {
+public abstract class AbstractMediaJwtFilter extends OncePerRequestFilter {
 
     protected final JwtUtils jwtUtils;
     protected final UserRepository userRepository;
     protected final BookLoreUserTransformer bookLoreUserTransformer;
 
+    private String extractTokenFromHeader(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
+    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-        String token = request.getParameter("token");
+
+        String token = extractTokenFromHeader(request);
+        if (token == null) {
+            token = request.getParameter("token");
+        }
+
         if (token == null || token.isEmpty()) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Missing authentication token");
             return;

--- a/booklore-api/src/main/java/org/booklore/config/security/filter/CoverJwtFilter.java
+++ b/booklore-api/src/main/java/org/booklore/config/security/filter/CoverJwtFilter.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CoverJwtFilter extends AbstractQueryParameterJwtFilter {
+public class CoverJwtFilter extends AbstractMediaJwtFilter {
 
     public CoverJwtFilter(
             JwtUtils jwtUtils,

--- a/booklore-api/src/main/java/org/booklore/config/security/filter/CustomFontJwtFilter.java
+++ b/booklore-api/src/main/java/org/booklore/config/security/filter/CustomFontJwtFilter.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CustomFontJwtFilter extends AbstractQueryParameterJwtFilter {
+public class CustomFontJwtFilter extends AbstractMediaJwtFilter {
 
     public CustomFontJwtFilter(
             JwtUtils jwtUtils,


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
updates the `CoverJwtFilter` and `CustomFontJwtFilter` to support authorization headers alongside the existing `token` query parameters for consistency.

**Linked Issue:** Fixes #405

## Changes

* Renames `AbstractQueryParameterJwtFilter` to `AbstractMediaJwtFilter`
* Adds support for authorization headers in the `AbstractMediaJwtFilter`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * JWT authentication now supports Bearer token scheme in the Authorization header for media endpoints, following standard API authentication practices.
  * Maintains backward compatibility with query parameter-based token submission as a fallback mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->