### PR TITLE
fix(reader): optimize memory management for canvas and image handling in infinite scrolling

### DIFF
--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
@@ -100,7 +100,7 @@
       <div class="strip-width-constrain" [style.width]="cbxQuickSettingsState().stripMaxWidthPercent + '%'">
         @for (item of longStripImages; track item.page) {
         <img [src]="item.src" alt="Page {{ item.page + 1 }}" class="long-strip-image" [attr.data-page]="item.page"
-          draggable="false" (load)="onLongStripImageLoad($event, item.page)" />
+          draggable="false" loading="lazy" decoding="async" (load)="onLongStripImageLoad($event, item.page)" />
         }
         @if (nextBookInSeries) {
         <div class="cbx-continuation-spacer" aria-hidden="true"></div>
@@ -125,6 +125,7 @@
         @for (pageIdx of infiniteScrollPages; track pageIdx) {
         <img [src]="getPageImageUrl(pageIdx)" alt="Page {{ pageIdx + 1 }}" class="page-image"
           [attr.data-page]="pageIdx" role="button" tabindex="0" draggable="false"
+          loading="lazy" decoding="async"
           (click)="onImageClick()" (keydown.enter)="onImageClick()" (dblclick)="onImageDoubleClick()"
           (load)="onPageImageLoad($event, pageIdx)" />
         }

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
@@ -100,7 +100,7 @@
       <div class="strip-width-constrain" [style.width]="cbxQuickSettingsState().stripMaxWidthPercent + '%'">
         @for (item of longStripImages; track item.page) {
         <img [src]="item.src" alt="Page {{ item.page + 1 }}" class="long-strip-image" [attr.data-page]="item.page"
-          draggable="false" loading="lazy" decoding="async" (load)="onLongStripImageLoad($event, item.page)" />
+          draggable="false" [attr.loading]="item.page === currentPage ? 'eager' : 'lazy'" decoding="async" (load)="onLongStripImageLoad($event, item.page)" />
         }
         @if (nextBookInSeries) {
         <div class="cbx-continuation-spacer" aria-hidden="true"></div>
@@ -125,7 +125,7 @@
         @for (pageIdx of infiniteScrollPages; track pageIdx) {
         <img [src]="getPageImageUrl(pageIdx)" alt="Page {{ pageIdx + 1 }}" class="page-image"
           [attr.data-page]="pageIdx" role="button" tabindex="0" draggable="false"
-          loading="lazy" decoding="async"
+          [attr.loading]="pageIdx === currentPage ? 'eager' : 'lazy'" decoding="async"
           (click)="onImageClick()" (keydown.enter)="onImageClick()" (dblclick)="onImageDoubleClick()"
           (load)="onPageImageLoad($event, pageIdx)" />
         }

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -74,7 +74,11 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   private static readonly CONTINUATION_HINT_SHOW_PX = 220;
   private static readonly CONTINUATION_HINT_HIDE_PX = 380;
   private static readonly LONG_STRIP_BUFFER = 7;
+  /** Max pages kept in DOM for long strip; pages outside ±EVICTION_WINDOW are removed. */
+  private static readonly LONG_STRIP_EVICTION_WINDOW = 15;
   private static readonly AUTO_CLOSE_MENU_TIMEOUT = 3000;
+  /** Max pages kept in DOM for infinite scroll; pages outside this window are removed. */
+  private static readonly INFINITE_SCROLL_MAX_DOM_PAGES = 18;
 
   private destroy$ = new Subject<void>();
   private progressSaveSubject$ = new Subject<void>();
@@ -789,8 +793,9 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     const keepUrls = new Set(keepPages.map(p => this.getPageImageUrl(p)));
     this.currentImageUrls.forEach(url => keepUrls.add(url));
 
-    for (const url of this.preloadedImages.keys()) {
+    for (const [url, img] of this.preloadedImages.entries()) {
       if (!keepUrls.has(url)) {
+        img.src = '';
         this.preloadedImages.delete(url);
       }
     }
@@ -1170,6 +1175,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
       for (let i = lastLoadedIndex + 1; i < endIndex; i++) {
         this.infiniteScrollPages.push(i);
       }
+      this.trimInfiniteScrollPages('tail');
       this.isLoadingMore = false;
     });
   }
@@ -1198,12 +1204,29 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
       added.push(p);
     }
     this.infiniteScrollPages = [...added, ...this.infiniteScrollPages];
+    this.trimInfiniteScrollPages('head');
 
     this.afterNextPaint(() => {
       const afterTop = anchorEl.getBoundingClientRect().top;
       container.scrollTop += afterTop - beforeTop;
       this.isLoadingMore = false;
     });
+  }
+
+  /**
+   * Caps the infinite scroll DOM to INFINITE_SCROLL_MAX_DOM_PAGES pages.
+   * When appending ('tail'), oldest pages at the head are dropped.
+   * When prepending ('head'), newest pages at the tail are dropped.
+   */
+  private trimInfiniteScrollPages(growingSide: 'head' | 'tail'): void {
+    const max = CbxReaderComponent.INFINITE_SCROLL_MAX_DOM_PAGES;
+    if (this.infiniteScrollPages.length <= max) return;
+
+    if (growingSide === 'tail') {
+      this.infiniteScrollPages = this.infiniteScrollPages.slice(-max);
+    } else {
+      this.infiniteScrollPages = this.infiniteScrollPages.slice(0, max);
+    }
   }
 
   private updateCurrentPageFromScroll(container: HTMLElement): void {
@@ -1299,6 +1322,16 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
         this.longStripImages.push({ src: this.getPageImageUrl(i), page: i });
       }
     }
