### PR TITLE
fix(filter): update filter options to use CountedOption for read statuses and file types

### DIFF
--- a/booklore-api/src/main/java/org/booklore/app/dto/AppFilterOptions.java
+++ b/booklore-api/src/main/java/org/booklore/app/dto/AppFilterOptions.java
@@ -10,8 +10,8 @@ import java.util.List;
 public record AppFilterOptions(
         List<CountedOption> authors,
         List<LanguageOption> languages,
-        List<String> readStatuses,
-        List<String> fileTypes,
+        List<CountedOption> readStatuses,
+        List<CountedOption> fileTypes,
         List<CountedOption> categories,
         List<CountedOption> publishers,
         List<CountedOption> series,

--- a/booklore-api/src/main/java/org/booklore/app/dto/BookListRequest.java
+++ b/booklore-api/src/main/java/org/booklore/app/dto/BookListRequest.java
@@ -1,8 +1,6 @@
 package org.booklore.app.dto;
 
 import jakarta.validation.constraints.Size;
-import org.booklore.model.enums.BookFileType;
-import org.booklore.model.enums.ReadStatus;
 
 import java.util.List;
 
@@ -13,9 +11,9 @@ public record BookListRequest(
         String dir,
         Long libraryId,
         Long shelfId,
-        ReadStatus status,
+        @Size(max = 20) List<String> status,
         String search,
-        BookFileType fileType,
+        @Size(max = 20) List<String> fileType,
         Integer minRating,
         Integer maxRating,
         @Size(max = 20) List<String> authors,

--- a/booklore-api/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/booklore-api/src/main/java/org/booklore/app/service/AppBookService.java
@@ -362,7 +362,7 @@ public class AppBookService {
                         .authors(Collections.emptyList())
                         .languages(Collections.emptyList())
                         .fileTypes(Collections.emptyList())
-                        .readStatuses(getReadStatusOptions())
+                        .readStatuses(Collections.emptyList())
                         .categories(Collections.emptyList())
                         .publishers(Collections.emptyList())
                         .series(Collections.emptyList())
@@ -409,15 +409,20 @@ public class AppBookService {
                         c.count()))
                 .toList();
 
-        String fileTypeQuery = "SELECT DISTINCT bf.bookType FROM BookEntity b"
+        String fileTypeQuery = "SELECT bf.bookType, COUNT(DISTINCT b.id) FROM BookEntity b"
                 + " JOIN b.bookFiles bf"
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
                 + " AND b.bookFiles IS NOT EMPTY"
                 + " AND bf.isBookFormat = true"
-                + scopeClause;
-        var ftQ = entityManager.createQuery(fileTypeQuery, BookFileType.class);
+                + scopeClause
+                + " GROUP BY bf.bookType ORDER BY COUNT(DISTINCT b.id) DESC";
+        var ftQ = entityManager.createQuery(fileTypeQuery, Tuple.class);
         setFilterQueryParams(ftQ, accessibleLibraryIds, libraryId, shelfId, magicBookIds);
-        List<String> fileTypes = ftQ.getResultList().stream().map(Enum::name).sorted().toList();
+        List<AppFilterOptions.CountedOption> fileTypes = ftQ.getResultList().stream()
+                .map(t -> new AppFilterOptions.CountedOption(
+                        t.get(0, BookFileType.class).name(),
+                        t.get(1, Long.class)))
+                .toList();
 
         List<AppFilterOptions.CountedOption> categories = queryCountedOptions(
                 "c.name", "JOIN b.metadata m JOIN m.categories c", "",
@@ -446,11 +451,14 @@ public class AppBookService {
                 "AND m.narrator IS NOT NULL AND m.narrator <> ''",
                 scopeClause, accessibleLibraryIds, libraryId, shelfId, magicBookIds);
 
+        List<AppFilterOptions.CountedOption> readStatuses = queryReadStatusCounts(
+                userId, scopeClause, accessibleLibraryIds, libraryId, shelfId, magicBookIds);
+
         AppFilterOptions result = AppFilterOptions.builder()
                 .authors(authors)
                 .languages(languages)
                 .fileTypes(fileTypes)
-                .readStatuses(getReadStatusOptions())
+                .readStatuses(readStatuses)
                 .categories(categories)
                 .publishers(publishers)
                 .series(seriesOptions)
@@ -514,10 +522,26 @@ public class AppBookService {
                 .getResultList());
     }
 
-    private List<String> getReadStatusOptions() {
-        return Arrays.stream(ReadStatus.values())
-                .filter(s -> s != ReadStatus.UNSET)
-                .map(Enum::name)
+    private List<AppFilterOptions.CountedOption> queryReadStatusCounts(
+            Long userId, String scopeClause, Set<Long> accessibleLibraryIds,
+            Long libraryId, Long shelfId, Set<Long> magicBookIds) {
+        String jpql = "SELECT ubp.readStatus, COUNT(DISTINCT ubp.book.id) FROM UserBookProgressEntity ubp"
+                + " WHERE ubp.user.id = :userId"
+                + " AND ubp.readStatus <> org.booklore.model.enums.ReadStatus.UNSET"
+                + " AND ubp.book.id IN ("
+                + "   SELECT b.id FROM BookEntity b"
+                + "   WHERE (b.deleted IS NULL OR b.deleted = false)"
+                + "   AND b.bookFiles IS NOT EMPTY"
+                + scopeClause
+                + " )"
+                + " GROUP BY ubp.readStatus ORDER BY COUNT(DISTINCT ubp.book.id) DESC";
+        var q = entityManager.createQuery(jpql, Tuple.class);
+        q.setParameter("userId", userId);
+        setFilterQueryParams(q, accessibleLibraryIds, libraryId, shelfId, magicBookIds);
+        return q.getResultList().stream()
+                .map(t -> new AppFilterOptions.CountedOption(
+                        t.get(0, ReadStatus.class).name(),
+                        t.get(1, Long.class)))
                 .toList();
     }
 
@@ -624,16 +648,22 @@ public class AppBookService {
             specs.add(AppBookSpecification.inShelf(req.shelfId()));
         }
 
-        if (req.status() != null) {
-            specs.add(AppBookSpecification.withReadStatus(req.status(), userId));
+        if (req.status() != null && !req.status().isEmpty()) {
+            List<String> cleaned = BookListRequest.cleanValues(req.status());
+            if (!cleaned.isEmpty()) {
+                specs.add(AppBookSpecification.withReadStatuses(cleaned, userId, req.effectiveFilterMode()));
+            }
         }
 
         if (req.search() != null && !req.search().trim().isEmpty()) {
             specs.add(AppBookSpecification.searchText(req.search()));
         }
 
-        if (req.fileType() != null) {
-            specs.add(AppBookSpecification.withFileType(req.fileType()));
+        if (req.fileType() != null && !req.fileType().isEmpty()) {
+            List<String> cleaned = BookListRequest.cleanValues(req.fileType());
+            if (!cleaned.isEmpty()) {
+                specs.add(AppBookSpecification.withFileTypes(cleaned, req.effectiveFilterMode()));
+            }
         }
 
         if (req.minRating() != null) {

--- a/booklore-api/src/main/java/org/booklore/app/specification/AppBookSpecification.java
+++ b/booklore-api/src/main/java/org/booklore/app/specification/AppBookSpecification.java
@@ -1,16 +1,19 @@
 package org.booklore.app.specification;
 
+import org.booklore.exception.APIException;
 import org.booklore.model.entity.*;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.model.enums.ReadStatus;
 import jakarta.persistence.criteria.*;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class AppBookSpecification {
 
@@ -180,14 +183,23 @@ public class AppBookSpecification {
      */
     public static Specification<BookEntity> withFileTypes(List<String> fileTypes, String mode) {
         return (root, query, cb) -> {
+            List<String> unknown = new ArrayList<>();
             List<BookFileType> parsed = fileTypes.stream()
                     .filter(s -> s != null && !s.isBlank())
                     .map(s -> {
-                        try { return BookFileType.valueOf(s.trim().toUpperCase()); }
-                        catch (IllegalArgumentException e) { return null; }
+                        String trimmed = s.trim().toUpperCase();
+                        try {
+                            return BookFileType.valueOf(trimmed);
+                        } catch (IllegalArgumentException e) {
+                            unknown.add(s.trim());
+                            return null;
+                        }
                     })
-                    .filter(java.util.Objects::nonNull)
+                    .filter(Objects::nonNull)
                     .toList();
+            if (!unknown.isEmpty()) {
+                throw new APIException("Invalid fileType values: " + unknown + ". Valid values: " + List.of(BookFileType.values()), HttpStatus.BAD_REQUEST);
+            }
             if (parsed.isEmpty()) return cb.conjunction();
 
             if ("and".equals(mode)) {
@@ -223,14 +235,23 @@ public class AppBookSpecification {
     public static Specification<BookEntity> withReadStatuses(List<String> statuses, Long userId, String mode) {
         return (root, query, cb) -> {
             if (userId == null) return cb.conjunction();
+            List<String> unknown = new ArrayList<>();
             List<ReadStatus> parsed = statuses.stream()
                     .filter(s -> s != null && !s.isBlank())
                     .map(s -> {
-                        try { return ReadStatus.valueOf(s.trim().toUpperCase()); }
-                        catch (IllegalArgumentException e) { return null; }
+                        String trimmed = s.trim().toUpperCase();
+                        try {
+                            return ReadStatus.valueOf(trimmed);
+                        } catch (IllegalArgumentException e) {
+                            unknown.add(s.trim());
+                            return null;
+                        }
                     })
-                    .filter(java.util.Objects::nonNull)
+                    .filter(Objects::nonNull)
                     .toList();
+            if (!unknown.isEmpty()) {
+                throw new APIException("Invalid status values: " + unknown + ". Valid values: " + List.of(ReadStatus.values()), HttpStatus.BAD_REQUEST);
+            }
             if (parsed.isEmpty()) return cb.conjunction();
 
             Subquery<Long> sub = query.subquery(Long.class);

--- a/booklore-api/src/main/java/org/booklore/app/specification/AppBookSpecification.java
+++ b/booklore-api/src/main/java/org/booklore/app/specification/AppBookSpecification.java
@@ -173,6 +173,82 @@ public class AppBookSpecification {
     }
 
     /**
+     * Filter books by multiple file types with mode support.
+     * OR  = books with at least one file of ANY listed type
+     * AND = books with files of ALL listed types
+     * NOT = books with NONE of the listed file types
+     */
+    public static Specification<BookEntity> withFileTypes(List<String> fileTypes, String mode) {
+        return (root, query, cb) -> {
+            List<BookFileType> parsed = fileTypes.stream()
+                    .filter(s -> s != null && !s.isBlank())
+                    .map(s -> {
+                        try { return BookFileType.valueOf(s.trim().toUpperCase()); }
+                        catch (IllegalArgumentException e) { return null; }
+                    })
+                    .filter(java.util.Objects::nonNull)
+                    .toList();
+            if (parsed.isEmpty()) return cb.conjunction();
+
+            if ("and".equals(mode)) {
+                List<Predicate> predicates = new ArrayList<>();
+                for (BookFileType ft : parsed) {
+                    Subquery<Long> sub = query.subquery(Long.class);
+                    Root<BookFileEntity> bfRoot = sub.from(BookFileEntity.class);
+                    sub.select(bfRoot.get("book").get("id"))
+                            .where(cb.equal(bfRoot.get("bookType"), ft));
+                    predicates.add(root.get("id").in(sub));
+                }
+                return cb.and(predicates.toArray(new Predicate[0]));
+            }
+
+            Subquery<Long> sub = query.subquery(Long.class);
+            Root<BookFileEntity> bfRoot = sub.from(BookFileEntity.class);
+            sub.select(bfRoot.get("book").get("id"))
+                    .where(bfRoot.get("bookType").in(parsed));
+
+            if ("not".equals(mode)) {
+                return cb.not(root.get("id").in(sub));
+            }
+            return root.get("id").in(sub);
+        };
+    }
+
+    /**
+     * Filter books by multiple read statuses with mode support (per-user).
+     * OR  = books with ANY of the listed read statuses
+     * AND = impossible for a single-value field, treated as OR
+     * NOT = books with NONE of the listed read statuses
+     */
+    public static Specification<BookEntity> withReadStatuses(List<String> statuses, Long userId, String mode) {
+        return (root, query, cb) -> {
+            if (userId == null) return cb.conjunction();
+            List<ReadStatus> parsed = statuses.stream()
+                    .filter(s -> s != null && !s.isBlank())
+                    .map(s -> {
+                        try { return ReadStatus.valueOf(s.trim().toUpperCase()); }
+                        catch (IllegalArgumentException e) { return null; }
+                    })
+                    .filter(java.util.Objects::nonNull)
+                    .toList();
+            if (parsed.isEmpty()) return cb.conjunction();
+
+            Subquery<Long> sub = query.subquery(Long.class);
+            Root<UserBookProgressEntity> progressRoot = sub.from(UserBookProgressEntity.class);
+            sub.select(progressRoot.get("book").get("id"))
+                    .where(
+                            cb.equal(progressRoot.get("user").get("id"), userId),
+                            progressRoot.get("readStatus").in(parsed)
+                    );
+
+            if ("not".equals(mode)) {
+                return cb.not(root.get("id").in(sub));
+            }
+            return root.get("id").in(sub);
+        };
+    }
+
+    /**
      * Filter books where the user's personal rating is >= minRating.
      */
     public static Specification<BookEntity> withMinRating(int minRating, Long userId) {

--- a/booklore-api/src/test/java/org/booklore/app/controller/AppFilterControllerTest.java
+++ b/booklore-api/src/test/java/org/booklore/app/controller/AppFilterControllerTest.java
@@ -79,11 +79,17 @@ class AppFilterControllerTest {
         List<AppFilterOptions.LanguageOption> languages = langCodes.stream()
                 .map(code -> new AppFilterOptions.LanguageOption(code, code, 1L))
                 .toList();
+        List<AppFilterOptions.CountedOption> fileTypeOptions = fileTypes.stream()
+                .map(ft -> new AppFilterOptions.CountedOption(ft, 1L))
+                .toList();
+        List<AppFilterOptions.CountedOption> readStatusOptions = List.of("READ", "READING", "UNREAD").stream()
+                .map(rs -> new AppFilterOptions.CountedOption(rs, 1L))
+                .toList();
         return AppFilterOptions.builder()
                 .authors(authors)
                 .languages(languages)
-                .fileTypes(fileTypes)
-                .readStatuses(List.of("READ", "READING", "UNREAD"))
+                .fileTypes(fileTypeOptions)
+                .readStatuses(readStatusOptions)
                 .build();
     }
 }

--- a/booklore-api/src/test/java/org/booklore/app/service/AppBookServiceFilterOptionsTest.java
+++ b/booklore-api/src/test/java/org/booklore/app/service/AppBookServiceFilterOptionsTest.java
@@ -12,7 +12,6 @@ import org.booklore.model.dto.Library;
 import org.booklore.model.entity.BookLoreUserEntity;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.ShelfEntity;
-import org.booklore.model.enums.BookFileType;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.ShelfRepository;
 import org.booklore.repository.UserBookFileProgressRepository;
@@ -81,7 +80,7 @@ class AppBookServiceFilterOptionsTest {
         assertNotNull(result.authors());
         assertNotNull(result.languages());
         assertNotNull(result.fileTypes());
-        assertFalse(result.readStatuses().isEmpty());
+        assertNotNull(result.readStatuses());
     }
 
     // -------------------------------------------------------------------------
@@ -96,7 +95,7 @@ class AppBookServiceFilterOptionsTest {
         AppFilterOptions result = service.getFilterOptions(5L, null, null);
 
         assertNotNull(result);
-        verify(entityManager, times(9)).createQuery(anyString(), any(Class.class));
+        verify(entityManager, times(10)).createQuery(anyString(), any(Class.class));
     }
 
     @Test
@@ -179,7 +178,7 @@ class AppBookServiceFilterOptionsTest {
         assertTrue(result.authors().isEmpty());
         assertTrue(result.languages().isEmpty());
         assertTrue(result.fileTypes().isEmpty());
-        assertFalse(result.readStatuses().isEmpty());
+        assertTrue(result.readStatuses().isEmpty());
     }
 
     @Test
@@ -263,13 +262,7 @@ class AppBookServiceFilterOptionsTest {
         when(tupleQuery.setMaxResults(anyInt())).thenReturn(tupleQuery);
         when(tupleQuery.getResultList()).thenReturn(Collections.emptyList());
 
-        TypedQuery<BookFileType> ftQuery = mock(TypedQuery.class);
-        when(ftQuery.setParameter(anyString(), any())).thenReturn(ftQuery);
-        when(ftQuery.getResultList()).thenReturn(Collections.emptyList());
-
         when(entityManager.createQuery(anyString(), eq(Tuple.class)))
                 .thenReturn(tupleQuery);
-        when(entityManager.createQuery(anyString(), eq(BookFileType.class)))
-                .thenReturn(ftQuery);
     }
 }

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.html
@@ -318,7 +318,11 @@
             ></app-book-table>
           }
           @if (currentViewMode === 'grid') {
-            <virtual-scroller class="virtual-scroller" #scroll [items]="books" [bufferAmount]="16" (vsEnd)="onScrollEnd()">
+            <virtual-scroller class="virtual-scroller" #scroll
+              [items]="books"
+              [bufferAmount]="16"
+              [compareItems]="compareBookItems"
+              (vsEnd)="onScrollEnd()">
               <div
                 class="grid"
                 #container
@@ -326,7 +330,7 @@
                 @for (book of scroll.viewPortItems; let i = $index; track book.id) {
                   <div
                     class="virtual-scroller-item"
-                    [ngStyle]="{width: currentCardSize.width + 'px', height: getCardHeight(book) + 'px'}">
+                    [ngStyle]="{width: currentCardSize.width + 'px', height: currentCardSize.height + 'px'}">
                     <app-book-card
                       [index]="bookIndexById().get(book.id) ?? i"
                       [book]="book"

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, HostListener, computed, effect, inject, OnDestroy, OnInit, signal, untracked, ViewChild} from '@angular/core';
+import {AfterViewInit, ChangeDetectionStrategy, Component, HostListener, computed, effect, inject, OnDestroy, OnInit, signal, untracked, ViewChild} from '@angular/core';
 import {toObservable, toSignal} from '@angular/core/rxjs-interop';
 import {ActivatedRoute, NavigationStart, Router} from '@angular/router';
 import {ConfirmationService, MenuItem, MessageService} from 'primeng/api';
@@ -72,6 +72,7 @@ export enum EntityType {
   standalone: true,
   templateUrl: './book-browser.component.html',
   styleUrls: ['./book-browser.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     Button, VirtualScrollerModule, BookCardComponent, Menu, InputText, FormsModule,
     BookTableComponent, BookFilterComponent, Tooltip, NgClass, NgStyle, Popover,
@@ -226,8 +227,8 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
           case 'mood': scopeFilters.mood = strValues; break;
           case 'narrator': scopeFilters.narrator = strValues; break;
           case 'language': scopeFilters.language = strValues; break;
-          case 'readStatus': scopeFilters.status = strValues[0]; break;
-          case 'bookType': scopeFilters.fileType = strValues[0]; break;
+          case 'readStatus': scopeFilters.status = strValues; break;
+          case 'bookType': scopeFilters.fileType = strValues; break;
         }
       }
       const mode = this.selectedFilterMode();
@@ -256,34 +257,24 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
     return Number.isNaN(entityId) ? entityType : `${entityType}:${entityId}`;
   });
 
-  private readonly pipelineInputs = computed(() => ({
-    books: this.appBooksApi.books(),
-    entity: this.entityInfo(),
-    search: this.debouncedSearchTerm(),
-    filter: this.selectedFilter(),
-    filterMode: this.selectedFilterMode(),
-    collapsed: this.seriesCollapsed(),
-    forceExpand: this.forceExpandSeries(),
-    sort: this.sortCriteria(),
-  }));
+  private readonly pipelineInputs = computed(() => this.appBooksApi.books());
 
   private readonly renderBooksEffect = effect((onCleanup) => {
     const contextKey = this.booksContextKey();
-    this.pipelineInputs();
+    const books = this.pipelineInputs();
 
     const shouldRefreshInPlace = untracked(() => this.hasRenderedBooks()) && contextKey === this.lastBooksContextKey;
     this.lastBooksContextKey = contextKey;
 
     if (shouldRefreshInPlace) {
-      const requestId = this.booksRenderState.begin('refresh');
-      this.booksRenderState.commit(requestId, this.appBooksApi.books());
+      this.booksRenderState.update(books);
       return;
     }
 
     const requestId = this.booksRenderState.begin('reset');
 
     const timeout = globalThis.setTimeout(() => {
-      this.booksRenderState.commit(requestId, this.appBooksApi.books());
+      this.booksRenderState.commit(requestId, books);
     });
 
     onCleanup(() => {
@@ -302,6 +293,7 @@ export class BookBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     return map;
   });
+  readonly compareBookItems = (a: Book, b: Book): boolean => a?.id === b?.id;
   protected resetFilterSubject = new Subject<void>();
 
   readonly skeletonSlots = Array.from({length: 24}, (_, index) => index);

--- a/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
@@ -152,15 +152,9 @@ export class BookFilterService {
           bookCount: lang.count,
         }));
       case 'readStatus':
-        return (options.readStatuses ?? []).map((status: string) => ({
-          value: {id: status, name: status},
-          bookCount: 0,
-        }));
+        return this.countedToFilters(options.readStatuses);
       case 'bookType':
-        return (options.fileTypes ?? []).map((ft: string) => ({
-          value: {id: ft, name: ft},
-          bookCount: 0,
-        }));
+        return this.countedToFilters(options.fileTypes);
       default:
         return [];
     }

--- a/frontend/src/app/features/book/components/book-browser/deferred-render-state.ts
+++ b/frontend/src/app/features/book/components/book-browser/deferred-render-state.ts
@@ -29,6 +29,7 @@ export class DeferredRenderState<T> {
   /** Direct update without refresh animation used for in-place data swaps. */
   update(value: T): void {
     this._value.set(value);
+    this._isRefreshing.set(false);
   }
 
   commit(requestId: number, value: T): boolean {

--- a/frontend/src/app/features/book/components/book-browser/deferred-render-state.ts
+++ b/frontend/src/app/features/book/components/book-browser/deferred-render-state.ts
@@ -26,6 +26,11 @@ export class DeferredRenderState<T> {
     return this.activeRequestId;
   }
 
+  /** Direct update without refresh animation used for in-place data swaps. */
+  update(value: T): void {
+    this._value.set(value);
+  }
+
   commit(requestId: number, value: T): boolean {
     if (requestId !== this.activeRequestId) {
       return false;

--- a/frontend/src/app/features/book/model/app-book.model.ts
+++ b/frontend/src/app/features/book/model/app-book.model.ts
@@ -30,8 +30,8 @@ export interface AppBookSummary {
 export interface AppFilterOptions {
   authors: CountedOption[];
   languages: LanguageOption[];
-  readStatuses: string[];
-  fileTypes: string[];
+  readStatuses: CountedOption[];
+  fileTypes: CountedOption[];
   categories: CountedOption[];
   publishers: CountedOption[];
   series: CountedOption[];
@@ -56,9 +56,9 @@ export interface AppBookFilters {
   shelfId?: number;
   magicShelfId?: number;
   unshelved?: boolean;
-  status?: string;
+  status?: string[];
   search?: string;
-  fileType?: string;
+  fileType?: string[];
   minRating?: number;
   maxRating?: number;
   authors?: string[];

--- a/frontend/src/app/features/book/service/app-books-api.service.ts
+++ b/frontend/src/app/features/book/service/app-books-api.service.ts
@@ -62,6 +62,14 @@ export class AppBooksApiService {
     const data = this.booksQuery.data();
     if (!data) return [];
     return data.pages.flatMap(page => page.content.map(summaryToBook));
+  }, {
+    equal: (a, b) => {
+      if (a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) {
+        if (a[i].id !== b[i].id) return false;
+      }
+      return true;
+    }
   });
 
   readonly totalElements = computed(() => {
@@ -126,8 +134,6 @@ export class AppBooksApiService {
     if (filters.shelfId) params = params.set('shelfId', filters.shelfId.toString());
     if (filters.magicShelfId) params = params.set('magicShelfId', filters.magicShelfId.toString());
     if (filters.unshelved) params = params.set('unshelved', 'true');
-    if (filters.status) params = params.set('status', filters.status);
-    if (filters.fileType) params = params.set('fileType', filters.fileType);
     if (filters.minRating != null) params = params.set('minRating', filters.minRating.toString());
     if (filters.maxRating != null) params = params.set('maxRating', filters.maxRating.toString());
     if (filters.filterMode) params = params.set('filterMode', filters.filterMode);
@@ -142,6 +148,8 @@ export class AppBooksApiService {
       ['tag', filters.tag],
       ['mood', filters.mood],
       ['narrator', filters.narrator],
+      ['status', filters.status],
+      ['fileType', filters.fileType],
     ];
     for (const [key, values] of arrayFilters) {
       if (values?.length) {
@@ -178,7 +186,7 @@ function summaryToBook(summary: AppBookSummary): Book {
       audiobookCoverUpdatedOn: summary.audiobookCoverUpdatedOn,
     },
     primaryFile: summary.primaryFileType
-      ? {bookType: summary.primaryFileType as BookType}
+      ? {bookType: summary.primaryFileType as BookType, extension: summary.primaryFileType.toLowerCase()}
       : null,
     pdfProgress: summary.readProgress != null
       ? {page: 0, percentage: summary.readProgress}


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes
This pull request introduces improvements to the book filtering system, primarily by supporting multi-select filtering for read status and file type, and by enhancing backend and frontend logic to handle these filters more robustly. The changes affect both the API and the frontend, ensuring users can select multiple options for these filters and that counts for each option are displayed. Tests have also been updated to reflect the new data structures and behaviors.

**Backend: Filter Option and Query Enhancements**
- Changed the `AppFilterOptions` DTO so that `readStatuses` and `fileTypes` are now lists of `CountedOption` (with value and count), instead of plain strings. This allows the frontend to display the number of books for each filter option.
- Updated the logic in `AppBookService` to query and return counts for each file type and read status, and to support empty results when appropriate. 
- Added new query methods and specifications to support filtering books by multiple file types and read statuses, including support for AND/OR/NOT filter modes.

**API Request and Data Model Changes**
- Updated `BookListRequest` to accept lists for `status` and `fileType` fields, allowing multi-select filtering in API requests.
- Adjusted related code and validation to handle lists instead of single values for these fields.

**Frontend: Multi-select Filter Support**
- Modified the `BookBrowserComponent` to send arrays for read status and file type filters instead of single values, aligning with backend changes.
- Updated the virtual scroller to use a custom `compareBookItems` function to improve rendering performance and correctness when items change. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select filtering for book statuses and file types.
  * Filter options now include per-option book counts.

* **Improvements**
  * Filter option lists are ordered by popularity and reflect actual availability (empty states handled).
  * Grid view virtualization improved with stable item comparison and consistent card heights.
  * Faster, more consistent book list refreshes and server-backed array-style filter queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->