### PR TITLE
fix(api): use correct field lengths for file processors

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/Azw3Processor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/Azw3Processor.java
@@ -106,20 +106,20 @@ public class Azw3Processor extends AbstractFileProcessor implements BookFileProc
 
         metadata.setTitle(truncate(azw3Metadata.getTitle(), 1000));
         metadata.setSubtitle(truncate(azw3Metadata.getSubtitle(), 1000));
-        metadata.setDescription(truncate(azw3Metadata.getDescription(), 2000));
+        metadata.setDescription(truncate(azw3Metadata.getDescription(), 5000));
         metadata.setPublisher(truncate(azw3Metadata.getPublisher(), 1000));
         metadata.setPublishedDate(azw3Metadata.getPublishedDate());
         metadata.setSeriesName(truncate(azw3Metadata.getSeriesName(), 1000));
         metadata.setSeriesNumber(azw3Metadata.getSeriesNumber());
         metadata.setSeriesTotal(azw3Metadata.getSeriesTotal());
-        metadata.setIsbn13(truncate(azw3Metadata.getIsbn13(), 64));
-        metadata.setIsbn10(truncate(azw3Metadata.getIsbn10(), 64));
+        metadata.setIsbn13(truncate(azw3Metadata.getIsbn13(), 13));
+        metadata.setIsbn10(truncate(azw3Metadata.getIsbn10(), 10));
         metadata.setPageCount(azw3Metadata.getPageCount());
 
         String lang = azw3Metadata.getLanguage();
-        metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 1000));
+        metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 10));
 
-        metadata.setAsin(truncate(azw3Metadata.getAsin(), 20));
+        metadata.setAsin(truncate(azw3Metadata.getAsin(), 10));
         metadata.setAmazonRating(azw3Metadata.getAmazonRating());
         metadata.setAmazonReviewCount(azw3Metadata.getAmazonReviewCount());
         metadata.setGoodreadsId(truncate(azw3Metadata.getGoodreadsId(), 100));

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/CbxProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/CbxProcessor.java
@@ -145,14 +145,14 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
             metadata.setSeriesNumber(extracted.getSeriesNumber());
             metadata.setSeriesTotal(extracted.getSeriesTotal());
             metadata.setPageCount(extracted.getPageCount());
-            metadata.setLanguage(truncate(extracted.getLanguage(), 1000));
+            metadata.setLanguage(truncate(extracted.getLanguage(), 10));
 
             // ISBN fields
-            metadata.setIsbn13(truncate(extracted.getIsbn13(), 64));
-            metadata.setIsbn10(truncate(extracted.getIsbn10(), 64));
+            metadata.setIsbn13(truncate(extracted.getIsbn13(), 13));
+            metadata.setIsbn10(truncate(extracted.getIsbn10(), 10));
 
             // External IDs
-            metadata.setAsin(truncate(extracted.getAsin(), 20));
+            metadata.setAsin(truncate(extracted.getAsin(), 10));
             metadata.setGoodreadsId(truncate(extracted.getGoodreadsId(), 100));
             metadata.setHardcoverId(truncate(extracted.getHardcoverId(), 100));
             metadata.setHardcoverBookId(truncate(extracted.getHardcoverBookId(), 100));

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/EpubProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/EpubProcessor.java
@@ -120,14 +120,14 @@ public class EpubProcessor extends AbstractFileProcessor implements BookFileProc
         metadata.setSeriesName(truncate(epubMetadata.getSeriesName(), 1000));
         metadata.setSeriesNumber(epubMetadata.getSeriesNumber());
         metadata.setSeriesTotal(epubMetadata.getSeriesTotal());
-        metadata.setIsbn13(truncate(epubMetadata.getIsbn13(), 64));
-        metadata.setIsbn10(truncate(epubMetadata.getIsbn10(), 64));
+        metadata.setIsbn13(truncate(epubMetadata.getIsbn13(), 13));
+        metadata.setIsbn10(truncate(epubMetadata.getIsbn10(), 10));
         metadata.setPageCount(epubMetadata.getPageCount());
 
         String lang = epubMetadata.getLanguage();
-        metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 1000));
+        metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 10));
 
-        metadata.setAsin(truncate(epubMetadata.getAsin(), 20));
+        metadata.setAsin(truncate(epubMetadata.getAsin(), 10));
         metadata.setAmazonRating(epubMetadata.getAmazonRating());
         metadata.setAmazonReviewCount(epubMetadata.getAmazonReviewCount());
         metadata.setGoodreadsId(truncate(epubMetadata.getGoodreadsId(), 100));

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/Fb2Processor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/Fb2Processor.java
@@ -108,14 +108,14 @@ public class Fb2Processor extends AbstractFileProcessor implements BookFileProce
         metadata.setSeriesName(truncate(fb2Metadata.getSeriesName(), 1000));
         metadata.setSeriesNumber(fb2Metadata.getSeriesNumber());
         metadata.setSeriesTotal(fb2Metadata.getSeriesTotal());
