### PR TITLE
fix(ui): improve audible metadata provider detection

### DIFF
--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
@@ -290,6 +290,7 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
   }
 
   private getProviderFromMetadata(metadata: BookMetadata): string | null {
+    if (metadata.audibleId) return 'audible'; // Audible has to come before Amazon because they both have an ASIN.
     if (metadata.asin) return 'amazon';
     if (metadata.goodreadsId) return 'goodreads';
     if (metadata.googleId) return 'google';
@@ -298,7 +299,6 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
     if (metadata['lubimyczytacId']) return 'lubimyczytac';
     if (metadata.comicvineId) return 'comicvine';
     if (metadata.ranobedbId) return 'ranobedb';
-    if (metadata.audibleId) return 'audible';
     return metadata.provider?.toLowerCase() || null;
   }
 
@@ -411,11 +411,12 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
     if (metadata.goodreadsId && !metadata.description) {
       return {provider: 'GoodReads', id: metadata.goodreadsId};
     }
-    if (metadata.asin && !metadata.description) {
-      return {provider: 'Amazon', id: metadata.asin};
-    }
+    // Audible has to come before Amazon in this check as they both have ASIN
     if (metadata.audibleId && !metadata.description) {
       return {provider: 'Audible', id: metadata.audibleId};
+    }
+    if (metadata.asin && !metadata.description) {
+      return {provider: 'Amazon', id: metadata.asin};
     }
     return null;
   }
@@ -446,7 +447,10 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
   }
 
   buildProviderLink(metadata: BookMetadata): string {
-    if (metadata.asin) {
+    if (metadata.audibleId) {
+      // Audible has to come before Amazon because they both have an ASIN.
+      return `<a href="https://www.audible.com/pd/${metadata.audibleId}" target="_blank">Audible</a>`;
+    } else if (metadata.asin) {
       return `<a href="https://www.amazon.com/dp/${metadata.asin}" target="_blank">Amazon</a>`;
     } else if (metadata.goodreadsId) {
       return `<a href="https://www.goodreads.com/book/show/${metadata.goodreadsId}" target="_blank">Goodreads</a>`;
@@ -465,8 +469,6 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
       return `<a href="https://comicvine.gamespot.com/4050-${metadata.comicvineId}/" target="_blank">Comicvine</a>`;
     } else if (metadata.ranobedbId) {
       return `<a href="https://ranobedb.org/book/${metadata.ranobedbId}" target="_blank">RanobeDB</a>`;
-    } else if (metadata.audibleId) {
-      return `<a href="https://www.audible.com/pd/${metadata.audibleId}" target="_blank">Audible</a>`;
     } else if (metadata.externalUrl) {
       const providerName = metadata.provider || 'Link';
       return `<a href="${metadata.externalUrl}" target="_blank">${providerName}</a>`;


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
audible metadata also has an ASIN so it kept getting detected as amazon metadata, then showing up incorrectly in the UI


**Linked Issue:** Fixes #148

## Changes

* ensure audible gets the count for audible metadata in UI
* ensure audible provider source is noted for audible metadata
* ensure audible link is shown when audible metadata is selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Books with Audible information now resolve to Audible metadata first.
  * Book details now prioritize Audible enrichment when description data is missing.
  * Provider links now correctly point to Audible when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->