### PR TITLE
docs(readme): add DISK_TYPE to example compose file (#272)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ services:
       - DATABASE_USERNAME=${DB_USER}
       - DATABASE_PASSWORD=${DB_PASSWORD}
       - API_DOCS_ENABLED=${API_DOCS_ENABLED}
+      - DISK_TYPE=${DISK_TYPE}
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
## Description

the DISK_TYPE variable is now passed to the grimmory container

**Linked Issue:** Fixes #272

## Changes

example compose file

## Test

```
docker exec -it grimmory sh
/ # echo $DISK_TYPE
NETWORK
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Docker Compose example updated to include disk type configuration for storage mode selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->