### PR TITLE
fix(api): invert kobo book type check for downloads

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/KoboController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/KoboController.java
@@ -179,7 +179,6 @@ public class KoboController {
         }
 
         bookDownloadService.downloadKoboBook(Long.parseLong(bookId), response);
-
     }
 
     @Operation(summary = "Delete book from Kobo library", description = "Delete a book from the user's Kobo library.")

--- a/booklore-api/src/main/java/org/booklore/controller/KoboController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/KoboController.java
@@ -174,11 +174,12 @@ public class KoboController {
     @ApiResponse(responseCode = "200", description = "Book downloaded successfully")
     @GetMapping("/v1/books/{bookId}/download")
     public void downloadBook(@Parameter(description = "Book ID") @PathVariable String bookId, HttpServletResponse response) {
-        if (StringUtils.isNumeric(bookId)) {
-            bookDownloadService.downloadKoboBook(Long.parseLong(bookId), response);
+        if (!StringUtils.isNumeric(bookId)) {
+            throw ApiError.GENERIC_NOT_FOUND.createException("Not Found");
         }
 
-        throw ApiError.GENERIC_NOT_FOUND.createException("Not Found");
+        bookDownloadService.downloadKoboBook(Long.parseLong(bookId), response);
+
     }
 
     @Operation(summary = "Delete book from Kobo library", description = "Delete a book from the user's Kobo library.")


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
with the previous organization of code paths this leads to an exception being raised in the logs even though the response message is fine

**Linked Issue:** Related to #349


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Kobo book download functionality that was previously failing unconditionally. The download process now correctly validates input and proceeds with valid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->