### PR TITLE
fix(kobo): handle missing book when pulling kobo metadata

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/KoboController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/KoboController.java
@@ -124,12 +124,16 @@ public class KoboController {
     @GetMapping("/v1/library/{bookId}/metadata")
     public ResponseEntity<?> getBookMetadata(@Parameter(description = "Book ID") @PathVariable String bookId) {
         if (StringUtils.isNumeric(bookId)) {
-            return ResponseEntity.ok(List.of(koboEntitlementService.getMetadataForBook(Long.parseLong(bookId), token)));
+            KoboBookMetadata metadata = koboEntitlementService.getMetadataForBook(Long.parseLong(bookId), token);
+
+            if (metadata != null) {
+                return ResponseEntity.ok(List.of(metadata));
+            }
         } else if(isForwardingToKoboStore()) {
             return koboServerProxy.proxyCurrentRequest(null, false);
-        } else {
-            throw ApiError.GENERIC_NOT_FOUND.createException("Not Found");
         }
+
+        throw ApiError.GENERIC_NOT_FOUND.createException("Not Found");
     }
 
     @Operation(summary = "Get reading state", description = "Retrieve the reading state for a book.")

--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
@@ -276,11 +276,14 @@ public class KoboEntitlementService {
     }
 
     public KoboBookMetadata getMetadataForBook(long bookId, String token) {
-        List<BookEntity> books = bookQueryService.findAllWithMetadataByIds(Set.of(bookId))
+        Optional<BookEntity> book = bookQueryService.findAllWithMetadataByIds(Set.of(bookId))
                 .stream()
                 .filter(koboCompatibilityService::isBookSupportedForKobo)
-                .toList();
-        return mapToKoboMetadata(books.getFirst(), token);
+                .findFirst();
+
+        return book
+                .map(bookEntity -> mapToKoboMetadata(bookEntity, token))
+                .orElse(null);
     }
 
     private KoboBookMetadata mapToKoboMetadata(BookEntity book, String token) {

--- a/booklore-api/src/test/java/org/booklore/service/KoboEntitlementServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/KoboEntitlementServiceTest.java
@@ -52,6 +52,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -135,6 +136,26 @@ class KoboEntitlementServiceTest {
         assertNotNull(result);
         assertEquals("Test CBX Book", result.getTitle());
         verify(koboCompatibilityService).isBookSupportedForKobo(cbxBook);
+    }
+
+    @Test
+    void getMetadataForBook_shouldReturnNullWhenNoBook() {
+        long bookId = 1L;
+        String token = "test-token";
+
+        BookEntity cbxBook = createCbxBookEntity(bookId);
+        when(bookQueryService.findAllWithMetadataByIds(Set.of(bookId)))
+                .thenReturn(Collections.emptyList());
+        when(koboCompatibilityService.isBookSupportedForKobo(cbxBook))
+                .thenReturn(true);
+        when(koboUrlBuilder.downloadUrl(token, bookId))
+                .thenReturn("http://test.com/download/" + bookId);
+        when(appSettingService.getAppSettings())
+                .thenReturn(createAppSettingsWithKoboSettings());
+
+        KoboBookMetadata result = koboEntitlementService.getMetadataForBook(bookId, token);
+
+        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
instead of an uncaught error, missing books should be treated as a 404 not-found in the kobo metadata endpoint

**Linked Issue:** Fixes #274

## Changes

- return null instead of cause a `NullPointerException` when kobo book metadata won't exist
- return 404 when kobo book metadata is null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for the library metadata endpoint when requested books are not found, ensuring consistent HTTP 404 responses.
  * Enhanced robustness of metadata retrieval service to properly handle cases where book data is unavailable, preventing unexpected exceptions.
  * Added test coverage for null metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->