### PR TITLE
refactor(email): replace Booklore References In Email with Grimmory

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/email/SendEmailV2Service.java
+++ b/booklore-api/src/main/java/org/booklore/service/email/SendEmailV2Service.java
@@ -95,7 +95,7 @@ public class SendEmailV2Service {
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
         helper.setFrom(StringUtils.firstNonEmpty(emailProvider.getFromAddress(), emailProvider.getUsername()));
         helper.setTo(recipientEmail);
-        helper.setSubject("Your Book from Booklore: " + book.getMetadata().getTitle());
+        helper.setSubject("Your Book from Grimmory: " + book.getMetadata().getTitle());
         helper.setText(generateEmailBody(book.getMetadata().getTitle()));
         File bookFile = FileUtils.getBookFullPath(book, bookFileEntity).toFile();
         helper.addAttachment(bookFile.getName(), bookFile);
@@ -187,9 +187,9 @@ public class SendEmailV2Service {
         return String.format("""
                 Hello,
                 
-                You have received a book from Booklore. Please find the attached file titled '%s' for your reading pleasure.
+                You have received a book from Grimmory. Please find the attached file titled '%s' for your reading pleasure.
                 
-                Thank you for using Booklore! Hope you enjoy your book.
+                Thank you for using Grimmory! Hope you enjoy your book.
                 """, bookTitle);
     }
 


### PR DESCRIPTION
## Description

Replaces "Booklore" in `SendEmailV2Service.java` strings with "Grimmory"

**Linked Issue:** Fixes #430 

## Changes
Replace "Booklore" with "Grimmory" in lines 98, 190, 192

<img width="517" height="207" alt="image" src="https://github.com/user-attachments/assets/fd042be8-0fa5-4fbf-b38f-5e76dcbf9036" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed platform branding in all outbound email communications, including sender names, subject lines, and message content throughout the application. Users will notice updated brand terminology in all emails they receive. These changes align communications with current platform standards and naming conventions to ensure consistent brand representation across every user touchpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->