### PR TITLE
fix(reader): resolve epub preview runtime and audiobook download failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,4 +115,4 @@ ARG BOOKLORE_PORT=6060
 EXPOSE ${BOOKLORE_PORT}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["java", "--enable-native-access=ALL-UNNAMED", "-jar", "/app/app.jar"]
+CMD ["java", "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-jar", "/app/app.jar"]

--- a/booklore-api/src/main/java/org/booklore/controller/AdditionalFileController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AdditionalFileController.java
@@ -84,7 +84,7 @@ public class AdditionalFileController {
     public ResponseEntity<Resource> downloadAdditionalFile(
             @PathVariable Long bookId,
             @PathVariable Long fileId) throws IOException {
-        return additionalFileService.downloadAdditionalFile(fileId);
+        return additionalFileService.downloadAdditionalFile(bookId, fileId);
     }
 
     @Operation(
@@ -98,7 +98,7 @@ public class AdditionalFileController {
     public ResponseEntity<Void> deleteAdditionalFile(
             @PathVariable Long bookId,
             @PathVariable Long fileId) {
-        additionalFileService.deleteAdditionalFile(fileId);
+        additionalFileService.deleteAdditionalFile(bookId, fileId);
         return ResponseEntity.noContent().build();
     }
 

--- a/booklore-api/src/main/java/org/booklore/repository/BookAdditionalFileRepository.java
+++ b/booklore-api/src/main/java/org/booklore/repository/BookAdditionalFileRepository.java
@@ -28,6 +28,20 @@ public interface BookAdditionalFileRepository extends JpaRepository<BookFileEnti
     @Query("SELECT bf FROM BookFileEntity bf WHERE bf.book.library.id = :libraryId")
     List<BookFileEntity> findByLibraryId(@Param("libraryId") Long libraryId);
 
+    @Query("""
+            SELECT DISTINCT bf FROM BookFileEntity bf
+            LEFT JOIN FETCH bf.book b
+            LEFT JOIN FETCH b.libraryPath
+            LEFT JOIN FETCH b.library
+            LEFT JOIN FETCH b.bookFiles
+            WHERE bf.id = :id
+            AND b.id = :bookId
+            """)
+    Optional<BookFileEntity> findByIdAndBookIdWithBookAndLibraryPath(
+            @Param("id") Long id,
+            @Param("bookId") Long bookId
+    );
+
     @Modifying
     @Transactional
     @Query("""

--- a/booklore-api/src/main/java/org/booklore/service/file/AdditionalFileService.java
+++ b/booklore-api/src/main/java/org/booklore/service/file/AdditionalFileService.java
@@ -5,6 +5,7 @@ import org.booklore.model.dto.BookFile;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookFileEntity;
 import org.booklore.repository.BookAdditionalFileRepository;
+import org.booklore.repository.BookFileRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.monitoring.MonitoringRegistrationService;
 import lombok.AllArgsConstructor;
@@ -39,6 +40,7 @@ public class AdditionalFileService {
     private static final Pattern NON_ASCII = Pattern.compile("[^\\x00-\\x7F]");
 
     private final BookAdditionalFileRepository additionalFileRepository;
+    private final BookFileRepository bookFileRepository;
     private final BookRepository bookRepository;
     private final AdditionalFileMapper additionalFileMapper;
     private final MonitoringRegistrationService monitoringRegistrationService;
@@ -55,7 +57,7 @@ public class AdditionalFileService {
 
     @Transactional
     public void deleteAdditionalFile(Long fileId) {
-        Optional<BookFileEntity> fileOpt = additionalFileRepository.findById(fileId);
+        Optional<BookFileEntity> fileOpt = bookFileRepository.findByIdWithBookAndLibraryPath(fileId);
         if (fileOpt.isEmpty()) {
             throw new IllegalArgumentException("Additional file not found with id: " + fileId);
         }
@@ -97,7 +99,7 @@ public class AdditionalFileService {
     }
 
     public ResponseEntity<Resource> downloadAdditionalFile(Long fileId) throws IOException {
-        Optional<BookFileEntity> fileOpt = additionalFileRepository.findById(fileId);
+        Optional<BookFileEntity> fileOpt = bookFileRepository.findByIdWithBookAndLibraryPath(fileId);
         if (fileOpt.isEmpty()) {
             return ResponseEntity.notFound().build();
         }

--- a/booklore-api/src/main/java/org/booklore/service/file/AdditionalFileService.java
+++ b/booklore-api/src/main/java/org/booklore/service/file/AdditionalFileService.java
@@ -5,8 +5,6 @@ import org.booklore.model.dto.BookFile;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookFileEntity;
 import org.booklore.repository.BookAdditionalFileRepository;
-import org.booklore.repository.BookFileRepository;
-import org.booklore.repository.BookRepository;
 import org.booklore.service.monitoring.MonitoringRegistrationService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,8 +38,6 @@ public class AdditionalFileService {
     private static final Pattern NON_ASCII = Pattern.compile("[^\\x00-\\x7F]");
 
     private final BookAdditionalFileRepository additionalFileRepository;
-    private final BookFileRepository bookFileRepository;
-    private final BookRepository bookRepository;
     private final AdditionalFileMapper additionalFileMapper;
     private final MonitoringRegistrationService monitoringRegistrationService;
 
@@ -56,14 +52,15 @@ public class AdditionalFileService {
     }
 
     @Transactional
-    public void deleteAdditionalFile(Long fileId) {
-        Optional<BookFileEntity> fileOpt = bookFileRepository.findByIdWithBookAndLibraryPath(fileId);
+    public void deleteAdditionalFile(Long bookId, Long fileId) {
+        Optional<BookFileEntity> fileOpt = additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
         if (fileOpt.isEmpty()) {
             throw new IllegalArgumentException("Additional file not found with id: " + fileId);
         }
 
         BookFileEntity file = fileOpt.get();
         BookEntity book = file.getBook();
+        validateAdditionalFile(file, book);
 
         try {
             monitoringRegistrationService.unregisterSpecificPath(file.getFullFilePath().getParent());
@@ -98,13 +95,14 @@ public class AdditionalFileService {
         }
     }
 
-    public ResponseEntity<Resource> downloadAdditionalFile(Long fileId) throws IOException {
-        Optional<BookFileEntity> fileOpt = bookFileRepository.findByIdWithBookAndLibraryPath(fileId);
+    public ResponseEntity<Resource> downloadAdditionalFile(Long bookId, Long fileId) throws IOException {
+        Optional<BookFileEntity> fileOpt = additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
         if (fileOpt.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
 
         BookFileEntity file = fileOpt.get();
+        validateAdditionalFile(file, file.getBook());
         Path filePath = file.getFullFilePath();
 
         if (!Files.exists(filePath)) {
@@ -160,5 +158,11 @@ public class AdditionalFileService {
                 .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
                 .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(zipBytes.length))
                 .body(resource);
+    }
+
+    private void validateAdditionalFile(BookFileEntity file, BookEntity book) {
+        if (book != null && book.getPrimaryBookFile() != null && file.getId().equals(book.getPrimaryBookFile().getId())) {
+            throw new IllegalArgumentException("Primary book file cannot be processed as an additional file: " + file.getId());
+        }
     }
 }

--- a/booklore-api/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
@@ -6,6 +6,7 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.LibraryPathEntity;
 import org.booklore.repository.BookAdditionalFileRepository;
+import org.booklore.repository.BookFileRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.file.AdditionalFileService;
 import org.booklore.service.monitoring.MonitoringRegistrationService;
@@ -41,6 +42,9 @@ class AdditionalFileServiceTest {
 
     @Mock
     private BookRepository bookRepository;
+
+    @Mock
+    private BookFileRepository bookFileRepository;
 
     @Mock
     private AdditionalFileMapper additionalFileMapper;
@@ -150,7 +154,7 @@ class AdditionalFileServiceTest {
     @Test
     void deleteAdditionalFile_WhenFileNotFound_ShouldThrowException() {
         Long fileId = 1L;
-        when(additionalFileRepository.findById(fileId)).thenReturn(Optional.empty());
+        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.empty());
 
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
@@ -158,7 +162,7 @@ class AdditionalFileServiceTest {
         );
 
         assertEquals("Additional file not found with id: 1", exception.getMessage());
-        verify(additionalFileRepository).findById(fileId);
+        verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
         verify(additionalFileRepository, never()).delete(any());
         verify(monitoringRegistrationService, never()).unregisterSpecificPath(any());
     }
@@ -168,14 +172,14 @@ class AdditionalFileServiceTest {
         Long fileId = 1L;
         Path parentPath = fileEntity.getFullFilePath().getParent();
 
-        when(additionalFileRepository.findById(fileId)).thenReturn(Optional.of(fileEntity));
+        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(fileEntity));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             filesMock.when(() -> Files.deleteIfExists(fileEntity.getFullFilePath())).thenReturn(true);
 
             additionalFileService.deleteAdditionalFile(fileId);
 
-            verify(additionalFileRepository).findById(fileId);
+            verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
             verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
             filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
             verify(additionalFileRepository).delete(fileEntity);
@@ -188,14 +192,14 @@ class AdditionalFileServiceTest {
         Long fileId = 1L;
         Path parentPath = fileEntity.getFullFilePath().getParent();
 
-        when(additionalFileRepository.findById(fileId)).thenReturn(Optional.of(fileEntity));
+        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(fileEntity));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             filesMock.when(() -> Files.deleteIfExists(fileEntity.getFullFilePath())).thenThrow(new IOException("File access error"));
 
             additionalFileService.deleteAdditionalFile(fileId);
 
-            verify(additionalFileRepository).findById(fileId);
+            verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
             verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
             filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
             verify(additionalFileRepository).delete(fileEntity);
@@ -209,14 +213,14 @@ class AdditionalFileServiceTest {
         BookFileEntity invalidEntity = new BookFileEntity();
         invalidEntity.setId(fileId);
 
-        when(additionalFileRepository.findById(fileId)).thenReturn(Optional.of(invalidEntity));
+        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(invalidEntity));
 
         assertThrows(
                 IllegalStateException.class,
                 () -> additionalFileService.deleteAdditionalFile(fileId)
         );
 
-        verify(additionalFileRepository).findById(fileId);
+        verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
         verify(additionalFileRepository, never()).delete(any());
         verify(monitoringRegistrationService, never()).unregisterSpecificPath(any());
     }
@@ -224,13 +228,13 @@ class AdditionalFileServiceTest {
     @Test
     void downloadAdditionalFile_WhenFileNotFound_ShouldReturnNotFound() throws IOException {
         Long fileId = 1L;
-        when(additionalFileRepository.findById(fileId)).thenReturn(Optional.empty());
+        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.empty());
 
         ResponseEntity<Resource> result = additionalFileService.downloadAdditionalFile(fileId);
 
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
         assertNull(result.getBody());
-        verify(additionalFileRepository).findById(fileId);
+        verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
     }
 
     @Test
@@ -243,7 +247,7 @@ class AdditionalFileServiceTest {
         entityWithNonExistentFile.setFileName("non-existent.pdf");
         entityWithNonExistentFile.setFileSubPath(".");
 
-        when(additionalFileRepository.findById(fileId)).thenReturn(Optional.of(entityWithNonExistentFile));
+        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(entityWithNonExistentFile));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             Path actualPath = entityWithNonExistentFile.getFullFilePath();
@@ -253,7 +257,7 @@ class AdditionalFileServiceTest {
 
             assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
             assertNull(result.getBody());
-            verify(additionalFileRepository).findById(fileId);
+            verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
             filesMock.verify(() -> Files.exists(actualPath));
         }
     }
@@ -261,7 +265,7 @@ class AdditionalFileServiceTest {
     @Test
     void downloadAdditionalFile_WhenFileExists_ShouldReturnFileResource() throws Exception {
         Long fileId = 1L;
-        when(additionalFileRepository.findById(fileId)).thenReturn(Optional.of(fileEntity));
+        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(fileEntity));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             filesMock.when(() -> Files.exists(fileEntity.getFullFilePath())).thenReturn(true);
@@ -274,7 +278,7 @@ class AdditionalFileServiceTest {
             assertTrue(result.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION).contains("test-file.pdf"));
             assertEquals(MediaType.APPLICATION_OCTET_STREAM, result.getHeaders().getContentType());
 
-            verify(additionalFileRepository).findById(fileId);
+            verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
             filesMock.verify(() -> Files.exists(fileEntity.getFullFilePath()));
         }
     }
@@ -285,13 +289,13 @@ class AdditionalFileServiceTest {
         BookFileEntity invalidEntity = new BookFileEntity();
         invalidEntity.setId(fileId);
 
-        when(additionalFileRepository.findById(fileId)).thenReturn(Optional.of(invalidEntity));
+        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(invalidEntity));
 
         assertThrows(
                 IllegalStateException.class,
                 () -> additionalFileService.downloadAdditionalFile(fileId)
         );
 
-        verify(additionalFileRepository).findById(fileId);
+        verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
     }
 }

--- a/booklore-api/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
@@ -6,8 +6,6 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.LibraryPathEntity;
 import org.booklore.repository.BookAdditionalFileRepository;
-import org.booklore.repository.BookFileRepository;
-import org.booklore.repository.BookRepository;
 import org.booklore.service.file.AdditionalFileService;
 import org.booklore.service.monitoring.MonitoringRegistrationService;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -39,12 +38,6 @@ class AdditionalFileServiceTest {
 
     @Mock
     private BookAdditionalFileRepository additionalFileRepository;
-
-    @Mock
-    private BookRepository bookRepository;
-
-    @Mock
-    private BookFileRepository bookFileRepository;
 
     @Mock
     private AdditionalFileMapper additionalFileMapper;
@@ -81,6 +74,7 @@ class AdditionalFileServiceTest {
         fileEntity.setFileName("test-file.pdf");
         fileEntity.setFileSubPath(".");
         fileEntity.setBookFormat(true);
+        bookEntity.setBookFiles(new ArrayList<>(List.of(fileEntity)));
 
         additionalFile = mock(BookFile.class);
     }
@@ -153,92 +147,100 @@ class AdditionalFileServiceTest {
 
     @Test
     void deleteAdditionalFile_WhenFileNotFound_ShouldThrowException() {
+        Long bookId = 100L;
         Long fileId = 1L;
-        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.empty());
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.empty());
 
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> additionalFileService.deleteAdditionalFile(fileId)
+                () -> additionalFileService.deleteAdditionalFile(bookId, fileId)
         );
 
         assertEquals("Additional file not found with id: 1", exception.getMessage());
-        verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
+        verify(additionalFileRepository).findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
         verify(additionalFileRepository, never()).delete(any());
         verify(monitoringRegistrationService, never()).unregisterSpecificPath(any());
     }
 
     @Test
     void deleteAdditionalFile_WhenFileExists_ShouldDeleteSuccessfully() {
+        Long bookId = 100L;
         Long fileId = 1L;
         Path parentPath = fileEntity.getFullFilePath().getParent();
+        BookFileEntity primaryFile = createBookFile(2L, "primary.epub");
+        bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile, fileEntity)));
 
-        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(fileEntity));
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             filesMock.when(() -> Files.deleteIfExists(fileEntity.getFullFilePath())).thenReturn(true);
 
-            additionalFileService.deleteAdditionalFile(fileId);
+            additionalFileService.deleteAdditionalFile(bookId, fileId);
 
-            verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
+            verify(additionalFileRepository).findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
             verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
             filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
             verify(additionalFileRepository).delete(fileEntity);
-            verify(bookRepository, never()).save(any());
         }
     }
 
     @Test
     void deleteAdditionalFile_WhenIOExceptionOccurs_ShouldStillDeleteFromRepository() {
+        Long bookId = 100L;
         Long fileId = 1L;
         Path parentPath = fileEntity.getFullFilePath().getParent();
+        BookFileEntity primaryFile = createBookFile(2L, "primary.epub");
+        bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile, fileEntity)));
 
-        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(fileEntity));
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             filesMock.when(() -> Files.deleteIfExists(fileEntity.getFullFilePath())).thenThrow(new IOException("File access error"));
 
-            additionalFileService.deleteAdditionalFile(fileId);
+            additionalFileService.deleteAdditionalFile(bookId, fileId);
 
-            verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
+            verify(additionalFileRepository).findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
             verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
             filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
             verify(additionalFileRepository).delete(fileEntity);
-            verify(bookRepository, never()).save(any());
         }
     }
 
     @Test
     void deleteAdditionalFile_WhenEntityRelationshipsMissing_ShouldThrowIllegalStateException() {
+        Long bookId = 100L;
         Long fileId = 1L;
         BookFileEntity invalidEntity = new BookFileEntity();
         invalidEntity.setId(fileId);
 
-        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(invalidEntity));
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(invalidEntity));
 
         assertThrows(
                 IllegalStateException.class,
-                () -> additionalFileService.deleteAdditionalFile(fileId)
+                () -> additionalFileService.deleteAdditionalFile(bookId, fileId)
         );
 
-        verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
+        verify(additionalFileRepository).findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
         verify(additionalFileRepository, never()).delete(any());
         verify(monitoringRegistrationService, never()).unregisterSpecificPath(any());
     }
 
     @Test
     void downloadAdditionalFile_WhenFileNotFound_ShouldReturnNotFound() throws IOException {
+        Long bookId = 100L;
         Long fileId = 1L;
-        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.empty());
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.empty());
 
-        ResponseEntity<Resource> result = additionalFileService.downloadAdditionalFile(fileId);
+        ResponseEntity<Resource> result = additionalFileService.downloadAdditionalFile(bookId, fileId);
 
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
         assertNull(result.getBody());
-        verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
+        verify(additionalFileRepository).findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
     }
 
     @Test
     void downloadAdditionalFile_WhenPhysicalFileNotExists_ShouldReturnNotFound() throws IOException {
+        Long bookId = 100L;
         Long fileId = 1L;
 
         BookFileEntity entityWithNonExistentFile = new BookFileEntity();
@@ -246,31 +248,36 @@ class AdditionalFileServiceTest {
         entityWithNonExistentFile.setBook(bookEntity);
         entityWithNonExistentFile.setFileName("non-existent.pdf");
         entityWithNonExistentFile.setFileSubPath(".");
+        BookFileEntity primaryFile = createBookFile(2L, "primary.epub");
+        bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile, entityWithNonExistentFile)));
 
-        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(entityWithNonExistentFile));
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(entityWithNonExistentFile));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             Path actualPath = entityWithNonExistentFile.getFullFilePath();
             filesMock.when(() -> Files.exists(actualPath)).thenReturn(false);
 
-            ResponseEntity<Resource> result = additionalFileService.downloadAdditionalFile(fileId);
+            ResponseEntity<Resource> result = additionalFileService.downloadAdditionalFile(bookId, fileId);
 
             assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
             assertNull(result.getBody());
-            verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
+            verify(additionalFileRepository).findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
             filesMock.verify(() -> Files.exists(actualPath));
         }
     }
 
     @Test
     void downloadAdditionalFile_WhenFileExists_ShouldReturnFileResource() throws Exception {
+        Long bookId = 100L;
         Long fileId = 1L;
-        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(fileEntity));
+        BookFileEntity primaryFile = createBookFile(2L, "primary.epub");
+        bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile, fileEntity)));
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             filesMock.when(() -> Files.exists(fileEntity.getFullFilePath())).thenReturn(true);
 
-            ResponseEntity<Resource> result = additionalFileService.downloadAdditionalFile(fileId);
+            ResponseEntity<Resource> result = additionalFileService.downloadAdditionalFile(bookId, fileId);
 
             assertEquals(HttpStatus.OK, result.getStatusCode());
             assertNotNull(result.getBody());
@@ -278,24 +285,67 @@ class AdditionalFileServiceTest {
             assertTrue(result.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION).contains("test-file.pdf"));
             assertEquals(MediaType.APPLICATION_OCTET_STREAM, result.getHeaders().getContentType());
 
-            verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
+            verify(additionalFileRepository).findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
             filesMock.verify(() -> Files.exists(fileEntity.getFullFilePath()));
         }
     }
 
     @Test
     void downloadAdditionalFile_WhenEntityRelationshipsMissing_ShouldThrowIllegalStateException() {
+        Long bookId = 100L;
         Long fileId = 1L;
         BookFileEntity invalidEntity = new BookFileEntity();
         invalidEntity.setId(fileId);
 
-        when(bookFileRepository.findByIdWithBookAndLibraryPath(fileId)).thenReturn(Optional.of(invalidEntity));
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(invalidEntity));
 
         assertThrows(
                 IllegalStateException.class,
-                () -> additionalFileService.downloadAdditionalFile(fileId)
+                () -> additionalFileService.downloadAdditionalFile(bookId, fileId)
         );
 
-        verify(bookFileRepository).findByIdWithBookAndLibraryPath(fileId);
+        verify(additionalFileRepository).findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId);
+    }
+
+    @Test
+    void deleteAdditionalFile_WhenFileIsPrimaryBookFile_ShouldThrowException() {
+        Long bookId = 100L;
+        Long fileId = 1L;
+        bookEntity.setBookFiles(new ArrayList<>(List.of(fileEntity)));
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> additionalFileService.deleteAdditionalFile(bookId, fileId)
+        );
+
+        assertEquals("Primary book file cannot be processed as an additional file: 1", exception.getMessage());
+        verify(additionalFileRepository, never()).delete(any());
+        verify(monitoringRegistrationService, never()).unregisterSpecificPath(any());
+    }
+
+    @Test
+    void downloadAdditionalFile_WhenFileIsPrimaryBookFile_ShouldThrowException() {
+        Long bookId = 100L;
+        Long fileId = 1L;
+        bookEntity.setBookFiles(new ArrayList<>(List.of(fileEntity)));
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> additionalFileService.downloadAdditionalFile(bookId, fileId)
+        );
+
+        assertEquals("Primary book file cannot be processed as an additional file: 1", exception.getMessage());
+    }
+
+    private BookFileEntity createBookFile(Long id, String fileName) {
+        BookFileEntity entity = new BookFileEntity();
+        entity.setId(id);
+        entity.setBook(bookEntity);
+        entity.setFileName(fileName);
+        entity.setFileSubPath(".");
+        entity.setBookFormat(true);
+        return entity;
     }
 }


### PR DESCRIPTION
## Description

Fixes a bug in production nightly builds where EPUB/Audiobook files cannot be streamed/downloaded

Linked Issue: Fixes https://github.com/grimmory-tools/grimmory/issues/461

## Changes

- add `--enable-preview` to the Docker runtime command so EPUB endpoints can load `org.grimmory.epub4j.epub.EpubReader` in production
- fix additional file downloads by loading `BookFileEntity` with `book.libraryPath` before resolving file paths
- update additional file service tests to cover the download path with the corrected fetch behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Java preview features for container runtime.

* **Bug Fixes**
  * File download and deletion now validate that the target file belongs to the specified book and will reject attempts to act on a book’s primary file, returning appropriate errors for missing or invalid file/book relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->