### PR TITLE
feat(ui): allow copying nightly app versions from sidebar

### DIFF
--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
@@ -68,7 +68,13 @@
             {{ versionInfo.current }}
           </a>
         } @else {
-          <span class="version-label">{{ versionInfo.current }}</span>
+          <button
+            type="button"
+            class="version-label version-copy-trigger"
+            (click)="copyVersion(versionInfo.current)"
+          >
+            {{ versionInfo.current }}
+          </button>
         }
       </div>
       @if (isSemanticVersion(versionInfo.current) && versionInfo.latest && versionInfo.latest !== versionInfo.current) {

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.scss
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.scss
@@ -72,6 +72,27 @@
   font-size: 0.875rem;
 }
 
+.version-copy-trigger {
+  padding: 0;
+  border: 0;
+  background: none;
+  font-family: inherit;
+  line-height: inherit;
+  cursor: pointer;
+  user-select: text;
+
+  &:hover {
+    text-decoration: underline;
+    color: var(--high-contrast-text-color);
+  }
+
+  &:focus-visible {
+    outline: 1px solid var(--primary-color);
+    outline-offset: 0.2rem;
+    border-radius: 0.25rem;
+  }
+}
+
 .update-link {
   padding: 0;
   border: 0;

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
@@ -16,6 +16,7 @@ import { TranslocoDirective, TranslocoService } from '@jsverse/transloco';
 import { Slider } from 'primeng/slider';
 import { FormsModule } from '@angular/forms';
 import { Popover } from 'primeng/popover';
+import { MessageService } from 'primeng/api';
 import { LocalStorageService } from '../../service/local-storage.service';
 import type { MenuItem } from 'primeng/api';
 
@@ -54,6 +55,7 @@ export class AppMenuComponent {
   private readonly versionService = inject(VersionService);
   private readonly libraryShelfMenuService = inject(LibraryShelfMenuService);
   private readonly dialogLauncherService = inject(DialogLauncherService);
+  private readonly messageService = inject(MessageService);
   private readonly userService = inject(UserService);
   private readonly magicShelfService = inject(MagicShelfService);
   private readonly seriesDataService = inject(SeriesDataService);
@@ -320,6 +322,39 @@ export class AppMenuComponent {
 
   openChangelogDialog() {
     this.dialogLauncherService.openVersionChangelogDialog();
+  }
+
+  async copyVersion(version: string | undefined): Promise<void> {
+    if (!version) {
+      return;
+    }
+
+    const detailKey = 'layout.menu.versionCopyFailed';
+    const clipboard = globalThis.navigator?.clipboard;
+
+    if (!clipboard?.writeText) {
+      this.messageService.add({
+        severity: 'error',
+        summary: this.t.translate('common.error'),
+        detail: this.t.translate(detailKey, { version }),
+      });
+      return;
+    }
+
+    try {
+      await clipboard.writeText(version);
+      this.messageService.add({
+        severity: 'success',
+        summary: this.t.translate('common.success'),
+        detail: this.t.translate('layout.menu.versionCopied', { version }),
+      });
+    } catch {
+      this.messageService.add({
+        severity: 'error',
+        summary: this.t.translate('common.error'),
+        detail: this.t.translate(detailKey, { version }),
+      });
+    }
   }
 
   getVersionUrl(version: string | undefined): string {

--- a/frontend/src/i18n/en/layout.json
+++ b/frontend/src/i18n/en/layout.json
@@ -30,7 +30,9 @@
     "series": "Series",
     "authors": "Authors",
     "notebook": "Notebook",
-    "update": "(Update)"
+    "update": "(Update)",
+    "versionCopied": "Version {{ version }} copied to clipboard.",
+    "versionCopyFailed": "Unable to copy version {{ version }}."
   },
   "closeNavigation": "Close navigation",
   "changelog": {


### PR DESCRIPTION
## Description

Add support for highlighting non-release version text and copying it on click (improves UX for testing specific nightlies)

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/470

## Changes

- make non-release app versions in the sidebar clickable
- keep release versions as external links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The version number in the menu is now clickable and can be copied to your clipboard with a single click.
* Added visual feedback (underline and highlight) when hovering over the version number.
* Displays confirmation messages to confirm successful copying or alert you if the action fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->