### PR TITLE
fix(ui): parse magic shelf date values as local midnight

### DIFF
--- a/frontend/src/app/features/magic-shelf/service/book-rule-evaluator.service.ts
+++ b/frontend/src/app/features/magic-shelf/service/book-rule-evaluator.service.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 import {Book} from '../../book/model/book.model';
 import {GroupRule, Rule, RuleField} from '../component/magic-shelf-component';
+import {parseValue} from './magic-shelf-utils';
 
 @Injectable({providedIn: 'root'})
 export class BookRuleEvaluatorService {
@@ -32,8 +33,8 @@ export class BookRuleEvaluatorService {
       if (val instanceof Date) return val;
       if (typeof val === 'boolean') return String(val);
       if (typeof val === 'string') {
-        const date = new Date(val);
-        if (!isNaN(date.getTime())) return date;
+        const date = parseValue(val, 'date');
+        if (date != null) return date;
         return val.toLowerCase();
       }
       return val;
@@ -297,7 +298,7 @@ export class BookRuleEvaluatorService {
       case 'publisher':
         return book.metadata?.publisher?.toLowerCase() ?? null;
       case 'publishedDate':
-        return book.metadata?.publishedDate ? new Date(book.metadata.publishedDate) : null;
+        return parseValue(book.metadata?.publishedDate, 'date') ?? null;
       case 'dateFinished':
         return book.dateFinished ? new Date(book.dateFinished) : null;
       case 'lastReadTime':

--- a/frontend/src/app/features/magic-shelf/service/magic-shelf-utils.spec.ts
+++ b/frontend/src/app/features/magic-shelf/service/magic-shelf-utils.spec.ts
@@ -161,6 +161,13 @@ describe('magic-shelf-utils', () => {
       const result = parseValue('2024-06-15', 'date');
       expect(result).toBeInstanceOf(Date);
       expect((result as Date).getFullYear()).toBe(2024);
+      expect((result as Date).getDate()).toBe(15);
+    });
+
+    it('should parse date time values correctly', () => {
+      const result = parseValue('2024-06-15T01:02:03', 'date');
+      expect(result).toBeInstanceOf(Date);
+      expect((result as Date).getHours()).toBe(1);
     });
 
     it('should return null for invalid date values', () => {

--- a/frontend/src/app/features/magic-shelf/service/magic-shelf-utils.ts
+++ b/frontend/src/app/features/magic-shelf/service/magic-shelf-utils.ts
@@ -17,6 +17,28 @@ export const RELATIVE_DATE_OPERATORS: RuleOperator[] = [
   'this_period'
 ];
 
+function parseDate(val: unknown): Date | null {
+  if (typeof val === "string") {
+    if (val.match("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) {
+      // If `val` is a date-only string, add midnight local time to it
+      // when parsing so we don't get UTC time leading to confusion.
+      val = Date.parse(val + 'T00:00:00');
+    } else {
+      val = Date.parse(val);
+    }
+  }
+
+  if (typeof val === "number") {
+    val = new Date(val);
+  }
+
+  if (!(val instanceof Date) || isNaN(val.getTime())) {
+    return null;
+  }
+
+  return val;
+}
+
 export function parseValue(val: unknown, type: 'string' | 'number' | 'decimal' | 'date' | 'boolean' | undefined): unknown {
   if (val == null) return null;
   if (type === 'number' || type === 'decimal') {
@@ -24,8 +46,7 @@ export function parseValue(val: unknown, type: 'string' | 'number' | 'decimal' |
     return isNaN(num) ? null : num;
   }
   if (type === 'date') {
-    const d = new Date(val as string | number | Date);
-    return isNaN(d.getTime()) ? null : d;
+    return parseDate(val)
   }
   return val;
 }
@@ -45,6 +66,19 @@ export function removeNulls(obj: unknown): unknown {
   return obj;
 }
 
+function serializeDate(val: unknown) {
+  if (!(val instanceof Date)) {
+    return val;
+  }
+
+  // Manually craft the serialized date as a "local" date string
+  // so we don't have a timezone shifting the day-of-month.
+  const year = ("0000" + val.getFullYear()).slice(-4);
+  const month = ("00" + (val.getMonth() + 1)).slice(-2);
+  const day = ("00" + (val.getDate())).slice(-2);
+  return `${year}-${month}-${day}`;
+}
+
 export function serializeDateRules(ruleOrGroup: unknown): unknown {
   if (ruleOrGroup !== null && typeof ruleOrGroup === 'object' && 'rules' in ruleOrGroup) {
     const group = ruleOrGroup as { rules: unknown[] };
@@ -57,12 +91,11 @@ export function serializeDateRules(ruleOrGroup: unknown): unknown {
   const rule = ruleOrGroup as { field?: string; operator?: string; value?: unknown; valueStart?: unknown; valueEnd?: unknown; [key: string]: unknown };
   const isRelativeDateOp = RELATIVE_DATE_OPERATORS.includes(rule.operator as RuleOperator);
   const isDateField = !isRelativeDateOp && (rule.field === 'publishedDate' || rule.field === 'dateFinished' || rule.field === 'addedOn' || rule.field === 'lastReadTime');
-  const serialize = (val: unknown) => (val instanceof Date ? val.toISOString().split('T')[0] : val);
 
   return {
     ...(ruleOrGroup as Record<string, unknown>),
-    value: isDateField ? serialize(rule.value) : rule.value,
-    valueStart: isDateField ? serialize(rule.valueStart) : rule.valueStart,
-    valueEnd: isDateField ? serialize(rule.valueEnd) : rule.valueEnd
+    value: isDateField ? serializeDate(rule.value) : rule.value,
+    valueStart: isDateField ? serializeDate(rule.valueStart) : rule.valueStart,
+    valueEnd: isDateField ? serializeDate(rule.valueEnd) : rule.valueEnd
   };
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

parses the magic shelf values as dates with a local midnight rather than as no-time-dates that become UTC.  this is because the date display is in local time dates rather than UTC dates

**Linked Issue:** Fixes #488

## Changes

* updates magic shelf date picker to append `T00:00:00` to dates before parsing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date parsing and serialization so date-only values and datetimes consistently preserve the intended calendar date and time using local date components.

* **Tests**
  * Expanded date normalization tests to cover parsing and serialization, including assertions for day and hour handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->