### PR TITLE
chore(api): add the base OpenAPI metadata config

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ just ui dev        # Start the frontend dev server
 
 ## API Reference Docs
 
-When enabled, API reference documentation is available as both an `openapi.json` and as publicly accessible docs. The endpoints are:
+When enabled via `API_DOCS_ENABLED`, API reference documentation is available as both an `openapi.json` and as publicly accessible docs. The endpoints are:
 - API reference docs are available at `http://localhost:6060/api/docs`
 - OpenAPI JSON is available at `http://localhost:6060/api/openapi.json`
 

--- a/booklore-api/src/main/java/org/booklore/config/openapi/OpenApiConfig.java
+++ b/booklore-api/src/main/java/org/booklore/config/openapi/OpenApiConfig.java
@@ -1,0 +1,34 @@
+package org.booklore.config.openapi;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import lombok.RequiredArgsConstructor;
+import org.booklore.config.AppProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.api-docs.enabled", havingValue = "true", matchIfMissing = false)
+public class OpenApiConfig {
+
+    private final AppProperties appProperties;
+
+    @Bean
+    public OpenAPI openApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Grimmory API")
+                        .description("REST API documentation for managing libraries, readers, metadata, and device integrations in Grimmory.")
+                        .version(appProperties.getVersion())
+                        .contact(new Contact()
+                                .name("Grimmory")
+                                .url("https://github.com/grimmory-tools/grimmory"))
+                        .license(new License()
+                                .name("AGPL-3.0")
+                                .url("https://www.gnu.org/licenses/agpl-3.0.html")));
+    }
+}

--- a/booklore-api/src/main/resources/static/scalar.html
+++ b/booklore-api/src/main/resources/static/scalar.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>Grimmory API Reference</title>
+  <title>Grimmory API</title>
   <meta charset="UTF-8" />
   <meta
     name="viewport"

--- a/booklore-api/src/test/java/org/booklore/config/openapi/OpenApiConfigIntegrationTest.java
+++ b/booklore-api/src/test/java/org/booklore/config/openapi/OpenApiConfigIntegrationTest.java
@@ -24,9 +24,9 @@ class OpenApiConfigIntegrationTest {
                     OpenAPI openAPI = context.getBean(OpenAPI.class);
                     assertThat(openAPI.getInfo().getTitle()).isEqualTo("Grimmory API");
                     assertThat(openAPI.getInfo().getDescription())
-                            .isEqualTo("REST API for managing libraries, readers, metadata, and device integrations in Grimmory.");
+                            .isEqualTo("REST API documentation for managing libraries, readers, metadata, and device integrations in Grimmory.");
                     assertThat(openAPI.getInfo().getVersion()).isEqualTo("9.9.9-test");
-                    assertThat(openAPI.getInfo().getContact().getName()).isEqualTo("Grimmory Maintainers");
+                    assertThat(openAPI.getInfo().getContact().getName()).isEqualTo("Grimmory");
                     assertThat(openAPI.getInfo().getContact().getUrl())
                             .isEqualTo("https://github.com/grimmory-tools/grimmory");
                     assertThat(openAPI.getInfo().getLicense().getName()).isEqualTo("AGPL-3.0");

--- a/booklore-api/src/test/java/org/booklore/config/openapi/OpenApiConfigIntegrationTest.java
+++ b/booklore-api/src/test/java/org/booklore/config/openapi/OpenApiConfigIntegrationTest.java
@@ -1,0 +1,48 @@
+package org.booklore.config.openapi;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.booklore.config.AppProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenApiConfigIntegrationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(OpenApiConfig.class, TestConfiguration.class);
+
+    @Test
+    void shouldPublishConfiguredApiMetadata() {
+        contextRunner
+                .withPropertyValues("app.api-docs.enabled=true")
+                .run(context -> {
+                    assertThat(context.getBeansOfType(OpenAPI.class)).hasSize(1);
+
+                    OpenAPI openAPI = context.getBean(OpenAPI.class);
+                    assertThat(openAPI.getInfo().getTitle()).isEqualTo("Grimmory API");
+                    assertThat(openAPI.getInfo().getDescription())
+                            .isEqualTo("REST API for managing libraries, readers, metadata, and device integrations in Grimmory.");
+                    assertThat(openAPI.getInfo().getVersion()).isEqualTo("9.9.9-test");
+                    assertThat(openAPI.getInfo().getContact().getName()).isEqualTo("Grimmory Maintainers");
+                    assertThat(openAPI.getInfo().getContact().getUrl())
+                            .isEqualTo("https://github.com/grimmory-tools/grimmory");
+                    assertThat(openAPI.getInfo().getLicense().getName()).isEqualTo("AGPL-3.0");
+                    assertThat(openAPI.getInfo().getLicense().getUrl())
+                            .isEqualTo("https://www.gnu.org/licenses/agpl-3.0.html");
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TestConfiguration {
+
+        @Bean
+        AppProperties appProperties() {
+            AppProperties appProperties = new AppProperties();
+            appProperties.setVersion("9.9.9-test");
+            return appProperties;
+        }
+    }
+}

--- a/booklore-api/src/test/java/org/booklore/config/openapi/OpenApiDocsDisabledIntegrationTest.java
+++ b/booklore-api/src/test/java/org/booklore/config/openapi/OpenApiDocsDisabledIntegrationTest.java
@@ -1,0 +1,34 @@
+package org.booklore.config.openapi;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.booklore.config.AppProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenApiDocsDisabledIntegrationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(OpenApiConfig.class, TestConfiguration.class);
+
+    @Test
+    void shouldNotRegisterOpenApiBeanWhenDocsAreDisabled() {
+        contextRunner
+                .withPropertyValues("app.api-docs.enabled=false")
+                .run(context -> assertThat(context.getBeansOfType(OpenAPI.class)).isEmpty());
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TestConfiguration {
+
+        @Bean
+        AppProperties appProperties() {
+            AppProperties appProperties = new AppProperties();
+            appProperties.setVersion("9.9.9-test");
+            return appProperties;
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the base metadata config in for the `openapi.json` generation. This is the first step in adding more rich config details to our API docs. Now that https://github.com/grimmory-tools/grimmory/issues/361 is in, we can begin refactoring `SecurityConfig` to surface auth schemes.

**Linked Issue:** https://github.com/grimmory-tools/grimmory/issues/290

## Changes

- Mentions the API doc ref env var more in the README (was a note about not finding it easily enough)
- Add `OpenApiConfig` to handle base config setup. Will be expanded on in a future commit to establish auth schemes
- Added test coverage for the new config and to verify it is not accessible while API docs are disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API reference availability is now explicitly conditional on the API_DOCS_ENABLED environment setting.

* **Documentation**
  * README clarified how API documentation availability is governed by configuration.

* **Tests**
  * Added integration tests to confirm API documentation is published only when the configuration is enabled and omitted when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->