### PR TITLE
fix(ui): use RFC3339 format for magic shelf date picker

### DIFF
--- a/frontend/src/app/features/magic-shelf/component/magic-shelf-component.html
+++ b/frontend/src/app/features/magic-shelf/component/magic-shelf-component.html
@@ -147,11 +147,11 @@
                   <p-select [options]="datePeriodOptions" formControlName="value" [placeholder]="t('placeholders.selectPeriod')" appendTo="body" class="value-input"></p-select>
                 } @else if (ruleCtrl.get('operator')?.value === 'in_between') {
                   @if (ruleCtrl.get('field')?.value === 'publishedDate') {
-                    <p-datepicker [formControl]="ruleCtrl.get('valueStart')" dateFormat="dd-M-yy" [placeholder]="t('placeholders.startYear')" appendTo="body" fluid class="value-input"></p-datepicker>
-                    <p-datepicker [formControl]="ruleCtrl.get('valueEnd')" dateFormat="dd-M-yy" [placeholder]="t('placeholders.endYear')" appendTo="body" fluid class="value-input"></p-datepicker>
+                    <p-datepicker [formControl]="ruleCtrl.get('valueStart')" dateFormat="yy-mm-dd" [placeholder]="t('placeholders.startYear')" appendTo="body" fluid class="value-input"></p-datepicker>
+                    <p-datepicker [formControl]="ruleCtrl.get('valueEnd')" dateFormat="yy-mm-dd" [placeholder]="t('placeholders.endYear')" appendTo="body" fluid class="value-input"></p-datepicker>
                   } @else if (['dateFinished', 'addedOn', 'lastReadTime'].includes(ruleCtrl.get('field')?.value)) {
-                    <p-datepicker [formControl]="ruleCtrl.get('valueStart')" dateFormat="dd-M-yy" [placeholder]="t('placeholders.startDate')" appendTo="body" fluid class="value-input"></p-datepicker>
-                    <p-datepicker [formControl]="ruleCtrl.get('valueEnd')" dateFormat="dd-M-yy" [placeholder]="t('placeholders.endDate')" appendTo="body" fluid class="value-input"></p-datepicker>
+                    <p-datepicker [formControl]="ruleCtrl.get('valueStart')" dateFormat="yy-mm-dd" [placeholder]="t('placeholders.startDate')" appendTo="body" fluid class="value-input"></p-datepicker>
+                    <p-datepicker [formControl]="ruleCtrl.get('valueEnd')" dateFormat="yy-mm-dd" [placeholder]="t('placeholders.endDate')" appendTo="body" fluid class="value-input"></p-datepicker>
                   } @else if (numericFieldConfigMap.get(ruleCtrl.get('field')?.value)?.type === 'number') {
                     <p-inputNumber [formControl]="ruleCtrl.get('valueStart')" [min]="0" class="value-input" [placeholder]="t('placeholders.startValue')" [showButtons]="true"></p-inputNumber>
                     <p-inputNumber [formControl]="ruleCtrl.get('valueEnd')" [min]="0" class="value-input" [placeholder]="t('placeholders.endValue')" [showButtons]="true"></p-inputNumber>
@@ -164,9 +164,9 @@
                   }
                 } @else {
                   @if (ruleCtrl.get('field')?.value === 'publishedDate') {
-                    <p-datepicker formControlName="value" dateFormat="dd-M-yy" appendTo="body" fluid class="value-input"></p-datepicker>
+                    <p-datepicker formControlName="value" dateFormat="yy-mm-dd" appendTo="body" fluid class="value-input"></p-datepicker>
                   } @else if (['dateFinished', 'addedOn', 'lastReadTime'].includes(ruleCtrl.get('field')?.value)) {
-                    <p-datepicker formControlName="value" dateFormat="dd-M-yy" appendTo="body" fluid class="value-input"></p-datepicker>
+                    <p-datepicker formControlName="value" dateFormat="yy-mm-dd" appendTo="body" fluid class="value-input"></p-datepicker>
                   } @else if (numericFieldConfigMap.get(ruleCtrl.get('field')?.value)?.type === 'boolean') {
                     <p-select [options]="booleanOptions" formControlName="value" [placeholder]="t('placeholders.selectValue')" appendTo="body" class="value-input"></p-select>
                   } @else if (numericFieldConfigMap.get(ruleCtrl.get('field')?.value)?.type === 'number') {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

uses a more standard, less locale specific date format - [`full-date` in RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)

Before: 
<img width="1411" height="146" alt="image" src="https://github.com/user-attachments/assets/dbb9ae38-a3f6-4f8c-b0b5-6be43430faa5" />

After:
<img width="1428" height="176" alt="image" src="https://github.com/user-attachments/assets/00452693-3db5-44f2-85a3-1cf2dc31f3fa" />


**Linked Issue:** Fixes #490<!-- issue number leave empty if none -->

## Changes

- switch date picker to use `yy-mm-dd`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated date format in date pickers from `dd-M-yy` to `yy-mm-dd` for consistent date display across date-based filters and inputs throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->