### PR TITLE
chore(api): drop unused book download proxy

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/KoboController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/KoboController.java
@@ -176,11 +176,9 @@ public class KoboController {
     public void downloadBook(@Parameter(description = "Book ID") @PathVariable String bookId, HttpServletResponse response) {
         if (StringUtils.isNumeric(bookId)) {
             bookDownloadService.downloadKoboBook(Long.parseLong(bookId), response);
-        } else if (isForwardingToKoboStore()) {
-            koboServerProxy.proxyCurrentRequest(null, false);
-        } else {
-            throw ApiError.GENERIC_NOT_FOUND.createException("Not Found");
         }
+
+        throw ApiError.GENERIC_NOT_FOUND.createException("Not Found");
     }
 
     @Operation(summary = "Delete book from Kobo library", description = "Delete a book from the user's Kobo library.")


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
the book download proxy code path should never be called.  this is because the book download URL received as part of the kobo proxy points at the Rakuten Kobo CDN rather than at grimmory.  further, even if this code could download the file from the CDN (it doesn't), it would be pointless as we don't return it.  instead of fixing the return this drops the proxy from that code path

**Linked Issue:** Fixes #349

## Changes

* drops unused book download kobo store proxy call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid book IDs in the download functionality, now properly returning "Not Found" responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->