### PR TITLE
fix(bookdrop): clean bookdrop metadata before persisting

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
@@ -153,6 +153,7 @@ public class BookdropMetadataService {
 
                 // External IDs
                 .asin(truncate(extracted.getAsin(), 10))
+                .audibleId(truncate(extracted.getAudibleId(), 10))
                 .goodreadsId(truncate(extracted.getGoodreadsId(), 100))
                 .hardcoverId(truncate(extracted.getHardcoverId(), 100))
                 .hardcoverBookId(truncate(extracted.getHardcoverBookId(), 100))
@@ -160,8 +161,11 @@ public class BookdropMetadataService {
                 .comicvineId(truncate(extracted.getComicvineId(), 100))
                 .lubimyczytacId(truncate(extracted.getLubimyczytacId(), 100))
                 .ranobedbId(truncate(extracted.getRanobedbId(), 100))
+                .doubanId(truncate(extracted.getDoubanId(), 100))
 
                 // Ratings
+                .audibleRating(extracted.getAudibleRating())
+                .audibleReviewCount(extracted.getAudibleReviewCount())
                 .amazonRating(extracted.getAmazonRating())
                 .amazonReviewCount(extracted.getAmazonReviewCount())
                 .goodreadsRating(extracted.getGoodreadsRating())
@@ -170,6 +174,8 @@ public class BookdropMetadataService {
                 .hardcoverReviewCount(extracted.getHardcoverReviewCount())
                 .lubimyczytacRating(extracted.getLubimyczytacRating())
                 .ranobedbRating(extracted.getRanobedbRating())
+                .doubanRating(extracted.getDoubanRating())
+                .doubanReviewCount(extracted.getDoubanReviewCount())
 
                 // Relationships
                 .authors(extracted.getAuthors())

--- a/booklore-api/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
@@ -133,7 +133,10 @@ public class BookdropMetadataService {
             return null;
         }
 
-        return BookMetadata.builder()
+        // Created a builder from `extracted` to perform a shallow clone
+        // where we overwrite only truncated fields.
+
+        return extracted.toBuilder()
 
                 // Basic Fields
                 .title(truncate(extracted.getTitle(), 1000))
@@ -142,9 +145,6 @@ public class BookdropMetadataService {
                 .publisher(truncate(extracted.getPublisher(), 1000))
                 .publishedDate(extracted.getPublishedDate())
                 .seriesName(truncate(extracted.getSeriesName(), 1000))
-                .seriesNumber(extracted.getSeriesNumber())
-                .seriesTotal(extracted.getSeriesTotal())
-                .pageCount(extracted.getPageCount())
                 .language(truncate(extracted.getLanguage(), 10))
 
                 // ISBN
@@ -163,25 +163,6 @@ public class BookdropMetadataService {
                 .ranobedbId(truncate(extracted.getRanobedbId(), 100))
                 .doubanId(truncate(extracted.getDoubanId(), 100))
 
-                // Ratings
-                .audibleRating(extracted.getAudibleRating())
-                .audibleReviewCount(extracted.getAudibleReviewCount())
-                .amazonRating(extracted.getAmazonRating())
-                .amazonReviewCount(extracted.getAmazonReviewCount())
-                .goodreadsRating(extracted.getGoodreadsRating())
-                .goodreadsReviewCount(extracted.getGoodreadsReviewCount())
-                .hardcoverRating(extracted.getHardcoverRating())
-                .hardcoverReviewCount(extracted.getHardcoverReviewCount())
-                .lubimyczytacRating(extracted.getLubimyczytacRating())
-                .ranobedbRating(extracted.getRanobedbRating())
-                .doubanRating(extracted.getDoubanRating())
-                .doubanReviewCount(extracted.getDoubanReviewCount())
-
-                // Relationships
-                .authors(extracted.getAuthors())
-                .categories(extracted.getCategories())
-                .moods(extracted.getMoods())
-                .tags(extracted.getTags())
                 .build();
     }
 

--- a/booklore-api/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
 import static org.booklore.model.entity.BookdropFileEntity.Status.PENDING_REVIEW;
+import static org.booklore.util.FileService.truncate;
 
 @Slf4j
 @AllArgsConstructor
@@ -127,11 +128,62 @@ public class BookdropMetadataService {
         return bookdropFileRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Bookdrop file not found: " + id));
     }
 
+    private BookMetadata cleanInitialMetadata(BookMetadata extracted) {
+        if (extracted == null) {
+            return null;
+        }
+
+        return BookMetadata.builder()
+
+                // Basic Fields
+                .title(truncate(extracted.getTitle(), 1000))
+                .subtitle(truncate(extracted.getSubtitle(), 1000))
+                .description(truncate(extracted.getDescription(), 5000))
+                .publisher(truncate(extracted.getPublisher(), 1000))
+                .publishedDate(extracted.getPublishedDate())
+                .seriesName(truncate(extracted.getSeriesName(), 1000))
+                .seriesNumber(extracted.getSeriesNumber())
+                .seriesTotal(extracted.getSeriesTotal())
+                .pageCount(extracted.getPageCount())
+                .language(truncate(extracted.getLanguage(), 10))
+
+                // ISBN
+                .isbn10(truncate(extracted.getIsbn10(), 10))
+                .isbn13(truncate(extracted.getIsbn13(), 13))
+
+                // External IDs
+                .asin(truncate(extracted.getAsin(), 10))
+                .goodreadsId(truncate(extracted.getGoodreadsId(), 100))
+                .hardcoverId(truncate(extracted.getHardcoverId(), 100))
+                .hardcoverBookId(truncate(extracted.getHardcoverBookId(), 100))
+                .googleId(truncate(extracted.getGoogleId(), 100))
+                .comicvineId(truncate(extracted.getComicvineId(), 100))
+                .lubimyczytacId(truncate(extracted.getLubimyczytacId(), 100))
+                .ranobedbId(truncate(extracted.getRanobedbId(), 100))
+
+                // Ratings
+                .amazonRating(extracted.getAmazonRating())
+                .amazonReviewCount(extracted.getAmazonReviewCount())
+                .goodreadsRating(extracted.getGoodreadsRating())
+                .goodreadsReviewCount(extracted.getGoodreadsReviewCount())
+                .hardcoverRating(extracted.getHardcoverRating())
+                .hardcoverReviewCount(extracted.getHardcoverReviewCount())
+                .lubimyczytacRating(extracted.getLubimyczytacRating())
+                .ranobedbRating(extracted.getRanobedbRating())
+
+                // Relationships
+                .authors(extracted.getAuthors())
+                .categories(extracted.getCategories())
+                .moods(extracted.getMoods())
+                .tags(extracted.getTags())
+                .build();
+    }
+
     private BookMetadata extractInitialMetadata(BookdropFileEntity entity) {
         File file = new File(entity.getFilePath());
         BookFileExtension fileExt = BookFileExtension.fromFileName(file.getName())
             .orElseThrow(() -> ApiError.INVALID_FILE_FORMAT.createException("Unsupported file extension"));
-        return metadataExtractorFactory.extractMetadata(fileExt, file);
+        return cleanInitialMetadata(metadataExtractorFactory.extractMetadata(fileExt, file));
     }
 
     private void extractAndSaveCover(BookdropFileEntity entity) {

--- a/booklore-api/src/test/java/org/booklore/service/BookdropMetadataServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/BookdropMetadataServiceTest.java
@@ -19,6 +19,7 @@ import org.booklore.util.FileService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -123,13 +124,40 @@ class BookdropMetadataServiceTest {
 
         when(bookdropFileRepository.findById(1L)).thenReturn(Optional.of(sampleFile));
         when(metadataExtractorFactory.extractMetadata(eq(BookFileExtension.EPUB), any(File.class))).thenReturn(metadata);
-        when(objectMapper.writeValueAsString(metadata)).thenReturn("{\"title\":\"No Cover Book\"}");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"title\":\"No Cover Book\"}");
         when(bookdropFileRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         BookdropFileEntity result = bookdropMetadataService.attachInitialMetadata(1L);
 
         assertThat(result.getOriginalMetadata()).contains("No Cover Book");
         verify(bookdropFileRepository).save(result);
+    }
+
+    @Test()
+    void attachInitialMetadata_shouldTruncateFields() throws Exception {
+        BookMetadata metadata = BookMetadata.builder()
+                .asin("SAMPLEASINTOOLONG")
+                .isbn10("00000000000000000000000000000")
+                .isbn13("00000000000000000000000000000")
+                .language("US EnglishTOOLONG")
+                .build();
+
+        when(bookdropFileRepository.findById(1L)).thenReturn(Optional.of(sampleFile));
+        when(metadataExtractorFactory.extractMetadata(eq(BookFileExtension.EPUB), any(File.class))).thenReturn(metadata);
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"title\":\"No Cover Book\"}");
+        when(bookdropFileRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        bookdropMetadataService.attachInitialMetadata(1L);
+
+        ArgumentCaptor<BookMetadata> argument = ArgumentCaptor.forClass(BookMetadata.class);
+        verify(objectMapper).writeValueAsString(argument.capture());
+
+        BookMetadata actual = argument.getValue();
+
+        assertThat(actual.getAsin()).isEqualTo("SAMPLEASIN");
+        assertThat(actual.getIsbn10()).isEqualTo("0000000000");
+        assertThat(actual.getIsbn13()).isEqualTo("0000000000000");
+        assertThat(actual.getLanguage()).isEqualTo("US English");
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
updates the bookdrop initial metadata to truncate values - similar to the `FileProcessor` - so that data suggested in bookdrop metadata are of valid lengths

**Linked Issue:** Fixes #452

## Changes

* adds a `cleanInitialMetadata` method for truncating initial 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata extraction now cleans and truncates long text and identifier fields (titles, descriptions, publishers, ISBNs, language, external IDs) and treats null extractor results gracefully so stored original metadata is consistent.
* **Tests**
  * Added and updated tests to verify metadata truncation and correct serialization behavior during initial metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->