### PR TITLE
fix(api): ignore invalid ASIN for mobi data extractor

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/MobiBaseMetadataExtractor.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/MobiBaseMetadataExtractor.java
@@ -135,10 +135,11 @@ public abstract class MobiBaseMetadataExtractor implements FileMetadataExtractor
                     }
                     case EXTH_LANGUAGE -> builder.language(value.trim());
                     case EXTH_ASIN -> {
-                        if (ASIN_PATTERN.matcher(value.trim()).matches()) {
-                            builder.asin(value.trim());
+                        String possibleASIN = value.trim().toUpperCase();
+                        if (ASIN_PATTERN.matcher(possibleASIN).matches()) {
+                            builder.asin(possibleASIN);
                         } else {
-                            log.debug("Ignoring invalid ASIN in mobi file {}: {}", file, value.trim());
+                            log.debug("Ignoring invalid ASIN in mobi file {}", file);
                         }
                     }
                 }

--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/MobiBaseMetadataExtractor.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/MobiBaseMetadataExtractor.java
@@ -32,6 +32,7 @@ public abstract class MobiBaseMetadataExtractor implements FileMetadataExtractor
     private static final Pattern DATE_DASH_FORMAT_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
     private static final Pattern CATEGORY_SEPARATOR_PATTERN = Pattern.compile("[;,]");
     private static final Pattern ISBN_INVALID_CHARS_PATTERN = Pattern.compile("[^0-9Xx]");
+    private static final Pattern ASIN_PATTERN = Pattern.compile("([A-Z0-9]{10})");
 
     protected abstract String getFormatName();
 
@@ -133,7 +134,13 @@ public abstract class MobiBaseMetadataExtractor implements FileMetadataExtractor
                         }
                     }
                     case EXTH_LANGUAGE -> builder.language(value.trim());
-                    case EXTH_ASIN -> builder.asin(value.trim());
+                    case EXTH_ASIN -> {
+                        if (ASIN_PATTERN.matcher(value.trim()).matches()) {
+                            builder.asin(value.trim());
+                        } else {
+                            log.debug("Ignoring invalid ASIN in mobi file {}: {}", file, value.trim());
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

some mobi files seem to have invalid ASIN identifiers.  in bookdrop, we extract metadata for completing the bookdrop but invalid ASINs cause failure to finalize a bookdrop

this change validates the ASIN before we expose the value as part of the extractor

**Linked Issue:** Fixes #452

## Changes

adds ASIN validation to mobi extractor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ASIN handling during metadata extraction: ASINs are now normalized (uppercased), validated against the expected format, and only stored when valid. Malformed ASINs are rejected and recorded in debug logs alongside the source file to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->