+
+    // Evict pages far from the current viewport to cap DOM size
+    const evictionWindow = CbxReaderComponent.LONG_STRIP_EVICTION_WINDOW;
+    const keepStart = Math.max(0, pageNum - evictionWindow);
+    const keepEnd = Math.min(this.pages.length - 1, pageNum + evictionWindow);
+    this.longStripImages = this.longStripImages.filter(item => {
+      if (item.page >= keepStart && item.page <= keepEnd) return true;
+      this.longStripLoadedPages.delete(item.page);
+      return false;
+    });
 
     // Keep sorted by page number
     this.longStripImages.sort((a, b) => a.page - b.page);
@@ -2240,6 +2273,18 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     if (this.autoCloseMenuTimer) {
       clearTimeout(this.autoCloseMenuTimer);
     }
+
+    // Release all preloaded image memory
+    for (const img of this.preloadedImages.values()) {
+      img.src = '';
+    }
+    this.preloadedImages.clear();
+
+    // Clear infinite scroll DOM references
+    this.infiniteScrollPages = [];
+    this.currentImageUrls = [];
+    this.previousImageUrls = [];
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -795,7 +795,8 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
     for (const [url, img] of this.preloadedImages.entries()) {
       if (!keepUrls.has(url)) {
-        img.src = '';
+        img.onload = null;
+        img.onerror = null;
         this.preloadedImages.delete(url);
       }
     }
@@ -2276,7 +2277,8 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
     // Release all preloaded image memory
     for (const img of this.preloadedImages.values()) {
-      img.src = '';
+      img.onload = null;
+      img.onerror = null;
     }
     this.preloadedImages.clear();
 

--- a/frontend/src/app/features/readers/cbx-reader/renderers/canvas-renderer.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/renderers/canvas-renderer.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewInit} from '@angular/core';
+import {Component, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild, ElementRef, AfterViewInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {CbxPageSplitOption} from '../../../settings/user-management/user.service';
 
@@ -42,7 +42,7 @@ export type CanvasSplitState = 'NO_SPLIT' | 'LEFT_PART' | 'RIGHT_PART';
     }
   `]
 })
-export class CanvasRendererComponent implements OnChanges, AfterViewInit {
+export class CanvasRendererComponent implements OnChanges, AfterViewInit, OnDestroy {
   @Input() imageUrl = '';
   @Input() splitState: CanvasSplitState = 'NO_SPLIT';
   @Input() splitOption: CbxPageSplitOption = CbxPageSplitOption.NO_SPLIT;
@@ -58,6 +58,19 @@ export class CanvasRendererComponent implements OnChanges, AfterViewInit {
   ngAfterViewInit(): void {
     if (this.imageUrl) {
       this.loadAndDraw();
+    }
+  }
+
+  ngOnDestroy(): void {
+    // Release canvas memory
+    const canvas = this.canvasRef?.nativeElement;
+    if (canvas) {
+      canvas.width = 0;
+      canvas.height = 0;
+    }
+    if (this.currentImage) {
+      this.currentImage.src = '';
+      this.currentImage = null;
     }
   }
 

--- a/frontend/src/app/features/readers/cbx-reader/renderers/canvas-renderer.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/renderers/canvas-renderer.component.ts
@@ -51,6 +51,7 @@ export class CanvasRendererComponent implements OnChanges, AfterViewInit, OnDest
 
   imageLoaded = false;
   private currentImage: HTMLImageElement | null = null;
+  private pendingImage: HTMLImageElement | null = null;
 
   private static readonly MAX_CANVAS_SAFARI = 4096;
   private static readonly MAX_CANVAS_OTHER = 16384;
@@ -68,7 +69,10 @@ export class CanvasRendererComponent implements OnChanges, AfterViewInit, OnDest
       canvas.width = 0;
       canvas.height = 0;
     }
+    this.cancelPendingImage();
     if (this.currentImage) {
+      this.currentImage.onload = null;
+      this.currentImage.onerror = null;
       this.currentImage.src = '';
       this.currentImage = null;
     }
@@ -87,15 +91,30 @@ export class CanvasRendererComponent implements OnChanges, AfterViewInit, OnDest
   private loadAndDraw(): void {
     if (!this.imageUrl) return;
 
+    this.cancelPendingImage();
+
     this.imageLoaded = false;
     const img = new Image();
     img.crossOrigin = 'anonymous';
+    this.pendingImage = img;
     img.onload = () => {
-      this.currentImage = img;
-      this.drawImage(img);
-      this.imageLoaded = true;
+      if (this.pendingImage === img) {
+        this.currentImage = img;
+        this.drawImage(img);
+        this.imageLoaded = true;
+        this.pendingImage = null;
+      }
     };
     img.src = this.imageUrl;
+  }
+
+  private cancelPendingImage(): void {
+    if (this.pendingImage) {
+      this.pendingImage.onload = null;
+      this.pendingImage.onerror = null;
+      this.pendingImage.src = '';
+      this.pendingImage = null;
+    }
   }
 
   private drawImage(img: HTMLImageElement): void {


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request focuses on improving memory management and performance for the CBZ reader, especially around image handling and infinite scrolling. It introduces eviction strategies to limit the number of images and DOM elements kept in memory, adds lazy loading hints to images, and ensures resources are released when components are destroyed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory cleanup for image caching and canvas rendering to prevent leaks and stale callbacks.
  * Capped DOM growth in infinite scroll and evicted off-screen long-strip images to reduce resource use and improve stability.

* **Performance**
  * Smarter image loading priorities and async decoding so current pages load eagerly while others load lazily, improving scroll responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->