### PR TITLE
docs(api): normalize OpenAPI tagging and operation metadata for app + auth/task endpoints

### DIFF
--- a/booklore-api/src/main/java/org/booklore/app/controller/AppAuthorController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppAuthorController.java
@@ -21,7 +21,8 @@ public class AppAuthorController {
     @Operation(
             summary = "List app authors",
             description = "Retrieve paginated authors for the app with optional filtering and sorting.",
-            operationId = "appListAuthors")
+            operationId = "appListAuthors"
+    )
     @GetMapping
     public ResponseEntity<AppPageResponse<AppAuthorSummary>> getAuthors(
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -38,7 +39,8 @@ public class AppAuthorController {
     @Operation(
             summary = "Get app author details",
             description = "Retrieve detailed app-facing information for a single author.",
-            operationId = "appGetAuthorDetail")
+            operationId = "appGetAuthorDetail"
+    )
     @GetMapping("/{authorId}")
     public ResponseEntity<AppAuthorDetail> getAuthorDetail(
             @PathVariable Long authorId) {

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppAuthorController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppAuthorController.java
@@ -1,5 +1,7 @@
 package org.booklore.app.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.app.dto.AppAuthorDetail;
 import org.booklore.app.dto.AppAuthorSummary;
 import org.booklore.app.dto.AppPageResponse;
@@ -11,10 +13,15 @@ import org.springframework.web.bind.annotation.*;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/app/authors")
+@Tag(name = "App Authors", description = "Endpoints for browsing authors in the app experience")
 public class AppAuthorController {
 
     private final AppAuthorService mobileAuthorService;
 
+    @Operation(
+            summary = "List app authors",
+            description = "Retrieve paginated authors for the app with optional filtering and sorting.",
+            operationId = "appListAuthors")
     @GetMapping
     public ResponseEntity<AppPageResponse<AppAuthorSummary>> getAuthors(
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -28,6 +35,10 @@ public class AppAuthorController {
         return ResponseEntity.ok(mobileAuthorService.getAuthors(page, size, sort, dir, libraryId, search, hasPhoto));
     }
 
+    @Operation(
+            summary = "Get app author details",
+            description = "Retrieve detailed app-facing information for a single author.",
+            operationId = "appGetAuthorDetail")
     @GetMapping("/{authorId}")
     public ResponseEntity<AppAuthorDetail> getAuthorDetail(
             @PathVariable Long authorId) {

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppAuthorController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppAuthorController.java
@@ -21,7 +21,7 @@ public class AppAuthorController {
     @Operation(
             summary = "List app authors",
             description = "Retrieve paginated authors for the app with optional filtering and sorting.",
-            operationId = "appListAuthors"
+            operationId = "appGetAuthors"
     )
     @GetMapping
     public ResponseEntity<AppPageResponse<AppAuthorSummary>> getAuthors(

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppBookController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppBookController.java
@@ -24,7 +24,8 @@ public class AppBookController {
     @Operation(
             summary = "List app books",
             description = "Retrieve paginated books for the app with optional filtering and sorting.",
-            operationId = "appListBooks")
+            operationId = "appListBooks"
+    )
     @GetMapping
     public ResponseEntity<AppPageResponse<AppBookSummary>> getBooks(
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -49,7 +50,8 @@ public class AppBookController {
     @Operation(
             summary = "Get app book details",
             description = "Retrieve detailed app-facing information for a single book.",
-            operationId = "appGetBookDetail")
+            operationId = "appGetBookDetail"
+    )
     @GetMapping("/{bookId}")
     public ResponseEntity<AppBookDetail> getBookDetail(
             @PathVariable Long bookId) {
@@ -60,7 +62,8 @@ public class AppBookController {
     @Operation(
             summary = "Search app books",
             description = "Search books in the app catalog using a free-text query.",
-            operationId = "appSearchBooks")
+            operationId = "appSearchBooks"
+    )
     @GetMapping("/search")
     public ResponseEntity<AppPageResponse<AppBookSummary>> searchBooks(
             @RequestParam String q,
@@ -73,7 +76,8 @@ public class AppBookController {
     @Operation(
             summary = "Get continue reading books",
             description = "Retrieve books currently in progress for reading in the app.",
-            operationId = "appGetContinueReadingBooks")
+            operationId = "appGetContinueReadingBooks"
+    )
     @GetMapping("/continue-reading")
     public ResponseEntity<List<AppBookSummary>> getContinueReading(
             @RequestParam(required = false, defaultValue = "10") Integer limit) {
@@ -84,7 +88,8 @@ public class AppBookController {
     @Operation(
             summary = "Get continue listening books",
             description = "Retrieve audiobooks currently in progress for listening in the app.",
-            operationId = "appGetContinueListeningBooks")
+            operationId = "appGetContinueListeningBooks"
+    )
     @GetMapping("/continue-listening")
     public ResponseEntity<List<AppBookSummary>> getContinueListening(
             @RequestParam(required = false, defaultValue = "10") Integer limit) {
@@ -95,7 +100,8 @@ public class AppBookController {
     @Operation(
             summary = "Get recently added books",
             description = "Retrieve recently added books for the app home experience.",
-            operationId = "appGetRecentlyAddedBooks")
+            operationId = "appGetRecentlyAddedBooks"
+    )
     @GetMapping("/recently-added")
     public ResponseEntity<List<AppBookSummary>> getRecentlyAdded(
             @RequestParam(required = false, defaultValue = "10") Integer limit) {
@@ -106,7 +112,8 @@ public class AppBookController {
     @Operation(
             summary = "Get recently scanned books",
             description = "Retrieve recently scanned books for the app home experience.",
-            operationId = "appGetRecentlyScannedBooks")
+            operationId = "appGetRecentlyScannedBooks"
+    )
     @GetMapping("/recently-scanned")
     public ResponseEntity<List<AppBookSummary>> getRecentlyScanned(
             @RequestParam(required = false, defaultValue = "10") Integer limit) {
@@ -117,7 +124,8 @@ public class AppBookController {
     @Operation(
             summary = "Update app book read status",
             description = "Update the read status of a book from the app interface.",
-            operationId = "appUpdateBookReadStatus")
+            operationId = "appUpdateBookReadStatus"
+    )
     @PutMapping("/{bookId}/status")
     public ResponseEntity<Void> updateStatus(
             @PathVariable Long bookId,
@@ -130,7 +138,8 @@ public class AppBookController {
     @Operation(
             summary = "Update app book rating",
             description = "Update the personal rating of a book from the app interface.",
-            operationId = "appUpdateBookRating")
+            operationId = "appUpdateBookRating"
+    )
     @PutMapping("/{bookId}/rating")
     public ResponseEntity<Void> updateRating(
             @PathVariable Long bookId,
@@ -143,7 +152,8 @@ public class AppBookController {
     @Operation(
             summary = "Get random app books",
             description = "Retrieve a paginated random selection of books for discovery in the app.",
-            operationId = "appGetRandomBooks")
+            operationId = "appGetRandomBooks"
+    )
     @GetMapping("/random")
     public ResponseEntity<AppPageResponse<AppBookSummary>> getRandomBooks(
             @RequestParam(required = false, defaultValue = "0") Integer page,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppBookController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppBookController.java
@@ -24,7 +24,7 @@ public class AppBookController {
     @Operation(
             summary = "List app books",
             description = "Retrieve paginated books for the app with optional filtering and sorting.",
-            operationId = "appListBooks"
+            operationId = "appGetBooks"
     )
     @GetMapping
     public ResponseEntity<AppPageResponse<AppBookSummary>> getBooks(
@@ -76,7 +76,7 @@ public class AppBookController {
     @Operation(
             summary = "Get continue reading books",
             description = "Retrieve books currently in progress for reading in the app.",
-            operationId = "appGetContinueReadingBooks"
+            operationId = "appGetContinueReading"
     )
     @GetMapping("/continue-reading")
     public ResponseEntity<List<AppBookSummary>> getContinueReading(
@@ -88,7 +88,7 @@ public class AppBookController {
     @Operation(
             summary = "Get continue listening books",
             description = "Retrieve audiobooks currently in progress for listening in the app.",
-            operationId = "appGetContinueListeningBooks"
+            operationId = "appGetContinueListening"
     )
     @GetMapping("/continue-listening")
     public ResponseEntity<List<AppBookSummary>> getContinueListening(
@@ -100,7 +100,7 @@ public class AppBookController {
     @Operation(
             summary = "Get recently added books",
             description = "Retrieve recently added books for the app home experience.",
-            operationId = "appGetRecentlyAddedBooks"
+            operationId = "appGetRecentlyAdded"
     )
     @GetMapping("/recently-added")
     public ResponseEntity<List<AppBookSummary>> getRecentlyAdded(
@@ -112,7 +112,7 @@ public class AppBookController {
     @Operation(
             summary = "Get recently scanned books",
             description = "Retrieve recently scanned books for the app home experience.",
-            operationId = "appGetRecentlyScannedBooks"
+            operationId = "appGetRecentlyScanned"
     )
     @GetMapping("/recently-scanned")
     public ResponseEntity<List<AppBookSummary>> getRecentlyScanned(
@@ -124,7 +124,7 @@ public class AppBookController {
     @Operation(
             summary = "Update app book read status",
             description = "Update the read status of a book from the app interface.",
-            operationId = "appUpdateBookReadStatus"
+            operationId = "appUpdateStatus"
     )
     @PutMapping("/{bookId}/status")
     public ResponseEntity<Void> updateStatus(
@@ -138,7 +138,7 @@ public class AppBookController {
     @Operation(
             summary = "Update app book rating",
             description = "Update the personal rating of a book from the app interface.",
-            operationId = "appUpdateBookRating"
+            operationId = "appUpdateRating"
     )
     @PutMapping("/{bookId}/rating")
     public ResponseEntity<Void> updateRating(

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppBookController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppBookController.java
@@ -1,5 +1,7 @@
 package org.booklore.app.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.app.dto.*;
 import org.booklore.app.service.AppBookService;
 import org.booklore.model.enums.BookFileType;
@@ -14,10 +16,15 @@ import java.util.List;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/app/books")
+@Tag(name = "App Books", description = "Endpoints for browsing and updating books in the app experience")
 public class AppBookController {
 
     private final AppBookService mobileBookService;
 
+    @Operation(
+            summary = "List app books",
+            description = "Retrieve paginated books for the app with optional filtering and sorting.",
+            operationId = "appListBooks")
     @GetMapping
     public ResponseEntity<AppPageResponse<AppBookSummary>> getBooks(
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -39,6 +46,10 @@ public class AppBookController {
                 fileType, minRating, maxRating, authors, language));
     }
 
+    @Operation(
+            summary = "Get app book details",
+            description = "Retrieve detailed app-facing information for a single book.",
+            operationId = "appGetBookDetail")
     @GetMapping("/{bookId}")
     public ResponseEntity<AppBookDetail> getBookDetail(
             @PathVariable Long bookId) {
@@ -46,6 +57,10 @@ public class AppBookController {
         return ResponseEntity.ok(mobileBookService.getBookDetail(bookId));
     }
 
+    @Operation(
+            summary = "Search app books",
+            description = "Search books in the app catalog using a free-text query.",
+            operationId = "appSearchBooks")
     @GetMapping("/search")
     public ResponseEntity<AppPageResponse<AppBookSummary>> searchBooks(
             @RequestParam String q,
@@ -55,6 +70,10 @@ public class AppBookController {
         return ResponseEntity.ok(mobileBookService.searchBooks(q, page, size));
     }
 
+    @Operation(
+            summary = "Get continue reading books",
+            description = "Retrieve books currently in progress for reading in the app.",
+            operationId = "appGetContinueReadingBooks")
     @GetMapping("/continue-reading")
     public ResponseEntity<List<AppBookSummary>> getContinueReading(
             @RequestParam(required = false, defaultValue = "10") Integer limit) {
@@ -62,6 +81,10 @@ public class AppBookController {
         return ResponseEntity.ok(mobileBookService.getContinueReading(limit));
     }
 
+    @Operation(
+            summary = "Get continue listening books",
+            description = "Retrieve audiobooks currently in progress for listening in the app.",
+            operationId = "appGetContinueListeningBooks")
     @GetMapping("/continue-listening")
     public ResponseEntity<List<AppBookSummary>> getContinueListening(
             @RequestParam(required = false, defaultValue = "10") Integer limit) {
@@ -69,6 +92,10 @@ public class AppBookController {
         return ResponseEntity.ok(mobileBookService.getContinueListening(limit));
     }
 
+    @Operation(
+            summary = "Get recently added books",
+            description = "Retrieve recently added books for the app home experience.",
+            operationId = "appGetRecentlyAddedBooks")
     @GetMapping("/recently-added")
     public ResponseEntity<List<AppBookSummary>> getRecentlyAdded(
             @RequestParam(required = false, defaultValue = "10") Integer limit) {
@@ -76,6 +103,10 @@ public class AppBookController {
         return ResponseEntity.ok(mobileBookService.getRecentlyAdded(limit));
     }
 
+    @Operation(
+            summary = "Get recently scanned books",
+            description = "Retrieve recently scanned books for the app home experience.",
+            operationId = "appGetRecentlyScannedBooks")
     @GetMapping("/recently-scanned")
     public ResponseEntity<List<AppBookSummary>> getRecentlyScanned(
             @RequestParam(required = false, defaultValue = "10") Integer limit) {
@@ -83,6 +114,10 @@ public class AppBookController {
         return ResponseEntity.ok(mobileBookService.getRecentlyScanned(limit));
     }
 
+    @Operation(
+            summary = "Update app book read status",
+            description = "Update the read status of a book from the app interface.",
+            operationId = "appUpdateBookReadStatus")
     @PutMapping("/{bookId}/status")
     public ResponseEntity<Void> updateStatus(
             @PathVariable Long bookId,
@@ -92,6 +127,10 @@ public class AppBookController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(
+            summary = "Update app book rating",
+            description = "Update the personal rating of a book from the app interface.",
+            operationId = "appUpdateBookRating")
     @PutMapping("/{bookId}/rating")
     public ResponseEntity<Void> updateRating(
             @PathVariable Long bookId,
@@ -101,6 +140,10 @@ public class AppBookController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(
+            summary = "Get random app books",
+            description = "Retrieve a paginated random selection of books for discovery in the app.",
+            operationId = "appGetRandomBooks")
     @GetMapping("/random")
     public ResponseEntity<AppPageResponse<AppBookSummary>> getRandomBooks(
             @RequestParam(required = false, defaultValue = "0") Integer page,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppFilterController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppFilterController.java
@@ -22,7 +22,8 @@ public class AppFilterController {
     @Operation(
             summary = "Get app filter options",
             description = "Retrieve available filter values for app book browsing.",
-            operationId = "appGetFilterOptions")
+            operationId = "appGetFilterOptions"
+    )
     @GetMapping("/filter-options")
     public ResponseEntity<AppFilterOptions> getFilterOptions(
             @RequestParam(required = false) Long libraryId,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppFilterController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppFilterController.java
@@ -1,5 +1,7 @@
 package org.booklore.app.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.app.dto.AppFilterOptions;
 import org.booklore.app.service.AppBookService;
 import lombok.AllArgsConstructor;
@@ -12,10 +14,15 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/app")
+@Tag(name = "App Filters", description = "Endpoints for retrieving app filter options")
 public class AppFilterController {
 
     private final AppBookService mobileBookService;
 
+    @Operation(
+            summary = "Get app filter options",
+            description = "Retrieve available filter values for app book browsing.",
+            operationId = "appGetFilterOptions")
     @GetMapping("/filter-options")
     public ResponseEntity<AppFilterOptions> getFilterOptions(
             @RequestParam(required = false) Long libraryId,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppLibraryController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppLibraryController.java
@@ -33,7 +33,8 @@ public class AppLibraryController {
     @Operation(
             summary = "List app libraries",
             description = "Retrieve libraries visible to the current app user, including per-library book counts.",
-            operationId = "appListLibraries")
+            operationId = "appListLibraries"
+    )
     @GetMapping
     public ResponseEntity<List<AppLibrarySummary>> getLibraries() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppLibraryController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppLibraryController.java
@@ -1,5 +1,7 @@
 package org.booklore.app.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.app.dto.AppLibrarySummary;
 import org.booklore.app.mapper.AppBookMapper;
@@ -20,6 +22,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/app/libraries")
+@Tag(name = "App Libraries", description = "Endpoints for retrieving libraries in the app experience")
 public class AppLibraryController {
 
     private final AuthenticationService authenticationService;
@@ -27,6 +30,10 @@ public class AppLibraryController {
     private final BookRepository bookRepository;
     private final AppBookMapper mobileBookMapper;
 
+    @Operation(
+            summary = "List app libraries",
+            description = "Retrieve libraries visible to the current app user, including per-library book counts.",
+            operationId = "appListLibraries")
     @GetMapping
     public ResponseEntity<List<AppLibrarySummary>> getLibraries() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppLibraryController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppLibraryController.java
@@ -33,7 +33,7 @@ public class AppLibraryController {
     @Operation(
             summary = "List app libraries",
             description = "Retrieve libraries visible to the current app user, including per-library book counts.",
-            operationId = "appListLibraries"
+            operationId = "appGetLibraries"
     )
     @GetMapping
     public ResponseEntity<List<AppLibrarySummary>> getLibraries() {

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppNotebookController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppNotebookController.java
@@ -25,7 +25,7 @@ public class AppNotebookController {
     @Operation(
             summary = "List notebook books",
             description = "Retrieve paginated books that contain notebook entries in the app.",
-            operationId = "appListNotebookBooks"
+            operationId = "appGetBooksWithAnnotations"
     )
     @GetMapping("/books")
     public ResponseEntity<AppPageResponse<AppNotebookBookSummary>> getBooksWithAnnotations(
@@ -39,7 +39,7 @@ public class AppNotebookController {
     @Operation(
             summary = "List notebook entries for book",
             description = "Retrieve paginated notebook entries for a specific book in the app.",
-            operationId = "appListNotebookEntriesForBook"
+            operationId = "appGetEntriesForBook"
     )
     @GetMapping("/books/{bookId}/entries")
     public ResponseEntity<AppPageResponse<AppNotebookEntry>> getEntriesForBook(
@@ -56,7 +56,7 @@ public class AppNotebookController {
     @Operation(
             summary = "Update notebook entry",
             description = "Update an existing notebook entry in the app.",
-            operationId = "appUpdateNotebookEntry"
+            operationId = "appUpdateEntry"
     )
     @PutMapping("/entries/{entryId}")
     public ResponseEntity<AppNotebookEntry> updateEntry(
@@ -70,7 +70,7 @@ public class AppNotebookController {
     @Operation(
             summary = "Delete notebook entry",
             description = "Delete an existing notebook entry in the app.",
-            operationId = "appDeleteNotebookEntry"
+            operationId = "appDeleteEntry"
     )
     @DeleteMapping("/entries/{entryId}")
     public ResponseEntity<Void> deleteEntry(

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppNotebookController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppNotebookController.java
@@ -1,5 +1,7 @@
 package org.booklore.app.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.app.dto.AppNotebookBookSummary;
 import org.booklore.app.dto.AppNotebookEntry;
 import org.booklore.app.dto.AppNotebookUpdateRequest;
@@ -15,10 +17,15 @@ import java.util.Set;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/app/notebook")
+@Tag(name = "App Notebook", description = "Endpoints for notebook browsing and editing in the app experience")
 public class AppNotebookController {
 
     private final AppNotebookService mobileNotebookService;
 
+    @Operation(
+            summary = "List notebook books",
+            description = "Retrieve paginated books that contain notebook entries in the app.",
+            operationId = "appListNotebookBooks")
     @GetMapping("/books")
     public ResponseEntity<AppPageResponse<AppNotebookBookSummary>> getBooksWithAnnotations(
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -28,6 +35,10 @@ public class AppNotebookController {
         return ResponseEntity.ok(mobileNotebookService.getBooksWithAnnotations(page, size, search));
     }
 
+    @Operation(
+            summary = "List notebook entries for book",
+            description = "Retrieve paginated notebook entries for a specific book in the app.",
+            operationId = "appListNotebookEntriesForBook")
     @GetMapping("/books/{bookId}/entries")
     public ResponseEntity<AppPageResponse<AppNotebookEntry>> getEntriesForBook(
             @PathVariable Long bookId,
@@ -40,6 +51,10 @@ public class AppNotebookController {
         return ResponseEntity.ok(mobileNotebookService.getEntriesForBook(bookId, page, size, types, search, sort));
     }
 
+    @Operation(
+            summary = "Update notebook entry",
+            description = "Update an existing notebook entry in the app.",
+            operationId = "appUpdateNotebookEntry")
     @PutMapping("/entries/{entryId}")
     public ResponseEntity<AppNotebookEntry> updateEntry(
             @PathVariable Long entryId,
@@ -49,6 +64,10 @@ public class AppNotebookController {
         return ResponseEntity.ok(mobileNotebookService.updateEntry(entryId, type, request));
     }
 
+    @Operation(
+            summary = "Delete notebook entry",
+            description = "Delete an existing notebook entry in the app.",
+            operationId = "appDeleteNotebookEntry")
     @DeleteMapping("/entries/{entryId}")
     public ResponseEntity<Void> deleteEntry(
             @PathVariable Long entryId,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppNotebookController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppNotebookController.java
@@ -25,7 +25,8 @@ public class AppNotebookController {
     @Operation(
             summary = "List notebook books",
             description = "Retrieve paginated books that contain notebook entries in the app.",
-            operationId = "appListNotebookBooks")
+            operationId = "appListNotebookBooks"
+    )
     @GetMapping("/books")
     public ResponseEntity<AppPageResponse<AppNotebookBookSummary>> getBooksWithAnnotations(
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -38,7 +39,8 @@ public class AppNotebookController {
     @Operation(
             summary = "List notebook entries for book",
             description = "Retrieve paginated notebook entries for a specific book in the app.",
-            operationId = "appListNotebookEntriesForBook")
+            operationId = "appListNotebookEntriesForBook"
+    )
     @GetMapping("/books/{bookId}/entries")
     public ResponseEntity<AppPageResponse<AppNotebookEntry>> getEntriesForBook(
             @PathVariable Long bookId,
@@ -54,7 +56,8 @@ public class AppNotebookController {
     @Operation(
             summary = "Update notebook entry",
             description = "Update an existing notebook entry in the app.",
-            operationId = "appUpdateNotebookEntry")
+            operationId = "appUpdateNotebookEntry"
+    )
     @PutMapping("/entries/{entryId}")
     public ResponseEntity<AppNotebookEntry> updateEntry(
             @PathVariable Long entryId,
@@ -67,7 +70,8 @@ public class AppNotebookController {
     @Operation(
             summary = "Delete notebook entry",
             description = "Delete an existing notebook entry in the app.",
-            operationId = "appDeleteNotebookEntry")
+            operationId = "appDeleteNotebookEntry"
+    )
     @DeleteMapping("/entries/{entryId}")
     public ResponseEntity<Void> deleteEntry(
             @PathVariable Long entryId,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppSeriesController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppSeriesController.java
@@ -21,7 +21,7 @@ public class AppSeriesController {
     @Operation(
             summary = "List app series",
             description = "Retrieve paginated series for the app with optional filtering and sorting.",
-            operationId = "appListSeries"
+            operationId = "appGetSeries"
     )
     @GetMapping
     public ResponseEntity<AppPageResponse<AppSeriesSummary>> getSeries(
@@ -44,7 +44,7 @@ public class AppSeriesController {
     @Operation(
             summary = "List books in app series",
             description = "Retrieve paginated books belonging to a specific series for the app.",
-            operationId = "appListSeriesBooks"
+            operationId = "appGetSeriesBooks"
     )
     @GetMapping("/{seriesName}/books")
     public ResponseEntity<AppPageResponse<AppBookSummary>> getSeriesBooks(

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppSeriesController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppSeriesController.java
@@ -21,7 +21,8 @@ public class AppSeriesController {
     @Operation(
             summary = "List app series",
             description = "Retrieve paginated series for the app with optional filtering and sorting.",
-            operationId = "appListSeries")
+            operationId = "appListSeries"
+    )
     @GetMapping
     public ResponseEntity<AppPageResponse<AppSeriesSummary>> getSeries(
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -43,7 +44,8 @@ public class AppSeriesController {
     @Operation(
             summary = "List books in app series",
             description = "Retrieve paginated books belonging to a specific series for the app.",
-            operationId = "appListSeriesBooks")
+            operationId = "appListSeriesBooks"
+    )
     @GetMapping("/{seriesName}/books")
     public ResponseEntity<AppPageResponse<AppBookSummary>> getSeriesBooks(
             @PathVariable String seriesName,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppSeriesController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppSeriesController.java
@@ -1,5 +1,7 @@
 package org.booklore.app.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.booklore.app.dto.AppBookSummary;
 import org.booklore.app.dto.AppPageResponse;
@@ -11,10 +13,15 @@ import org.springframework.web.bind.annotation.*;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/app/series")
+@Tag(name = "App Series", description = "Endpoints for browsing series in the app experience")
 public class AppSeriesController {
 
     private final AppSeriesService mobileSeriesService;
 
+    @Operation(
+            summary = "List app series",
+            description = "Retrieve paginated series for the app with optional filtering and sorting.",
+            operationId = "appListSeries")
     @GetMapping
     public ResponseEntity<AppPageResponse<AppSeriesSummary>> getSeries(
             @RequestParam(required = false, defaultValue = "0") Integer page,
@@ -33,6 +40,10 @@ public class AppSeriesController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "List books in app series",
+            description = "Retrieve paginated books belonging to a specific series for the app.",
+            operationId = "appListSeriesBooks")
     @GetMapping("/{seriesName}/books")
     public ResponseEntity<AppPageResponse<AppBookSummary>> getSeriesBooks(
             @PathVariable String seriesName,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppShelfController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppShelfController.java
@@ -1,5 +1,7 @@
 package org.booklore.app.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.app.dto.AppBookSummary;
 import org.booklore.app.dto.AppMagicShelfSummary;
@@ -25,6 +27,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/app/shelves")
+@Tag(name = "App Shelves", description = "Endpoints for browsing shelves and magic shelves in the app experience")
 public class AppShelfController {
 
     private final AuthenticationService authenticationService;
@@ -33,6 +36,10 @@ public class AppShelfController {
     private final AppBookMapper mobileBookMapper;
     private final AppBookService mobileBookService;
 
+    @Operation(
+            summary = "List app shelves",
+            description = "Retrieve all regular shelves visible to the current app user.",
+            operationId = "appListShelves")
     @GetMapping
     public ResponseEntity<List<AppShelfSummary>> getShelves() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
@@ -47,6 +54,10 @@ public class AppShelfController {
         return ResponseEntity.ok(summaries);
     }
 
+    @Operation(
+            summary = "List app magic shelves",
+            description = "Retrieve all magic shelves visible to the current app user.",
+            operationId = "appListMagicShelves")
     @GetMapping("/magic")
     public ResponseEntity<List<AppMagicShelfSummary>> getMagicShelves() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
@@ -80,6 +91,10 @@ public class AppShelfController {
         return ResponseEntity.ok(summaries);
     }
 
+    @Operation(
+            summary = "List books in app magic shelf",
+            description = "Retrieve paginated books contained in a specific magic shelf for the app.",
+            operationId = "appListMagicShelfBooks")
     @GetMapping("/magic/{magicShelfId}/books")
     public ResponseEntity<AppPageResponse<AppBookSummary>> getBooksByMagicShelf(
             @PathVariable Long magicShelfId,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppShelfController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppShelfController.java
@@ -39,7 +39,8 @@ public class AppShelfController {
     @Operation(
             summary = "List app shelves",
             description = "Retrieve all regular shelves visible to the current app user.",
-            operationId = "appListShelves")
+            operationId = "appListShelves"
+    )
     @GetMapping
     public ResponseEntity<List<AppShelfSummary>> getShelves() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
@@ -57,7 +58,8 @@ public class AppShelfController {
     @Operation(
             summary = "List app magic shelves",
             description = "Retrieve all magic shelves visible to the current app user.",
-            operationId = "appListMagicShelves")
+            operationId = "appListMagicShelves"
+    )
     @GetMapping("/magic")
     public ResponseEntity<List<AppMagicShelfSummary>> getMagicShelves() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
@@ -94,7 +96,8 @@ public class AppShelfController {
     @Operation(
             summary = "List books in app magic shelf",
             description = "Retrieve paginated books contained in a specific magic shelf for the app.",
-            operationId = "appListMagicShelfBooks")
+            operationId = "appListMagicShelfBooks"
+    )
     @GetMapping("/magic/{magicShelfId}/books")
     public ResponseEntity<AppPageResponse<AppBookSummary>> getBooksByMagicShelf(
             @PathVariable Long magicShelfId,

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppShelfController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppShelfController.java
@@ -39,7 +39,7 @@ public class AppShelfController {
     @Operation(
             summary = "List app shelves",
             description = "Retrieve all regular shelves visible to the current app user.",
-            operationId = "appListShelves"
+            operationId = "appGetShelves"
     )
     @GetMapping
     public ResponseEntity<List<AppShelfSummary>> getShelves() {
@@ -58,7 +58,7 @@ public class AppShelfController {
     @Operation(
             summary = "List app magic shelves",
             description = "Retrieve all magic shelves visible to the current app user.",
-            operationId = "appListMagicShelves"
+            operationId = "appGetMagicShelves"
     )
     @GetMapping("/magic")
     public ResponseEntity<List<AppMagicShelfSummary>> getMagicShelves() {
@@ -96,7 +96,7 @@ public class AppShelfController {
     @Operation(
             summary = "List books in app magic shelf",
             description = "Retrieve paginated books contained in a specific magic shelf for the app.",
-            operationId = "appListMagicShelfBooks"
+            operationId = "appGetBooksByMagicShelf"
     )
     @GetMapping("/magic/{magicShelfId}/books")
     public ResponseEntity<AppPageResponse<AppBookSummary>> getBooksByMagicShelf(

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppUserController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppUserController.java
@@ -1,5 +1,7 @@
 package org.booklore.app.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.app.dto.AppUserInfo;
 import org.booklore.model.dto.BookLoreUser;
@@ -13,11 +15,16 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/app/users")
+@Tag(name = "App Users", description = "Endpoints for retrieving app user capabilities and profile information")
 public class AppUserController {
 
     private final AuthenticationService authenticationService;
     private final AppSettingService appSettingService;
 
+    @Operation(
+            summary = "Get current app user",
+            description = "Retrieve current user flags and capability information used by the app experience.",
+            operationId = "appGetCurrentUser")
     @GetMapping("/me")
     public ResponseEntity<AppUserInfo> getCurrentUser() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();

--- a/booklore-api/src/main/java/org/booklore/app/controller/AppUserController.java
+++ b/booklore-api/src/main/java/org/booklore/app/controller/AppUserController.java
@@ -24,7 +24,8 @@ public class AppUserController {
     @Operation(
             summary = "Get current app user",
             description = "Retrieve current user flags and capability information used by the app experience.",
-            operationId = "appGetCurrentUser")
+            operationId = "appGetCurrentUser"
+    )
     @GetMapping("/me")
     public ResponseEntity<AppUserInfo> getCurrentUser() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();

--- a/booklore-api/src/main/java/org/booklore/controller/AdditionalFileController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AdditionalFileController.java
@@ -1,5 +1,7 @@
 package org.booklore.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.config.security.annotation.CheckBookAccess;
 import org.booklore.model.dto.BookFile;
 import org.booklore.model.dto.request.DetachBookFileRequest;
@@ -21,12 +23,17 @@ import java.util.List;
 @RequestMapping("/api/v1/books/{bookId}/files")
 @RestController
 @AllArgsConstructor
+@Tag(name = "Book Files", description = "Endpoints for managing additional files attached to books")
 public class AdditionalFileController {
 
     private final AdditionalFileService additionalFileService;
     private final FileUploadService fileUploadService;
     private final BookFileDetachmentService bookFileDetachmentService;
 
+    @Operation(
+            summary = "List additional book files",
+            description = "Retrieve additional files for a specific book.",
+            operationId = "listAdditionalBookFiles")
     @GetMapping
     @CheckBookAccess(bookIdParam = "bookId")
     public ResponseEntity<List<BookFile>> getAdditionalFiles(@PathVariable Long bookId) {
@@ -34,6 +41,10 @@ public class AdditionalFileController {
         return ResponseEntity.ok(files);
     }
 
+    @Operation(
+            summary = "List additional files by type",
+            description = "Retrieve additional files for a specific book filtered by whether they are primary book files.",
+            operationId = "listAdditionalBookFilesByType")
     @GetMapping(params = "isBook")
     @CheckBookAccess(bookIdParam = "bookId")
     public ResponseEntity<List<BookFile>> getFilesByIsBook(
@@ -43,6 +54,10 @@ public class AdditionalFileController {
         return ResponseEntity.ok(files);
     }
 
+    @Operation(
+            summary = "Upload additional book file",
+            description = "Upload and attach a new additional file to a specific book.",
+            operationId = "uploadAdditionalBookFile")
     @PostMapping(consumes = "multipart/form-data")
     @CheckBookAccess(bookIdParam = "bookId")
     @PreAuthorize("@securityUtil.canUpload() or @securityUtil.isAdmin()")
@@ -56,6 +71,10 @@ public class AdditionalFileController {
         return ResponseEntity.ok(additionalFile);
     }
 
+    @Operation(
+            summary = "Download additional book file",
+            description = "Download a specific additional file attached to a book.",
+            operationId = "downloadAdditionalBookFile")
     @GetMapping("/{fileId}/download")
     @CheckBookAccess(bookIdParam = "bookId")
     public ResponseEntity<Resource> downloadAdditionalFile(
@@ -64,6 +83,10 @@ public class AdditionalFileController {
         return additionalFileService.downloadAdditionalFile(fileId);
     }
 
+    @Operation(
+            summary = "Delete additional book file",
+            description = "Delete a specific additional file attached to a book.",
+            operationId = "deleteAdditionalBookFile")
     @DeleteMapping("/{fileId}")
     @CheckBookAccess(bookIdParam = "bookId")
     @PreAuthorize("@securityUtil.canDeleteBook() or @securityUtil.isAdmin()")
@@ -74,6 +97,10 @@ public class AdditionalFileController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(
+            summary = "Detach additional book file",
+            description = "Detach a specific additional file from a book and optionally copy metadata.",
+            operationId = "detachAdditionalBookFile")
     @PostMapping("/{fileId}/detach")
     @CheckBookAccess(bookIdParam = "bookId")
     @PreAuthorize("@securityUtil.canManageLibrary() or @securityUtil.isAdmin()")

--- a/booklore-api/src/main/java/org/booklore/controller/AdditionalFileController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AdditionalFileController.java
@@ -33,7 +33,8 @@ public class AdditionalFileController {
     @Operation(
             summary = "List additional book files",
             description = "Retrieve additional files for a specific book.",
-            operationId = "listAdditionalBookFiles")
+            operationId = "listAdditionalBookFiles"
+    )
     @GetMapping
     @CheckBookAccess(bookIdParam = "bookId")
     public ResponseEntity<List<BookFile>> getAdditionalFiles(@PathVariable Long bookId) {
@@ -44,7 +45,8 @@ public class AdditionalFileController {
     @Operation(
             summary = "List additional files by type",
             description = "Retrieve additional files for a specific book filtered by whether they are primary book files.",
-            operationId = "listAdditionalBookFilesByType")
+            operationId = "listAdditionalBookFilesByType"
+    )
     @GetMapping(params = "isBook")
     @CheckBookAccess(bookIdParam = "bookId")
     public ResponseEntity<List<BookFile>> getFilesByIsBook(
@@ -57,7 +59,8 @@ public class AdditionalFileController {
     @Operation(
             summary = "Upload additional book file",
             description = "Upload and attach a new additional file to a specific book.",
-            operationId = "uploadAdditionalBookFile")
+            operationId = "uploadAdditionalBookFile"
+    )
     @PostMapping(consumes = "multipart/form-data")
     @CheckBookAccess(bookIdParam = "bookId")
     @PreAuthorize("@securityUtil.canUpload() or @securityUtil.isAdmin()")
@@ -74,7 +77,8 @@ public class AdditionalFileController {
     @Operation(
             summary = "Download additional book file",
             description = "Download a specific additional file attached to a book.",
-            operationId = "downloadAdditionalBookFile")
+            operationId = "downloadAdditionalBookFile"
+    )
     @GetMapping("/{fileId}/download")
     @CheckBookAccess(bookIdParam = "bookId")
     public ResponseEntity<Resource> downloadAdditionalFile(
@@ -86,7 +90,8 @@ public class AdditionalFileController {
     @Operation(
             summary = "Delete additional book file",
             description = "Delete a specific additional file attached to a book.",
-            operationId = "deleteAdditionalBookFile")
+            operationId = "deleteAdditionalBookFile"
+    )
     @DeleteMapping("/{fileId}")
     @CheckBookAccess(bookIdParam = "bookId")
     @PreAuthorize("@securityUtil.canDeleteBook() or @securityUtil.isAdmin()")
@@ -100,7 +105,8 @@ public class AdditionalFileController {
     @Operation(
             summary = "Detach additional book file",
             description = "Detach a specific additional file from a book and optionally copy metadata.",
-            operationId = "detachAdditionalBookFile")
+            operationId = "detachAdditionalBookFile"
+    )
     @PostMapping("/{fileId}/detach")
     @CheckBookAccess(bookIdParam = "bookId")
     @PreAuthorize("@securityUtil.canManageLibrary() or @securityUtil.isAdmin()")

--- a/booklore-api/src/main/java/org/booklore/controller/AdditionalFileController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AdditionalFileController.java
@@ -33,7 +33,7 @@ public class AdditionalFileController {
     @Operation(
             summary = "List additional book files",
             description = "Retrieve additional files for a specific book.",
-            operationId = "listAdditionalBookFiles"
+            operationId = "additionalFileGetAdditionalFiles"
     )
     @GetMapping
     @CheckBookAccess(bookIdParam = "bookId")
@@ -45,7 +45,7 @@ public class AdditionalFileController {
     @Operation(
             summary = "List additional files by type",
             description = "Retrieve additional files for a specific book filtered by whether they are primary book files.",
-            operationId = "listAdditionalBookFilesByType"
+            operationId = "additionalFileGetFilesByIsBook"
     )
     @GetMapping(params = "isBook")
     @CheckBookAccess(bookIdParam = "bookId")
@@ -59,7 +59,7 @@ public class AdditionalFileController {
     @Operation(
             summary = "Upload additional book file",
             description = "Upload and attach a new additional file to a specific book.",
-            operationId = "uploadAdditionalBookFile"
+            operationId = "additionalFileUploadAdditionalFile"
     )
     @PostMapping(consumes = "multipart/form-data")
     @CheckBookAccess(bookIdParam = "bookId")
@@ -77,7 +77,7 @@ public class AdditionalFileController {
     @Operation(
             summary = "Download additional book file",
             description = "Download a specific additional file attached to a book.",
-            operationId = "downloadAdditionalBookFile"
+            operationId = "additionalFileDownloadAdditionalFile"
     )
     @GetMapping("/{fileId}/download")
     @CheckBookAccess(bookIdParam = "bookId")
@@ -90,7 +90,7 @@ public class AdditionalFileController {
     @Operation(
             summary = "Delete additional book file",
             description = "Delete a specific additional file attached to a book.",
-            operationId = "deleteAdditionalBookFile"
+            operationId = "additionalFileDeleteAdditionalFile"
     )
     @DeleteMapping("/{fileId}")
     @CheckBookAccess(bookIdParam = "bookId")
@@ -105,7 +105,7 @@ public class AdditionalFileController {
     @Operation(
             summary = "Detach additional book file",
             description = "Detach a specific additional file from a book and optionally copy metadata.",
-            operationId = "detachAdditionalBookFile"
+            operationId = "additionalFileDetachFile"
     )
     @PostMapping("/{fileId}/detach")
     @CheckBookAccess(bookIdParam = "bookId")

--- a/booklore-api/src/main/java/org/booklore/controller/LogoutController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/LogoutController.java
@@ -1,5 +1,7 @@
 package org.booklore.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.booklore.config.security.service.LogoutService;
 import org.booklore.model.dto.request.LogoutRequest;
@@ -15,10 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/auth")
+@Tag(name = "Authentication", description = "Endpoints for user authentication, registration, and token management")
 public class LogoutController {
 
     private final LogoutService logoutService;
 
+    @Operation(
+            summary = "Logout user",
+            description = "Logout the current user and invalidate refresh token state when provided.",
+            operationId = "logoutUser")
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(Authentication auth,
                                                   @RequestBody(required = false) LogoutRequest request,

--- a/booklore-api/src/main/java/org/booklore/controller/LogoutController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/LogoutController.java
@@ -25,7 +25,7 @@ public class LogoutController {
     @Operation(
             summary = "Logout user",
             description = "Logout the current user and invalidate refresh token state when provided.",
-            operationId = "logoutUser"
+            operationId = "logout"
     )
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(Authentication auth,

--- a/booklore-api/src/main/java/org/booklore/controller/LogoutController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/LogoutController.java
@@ -25,7 +25,8 @@ public class LogoutController {
     @Operation(
             summary = "Logout user",
             description = "Logout the current user and invalidate refresh token state when provided.",
-            operationId = "logoutUser")
+            operationId = "logoutUser"
+    )
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(Authentication auth,
                                                   @RequestBody(required = false) LogoutRequest request,

--- a/booklore-api/src/main/java/org/booklore/controller/OidcAuthController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/OidcAuthController.java
@@ -39,7 +39,7 @@ public class OidcAuthController {
     @Operation(
             summary = "Generate OIDC state",
             description = "Generate a one-time state value for initiating an OIDC authentication flow.",
-            operationId = "generateOidcState"
+            operationId = "oidcGenerateState"
     )
     @GetMapping("/state")
     public ResponseEntity<Map<String, String>> generateState() {
@@ -49,7 +49,7 @@ public class OidcAuthController {
     @Operation(
             summary = "Handle OIDC callback",
             description = "Process the OIDC callback payload and exchange authorization code for tokens.",
-            operationId = "handleOidcCallback"
+            operationId = "oidcHandleCallback"
     )
     @PostMapping("/callback")
     public ResponseEntity<Map<String, String>> handleCallback(
@@ -74,7 +74,7 @@ public class OidcAuthController {
     @Operation(
             summary = "Handle OIDC redirect callback",
             description = "Handle redirect-based OIDC callback and redirect back to the app with token information.",
-            operationId = "handleOidcRedirectCallback"
+            operationId = "oidcHandleRedirect"
     )
     @GetMapping("/redirect")
     public ResponseEntity<Void> handleRedirect(
@@ -125,7 +125,7 @@ public class OidcAuthController {
     @Operation(
             summary = "Handle OIDC mobile callback",
             description = "Process mobile OIDC callback parameters and exchange authorization code for tokens.",
-            operationId = "handleOidcMobileCallback"
+            operationId = "oidcHandleMobileCallback"
     )
     @PostMapping("/mobile/callback")
     public ResponseEntity<Map<String, String>> handleMobileCallback(
@@ -148,7 +148,7 @@ public class OidcAuthController {
     @Operation(
             summary = "Handle OIDC backchannel logout",
             description = "Process OIDC backchannel logout token and invalidate matching session state.",
-            operationId = "handleOidcBackchannelLogout"
+            operationId = "oidcBackchannelLogout"
     )
     @PostMapping(value = "/backchannel-logout", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public ResponseEntity<Void> backchannelLogout(@RequestParam("logout_token") String logoutToken) {

--- a/booklore-api/src/main/java/org/booklore/controller/OidcAuthController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/OidcAuthController.java
@@ -39,7 +39,8 @@ public class OidcAuthController {
     @Operation(
             summary = "Generate OIDC state",
             description = "Generate a one-time state value for initiating an OIDC authentication flow.",
-            operationId = "generateOidcState")
+            operationId = "generateOidcState"
+    )
     @GetMapping("/state")
     public ResponseEntity<Map<String, String>> generateState() {
         return ResponseEntity.ok(Map.of("state", oidcStateService.generateState()));
@@ -48,7 +49,8 @@ public class OidcAuthController {
     @Operation(
             summary = "Handle OIDC callback",
             description = "Process the OIDC callback payload and exchange authorization code for tokens.",
-            operationId = "handleOidcCallback")
+            operationId = "handleOidcCallback"
+    )
     @PostMapping("/callback")
     public ResponseEntity<Map<String, String>> handleCallback(
             @RequestBody @Valid OidcCallbackRequest request,
@@ -72,7 +74,8 @@ public class OidcAuthController {
     @Operation(
             summary = "Handle OIDC redirect callback",
             description = "Handle redirect-based OIDC callback and redirect back to the app with token information.",
-            operationId = "handleOidcRedirectCallback")
+            operationId = "handleOidcRedirectCallback"
+    )
     @GetMapping("/redirect")
     public ResponseEntity<Void> handleRedirect(
             @RequestParam("code") String code,
@@ -122,7 +125,8 @@ public class OidcAuthController {
     @Operation(
             summary = "Handle OIDC mobile callback",
             description = "Process mobile OIDC callback parameters and exchange authorization code for tokens.",
-            operationId = "handleOidcMobileCallback")
+            operationId = "handleOidcMobileCallback"
+    )
     @PostMapping("/mobile/callback")
     public ResponseEntity<Map<String, String>> handleMobileCallback(
             @RequestParam("code") String code,
@@ -144,7 +148,8 @@ public class OidcAuthController {
     @Operation(
             summary = "Handle OIDC backchannel logout",
             description = "Process OIDC backchannel logout token and invalidate matching session state.",
-            operationId = "handleOidcBackchannelLogout")
+            operationId = "handleOidcBackchannelLogout"
+    )
     @PostMapping(value = "/backchannel-logout", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public ResponseEntity<Void> backchannelLogout(@RequestParam("logout_token") String logoutToken) {
         try {

--- a/booklore-api/src/main/java/org/booklore/controller/OidcAuthController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/OidcAuthController.java
@@ -1,5 +1,7 @@
 package org.booklore.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -26,6 +28,7 @@ import java.util.Map;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/auth/oidc")
+@Tag(name = "OIDC Authentication", description = "Endpoints for OIDC state generation, callbacks, and logout flows")
 public class OidcAuthController {
 
     private final OidcAuthService oidcAuthService;
@@ -33,11 +36,19 @@ public class OidcAuthController {
     private final OidcStateService oidcStateService;
     private final AuditService auditService;
 
+    @Operation(
+            summary = "Generate OIDC state",
+            description = "Generate a one-time state value for initiating an OIDC authentication flow.",
+            operationId = "generateOidcState")
     @GetMapping("/state")
     public ResponseEntity<Map<String, String>> generateState() {
         return ResponseEntity.ok(Map.of("state", oidcStateService.generateState()));
     }
 
+    @Operation(
+            summary = "Handle OIDC callback",
+            description = "Process the OIDC callback payload and exchange authorization code for tokens.",
+            operationId = "handleOidcCallback")
     @PostMapping("/callback")
     public ResponseEntity<Map<String, String>> handleCallback(
             @RequestBody @Valid OidcCallbackRequest request,
@@ -58,6 +69,10 @@ public class OidcAuthController {
         }
     }
 
+    @Operation(
+            summary = "Handle OIDC redirect callback",
+            description = "Handle redirect-based OIDC callback and redirect back to the app with token information.",
+            operationId = "handleOidcRedirectCallback")
     @GetMapping("/redirect")
     public ResponseEntity<Void> handleRedirect(
             @RequestParam("code") String code,
@@ -104,6 +119,10 @@ public class OidcAuthController {
         }
     }
 
+    @Operation(
+            summary = "Handle OIDC mobile callback",
+            description = "Process mobile OIDC callback parameters and exchange authorization code for tokens.",
+            operationId = "handleOidcMobileCallback")
     @PostMapping("/mobile/callback")
     public ResponseEntity<Map<String, String>> handleMobileCallback(
             @RequestParam("code") String code,
@@ -122,6 +141,10 @@ public class OidcAuthController {
         }
     }
 
+    @Operation(
+            summary = "Handle OIDC backchannel logout",
+            description = "Process OIDC backchannel logout token and invalidate matching session state.",
+            operationId = "handleOidcBackchannelLogout")
     @PostMapping(value = "/backchannel-logout", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public ResponseEntity<Void> backchannelLogout(@RequestParam("logout_token") String logoutToken) {
         try {

--- a/booklore-api/src/main/java/org/booklore/controller/OidcGroupMappingController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/OidcGroupMappingController.java
@@ -23,7 +23,7 @@ public class OidcGroupMappingController {
     @Operation(
             summary = "List OIDC group mappings",
             description = "Retrieve all configured OIDC group mappings.",
-            operationId = "listOidcGroupMappings"
+            operationId = "oidcGroupMappingGetAll"
     )
     @GetMapping
     public List<OidcGroupMapping> getAll() {
@@ -33,7 +33,7 @@ public class OidcGroupMappingController {
     @Operation(
             summary = "Create OIDC group mapping",
             description = "Create a new OIDC group mapping.",
-            operationId = "createOidcGroupMapping"
+            operationId = "oidcGroupMappingCreate"
     )
     @PostMapping
     public OidcGroupMapping create(@Valid @RequestBody OidcGroupMapping mapping) {
@@ -43,7 +43,7 @@ public class OidcGroupMappingController {
     @Operation(
             summary = "Update OIDC group mapping",
             description = "Update an existing OIDC group mapping by ID.",
-            operationId = "updateOidcGroupMapping"
+            operationId = "oidcGroupMappingUpdate"
     )
     @PutMapping("/{id}")
     public OidcGroupMapping update(@PathVariable Long id, @Valid @RequestBody OidcGroupMapping mapping) {
@@ -53,7 +53,7 @@ public class OidcGroupMappingController {
     @Operation(
             summary = "Delete OIDC group mapping",
             description = "Delete an OIDC group mapping by ID.",
-            operationId = "deleteOidcGroupMapping"
+            operationId = "oidcGroupMappingDelete"
     )
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {

--- a/booklore-api/src/main/java/org/booklore/controller/OidcGroupMappingController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/OidcGroupMappingController.java
@@ -1,5 +1,7 @@
 package org.booklore.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.booklore.model.dto.OidcGroupMapping;
 import org.booklore.service.oidc.OidcGroupMappingService;
@@ -13,25 +15,42 @@ import java.util.List;
 @RequestMapping("/api/v1/admin/oidc-group-mappings")
 @PreAuthorize("@securityUtil.isAdmin()")
 @AllArgsConstructor
+@Tag(name = "OIDC Group Mappings", description = "Endpoints for managing OIDC group-to-role mappings")
 public class OidcGroupMappingController {
 
     private final OidcGroupMappingService oidcGroupMappingService;
 
+    @Operation(
+            summary = "List OIDC group mappings",
+            description = "Retrieve all configured OIDC group mappings.",
+            operationId = "listOidcGroupMappings")
     @GetMapping
     public List<OidcGroupMapping> getAll() {
         return oidcGroupMappingService.getAll();
     }
 
+    @Operation(
+            summary = "Create OIDC group mapping",
+            description = "Create a new OIDC group mapping.",
+            operationId = "createOidcGroupMapping")
     @PostMapping
     public OidcGroupMapping create(@Valid @RequestBody OidcGroupMapping mapping) {
         return oidcGroupMappingService.create(mapping);
     }
 
+    @Operation(
+            summary = "Update OIDC group mapping",
+            description = "Update an existing OIDC group mapping by ID.",
+            operationId = "updateOidcGroupMapping")
     @PutMapping("/{id}")
     public OidcGroupMapping update(@PathVariable Long id, @Valid @RequestBody OidcGroupMapping mapping) {
         return oidcGroupMappingService.update(id, mapping);
     }
 
+    @Operation(
+            summary = "Delete OIDC group mapping",
+            description = "Delete an OIDC group mapping by ID.",
+            operationId = "deleteOidcGroupMapping")
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         oidcGroupMappingService.delete(id);

--- a/booklore-api/src/main/java/org/booklore/controller/OidcGroupMappingController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/OidcGroupMappingController.java
@@ -23,7 +23,8 @@ public class OidcGroupMappingController {
     @Operation(
             summary = "List OIDC group mappings",
             description = "Retrieve all configured OIDC group mappings.",
-            operationId = "listOidcGroupMappings")
+            operationId = "listOidcGroupMappings"
+    )
     @GetMapping
     public List<OidcGroupMapping> getAll() {
         return oidcGroupMappingService.getAll();
@@ -32,7 +33,8 @@ public class OidcGroupMappingController {
     @Operation(
             summary = "Create OIDC group mapping",
             description = "Create a new OIDC group mapping.",
-            operationId = "createOidcGroupMapping")
+            operationId = "createOidcGroupMapping"
+    )
     @PostMapping
     public OidcGroupMapping create(@Valid @RequestBody OidcGroupMapping mapping) {
         return oidcGroupMappingService.create(mapping);
@@ -41,7 +43,8 @@ public class OidcGroupMappingController {
     @Operation(
             summary = "Update OIDC group mapping",
             description = "Update an existing OIDC group mapping by ID.",
-            operationId = "updateOidcGroupMapping")
+            operationId = "updateOidcGroupMapping"
+    )
     @PutMapping("/{id}")
     public OidcGroupMapping update(@PathVariable Long id, @Valid @RequestBody OidcGroupMapping mapping) {
         return oidcGroupMappingService.update(id, mapping);
@@ -50,7 +53,8 @@ public class OidcGroupMappingController {
     @Operation(
             summary = "Delete OIDC group mapping",
             description = "Delete an OIDC group mapping by ID.",
-            operationId = "deleteOidcGroupMapping")
+            operationId = "deleteOidcGroupMapping"
+    )
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         oidcGroupMappingService.delete(id);

--- a/booklore-api/src/main/java/org/booklore/controller/ReadingSessionController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/ReadingSessionController.java
@@ -6,6 +6,7 @@ import org.booklore.service.ReadingSessionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/v1/reading-sessions")
+@Tag(name = "Reading Sessions", description = "Endpoints for recording and retrieving user reading sessions")
 public class ReadingSessionController {
 
     private final ReadingSessionService readingSessionService;

--- a/booklore-api/src/main/java/org/booklore/controller/TaskController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/TaskController.java
@@ -35,7 +35,7 @@ public class TaskController {
     @Operation(
             summary = "List available tasks",
             description = "Retrieve all task types available to the current user.",
-            operationId = "listAvailableTasks"
+            operationId = "taskGetAvailableTasks"
     )
     @GetMapping
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
@@ -47,7 +47,7 @@ public class TaskController {
     @Operation(
             summary = "Start task",
             description = "Start a task immediately with the provided task request payload.",
-            operationId = "startTask"
+            operationId = "taskStartTask"
     )
     @PostMapping("/start")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
@@ -62,7 +62,7 @@ public class TaskController {
     @Operation(
             summary = "Cancel task",
             description = "Cancel an in-progress task by task ID.",
-            operationId = "cancelTask"
+            operationId = "taskCancelTask"
     )
     @DeleteMapping("/{taskId}/cancel")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
@@ -74,7 +74,7 @@ public class TaskController {
     @Operation(
             summary = "Get latest tasks by type",
             description = "Retrieve the latest task execution entry for each task type.",
-            operationId = "getLatestTasksByType"
+            operationId = "taskGetLatestTasksForEachType"
     )
     @GetMapping("/last")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
@@ -86,7 +86,7 @@ public class TaskController {
     @Operation(
             summary = "Update task cron configuration",
             description = "Patch cron schedule configuration for a task type and reschedule execution.",
-            operationId = "updateTaskCronConfig"
+            operationId = "taskPatchCronConfig"
     )
     @PatchMapping("/{taskType}/cron")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")

--- a/booklore-api/src/main/java/org/booklore/controller/TaskController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/TaskController.java
@@ -1,5 +1,7 @@
 package org.booklore.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.booklore.model.dto.TaskInfo;
 import org.booklore.model.dto.request.TaskCreateRequest;
 import org.booklore.model.dto.request.TaskCronConfigRequest;
@@ -23,12 +25,17 @@ import java.util.List;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/tasks")
+@Tag(name = "Tasks", description = "Endpoints for listing, starting, canceling, and scheduling background tasks")
 public class TaskController {
 
     private final TaskService service;
     private final TaskHistoryService taskHistoryService;
     private final TaskCronService taskCronService;
 
+    @Operation(
+            summary = "List available tasks",
+            description = "Retrieve all task types available to the current user.",
+            operationId = "listAvailableTasks")
     @GetMapping
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<List<TaskInfo>> getAvailableTasks() {
@@ -36,6 +43,10 @@ public class TaskController {
         return ResponseEntity.ok(taskInfos);
     }
 
+    @Operation(
+            summary = "Start task",
+            description = "Start a task immediately with the provided task request payload.",
+            operationId = "startTask")
     @PostMapping("/start")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<TaskCreateResponse> startTask(@RequestBody TaskCreateRequest request) {
@@ -46,6 +57,10 @@ public class TaskController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "Cancel task",
+            description = "Cancel an in-progress task by task ID.",
+            operationId = "cancelTask")
     @DeleteMapping("/{taskId}/cancel")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<TaskCancelResponse> cancelTask(@PathVariable String taskId) {
@@ -53,6 +68,10 @@ public class TaskController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "Get latest tasks by type",
+            description = "Retrieve the latest task execution entry for each task type.",
+            operationId = "getLatestTasksByType")
     @GetMapping("/last")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<TasksHistoryResponse> getLatestTasksForEachType() {
@@ -60,6 +79,10 @@ public class TaskController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "Update task cron configuration",
+            description = "Patch cron schedule configuration for a task type and reschedule execution.",
+            operationId = "updateTaskCronConfig")
     @PatchMapping("/{taskType}/cron")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<CronConfig> patchCronConfig(@PathVariable TaskType taskType, @RequestBody TaskCronConfigRequest request) {

--- a/booklore-api/src/main/java/org/booklore/controller/TaskController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/TaskController.java
@@ -35,7 +35,8 @@ public class TaskController {
     @Operation(
             summary = "List available tasks",
             description = "Retrieve all task types available to the current user.",
-            operationId = "listAvailableTasks")
+            operationId = "listAvailableTasks"
+    )
     @GetMapping
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<List<TaskInfo>> getAvailableTasks() {
@@ -46,7 +47,8 @@ public class TaskController {
     @Operation(
             summary = "Start task",
             description = "Start a task immediately with the provided task request payload.",
-            operationId = "startTask")
+            operationId = "startTask"
+    )
     @PostMapping("/start")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<TaskCreateResponse> startTask(@RequestBody TaskCreateRequest request) {
@@ -60,7 +62,8 @@ public class TaskController {
     @Operation(
             summary = "Cancel task",
             description = "Cancel an in-progress task by task ID.",
-            operationId = "cancelTask")
+            operationId = "cancelTask"
+    )
     @DeleteMapping("/{taskId}/cancel")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<TaskCancelResponse> cancelTask(@PathVariable String taskId) {
@@ -71,7 +74,8 @@ public class TaskController {
     @Operation(
             summary = "Get latest tasks by type",
             description = "Retrieve the latest task execution entry for each task type.",
-            operationId = "getLatestTasksByType")
+            operationId = "getLatestTasksByType"
+    )
     @GetMapping("/last")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<TasksHistoryResponse> getLatestTasksForEachType() {
@@ -82,7 +86,8 @@ public class TaskController {
     @Operation(
             summary = "Update task cron configuration",
             description = "Patch cron schedule configuration for a task type and reschedule execution.",
-            operationId = "updateTaskCronConfig")
+            operationId = "updateTaskCronConfig"
+    )
     @PatchMapping("/{taskType}/cron")
     @PreAuthorize("@securityUtil.canAccessTaskManager() or @securityUtil.isAdmin()")
     public ResponseEntity<CronConfig> patchCronConfig(@PathVariable TaskType taskType, @RequestBody TaskCronConfigRequest request) {

--- a/booklore-api/src/main/java/org/booklore/controller/UserStatsController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/UserStatsController.java
@@ -5,6 +5,7 @@ import org.booklore.service.ReadingSessionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -15,6 +16,7 @@ import java.util.List;
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/v1/user-stats")
+@Tag(name = "User Stats", description = "Endpoints for reading and listening analytics derived from user sessions")
 public class UserStatsController {
 
     private final ReadingSessionService readingSessionService;
@@ -281,6 +283,7 @@ public class UserStatsController {
         return ResponseEntity.ok(readingSessionService.getListeningFinishFunnel());
     }
 
+    @Operation(summary = "Get listening peak hours", description = "Returns listening activity distribution by hour of day. Can be filtered by year and/or month.", operationId = "getListeningPeakHours")
     @GetMapping("/listening/peak-hours")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<PeakHoursResponse>> getListeningPeakHours(
@@ -289,24 +292,28 @@ public class UserStatsController {
         return ResponseEntity.ok(readingSessionService.getListeningPeakHours(year, month));
     }
 
+    @Operation(summary = "Get listening genre statistics", description = "Returns listening statistics grouped by audiobook genres/categories.", operationId = "getListeningGenreStatistics")
     @GetMapping("/listening/genres")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<GenreStatisticsResponse>> getListeningGenreStatistics() {
         return ResponseEntity.ok(readingSessionService.getListeningGenreStatistics());
     }
 
+    @Operation(summary = "Get listening author statistics", description = "Returns listening statistics grouped by audiobook authors.", operationId = "getListeningAuthorStats")
     @GetMapping("/listening/authors")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<ListeningAuthorResponse>> getListeningAuthorStats() {
         return ResponseEntity.ok(readingSessionService.getListeningAuthorStats());
     }
 
+    @Operation(summary = "Get listening session scatter data", description = "Returns individual listening session points for scatter plot visualizations.", operationId = "getListeningSessionScatter")
     @GetMapping("/listening/session-scatter")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<SessionScatterResponse>> getListeningSessionScatter() {
         return ResponseEntity.ok(readingSessionService.getListeningSessionScatter());
     }
 
+    @Operation(summary = "Get longest listened audiobooks", description = "Returns longest audiobooks ranked by listening duration.", operationId = "getListeningLongestBooks")
     @GetMapping("/listening/longest-books")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<LongestAudiobookResponse>> getListeningLongestBooks() {

--- a/booklore-api/src/main/java/org/booklore/controller/UserStatsController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/UserStatsController.java
@@ -283,7 +283,11 @@ public class UserStatsController {
         return ResponseEntity.ok(readingSessionService.getListeningFinishFunnel());
     }
 
-    @Operation(summary = "Get listening peak hours", description = "Returns listening activity distribution by hour of day. Can be filtered by year and/or month.", operationId = "getListeningPeakHours")
+    @Operation(
+            summary = "Get listening peak hours",
+            description = "Returns listening activity distribution by hour of day. Can be filtered by year and/or month.",
+            operationId = "getListeningPeakHours"
+    )
     @GetMapping("/listening/peak-hours")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<PeakHoursResponse>> getListeningPeakHours(
@@ -292,28 +296,44 @@ public class UserStatsController {
         return ResponseEntity.ok(readingSessionService.getListeningPeakHours(year, month));
     }
 
-    @Operation(summary = "Get listening genre statistics", description = "Returns listening statistics grouped by audiobook genres/categories.", operationId = "getListeningGenreStatistics")
+    @Operation(
+            summary = "Get listening genre statistics",
+            description = "Returns listening statistics grouped by audiobook genres/categories.",
+            operationId = "getListeningGenreStatistics"
+    )
     @GetMapping("/listening/genres")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<GenreStatisticsResponse>> getListeningGenreStatistics() {
         return ResponseEntity.ok(readingSessionService.getListeningGenreStatistics());
     }
 
-    @Operation(summary = "Get listening author statistics", description = "Returns listening statistics grouped by audiobook authors.", operationId = "getListeningAuthorStats")
+    @Operation(
+            summary = "Get listening author statistics",
+            description = "Returns listening statistics grouped by audiobook authors.",
+            operationId = "getListeningAuthorStats"
+    )
     @GetMapping("/listening/authors")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<ListeningAuthorResponse>> getListeningAuthorStats() {
         return ResponseEntity.ok(readingSessionService.getListeningAuthorStats());
     }
 
-    @Operation(summary = "Get listening session scatter data", description = "Returns individual listening session points for scatter plot visualizations.", operationId = "getListeningSessionScatter")
+    @Operation(
+            summary = "Get listening session scatter data",
+            description = "Returns individual listening session points for scatter plot visualizations.",
+            operationId = "getListeningSessionScatter"
+    )
     @GetMapping("/listening/session-scatter")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<SessionScatterResponse>> getListeningSessionScatter() {
         return ResponseEntity.ok(readingSessionService.getListeningSessionScatter());
     }
 
-    @Operation(summary = "Get longest listened audiobooks", description = "Returns longest audiobooks ranked by listening duration.", operationId = "getListeningLongestBooks")
+    @Operation(
+            summary = "Get longest listened audiobooks",
+            description = "Returns longest audiobooks ranked by listening duration.",
+            operationId = "getListeningLongestBooks"
+    )
     @GetMapping("/listening/longest-books")
     @PreAuthorize("@securityUtil.canAccessUserStats() or @securityUtil.isAdmin()")
     public ResponseEntity<List<LongestAudiobookResponse>> getListeningLongestBooks() {

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - DATABASE_PASSWORD=grimmory
       - REMOTE_DEBUG_ENABLED=true
       - ALLOWED_ORIGINS=http://localhost:4200
+      - API_DOCS_ENABLED=true
       - JAVA_TOOL_OPTIONS=-XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=8.0 -XX:+ExitOnOutOfMemoryError -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=64m -Xss512k -XX:CICompilerCount=2 -XX:+UnlockExperimentalVMOptions -XX:ShenandoahUncommitDelay=5000 -XX:ShenandoahGuaranteedGCInterval=30000
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Description

This PR improves OpenAPI documentation consistency by adding explicit `@Tag` and `@Operation` metadata (including stable `operationId`) to previously under-documented controllers.

It also sets `API_DOCS_ENABLED=true` by default for developer docker compose builds.

**Linked Issue:** Loosely associated with https://github.com/grimmory-tools/grimmory/issues/183

## Changes

- Enabled API docs by default for developer docker compose builds
- Added explicit OpenAPI `@Tag` annotations to previously untagged controllers so endpoints are grouped by domain rather than generated controller names
- Added explicit `@Operation` info (summary, description, `operationId`) to previously undocumented endpoints in app/auth/task/file surfaces
- Introduced stable `operationId` values for those endpoints to avoid generated suffix drift (_1, _2, etc.) in the OpenAPI output
- Added missing `user-stats`/`listening` `@Operation` annotations so those routes no longer appear without summaries/descriptions
- Added `@Tag` to `ReadingSessionController` to eliminate remaining controller-style categorization in that area

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation across app and platform endpoints (books, authors, series, shelves, libraries, notebooks, filters, users, auth, tasks, stats, files, sessions) with clearer operation summaries, descriptions and grouping for better discovery and integration.
* **Chores**
  * Enabled API documentation in the development environment via configuration to surface the new docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->