### PR TITLE
fix(pdf-reader): localize embedpdf viewer to active app language

### DIFF
--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -188,6 +188,16 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
     this.startChromeAutoHide();
     document.addEventListener('fullscreenchange', this.onFullscreenChange);
 
+    this.t.langChanges$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(lang => {
+        if (this.viewerMode === 'book') {
+          this.embedPdfBook.setLocale(lang);
+        } else if (this.embedPdfIframe?.contentWindow) {
+          this.embedPdfIframe.contentWindow.postMessage({ type: 'setLocale', locale: lang }, location.origin);
+        }
+      });
+
     // Listen for mousemove outside Angular zone to avoid constant change detection
     this.ngZone.runOutsideAngular(() => {
       const mouseMoveHandler = () => {
@@ -427,7 +437,8 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
       await this.embedPdfBook.init(
         targetEl,
         pdfUrl,
-        this.isDarkTheme ? 'dark' : 'light'
+        this.isDarkTheme ? 'dark' : 'light',
+        this.t.getActiveLang()
       );
       this.bookViewerInitialized = true;
 
@@ -861,7 +872,8 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
       iframe.contentWindow!.postMessage({
         type: 'init',
         wasmUrl: '/assets/pdfium/pdfium.wasm',
-        theme: this.isDarkTheme ? 'dark' : 'light'
+        theme: this.isDarkTheme ? 'dark' : 'light',
+        locale: this.t.getActiveLang()
       }, location.origin);
 
     } catch (err) {

--- a/frontend/src/app/features/readers/pdf-reader/services/embedpdf-book.service.ts
+++ b/frontend/src/app/features/readers/pdf-reader/services/embedpdf-book.service.ts
@@ -17,18 +17,7 @@ import type {
   RotateCapability,
   PanCapability,
   I18nCapability,
-  Locale,
 } from '@embedpdf/snippet';
-import {
-  englishTranslations,
-  germanTranslations,
-  dutchTranslations,
-  frenchTranslations,
-  spanishTranslations,
-  simplifiedChineseTranslations,
-  swedishTranslations,
-  japaneseTranslations,
-} from '@embedpdf/snippet/dist/config/translations';
 
 export interface PdfOutlineItem {
   title: string;
@@ -38,17 +27,6 @@ export interface PdfOutlineItem {
 
 @Injectable()
 export class EmbedPdfBookService {
-  private static readonly EMBED_PDF_LOCALES: Record<string, Locale> = {
-    en: englishTranslations,
-    de: germanTranslations,
-    nl: dutchTranslations,
-    fr: frenchTranslations,
-    es: spanishTranslations,
-    zh: simplifiedChineseTranslations,
-    sv: swedishTranslations,
-    ja: japaneseTranslations,
-  };
-
   private zone = inject(NgZone);
 
   private container: EmbedPdfContainer | null = null;
@@ -99,7 +77,7 @@ export class EmbedPdfBookService {
     const EmbedPDF = (await import('@embedpdf/snippet')).default;
 
     const wasmUrl = new URL('/assets/pdfium/pdfium.wasm', location.origin).href;
-    const resolvedLocale = this.resolveLocale(localeCode);
+    const requestedLocale = localeCode || 'en';
 
     this.container = EmbedPDF.init({
       type: 'container',
@@ -109,9 +87,8 @@ export class EmbedPdfBookService {
       worker: true,
       log: false,
       i18n: {
-        defaultLocale: resolvedLocale,
+        defaultLocale: requestedLocale,
         fallbackLocale: 'en',
-        locales: Object.values(EmbedPdfBookService.EMBED_PDF_LOCALES),
       },
       theme: {preference: theme},
       disabledCategories: [
@@ -176,7 +153,7 @@ export class EmbedPdfBookService {
 
     const i18nPlugin = this.registry.getPlugin('i18n');
     this.i18n = i18nPlugin?.provides?.() as I18nCapability ?? null;
-    this.i18n?.setLocale(resolvedLocale);
+    this.applyLocale(requestedLocale);
 
     // wire events
     if (this.scroll) {
@@ -231,7 +208,7 @@ export class EmbedPdfBookService {
   }
 
   setLocale(localeCode: string): void {
-    this.i18n?.setLocale(this.resolveLocale(localeCode));
+    this.applyLocale(localeCode || 'en');
   }
 
   scrollToPage(pageNumber: number, behavior: 'instant' | 'smooth' = 'smooth'): void {
@@ -417,17 +394,15 @@ export class EmbedPdfBookService {
     this.restoreDevicePixelRatio();
   }
 
-  private resolveLocale(localeCode: string): string {
-    if (EmbedPdfBookService.EMBED_PDF_LOCALES[localeCode]) {
-      return localeCode;
+  private applyLocale(localeCode: string): void {
+    if (!this.i18n) return;
+
+    if (this.i18n.hasLocale(localeCode)) {
+      this.i18n.setLocale(localeCode);
+      return;
     }
 
-    const baseLocale = localeCode.split('-')[0];
-    if (EmbedPdfBookService.EMBED_PDF_LOCALES[baseLocale]) {
-      return baseLocale;
-    }
-
-    return 'en';
+    this.i18n.setLocale('en');
   }
 
   private convertBookmarks(items: unknown[]): PdfOutlineItem[] {

--- a/frontend/src/app/features/readers/pdf-reader/services/embedpdf-book.service.ts
+++ b/frontend/src/app/features/readers/pdf-reader/services/embedpdf-book.service.ts
@@ -16,7 +16,19 @@ import type {
   SpreadMode,
   RotateCapability,
   PanCapability,
+  I18nCapability,
+  Locale,
 } from '@embedpdf/snippet';
+import {
+  englishTranslations,
+  germanTranslations,
+  dutchTranslations,
+  frenchTranslations,
+  spanishTranslations,
+  simplifiedChineseTranslations,
+  swedishTranslations,
+  japaneseTranslations,
+} from '@embedpdf/snippet/dist/config/translations';
 
 export interface PdfOutlineItem {
   title: string;
@@ -26,6 +38,17 @@ export interface PdfOutlineItem {
 
 @Injectable()
 export class EmbedPdfBookService {
+  private static readonly EMBED_PDF_LOCALES: Record<string, Locale> = {
+    en: englishTranslations,
+    de: germanTranslations,
+    nl: dutchTranslations,
+    fr: frenchTranslations,
+    es: spanishTranslations,
+    zh: simplifiedChineseTranslations,
+    sv: swedishTranslations,
+    ja: japaneseTranslations,
+  };
+
   private zone = inject(NgZone);
 
   private container: EmbedPdfContainer | null = null;
@@ -38,6 +61,7 @@ export class EmbedPdfBookService {
   private spread: SpreadCapability | null = null;
   private rotate: RotateCapability | null = null;
   private pan: PanCapability | null = null;
+  private i18n: I18nCapability | null = null;
 
   private currentDocumentId: string | null = null;
 
@@ -61,7 +85,7 @@ export class EmbedPdfBookService {
     return this.scroll?.getTotalPages() ?? 0;
   }
 
-  async init(target: HTMLElement, pdfUrl: string, theme: 'dark' | 'light'): Promise<void> {
+  async init(target: HTMLElement, pdfUrl: string, theme: 'dark' | 'light', localeCode: string): Promise<void> {
     // Recreate event streams so the service is reusable after destroy()
     this.pageChange$ = new Subject<PageChangeEvent>();
     this.annotationEvent$ = new Subject<AnnotationEvent>();
@@ -75,6 +99,7 @@ export class EmbedPdfBookService {
     const EmbedPDF = (await import('@embedpdf/snippet')).default;
 
     const wasmUrl = new URL('/assets/pdfium/pdfium.wasm', location.origin).href;
+    const resolvedLocale = this.resolveLocale(localeCode);
 
     this.container = EmbedPDF.init({
       type: 'container',
@@ -83,6 +108,11 @@ export class EmbedPdfBookService {
       wasmUrl,
       worker: true,
       log: false,
+      i18n: {
+        defaultLocale: resolvedLocale,
+        fallbackLocale: 'en',
+        locales: Object.values(EmbedPdfBookService.EMBED_PDF_LOCALES),
+      },
       theme: {preference: theme},
       disabledCategories: [
         'redaction',
@@ -144,6 +174,10 @@ export class EmbedPdfBookService {
     const panPlugin = this.registry.getPlugin('pan');
     this.pan = panPlugin?.provides?.() as PanCapability ?? null;
 
+    const i18nPlugin = this.registry.getPlugin('i18n');
+    this.i18n = i18nPlugin?.provides?.() as I18nCapability ?? null;
+    this.i18n?.setLocale(resolvedLocale);
+
     // wire events
     if (this.scroll) {
       this.pageChangeUnsub = this.scroll.onPageChange((ev: PageChangeEvent) => {
@@ -194,6 +228,10 @@ export class EmbedPdfBookService {
 
   setTheme(theme: 'dark' | 'light'): void {
     this.container?.setTheme(theme);
+  }
+
+  setLocale(localeCode: string): void {
+    this.i18n?.setLocale(this.resolveLocale(localeCode));
   }
 
   scrollToPage(pageNumber: number, behavior: 'instant' | 'smooth' = 'smooth'): void {
@@ -371,11 +409,25 @@ export class EmbedPdfBookService {
     this.spread = null;
     this.rotate = null;
     this.pan = null;
+    this.i18n = null;
     this.currentDocumentId = null;
 
     this.restoreWorkerShims();
     this.restoreReleasePointerCapture();
     this.restoreDevicePixelRatio();
+  }
+
+  private resolveLocale(localeCode: string): string {
+    if (EmbedPdfBookService.EMBED_PDF_LOCALES[localeCode]) {
+      return localeCode;
+    }
+
+    const baseLocale = localeCode.split('-')[0];
+    if (EmbedPdfBookService.EMBED_PDF_LOCALES[baseLocale]) {
+      return baseLocale;
+    }
+
+    return 'en';
   }
 
   private convertBookmarks(items: unknown[]): PdfOutlineItem[] {

--- a/frontend/src/assets/embedpdf-frame.html
+++ b/frontend/src/assets/embedpdf-frame.html
@@ -87,11 +87,38 @@
 </script>
 <script type="module">
   import EmbedPDF from '/assets/embedpdf/embedpdf.js';
+  import {
+    englishTranslations,
+    germanTranslations,
+    dutchTranslations,
+    frenchTranslations,
+    spanishTranslations,
+    simplifiedChineseTranslations,
+    swedishTranslations,
+    japaneseTranslations,
+  } from '/assets/embedpdf/embedpdf.js';
 
   let viewer = null;
   let objectUrl = null;
   let registry = null;
   const myOrigin = location.origin;
+  const embedPdfLocales = {
+    en: englishTranslations,
+    de: germanTranslations,
+    nl: dutchTranslations,
+    fr: frenchTranslations,
+    es: spanishTranslations,
+    zh: simplifiedChineseTranslations,
+    sv: swedishTranslations,
+    ja: japaneseTranslations,
+  };
+
+  function resolveLocale(locale) {
+    if (embedPdfLocales[locale]) return locale;
+    const baseLocale = (locale || '').split('-')[0];
+    if (embedPdfLocales[baseLocale]) return baseLocale;
+    return 'en';
+  }
 
   function log(...args) {
     console.log('[EmbedPDF-frame]', ...args);
@@ -284,6 +311,11 @@
       viewer = EmbedPDF.init({
         type: 'container',
         target: target,
+        i18n: {
+          defaultLocale: resolveLocale(msg.locale),
+          fallbackLocale: 'en',
+          locales: Object.values(embedPdfLocales),
+        },
         disabledCategories: [
           'document-open',
           'document-close',
@@ -303,6 +335,7 @@
 
       try {
         registry = await viewer.registry;
+        registry.getPlugin('i18n')?.provides()?.setLocale?.(resolveLocale(msg.locale));
         const dm = registry.getPlugin('document-manager')?.provides();
         if (dm) {
           dm.onDocumentOpened?.((ev) => {
@@ -397,6 +430,10 @@
 
     if (msg.type === 'setTheme') {
       viewer?.setTheme?.(msg.theme);
+    }
+
+    if (msg.type === 'setLocale') {
+      registry?.getPlugin('i18n')?.provides()?.setLocale?.(resolveLocale(msg.locale));
     }
 
     if (msg.type === 'scrollToPage') {

--- a/frontend/src/assets/embedpdf-frame.html
+++ b/frontend/src/assets/embedpdf-frame.html
@@ -87,37 +87,22 @@
 </script>
 <script type="module">
   import EmbedPDF from '/assets/embedpdf/embedpdf.js';
-  import {
-    englishTranslations,
-    germanTranslations,
-    dutchTranslations,
-    frenchTranslations,
-    spanishTranslations,
-    simplifiedChineseTranslations,
-    swedishTranslations,
-    japaneseTranslations,
-  } from '/assets/embedpdf/embedpdf.js';
 
   let viewer = null;
   let objectUrl = null;
   let registry = null;
   const myOrigin = location.origin;
-  const embedPdfLocales = {
-    en: englishTranslations,
-    de: germanTranslations,
-    nl: dutchTranslations,
-    fr: frenchTranslations,
-    es: spanishTranslations,
-    zh: simplifiedChineseTranslations,
-    sv: swedishTranslations,
-    ja: japaneseTranslations,
-  };
 
-  function resolveLocale(locale) {
-    if (embedPdfLocales[locale]) return locale;
-    const baseLocale = (locale || '').split('-')[0];
-    if (embedPdfLocales[baseLocale]) return baseLocale;
-    return 'en';
+  function applyLocale(i18n, locale) {
+    if (!i18n) return;
+
+    const requestedLocale = locale || 'en';
+    if (i18n.hasLocale?.(requestedLocale)) {
+      i18n.setLocale?.(requestedLocale);
+      return;
+    }
+
+    i18n.setLocale?.('en');
   }
 
   function log(...args) {
@@ -312,9 +297,8 @@
         type: 'container',
         target: target,
         i18n: {
-          defaultLocale: resolveLocale(msg.locale),
+          defaultLocale: msg.locale || 'en',
           fallbackLocale: 'en',
-          locales: Object.values(embedPdfLocales),
         },
         disabledCategories: [
           'document-open',
@@ -335,7 +319,7 @@
 
       try {
         registry = await viewer.registry;
-        registry.getPlugin('i18n')?.provides()?.setLocale?.(resolveLocale(msg.locale));
+        applyLocale(registry.getPlugin('i18n')?.provides?.(), msg.locale);
         const dm = registry.getPlugin('document-manager')?.provides();
         if (dm) {
           dm.onDocumentOpened?.((ev) => {
@@ -433,7 +417,7 @@
     }
 
     if (msg.type === 'setLocale') {
-      registry?.getPlugin('i18n')?.provides()?.setLocale?.(resolveLocale(msg.locale));
+      applyLocale(registry?.getPlugin('i18n')?.provides?.(), msg.locale);
     }
 
     if (msg.type === 'scrollToPage') {

--- a/frontend/src/i18n/en/reader-pdf.json
+++ b/frontend/src/i18n/en/reader-pdf.json
@@ -65,7 +65,7 @@
     "annotationFailed": "Failed to save annotations"
   },
   "docViewer": {
-    "changesSavedInfo": "Changes are written to file here",
+    "changesSavedInfo": "Edits in the Document Viewer are automatically saved to the PDF.",
     "dismiss": "Dismiss"
   }
 }


### PR DESCRIPTION
## Description

Add localization to the pdf reader

Linked Issue: Fixes https://github.com/grimmory-tools/grimmory/issues/464

## Changes

- pass the active Grimmory language into the EmbedPDF book viewer during initialization
- update the PDF reader to propagate runtime language changes to the active viewer without requiring a page reload
- add locale support to the iframe-based PDF document viewer path as well as the in-app EmbedPDF path
- map unsupported Grimmory locales to English so the PDF viewer degrades safely when EmbedPDF does not provide a matching translation

This is necessary since unfortunately EmbedPDF does not support the entire breadth of languages Grimmory does

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF reader now supports locale-aware UI for both book and document views.
  * Active language is passed to the viewer on load and can be changed at runtime with immediate effect.
  * Viewer falls back to English when a requested locale isn’t available.

* **Documentation**
  * Clarified English message describing that document viewer edits are automatically saved to the PDF.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->