### PR TITLE
fix(book-card): prefer audiobook covers for square mixed-format cards

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.spec.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.spec.ts
@@ -299,6 +299,37 @@ describe('BookCardComponent', () => {
     expect(component.titleTooltip()).toContain('Volume One');
   });
 
+  it('prefers the audiobook thumbnail for square covers when the book has an audiobook format', () => {
+    ref.setInput('book', makeBook({
+      id: 9,
+      primaryFile: {
+        id: 91,
+        bookId: 9,
+        bookType: 'EPUB',
+        extension: 'epub',
+        filePath: 'books/volume-nine.epub',
+      },
+      alternativeFormats: [
+        {
+          id: 92,
+          bookId: 9,
+          bookType: 'AUDIOBOOK',
+          extension: 'm4b',
+          filePath: 'books/volume-nine.m4b',
+        } as AdditionalFile,
+      ],
+    }));
+    ref.setInput('useSquareCovers', true);
+    fixture.detectChanges();
+
+    expect(component.coverImageUrl()).toBe('audio-thumb:9:2024-01-02');
+
+    ref.setInput('useSquareCovers', false);
+    fixture.detectChanges();
+
+    expect(component.coverImageUrl()).toBe('thumb:9:2024-01-01');
+  });
+
   it('uses forced ebook mode for audiobook reads and falls back to the normal read flow otherwise', () => {
     const audiobookWithAlternativeFormat = makeBook({
       id: 12,

--- a/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.ts
@@ -111,8 +111,14 @@ export class BookCardComponent {
     this.book().primaryFile?.bookType === 'AUDIOBOOK' && !this.forceEbookMode()
   );
 
+  readonly hasAudiobookFormat = computed(() => {
+    const primaryFile = this.book().primaryFile;
+    const alternativeFormats = this.book().alternativeFormats ?? [];
+    return primaryFile?.bookType === 'AUDIOBOOK' || alternativeFormats.some(file => file.bookType === 'AUDIOBOOK');
+  });
+
   readonly coverImageUrl = computed(() =>
-    this.isAudiobook()
+    (this.isAudiobook() || (this.useSquareCovers() && this.hasAudiobookFormat()))
       ? this.urlHelper.getAudiobookThumbnailUrl(this.book().id, this.book().metadata?.audiobookCoverUpdatedOn)
       : this.urlHelper.getThumbnailUrl(this.book().id, this.book().metadata?.coverUpdatedOn)
   );


### PR DESCRIPTION
## Description

Linked Issue: Fixes https://github.com/grimmory-tools/grimmory/issues/465

## Changes

- update book card cover selection to prefer audiobook thumbnails when square covers are enabled and the book has an audiobook format
- add focused test coverage for mixed-format books with square covers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated book cover image selection logic to display audiobook thumbnails when square covers are enabled and an audiobook format is available (whether as primary or alternative format).

* **Tests**
  * Added unit test coverage for cover image URL selection with audiobook formats and square cover preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->