### PR TITLE
chore(unraid): sync unraid template with README

### DIFF
--- a/unraid.xml
+++ b/unraid.xml
@@ -8,9 +8,9 @@
     <Shell>bash</Shell>
     <Privileged>false</Privileged>
     <Support>https://github.com/grimmory-tools/grimmory/issues</Support>
-    <Discord>https://discord.gg/FwqHeFWk</Discord>
+    <Discord>https://discord.gg/9YJ7HB4n8T</Discord>
     <Project>https://github.com/grimmory-tools/grimmory</Project>
-    <Overview>Grimmory is a self-hosted application for managing your entire book collection in one place. Organize, read, annotate, sync across devices, and share without relying on third-party services.</Overview>
+    <Overview>Grimmory is a self-hosted application for managing your entire book collection in one place: organize, read, annotate, sync across devices, and share without relying on third-party services.</Overview>
     <Category>MediaApp:Books MediaServer:Books</Category>
     <WebUI>http://[IP]:[PORT:6060]/</WebUI>
     <Icon>https://raw.githubusercontent.com/grimmory-tools/grimmory/main/assets/favicons/apple-touch-icon-144x144.png</Icon>
@@ -27,14 +27,15 @@
         <Screenshot>https://raw.githubusercontent.com/grimmory-tools/grimmory/main/assets/demo.gif</Screenshot>
     </Screenshots>
     <Network>bridge</Network>
-    <Requires>MariaDB is required. See additional installation instructions at the project repo: https://github.com/grimmory-tools/grimmory/issues</Requires>
+    <Requires>MariaDB is required. See setup and configuration docs: https://grimmory.org/docs/getting-started</Requires>
     <Config Name="Web UI Host Port" Target="6060" Default="6060" Mode="tcp" Description="Port for Grimmory's web interface." Type="Port" Display="always" Required="true" Mask="false">6060</Config>
     <Config Name="Config Location" Target="/app/data" Default="/mnt/user/appdata/grimmory" Mode="rw" Description="Persistent config files" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/grimmory</Config>
-    <Config Name="Book Library" Target="/data/media/books" Default="/mnt/user/data/media/books" Mode="rw" Description="Your ebook/audiobook library. This is currently set up to support hardlinks, if your server is already set to use them." Type="Path" Display="always" Required="true" Mask="false"/>
+    <Config Name="Book Library" Target="/books" Default="/mnt/user/data/media/books" Mode="rw" Description="Your ebook/audiobook library. Support hardlinks if your server is already set to use them." Type="Path" Display="always" Required="true" Mask="false"/>
     <Config Name="Book-Drop Location" Target="/bookdrop" Default="/mnt/user/data/media/bookdrop" Mode="rw" Description="Location of a watched folder where Grimmory can detect, enrich, and queue books for import automatically." Type="Path" Display="always" Required="true" Mask="false"/>
     <Config Name="DATABASE_URL" Target="DATABASE_URL" Default="jdbc:mariadb://mariadb:3306/grimmory" Mode="" Description="MariaDB Database connection URL. You must ensure the database is accessible from the container (ex: replace `mariadb` with the DB container's IP/hostname)." Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="DATABASE_USERNAME" Target="DATABASE_USERNAME" Default="grimmory" Mode="" Description="MariaDB Database username" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="DATABASE_PASSWORD" Target="DATABASE_PASSWORD" Default="ChangeMe_Grimmory_2025!" Mode="" Description="MariaDB Database password" Type="Variable" Display="always" Required="true" Mask="true"/>
+    <Config Name="API_DOCS_ENABLED" Target="API_DOCS_ENABLED" Default="false" Mode="" Description="Enable public API docs and OpenAPI JSON endpoints." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
     <Config Name="DISK_TYPE" Target="DISK_TYPE" Default="LOCAL" Mode="" Description="Storage type: LOCAL (default) or NETWORK (disables file operations for network-mounted storage)." Type="Variable" Display="advanced" Required="false" Mask="false">LOCAL</Config>
     <Config Name="ALLOWED_ORIGINS" Target="ALLOWED_ORIGINS" Default="*" Mode="" Description="Comma-separated list of allowed cross-origin URLs for CORS (e.g. https://app.example.com). Defaults to '*' (allow all) if unset. Leave empty to restrict to same-origin." Type="Variable" Display="advanced" Required="false" Mask="false">*</Config>
     <Config Name="USER_ID" Target="USER_ID" Default="99" Mode="" Description="" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>


### PR DESCRIPTION
## Description

This PR updates the Unraid template to reflect the current README and runtime defaults.

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/416

## Changes

- Updated Discord link to the current server invite
- Added support for Unraid to customize availability of the API docs
- Changed setup guidance link to docs (`grimmory.org/docs/getting-started`)
- Corrected library mount target from /data/media/books to /books

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration to control public API documentation availability.

* **Configuration Changes**
  * Updated Book Library target path for improved organization.
  * Adjusted documentation reference for better setup guidance.

* **Documentation**
  * Enhanced configuration overview text for clarity.
  * Updated community support link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->