### PR TITLE
chore(frontend): fix build warnings + set build warning threshold to zero

### DIFF
--- a/.github/workflows/angular-lint-threshold.yml
+++ b/.github/workflows/angular-lint-threshold.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       LINT_WARNING_THRESHOLD: 0
       LINT_ERROR_THRESHOLD: 0
-      BUILD_WARNING_THRESHOLD: 24
+      BUILD_WARNING_THRESHOLD: 0
 
     steps:
       - name: Checkout Repository

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -72,7 +72,8 @@
               "path-webpack",
               "jszip/dist/jszip",
               "localforage",
-              "marks-pane"
+              "marks-pane",
+              "@stomp/stompjs"
             ]
           },
           "configurations": {

--- a/frontend/src/app/features/settings/global-preferences/global-preferences.component.ts
+++ b/frontend/src/app/features/settings/global-preferences/global-preferences.component.ts
@@ -10,7 +10,6 @@ import {BookMetadataManageService} from '../../book/service/book-metadata-manage
 import {AppSettingKey, CoverCroppingSettings} from '../../../shared/model/app-settings.model';
 import {InputText} from 'primeng/inputtext';
 import {Slider} from 'primeng/slider';
-import {ExternalDocLinkComponent} from '../../../shared/components/external-doc-link/external-doc-link.component';
 import {TranslocoDirective, TranslocoPipe, TranslocoService} from '@jsverse/transloco';
 
 @Component({
@@ -23,7 +22,6 @@ import {TranslocoDirective, TranslocoPipe, TranslocoService} from '@jsverse/tran
     InputText,
     Slider,
     SplitButton,
-    ExternalDocLinkComponent,
     TranslocoDirective,
     TranslocoPipe
   ],


### PR DESCRIPTION
## Description

Removes remaining frontend build warnings and aligns the CI frontend build warning threshold to 0

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/420

**NOTE:** These changes were initially included in https://github.com/grimmory-tools/grimmory/pull/239, but due to merge conflicts and the majority of the changes being implemented in another refactor PR, that was closed and the remaining unresolved changes have been implemented here.

## Changes

- Removed unused `ExternalDocLinkComponent` import
- Added `@stomp/stompjs` to Angular `allowedCommonJsDependencies` to suppress the CommonJS warning
- Updated CI frontend thresholds to enforce zero build warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enforced stricter build warning thresholds for enhanced code quality standards.
  * Extended build configuration to support additional WebSocket communication library.
  * Removed external documentation link component from settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->