-        metadata.setIsbn13(truncate(fb2Metadata.getIsbn13(), 64));
-        metadata.setIsbn10(truncate(fb2Metadata.getIsbn10(), 64));
+        metadata.setIsbn13(truncate(fb2Metadata.getIsbn13(), 13));
+        metadata.setIsbn10(truncate(fb2Metadata.getIsbn10(), 10));
         metadata.setPageCount(fb2Metadata.getPageCount());
 
         String lang = fb2Metadata.getLanguage();
-        metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 1000));
+        metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 10));
 
-        metadata.setAsin(truncate(fb2Metadata.getAsin(), 20));
+        metadata.setAsin(truncate(fb2Metadata.getAsin(), 10));
         metadata.setAmazonRating(fb2Metadata.getAmazonRating());
         metadata.setAmazonReviewCount(fb2Metadata.getAmazonReviewCount());
         metadata.setGoodreadsId(truncate(fb2Metadata.getGoodreadsId(), 100));

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/MobiProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/MobiProcessor.java
@@ -113,14 +113,14 @@ public class MobiProcessor extends AbstractFileProcessor implements BookFileProc
         metadata.setSeriesName(truncate(mobiMetadata.getSeriesName(), 1000));
         metadata.setSeriesNumber(mobiMetadata.getSeriesNumber());
         metadata.setSeriesTotal(mobiMetadata.getSeriesTotal());
-        metadata.setIsbn13(truncate(mobiMetadata.getIsbn13(), 64));
-        metadata.setIsbn10(truncate(mobiMetadata.getIsbn10(), 64));
+        metadata.setIsbn13(truncate(mobiMetadata.getIsbn13(), 13));
+        metadata.setIsbn10(truncate(mobiMetadata.getIsbn10(), 10));
         metadata.setPageCount(mobiMetadata.getPageCount());
 
         String lang = mobiMetadata.getLanguage();
-        metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 1000));
+        metadata.setLanguage(truncate((lang == null || "UND".equalsIgnoreCase(lang)) ? "en" : lang, 10));
 
-        metadata.setAsin(truncate(mobiMetadata.getAsin(), 20));
+        metadata.setAsin(truncate(mobiMetadata.getAsin(), 10));
         metadata.setAmazonRating(mobiMetadata.getAmazonRating());
         metadata.setAmazonReviewCount(mobiMetadata.getAmazonReviewCount());
         metadata.setGoodreadsId(truncate(mobiMetadata.getGoodreadsId(), 100));

--- a/booklore-api/src/main/java/org/booklore/service/fileprocessor/PdfProcessor.java
+++ b/booklore-api/src/main/java/org/booklore/service/fileprocessor/PdfProcessor.java
@@ -130,7 +130,7 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
                 bookEntity.getMetadata().setPublishedDate(extracted.getPublishedDate());
             }
             if (StringUtils.isNotBlank(extracted.getLanguage())) {
-                bookEntity.getMetadata().setLanguage(extracted.getLanguage());
+                bookEntity.getMetadata().setLanguage(truncate(extracted.getLanguage(), 10));
             }
             if (extracted.getPageCount() != null) {
                 bookEntity.getMetadata().setPageCount(extracted.getPageCount());
@@ -138,7 +138,7 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
             
             // External IDs
             if (StringUtils.isNotBlank(extracted.getAsin())) {
-                bookEntity.getMetadata().setAsin(extracted.getAsin());
+                bookEntity.getMetadata().setAsin(truncate(extracted.getAsin(), 10));
             }
             if (StringUtils.isNotBlank(extracted.getGoogleId())) {
                 bookEntity.getMetadata().setGoogleId(extracted.getGoogleId());
@@ -162,10 +162,10 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
                 bookEntity.getMetadata().setLubimyczytacId(extracted.getLubimyczytacId());
             }
             if (StringUtils.isNotBlank(extracted.getIsbn10())) {
-                bookEntity.getMetadata().setIsbn10(extracted.getIsbn10());
+                bookEntity.getMetadata().setIsbn10(truncate(extracted.getIsbn10(), 10));
             }
             if (StringUtils.isNotBlank(extracted.getIsbn13())) {
-                bookEntity.getMetadata().setIsbn13(extracted.getIsbn13());
+                bookEntity.getMetadata().setIsbn13(truncate(extracted.getIsbn13(), 13));
             }
             
             // Categories, moods, and tags


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

The various processors truncate extracted metadata fields so they properly fit in database metadata fields.

However, the ASIN, ISBN, and language fields were improperly truncated, and were too long which caused database errors.

This updates the truncation length to 10 for language, 10 for ASIN, 10 for ISBN10, and 13 for ISBN13.

**Linked Issue:** Fixes #458

## Changes

* Updates truncation lengths for file processors to match BookMetadataEntity field lengths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized metadata field length constraints for ISBN numbers, language codes, and Amazon Standard Identifiers across all supported ebook formats (AZW3, EPUB, MOBI, FB2, CBX, PDF).
  * Enhanced book description field capacity for AZW3 format processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->