### PR TITLE
fix(metadata): refactor book metadata fetching to use fetch API and signals for state management

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/AuthorController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/AuthorController.java
@@ -144,11 +144,11 @@ public class AuthorController {
     @Operation(summary = "Search author photos", description = "Search for author photos using DuckDuckGo image search.")
     @ApiResponse(responseCode = "200", description = "Photo search results returned successfully")
     @PreAuthorize("@securityUtil.canEditMetadata() or @securityUtil.isAdmin()")
-    @GetMapping("/{authorId}/search-photos")
-    public ResponseEntity<List<CoverImage>> searchAuthorPhotos(
+    @GetMapping(value = "/{authorId}/search-photos", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<CoverImage> searchAuthorPhotos(
             @Parameter(description = "ID of the author") @PathVariable long authorId,
             @Parameter(description = "Author name to search") @RequestParam("q") String query) {
-        return ResponseEntity.ok(authorMetadataService.searchAuthorPhotos(query));
+        return authorMetadataService.searchAuthorPhotos(query);
     }
 
     @Operation(summary = "Upload author photo from URL", description = "Download an image from a URL and save it as the author's photo.")

--- a/booklore-api/src/main/java/org/booklore/controller/BookCoverController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookCoverController.java
@@ -6,16 +6,21 @@ import org.booklore.model.dto.request.BulkBookIdsRequest;
 import org.booklore.model.dto.request.CoverFetchRequest;
 import org.booklore.service.metadata.BookCoverService;
 import org.booklore.service.metadata.DuckDuckGoCoverService;
+import org.booklore.exception.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 import java.util.Map;
@@ -145,14 +150,17 @@ public class BookCoverController {
 
     @Operation(summary = "Get cover images for a book", description = "Fetch cover images for a book.")
     @ApiResponse(responseCode = "200", description = "Cover images returned successfully")
-    @PostMapping(value = "/{bookId}/metadata/covers", produces = org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PostMapping(value = "/{bookId}/metadata/covers", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @PreAuthorize("@securityUtil.canEditMetadata() or @securityUtil.isAdmin()")
-    public reactor.core.publisher.Flux<org.springframework.http.codec.ServerSentEvent<CoverImage>> getImages(@Parameter(description = "Cover fetch request") @RequestBody CoverFetchRequest request) {
+    @CheckBookAccess(bookIdParam = "bookId")
+    public Flux<ServerSentEvent<CoverImage>> getImages(
+            @Parameter(description = "ID of the book") @PathVariable Long bookId,
+            @Parameter(description = "Cover fetch request") @RequestBody CoverFetchRequest request) {
         return duckDuckGoCoverService.getCovers(request)
-                .subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic())
-                .map(image -> org.springframework.http.codec.ServerSentEvent.<CoverImage>builder()
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(image -> ServerSentEvent.<CoverImage>builder()
                         .data(image)
                         .build())
-                .onErrorResume(e -> reactor.core.publisher.Flux.empty());
+                .onErrorMap(e -> ApiError.INTERNAL_SERVER_ERROR.createException("DuckDuckGo cover fetch failed"));
     }
 }

--- a/booklore-api/src/main/java/org/booklore/controller/BookCoverController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/BookCoverController.java
@@ -145,9 +145,14 @@ public class BookCoverController {
 
     @Operation(summary = "Get cover images for a book", description = "Fetch cover images for a book.")
     @ApiResponse(responseCode = "200", description = "Cover images returned successfully")
-    @PostMapping("/{bookId}/metadata/covers")
+    @PostMapping(value = "/{bookId}/metadata/covers", produces = org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE)
     @PreAuthorize("@securityUtil.canEditMetadata() or @securityUtil.isAdmin()")
-    public ResponseEntity<List<CoverImage>> getImages(@Parameter(description = "Cover fetch request") @RequestBody CoverFetchRequest request) {
-        return ResponseEntity.ok(duckDuckGoCoverService.getCovers(request));
+    public reactor.core.publisher.Flux<org.springframework.http.codec.ServerSentEvent<CoverImage>> getImages(@Parameter(description = "Cover fetch request") @RequestBody CoverFetchRequest request) {
+        return duckDuckGoCoverService.getCovers(request)
+                .subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic())
+                .map(image -> org.springframework.http.codec.ServerSentEvent.<CoverImage>builder()
+                        .data(image)
+                        .build())
+                .onErrorResume(e -> reactor.core.publisher.Flux.empty());
     }
 }

--- a/booklore-api/src/main/java/org/booklore/service/AuthorMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/AuthorMetadataService.java
@@ -255,13 +255,10 @@ public class AuthorMetadataService {
         return toAuthorDetails(author);
     }
 
-    public List<CoverImage> searchAuthorPhotos(String name) {
+    public Flux<CoverImage> searchAuthorPhotos(String name) {
         String searchTerm = name + " author photo portrait";
-        List<CoverImage> results = duckDuckGoCoverService.searchImages(searchTerm);
-        if (results.size() > 50) {
-            results = results.subList(0, 50);
-        }
-        return results;
+        return duckDuckGoCoverService.searchImages(searchTerm)
+                .take(50);
     }
 
     public void uploadAuthorPhotoFromUrl(Long authorId, String imageUrl) {

--- a/booklore-api/src/main/java/org/booklore/service/metadata/BookCoverProvider.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/BookCoverProvider.java
@@ -3,9 +3,9 @@ package org.booklore.service.metadata;
 import org.booklore.model.dto.CoverImage;
 import org.booklore.model.dto.request.CoverFetchRequest;
 
-import java.util.List;
+import reactor.core.publisher.Flux;
 
 public interface BookCoverProvider {
-    List<CoverImage> getCovers(CoverFetchRequest request);
+    Flux<CoverImage> getCovers(CoverFetchRequest request);
 }
 

--- a/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
@@ -75,7 +75,7 @@ public class BookMetadataService {
 
         return Flux.fromIterable(request.getProviders())
                 .flatMap(provider ->
-                    getParser(provider).fetchMetadataStream(book, request)
+                    Flux.defer(() -> getParser(provider).fetchMetadataStream(book, request))
                             .subscribeOn(Schedulers.boundedElastic())
                             .onErrorResume(e -> {
                                 log.error("Error fetching metadata from provider: {}", provider, e);

--- a/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
@@ -75,9 +75,8 @@ public class BookMetadataService {
 
         return Flux.fromIterable(request.getProviders())
                 .flatMap(provider ->
-                    Mono.fromCallable(() -> fetchMetadataListFromAProvider(provider, book, request))
+                    getParser(provider).fetchMetadataStream(book, request)
                             .subscribeOn(Schedulers.boundedElastic())
-                            .flatMapMany(Flux::fromIterable)
                             .onErrorResume(e -> {
                                 log.error("Error fetching metadata from provider: {}", provider, e);
                                 return Flux.empty();

--- a/booklore-api/src/main/java/org/booklore/service/metadata/DuckDuckGoCoverService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/DuckDuckGoCoverService.java
@@ -137,8 +137,10 @@ public class DuckDuckGoCoverService implements BookCoverProvider {
                     for (CoverImage img : generalBookImages) {
                         if (sink.isCancelled()) return;
                         if (count >= 10) break;
+                        if (emittedUrls.contains(img.getUrl())) continue;
                         CoverImage indexedImg = new CoverImage(img.getUrl(), img.getWidth(), img.getHeight(), index.getAndIncrement());
                         sink.next(indexedImg);
+                        emittedUrls.add(img.getUrl());
                         count++;
                     }
                 }
@@ -224,6 +226,7 @@ public class DuckDuckGoCoverService implements BookCoverProvider {
             }
         } catch (Exception e) {
             log.error("Error fetching images from DuckDuckGo", e);
+            throw org.booklore.exception.ApiError.INTERNAL_SERVER_ERROR.createException("DuckDuckGo image fetch failed");
         }
         List<CoverImage> all = new ArrayList<>(priority);
         all.addAll(others);
@@ -240,7 +243,7 @@ public class DuckDuckGoCoverService implements BookCoverProvider {
                     .execute();
         } catch (IOException e) {
             log.error("Error fetching url: {}", url, e);
-            throw new RuntimeException(e);
+            throw ApiError.INTERNAL_SERVER_ERROR.createException("Error fetching URL: " + url);
         }
     }
 
@@ -249,7 +252,7 @@ public class DuckDuckGoCoverService implements BookCoverProvider {
             return response.parse();
         } catch (IOException e) {
             log.error("Error parsing response", e);
-            throw new RuntimeException(e);
+            throw ApiError.INTERNAL_SERVER_ERROR.createException("Error parsing response");
         }
     }
 

--- a/booklore-api/src/main/java/org/booklore/service/metadata/DuckDuckGoCoverService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/DuckDuckGoCoverService.java
@@ -11,10 +11,13 @@ import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
+import reactor.core.publisher.Flux;
+
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -62,104 +65,127 @@ public class DuckDuckGoCoverService implements BookCoverProvider {
 
     private final ObjectMapper mapper;
 
-    public List<CoverImage> getCovers(CoverFetchRequest request) {
-        String title = request.getTitle();
-        String author = request.getAuthor();
-        boolean isAudiobook = "audiobook".equalsIgnoreCase(request.getCoverType());
-        String bookType = isAudiobook ? "audiobook" : "book";
-        String searchTerm = (author != null && !author.isEmpty())
-                ? title + " " + author + " " + bookType
-                : title + " " + bookType;
+    public Flux<CoverImage> getCovers(CoverFetchRequest request) {
+        return Flux.create(sink -> {
+            try {
+                String title = request.getTitle();
+                String author = request.getAuthor();
+                boolean isAudiobook = "audiobook".equalsIgnoreCase(request.getCoverType());
+                String bookType = isAudiobook ? "audiobook" : "book";
+                String searchTerm = (author != null && !author.isEmpty())
+                        ? title + " " + author + " " + bookType
+                        : title + " " + bookType;
 
-        String searchParams = isAudiobook ? SEARCH_PARAMS_SQUARE : SEARCH_PARAMS_TALL;
-        String jsonParams = isAudiobook ? JSON_PARAMS_SQUARE : JSON_PARAMS_TALL;
+                String searchParams = isAudiobook ? SEARCH_PARAMS_SQUARE : SEARCH_PARAMS_TALL;
+                String jsonParams = isAudiobook ? JSON_PARAMS_SQUARE : JSON_PARAMS_TALL;
 
-        String encodedSiteQuery = URLEncoder.encode(searchTerm, StandardCharsets.UTF_8);
-        String siteUrl = SEARCH_BASE_URL + encodedSiteQuery + SITE_FILTER + searchParams;
-        Connection.Response siteResponse = getResponse(siteUrl);
-        Document siteDoc = parseResponse(siteResponse);
-        Map<String, String> cookies = siteResponse.cookies();
-        Pattern tokenPattern = Pattern.compile("vqd=\"(\\d+-\\d+)\"");
-        Matcher siteMatcher = tokenPattern.matcher(siteDoc.html());
-        if (!siteMatcher.find()) {
-            log.error("Could not find search token for site-filtered images!");
-            return Collections.emptyList();
-        }
-        String siteSearchToken = siteMatcher.group(1);
-        List<CoverImage> siteFilteredImages = fetchImagesFromApi(searchTerm + " (site:amazon.com OR site:goodreads.com)", siteSearchToken, cookies, siteUrl, jsonParams);
-        siteFilteredImages.removeIf(dto -> dto.getWidth() < 350);
-        if (isAudiobook) {
-            siteFilteredImages.removeIf(dto -> !isApproximatelySquare(dto.getWidth(), dto.getHeight()));
-        } else {
-            siteFilteredImages.removeIf(dto -> dto.getWidth() >= dto.getHeight());
-        }
-        if (siteFilteredImages.size() > 7) {
-            siteFilteredImages = siteFilteredImages.subList(0, 7);
-        }
+                AtomicInteger index = new AtomicInteger(1);
+                Set<String> emittedUrls = new HashSet<>();
 
-        String encodedGeneralQuery = URLEncoder.encode(searchTerm, StandardCharsets.UTF_8);
-        String generalUrl = SEARCH_BASE_URL + encodedGeneralQuery + searchParams;
-        Connection.Response generalResponse = getResponse(generalUrl);
-        Document generalDoc = parseResponse(generalResponse);
-        Map<String, String> generalCookies = generalResponse.cookies();
-        Matcher generalMatcher = tokenPattern.matcher(generalDoc.html());
-        List<CoverImage> generalBookImages = new ArrayList<>();
-        if (generalMatcher.find()) {
-            String generalSearchToken = generalMatcher.group(1);
-            generalBookImages = fetchImagesFromApi(searchTerm, generalSearchToken, generalCookies, generalUrl, jsonParams);
-            generalBookImages.removeIf(dto -> dto.getWidth() < 350);
-            if (isAudiobook) {
-                generalBookImages.removeIf(dto -> !isApproximatelySquare(dto.getWidth(), dto.getHeight()));
-            } else {
-                generalBookImages.removeIf(dto -> dto.getWidth() >= dto.getHeight());
+                // 1. Site-filtered search
+                String encodedSiteQuery = URLEncoder.encode(searchTerm, StandardCharsets.UTF_8);
+                String siteUrl = SEARCH_BASE_URL + encodedSiteQuery + SITE_FILTER + searchParams;
+                Connection.Response siteResponse = getResponse(siteUrl);
+                Document siteDoc = parseResponse(siteResponse);
+                Map<String, String> cookies = siteResponse.cookies();
+                Pattern tokenPattern = Pattern.compile("vqd=\"(\\d+-\\d+)\"");
+                Matcher siteMatcher = tokenPattern.matcher(siteDoc.html());
+
+                if (siteMatcher.find()) {
+                    String siteSearchToken = siteMatcher.group(1);
+                    List<CoverImage> siteFilteredImages = fetchImagesFromApi(searchTerm + " (site:amazon.com OR site:goodreads.com)", siteSearchToken, cookies, siteUrl, jsonParams);
+                    siteFilteredImages.removeIf(dto -> dto.getWidth() < 350);
+                    if (isAudiobook) {
+                        siteFilteredImages.removeIf(dto -> !isApproximatelySquare(dto.getWidth(), dto.getHeight()));
+                    } else {
+                        siteFilteredImages.removeIf(dto -> dto.getWidth() >= dto.getHeight());
+                    }
+
+                    int count = 0;
+                    for (CoverImage img : siteFilteredImages) {
+                        if (sink.isCancelled()) return;
+                        if (count >= 7) break;
+                        CoverImage indexedImg = new CoverImage(img.getUrl(), img.getWidth(), img.getHeight(), index.getAndIncrement());
+                        sink.next(indexedImg);
+                        emittedUrls.add(img.getUrl());
+                        count++;
+                    }
+                }
+
+                if (sink.isCancelled()) return;
+
+                // 2. General search
+                String encodedGeneralQuery = URLEncoder.encode(searchTerm, StandardCharsets.UTF_8);
+                String generalUrl = SEARCH_BASE_URL + encodedGeneralQuery + searchParams;
+                Connection.Response generalResponse = getResponse(generalUrl);
+                Document generalDoc = parseResponse(generalResponse);
+                Map<String, String> generalCookies = generalResponse.cookies();
+                Matcher generalMatcher = tokenPattern.matcher(generalDoc.html());
+
+                if (generalMatcher.find()) {
+                    String generalSearchToken = generalMatcher.group(1);
+                    List<CoverImage> generalBookImages = fetchImagesFromApi(searchTerm, generalSearchToken, generalCookies, generalUrl, jsonParams);
+                    generalBookImages.removeIf(dto -> dto.getWidth() < 350);
+                    if (isAudiobook) {
+                        generalBookImages.removeIf(dto -> !isApproximatelySquare(dto.getWidth(), dto.getHeight()));
+                    } else {
+                        generalBookImages.removeIf(dto -> dto.getWidth() >= dto.getHeight());
+                    }
+                    generalBookImages.removeIf(dto -> emittedUrls.contains(dto.getUrl()));
+
+                    int count = 0;
+                    for (CoverImage img : generalBookImages) {
+                        if (sink.isCancelled()) return;
+                        if (count >= 10) break;
+                        CoverImage indexedImg = new CoverImage(img.getUrl(), img.getWidth(), img.getHeight(), index.getAndIncrement());
+                        sink.next(indexedImg);
+                        count++;
+                    }
+                }
+
+                sink.complete();
+            } catch (Exception e) {
+                log.error("Error in getCovers stream", e);
+                sink.error(e);
             }
-            Set<String> siteUrls = siteFilteredImages.stream().map(CoverImage::getUrl).collect(Collectors.toSet());
-            generalBookImages.removeIf(dto -> siteUrls.contains(dto.getUrl()));
-            if (generalBookImages.size() > 10) {
-                generalBookImages = generalBookImages.subList(0, 10);
-            }
-        }
-
-        List<CoverImage> allImages = new ArrayList<>(siteFilteredImages);
-        allImages.addAll(generalBookImages);
-
-        for (int i = 0; i < allImages.size(); i++) {
-            CoverImage img = allImages.get(i);
-            allImages.set(i, new CoverImage(
-                    img.getUrl(),
-                    img.getWidth(),
-                    img.getHeight(),
-                    i + 1
-            ));
-        }
-
-        return allImages;
+        });
     }
 
-    public List<CoverImage> searchImages(String searchTerm) {
-        String searchParams = "&iar=images";
-        String jsonParams = "&iar=images";
+    public Flux<CoverImage> searchImages(String searchTerm) {
+        return Flux.create(sink -> {
+            try {
+                String searchParams = "&iar=images";
+                String jsonParams = "&iar=images";
 
-        String encodedQuery = URLEncoder.encode(searchTerm, StandardCharsets.UTF_8);
-        String searchUrl = SEARCH_BASE_URL + encodedQuery + searchParams;
-        Connection.Response response = getResponse(searchUrl);
-        Document doc = parseResponse(response);
-        Map<String, String> cookies = response.cookies();
-        Pattern tokenPattern = Pattern.compile("vqd=\"(\\d+-\\d+)\"");
-        Matcher matcher = tokenPattern.matcher(doc.html());
-        if (!matcher.find()) {
-            log.error("Could not find search token for image search");
-            return Collections.emptyList();
-        }
-        String searchToken = matcher.group(1);
-        List<CoverImage> images = fetchImagesFromApi(searchTerm, searchToken, cookies, searchUrl, jsonParams);
+                String encodedQuery = URLEncoder.encode(searchTerm, StandardCharsets.UTF_8);
+                String searchUrl = SEARCH_BASE_URL + encodedQuery + searchParams;
+                Connection.Response response = getResponse(searchUrl);
+                Document doc = parseResponse(response);
+                Map<String, String> cookies = response.cookies();
+                Pattern tokenPattern = Pattern.compile("vqd=\"(\\d+-\\d+)\"");
+                Matcher matcher = tokenPattern.matcher(doc.html());
 
-        for (int i = 0; i < images.size(); i++) {
-            CoverImage img = images.get(i);
-            images.set(i, new CoverImage(img.getUrl(), img.getWidth(), img.getHeight(), i + 1));
-        }
+                if (!matcher.find()) {
+                    log.error("Could not find search token for image search");
+                    sink.complete();
+                    return;
+                }
 
-        return images;
+                String searchToken = matcher.group(1);
+                List<CoverImage> images = fetchImagesFromApi(searchTerm, searchToken, cookies, searchUrl, jsonParams);
+
+                AtomicInteger index = new AtomicInteger(1);
+                for (CoverImage img : images) {
+                    if (sink.isCancelled()) return;
+                    sink.next(new CoverImage(img.getUrl(), img.getWidth(), img.getHeight(), index.getAndIncrement()));
+                }
+
+                sink.complete();
+            } catch (Exception e) {
+                log.error("Error in searchImages stream", e);
+                sink.error(e);
+            }
+        });
     }
 
     private List<CoverImage> fetchImagesFromApi(String query, String searchToken, Map<String, String> cookies, String referrerUrl, String jsonParams) {

--- a/booklore-api/src/main/java/org/booklore/service/metadata/DuckDuckGoCoverService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/DuckDuckGoCoverService.java
@@ -2,6 +2,7 @@ package org.booklore.service.metadata;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.booklore.exception.ApiError;
 import org.booklore.model.dto.CoverImage;
 import org.booklore.model.dto.request.CoverFetchRequest;
 import org.jsoup.Connection;
@@ -226,7 +227,7 @@ public class DuckDuckGoCoverService implements BookCoverProvider {
             }
         } catch (Exception e) {
             log.error("Error fetching images from DuckDuckGo", e);
-            throw org.booklore.exception.ApiError.INTERNAL_SERVER_ERROR.createException("DuckDuckGo image fetch failed");
+            throw ApiError.INTERNAL_SERVER_ERROR.createException("DuckDuckGo image fetch failed");
         }
         List<CoverImage> all = new ArrayList<>(priority);
         all.addAll(others);

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/BookParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/BookParser.java
@@ -3,12 +3,17 @@ package org.booklore.service.metadata.parser;
 import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookMetadata;
 import org.booklore.model.dto.request.FetchMetadataRequest;
+import reactor.core.publisher.Flux;
 
 import java.util.List;
 
 public interface BookParser {
 
     List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest);
+
+    default Flux<BookMetadata> fetchMetadataStream(Book book, FetchMetadataRequest fetchMetadataRequest) {
+        return Flux.fromIterable(fetchMetadata(book, fetchMetadataRequest));
+    }
 
     BookMetadata fetchTopMetadata(Book book, FetchMetadataRequest fetchMetadataRequest);
 }

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/BookParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/BookParser.java
@@ -12,7 +12,10 @@ public interface BookParser {
     List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest);
 
     default Flux<BookMetadata> fetchMetadataStream(Book book, FetchMetadataRequest fetchMetadataRequest) {
-        return Flux.fromIterable(fetchMetadata(book, fetchMetadataRequest));
+        return Flux.defer(() -> {
+            List<BookMetadata> metadata = fetchMetadata(book, fetchMetadataRequest);
+            return metadata != null ? Flux.fromIterable(metadata) : Flux.empty();
+        });
     }
 
     BookMetadata fetchTopMetadata(Book book, FetchMetadataRequest fetchMetadataRequest);

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
@@ -174,11 +174,32 @@ public class GoodReadsParser implements BookParser, DetailedMetadataProvider {
                 }
 
                 if (fetchMetadataRequest.getTitle() != null && !fetchMetadataRequest.getTitle().isBlank()
-                        && fetchMetadataRequest.getAuthor() != null && !fetchMetadataRequest.getAuthor().isBlank()) {
+                        && fetchMetadataRequest.getAuthor() != null && !fetchMetadataRequest.getAuthor().isBlank()
+                        && previews.isEmpty()) {
 
-                    // Check if we need to retry with title only (no results so far)
-                    // This is a bit tricky with Flux, but we can check if we want to continue.
-                    // For simplicity, we only retry if we have 0 results so far from this specific provider.
+                    log.info("GoodReads: No hits for Title + Author search, retrying with Title only: {}", fetchMetadataRequest.getTitle());
+                    FetchMetadataRequest titleOnlyRequest = FetchMetadataRequest.builder()
+                            .title(fetchMetadataRequest.getTitle())
+                            .build();
+
+                    List<BookMetadata> titleOnlyPreviews = fetchMetadataPreviews(book, titleOnlyRequest).stream()
+                            .limit(COUNT_DETAILED_METADATA_TO_GET_RETRY)
+                            .toList();
+
+                    for (BookMetadata preview : titleOnlyPreviews) {
+                        if (sink.isCancelled()) return;
+                        log.info("GoodReads: Fetching metadata (Title only hit) for: {}", preview.getTitle());
+                        try {
+                            Document document = fetchDoc(BASE_BOOK_URL + preview.getGoodreadsId());
+                            BookMetadata detailedMetadata = parseBookDetails(document, preview.getGoodreadsId());
+                            if (detailedMetadata != null) {
+                                sink.next(detailedMetadata);
+                            }
+                            Thread.sleep(ThreadLocalRandom.current().nextLong(500, 1501));
+                        } catch (Exception e) {
+                            log.error("Error fetching metadata for book (Title only retry): {}", preview.getGoodreadsId(), e);
+                        }
+                    }
                 }
 
                 sink.complete();

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
@@ -18,6 +18,7 @@ import org.jsoup.select.Elements;
 import org.springframework.boot.configurationprocessor.json.JSONArray;
 import org.springframework.boot.configurationprocessor.json.JSONObject;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 
 import java.io.IOException;
 import java.net.URI;
@@ -90,8 +91,7 @@ public class GoodReadsParser implements BookParser, DetailedMetadataProvider {
         if (preview.isEmpty()) {
             return null;
         }
-        List<BookMetadata> fetchedMetadata = fetchMetadataUsingPreviews(List.of(preview.get()));
-        return fetchedMetadata.isEmpty() ? null : fetchedMetadata.getFirst();
+        return fetchMetadataStream(book, fetchMetadataRequest).blockFirst();
     }
 
     private String getExistingGoodreadsId(Book book) {
@@ -134,60 +134,58 @@ public class GoodReadsParser implements BookParser, DetailedMetadataProvider {
 
     @Override
     public List<BookMetadata> fetchMetadata(Book book, FetchMetadataRequest fetchMetadataRequest) {
-        String isbn = ParserUtils.cleanIsbn(fetchMetadataRequest.getIsbn());
-        if (isbn != null && !isbn.isBlank()) {
-            log.info("Goodreads Query URL (ISBN): {}{}", BASE_ISBN_URL, isbn);
-            Document doc = fetchDoc(BASE_ISBN_URL + isbn);
-            String goodreadsId = extractGoodreadsIdFromOgUrl(doc);
-            if (goodreadsId != null) {
-                BookMetadata metadata = parseBookDetails(doc, goodreadsId);
-                if (metadata != null) {
-                    return List.of(metadata);
-                }
-            }
-        }
-
-        List<BookMetadata> previews = fetchMetadataPreviews(book, fetchMetadataRequest).stream()
-                .limit(COUNT_DETAILED_METADATA_TO_GET)
-                .toList();
-        List<BookMetadata> results = fetchMetadataUsingPreviews(previews);
-
-        if (results.isEmpty()
-                && fetchMetadataRequest.getTitle() != null && !fetchMetadataRequest.getTitle().isBlank()
-                && fetchMetadataRequest.getAuthor() != null && !fetchMetadataRequest.getAuthor().isBlank()) {
-            log.info("GoodReads: No results with title+author, retrying with title only.");
-            FetchMetadataRequest titleOnlyRequest = FetchMetadataRequest.builder()
-                    .bookId(fetchMetadataRequest.getBookId())
-                    .providers(fetchMetadataRequest.getProviders())
-                    .isbn(fetchMetadataRequest.getIsbn())
-                    .title(fetchMetadataRequest.getTitle())
-                    .asin(fetchMetadataRequest.getAsin())
-                    .build();
-            previews = fetchMetadataPreviews(book, titleOnlyRequest).stream()
-                    .limit(COUNT_DETAILED_METADATA_TO_GET_RETRY)
-                    .toList();
-            results = fetchMetadataUsingPreviews(previews);
-        }
-
-        return results;
+        return fetchMetadataStream(book, fetchMetadataRequest).collectList().block();
     }
 
-    private List<BookMetadata> fetchMetadataUsingPreviews(List<BookMetadata> previews) {
-        List<BookMetadata> fetchedMetadata = new ArrayList<>();
-        for (BookMetadata preview : previews) {
-            log.info("GoodReads: Fetching metadata for: {}", preview.getTitle());
+    @Override
+    public Flux<BookMetadata> fetchMetadataStream(Book book, FetchMetadataRequest fetchMetadataRequest) {
+        return Flux.create(sink -> {
             try {
-                Document document = fetchDoc(BASE_BOOK_URL + preview.getGoodreadsId());
-                BookMetadata detailedMetadata = parseBookDetails(document, preview.getGoodreadsId());
-                if (detailedMetadata != null) {
-                    fetchedMetadata.add(detailedMetadata);
+                String isbn = ParserUtils.cleanIsbn(fetchMetadataRequest.getIsbn());
+                if (isbn != null && !isbn.isBlank()) {
+                    log.info("Goodreads Query URL (ISBN): {}{}", BASE_ISBN_URL, isbn);
+                    Document doc = fetchDoc(BASE_ISBN_URL + isbn);
+                    String goodreadsId = extractGoodreadsIdFromOgUrl(doc);
+                    if (goodreadsId != null) {
+                        BookMetadata metadata = parseBookDetails(doc, goodreadsId);
+                        if (metadata != null) {
+                            sink.next(metadata);
+                        }
+                    }
                 }
-                Thread.sleep(ThreadLocalRandom.current().nextLong(500, 1501));
+
+                List<BookMetadata> previews = fetchMetadataPreviews(book, fetchMetadataRequest).stream()
+                        .limit(COUNT_DETAILED_METADATA_TO_GET)
+                        .toList();
+
+                for (BookMetadata preview : previews) {
+                    if (sink.isCancelled()) return;
+                    log.info("GoodReads: Fetching metadata for: {}", preview.getTitle());
+                    try {
+                        Document document = fetchDoc(BASE_BOOK_URL + preview.getGoodreadsId());
+                        BookMetadata detailedMetadata = parseBookDetails(document, preview.getGoodreadsId());
+                        if (detailedMetadata != null) {
+                            sink.next(detailedMetadata);
+                        }
+                        Thread.sleep(ThreadLocalRandom.current().nextLong(500, 1501));
+                    } catch (Exception e) {
+                        log.error("Error fetching metadata for book: {}", preview.getGoodreadsId(), e);
+                    }
+                }
+
+                if (fetchMetadataRequest.getTitle() != null && !fetchMetadataRequest.getTitle().isBlank()
+                        && fetchMetadataRequest.getAuthor() != null && !fetchMetadataRequest.getAuthor().isBlank()) {
+
+                    // Check if we need to retry with title only (no results so far)
+                    // This is a bit tricky with Flux, but we can check if we want to continue.
+                    // For simplicity, we only retry if we have 0 results so far from this specific provider.
+                }
+
+                sink.complete();
             } catch (Exception e) {
-                log.error("Error fetching metadata for book: {}", preview.getGoodreadsId(), e);
+                sink.error(e);
             }
-        }
-        return fetchedMetadata;
+        });
     }
 
     private BookMetadata parseBookDetails(Document document, String goodreadsId) {

--- a/booklore-api/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
@@ -143,14 +143,18 @@ public class GoodReadsParser implements BookParser, DetailedMetadataProvider {
             try {
                 String isbn = ParserUtils.cleanIsbn(fetchMetadataRequest.getIsbn());
                 if (isbn != null && !isbn.isBlank()) {
-                    log.info("Goodreads Query URL (ISBN): {}{}", BASE_ISBN_URL, isbn);
-                    Document doc = fetchDoc(BASE_ISBN_URL + isbn);
-                    String goodreadsId = extractGoodreadsIdFromOgUrl(doc);
-                    if (goodreadsId != null) {
-                        BookMetadata metadata = parseBookDetails(doc, goodreadsId);
-                        if (metadata != null) {
-                            sink.next(metadata);
+                    try {
+                        log.info("Goodreads Query URL (ISBN): {}{}", BASE_ISBN_URL, isbn);
+                        Document doc = fetchDoc(BASE_ISBN_URL + isbn);
+                        String goodreadsId = extractGoodreadsIdFromOgUrl(doc);
+                        if (goodreadsId != null) {
+                            BookMetadata metadata = parseBookDetails(doc, goodreadsId);
+                            if (metadata != null) {
+                                sink.next(metadata);
+                            }
                         }
+                    } catch (Exception e) {
+                        log.warn("GoodReads: ISBN lookup failed: {}, falling back to title search", e.getMessage());
                     }
                 }
 

--- a/booklore-api/src/test/java/org/booklore/service/metadata/DuckDuckGoCoverServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/DuckDuckGoCoverServiceTest.java
@@ -1,5 +1,6 @@
 package org.booklore.service.metadata;
 
+import org.booklore.exception.APIException;
 import org.booklore.model.dto.CoverImage;
 import org.booklore.model.dto.request.CoverFetchRequest;
 import org.jsoup.Connection;
@@ -579,8 +580,8 @@ class DuckDuckGoCoverServiceTest {
                         .title("Test").coverType("ebook").build();
 
                 assertThatThrownBy(() -> service.getCovers(request).collectList().block())
-                        .isInstanceOf(RuntimeException.class)
-                        .hasCauseInstanceOf(IOException.class);
+                        .isInstanceOf(APIException.class)
+                        .hasMessageContaining("Error fetching URL:");
             }
         }
     }
@@ -600,8 +601,8 @@ class DuckDuckGoCoverServiceTest {
                         .title("Test").coverType("ebook").build();
 
                 assertThatThrownBy(() -> service.getCovers(request).collectList().block())
-                        .isInstanceOf(RuntimeException.class)
-                        .hasCauseInstanceOf(IOException.class);
+                        .isInstanceOf(APIException.class)
+                        .hasMessageContaining("Error parsing response");
             }
         }
     }
@@ -610,7 +611,7 @@ class DuckDuckGoCoverServiceTest {
     class FetchImagesFromApi {
 
         @Test
-        void returnsEmptyListOnApiException() throws Exception {
+        void throwsRuntimeExceptionOnApiException() throws Exception {
             String htmlWithToken = "<html>vqd=\"12345-67890\"</html>";
 
             try (MockedStatic<Jsoup> jsoupMock = mockStatic(Jsoup.class, CALLS_REAL_METHODS)) {
@@ -619,16 +620,14 @@ class DuckDuckGoCoverServiceTest {
                 Connection.Response htmlResp = buildHtmlResponse(htmlWithToken, Map.of());
                 when(connection.execute())
                         .thenReturn(htmlResp)
-                        .thenThrow(new IOException("api error"))
-                        .thenReturn(htmlResp)
                         .thenThrow(new IOException("api error"));
 
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test").coverType("ebook").build();
 
-                List<CoverImage> result = service.getCovers(request).collectList().block();
-
-                assertThat(result).isEmpty();
+                assertThatThrownBy(() -> service.getCovers(request).collectList().block())
+                        .isInstanceOf(APIException.class)
+                        .hasMessageContaining("DuckDuckGo image fetch failed");
             }
         }
 

--- a/booklore-api/src/test/java/org/booklore/service/metadata/DuckDuckGoCoverServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/DuckDuckGoCoverServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
+import reactor.core.publisher.Flux;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -350,7 +352,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test Book").author("Author").coverType("ebook").build();
 
-                List<CoverImage> result = service.getCovers(request);
+                List<CoverImage> result = service.getCovers(request).collectList().block();
 
                 assertThat(result).isEmpty();
             }
@@ -386,7 +388,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test Book").author("Author").coverType("ebook").build();
 
-                List<CoverImage> result = service.getCovers(request);
+                List<CoverImage> result = service.getCovers(request).collectList().block();
 
                 assertThat(result).isNotEmpty();
                 assertThat(result).allSatisfy(img -> assertThat(img.getIndex()).isGreaterThan(0));
@@ -421,7 +423,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Audiobook Title").coverType("audiobook").build();
 
-                List<CoverImage> result = service.getCovers(request);
+                List<CoverImage> result = service.getCovers(request).collectList().block();
 
                 assertThat(result).allSatisfy(img ->
                         assertThat((double) img.getWidth() / img.getHeight()).isBetween(0.85, 1.15));
@@ -458,7 +460,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test Book").coverType("ebook").build();
 
-                List<CoverImage> result = service.getCovers(request);
+                List<CoverImage> result = service.getCovers(request).collectList().block();
 
                 assertThat(result).allSatisfy(img -> {
                     assertThat(img.getWidth()).isGreaterThanOrEqualTo(350);
@@ -508,7 +510,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test Book").coverType("ebook").build();
 
-                List<CoverImage> result = service.getCovers(request);
+                List<CoverImage> result = service.getCovers(request).collectList().block();
 
                 long sharedUrlCount = result.stream()
                         .filter(img -> img.getUrl().equals("https://amazon.com/shared.jpg"))
@@ -528,7 +530,7 @@ class DuckDuckGoCoverServiceTest {
                 Connection.Response htmlResp = buildHtmlResponse("<html>no token</html>", Map.of());
                 when(connection.execute()).thenReturn(htmlResp);
 
-                List<CoverImage> result = service.searchImages("test query");
+                List<CoverImage> result = service.searchImages("test query").collectList().block();
 
                 assertThat(result).isEmpty();
             }
@@ -555,7 +557,7 @@ class DuckDuckGoCoverServiceTest {
                 when(rootNode.path("results")).thenReturn(resultsNode);
                 when(mapper.readTree(jsonBody)).thenReturn(rootNode);
 
-                List<CoverImage> result = service.searchImages("test query");
+                List<CoverImage> result = service.searchImages("test query").collectList().block();
 
                 assertThat(result).hasSize(2);
                 assertThat(result.get(0).getIndex()).isEqualTo(1);
@@ -576,7 +578,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test").coverType("ebook").build();
 
-                assertThatThrownBy(() -> service.getCovers(request))
+                assertThatThrownBy(() -> service.getCovers(request).collectList().block())
                         .isInstanceOf(RuntimeException.class)
                         .hasCauseInstanceOf(IOException.class);
             }
@@ -597,7 +599,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test").coverType("ebook").build();
 
-                assertThatThrownBy(() -> service.getCovers(request))
+                assertThatThrownBy(() -> service.getCovers(request).collectList().block())
                         .isInstanceOf(RuntimeException.class)
                         .hasCauseInstanceOf(IOException.class);
             }
@@ -624,7 +626,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test").coverType("ebook").build();
 
-                List<CoverImage> result = service.getCovers(request);
+                List<CoverImage> result = service.getCovers(request).collectList().block();
 
                 assertThat(result).isEmpty();
             }
@@ -655,7 +657,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test").coverType("ebook").build();
 
-                List<CoverImage> result = service.getCovers(request);
+                List<CoverImage> result = service.getCovers(request).collectList().block();
 
                 assertThat(result).isEmpty();
             }
@@ -684,7 +686,7 @@ class DuckDuckGoCoverServiceTest {
                 CoverFetchRequest request = CoverFetchRequest.builder()
                         .title("Test").coverType("ebook").build();
 
-                List<CoverImage> result = service.getCovers(request);
+                List<CoverImage> result = service.getCovers(request).collectList().block();
 
                 assertThat(result).isEmpty();
             }

--- a/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.spec.ts
+++ b/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.spec.ts
@@ -51,11 +51,11 @@ describe('AuthorPhotoSearchComponent', () => {
   });
 
   it('hydrates the initial author query, performs the bootstrap search, and sorts the returned photos', () => {
-    searchAuthorPhotos.mockReturnValue(of<AuthorPhotoResult[]>([
+    searchAuthorPhotos.mockReturnValue(of(
       {index: 3, url: 'three', width: 300, height: 400},
       {index: 1, url: 'one', width: 100, height: 200},
       {index: 2, url: 'two', width: 200, height: 300},
-    ]));
+    ));
 
     const component = TestBed.runInInjectionContext(() => new AuthorPhotoSearchComponent());
     component.ngOnInit();

--- a/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.spec.ts
+++ b/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.spec.ts
@@ -3,7 +3,6 @@ import {of, throwError} from 'rxjs';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {TranslocoService} from '@jsverse/transloco';
-import type {AuthorPhotoResult} from '../../model/author.model';
 import {AuthorService} from '../../service/author.service';
 import {AuthorPhotoSearchComponent} from './author-photo-search.component';
 import {

--- a/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.ts
+++ b/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.ts
@@ -62,17 +62,20 @@ export class AuthorPhotoSearchComponent implements OnInit {
   onSearch(): void {
     if (!this.searchForm.valid) return;
     this.searching = true;
+    this.photos = [];
 
     this.authorService.searchAuthorPhotos(this.authorId, this.searchForm.value.query)
-      .pipe(finalize(() => this.searching = false))
+      .pipe(finalize(() => {
+        this.searching = false;
+        this.hasSearched = true;
+      }))
       .subscribe({
-        next: (photos) => {
-          this.photos = photos.sort((a, b) => a.index - b.index);
-          this.hasSearched = true;
+        next: (photo) => {
+          this.photos.push(photo);
+          this.photos.sort((a, b) => a.index - b.index);
         },
         error: () => {
-          this.photos = [];
-          this.hasSearched = true;
+          console.error('Error searching photos');
         }
       });
   }

--- a/frontend/src/app/features/author-browser/service/author.service.ts
+++ b/frontend/src/app/features/author-browser/service/author.service.ts
@@ -116,10 +116,25 @@ export class AuthorService {
     return this.http.delete<void>(this.baseUrl, {body: authorIds});
   }
 
-  searchAuthorPhotos(authorId: number, query: string): Observable<AuthorPhotoResult[]> {
-    return this.http.get<AuthorPhotoResult[]>(`${this.baseUrl}/${authorId}/search-photos`, {
-      params: {q: query}
-    });
+  searchAuthorPhotos(authorId: number, query: string): Observable<AuthorPhotoResult> {
+    const token = this.authService.getInternalAccessToken();
+    const headers = new HttpHeaders()
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${token}`);
+
+    return this.sseClient.stream(
+      `${this.baseUrl}/${authorId}/search-photos`,
+      {keepAlive: false, reconnectionDelay: 1000, responseType: 'event'},
+      {headers, params: {q: query}, withCredentials: true},
+      'GET'
+    ).pipe(
+      map(event => {
+        if (event.type === 'error') {
+          throw new Error((event as ErrorEvent).message);
+        }
+        return JSON.parse((event as MessageEvent).data) as AuthorPhotoResult;
+      })
+    );
   }
 
   uploadAuthorPhotoFromUrl(authorId: number, imageUrl: string): Observable<void> {

--- a/frontend/src/app/features/book/service/book-metadata.service.spec.ts
+++ b/frontend/src/app/features/book/service/book-metadata.service.spec.ts
@@ -103,7 +103,8 @@ describe('BookMetadataService', () => {
       status: 500
     };
 
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', fetchSpy);
 
     let error: Error | undefined;
     service.fetchBookMetadata(7, fetchRequest).subscribe({

--- a/frontend/src/app/features/book/service/book-metadata.service.spec.ts
+++ b/frontend/src/app/features/book/service/book-metadata.service.spec.ts
@@ -1,18 +1,16 @@
 import {provideHttpClient} from '@angular/common/http';
 import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
 import {TestBed} from '@angular/core/testing';
-import {of} from 'rxjs';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {AuthService} from '../../../shared/service/auth.service';
 import {BookMetadataService} from './book-metadata.service';
-import {SseClient} from 'ngx-sse-client';
 
 describe('BookMetadataService', () => {
   let service: BookMetadataService;
   let httpTestingController: HttpTestingController;
   let authService: {getInternalAccessToken: ReturnType<typeof vi.fn>};
-  let sseClient: {stream: ReturnType<typeof vi.fn>};
+  
   const fetchRequest = {
     bookId: 7,
     providers: ['google'],
@@ -25,9 +23,6 @@ describe('BookMetadataService', () => {
     authService = {
       getInternalAccessToken: vi.fn(() => 'token-123'),
     };
-    sseClient = {
-      stream: vi.fn(() => of({type: 'message', data: JSON.stringify({title: 'Dune'})})),
-    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -35,7 +30,6 @@ describe('BookMetadataService', () => {
         provideHttpClientTesting(),
         BookMetadataService,
         {provide: AuthService, useValue: authService},
-        {provide: SseClient, useValue: sseClient},
       ],
     });
 
@@ -47,6 +41,7 @@ describe('BookMetadataService', () => {
     httpTestingController.verify();
     TestBed.resetTestingModule();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('throws when fetching metadata without an auth token', () => {
@@ -57,40 +52,71 @@ describe('BookMetadataService', () => {
     );
   });
 
-  it('streams metadata over SSE with auth headers and maps message payloads', () => {
-    let result: unknown;
+  it('streams metadata over SSE with auth headers and maps message payloads', async () => {
+    const mockMetadata = {title: 'Dune'};
+    const encoder = new TextEncoder();
+    const dataChunk = encoder.encode(`data: ${JSON.stringify(mockMetadata)}\n`);
+    
+    // Mocking reader instead of using global ReadableStream which might be missing in jsdom
+    const mockReader = {
+      read: vi.fn()
+        .mockResolvedValueOnce({done: false, value: dataChunk})
+        .mockResolvedValueOnce({done: true, value: undefined}),
+      releaseLock: vi.fn()
+    };
 
+    const mockResponse = {
+      ok: true,
+      body: {
+        getReader: () => mockReader
+      }
+    };
+
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    let result: unknown;
     service.fetchBookMetadata(7, fetchRequest).subscribe(value => {
       result = value;
     });
 
-    const [url, clientConfig, requestOptions, method] = sseClient.stream.mock.calls[0] ?? [];
-    expect(url).toMatch(/\/api\/v1\/books\/7\/metadata\/prospective$/);
-    expect(clientConfig).toEqual({
-      keepAlive: false,
-      reconnectionDelay: 1000,
-      responseType: 'event'
-    });
-    expect(requestOptions.body).toEqual(fetchRequest);
-    expect(requestOptions.withCredentials).toBe(true);
-    expect(requestOptions.headers.get('Authorization')).toBe('Bearer token-123');
-    expect(requestOptions.headers.get('Content-Type')).toBe('application/json');
-    expect(method).toBe('POST');
-    expect(result).toEqual({title: 'Dune'});
+    // Wait for the stream to process
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/v1\/books\/7\/metadata\/prospective$/),
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer token-123'
+        },
+        body: JSON.stringify(fetchRequest)
+      })
+    );
+    expect(result).toEqual(mockMetadata);
   });
 
-  it('turns SSE error events into thrown errors', () => {
-    sseClient.stream.mockReturnValueOnce(of({type: 'error', message: 'bad stream'}));
+  it('turns SSE error events into thrown errors', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500
+    };
 
-    let error: unknown;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    let error: Error | undefined;
     service.fetchBookMetadata(7, fetchRequest).subscribe({
       error: err => {
         error = err;
       }
     });
 
+    // Wait for the fetch to resolve
+    await new Promise(resolve => setTimeout(resolve, 0));
+
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe('bad stream');
+    expect(error?.message).toContain('HTTP error! status: 500');
   });
 
   it('requests provider detail and ISBN lookup through HTTP endpoints', () => {

--- a/frontend/src/app/features/book/service/book-metadata.service.ts
+++ b/frontend/src/app/features/book/service/book-metadata.service.ts
@@ -81,6 +81,9 @@ export class BookMetadataService {
           }
         })
         .catch((error) => {
+          if (error instanceof Error && error.name === 'AbortError') {
+            return;
+          }
           subscriber.error(error);
         });
 

--- a/frontend/src/app/features/book/service/book-metadata.service.ts
+++ b/frontend/src/app/features/book/service/book-metadata.service.ts
@@ -4,16 +4,13 @@ import {API_CONFIG} from '../../../core/config/api-config';
 import {FetchMetadataRequest} from '../../metadata/model/request/fetch-metadata-request.model';
 import {BookMetadata} from '../model/book.model';
 import {AuthService} from '../../../shared/service/auth.service';
-import {SseClient} from 'ngx-sse-client';
-import {HttpClient, HttpHeaders} from '@angular/common/http';
-import {map} from 'rxjs/operators';
+import {HttpClient} from '@angular/common/http';
 
 @Injectable({providedIn: 'root'})
 export class BookMetadataService {
   private readonly url = `${API_CONFIG.BASE_URL}/api/v1/books`;
   private http = inject(HttpClient);
   private authService = inject(AuthService);
-  private sseClient = inject(SseClient);
 
   fetchBookMetadata(bookId: number, request: FetchMetadataRequest): Observable<BookMetadata> {
     const token = this.authService.getInternalAccessToken();
@@ -22,34 +19,75 @@ export class BookMetadataService {
       throw new Error('No authentication token available');
     }
 
-    const headers = new HttpHeaders()
-      .set('Content-Type', 'application/json')
-      .set('Authorization', `Bearer ${token}`);
+    return new Observable<BookMetadata>((subscriber) => {
+      const abortController = new AbortController();
 
-    return this.sseClient.stream(
-      `${this.url}/${bookId}/metadata/prospective`,
-      {
-        keepAlive: false,
-        reconnectionDelay: 1000,
-        responseType: 'event'
-      },
-      {
-        headers,
-        body: request,
-        withCredentials: true
-      },
-      'POST'
-    ).pipe(
-      map((event) => {
-        if (event.type === 'error') {
-          const errorEvent = event as ErrorEvent;
-          throw new Error(errorEvent.message);
-        } else {
-          const messageEvent = event as MessageEvent;
-          return JSON.parse(messageEvent.data) as BookMetadata;
-        }
+      fetch(`${this.url}/${bookId}/metadata/prospective`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify(request),
+        signal: abortController.signal,
       })
-    );
+        .then(async (response) => {
+          if (!response.ok) {
+            subscriber.error(new Error(`HTTP error! status: ${response.status}`));
+            return;
+          }
+
+          const reader = response.body?.getReader();
+          if (!reader) {
+            subscriber.error(new Error('Response body is null'));
+            return;
+          }
+
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          try {
+            while (true) {
+              const {done, value} = await reader.read();
+              if (done) break;
+
+              buffer += decoder.decode(value, {stream: true});
+              const lines = buffer.split('\n');
+              buffer = lines.pop() || '';
+
+              for (const line of lines) {
+                if (line.startsWith('data:')) {
+                  const data = line.slice(5).trim();
+                  if (data) {
+                    try {
+                      const metadata = JSON.parse(data) as BookMetadata;
+                      subscriber.next(metadata);
+                    } catch (e) {
+                      console.error('Error parsing SSE data:', e);
+                    }
+                  }
+                }
+              }
+            }
+            subscriber.complete();
+          } catch (error) {
+            if (error instanceof Error && error.name === 'AbortError') {
+              // Silently handle abort
+            } else {
+              subscriber.error(error);
+            }
+          } finally {
+            reader.releaseLock();
+          }
+        })
+        .catch((error) => {
+          subscriber.error(error);
+        });
+
+      return () => {
+        abortController.abort();
+      };
+    });
   }
 
   fetchMetadataDetail(provider: string, providerItemId: string): Observable<BookMetadata> {

--- a/frontend/src/app/features/book/service/book-metadata.service.ts
+++ b/frontend/src/app/features/book/service/book-metadata.service.ts
@@ -45,6 +45,23 @@ export class BookMetadataService {
 
           const decoder = new TextDecoder();
           let buffer = '';
+          const emitLine = (line: string) => {
+            if (!line.startsWith('data:')) {
+              return;
+            }
+
+            const data = line.slice(5).trim();
+            if (!data) {
+              return;
+            }
+
+            try {
+              const metadata = JSON.parse(data) as BookMetadata;
+              subscriber.next(metadata);
+            } catch (e) {
+              console.error('Error parsing SSE data:', e);
+            }
+          };
 
           try {
             while (true) {
@@ -56,18 +73,11 @@ export class BookMetadataService {
               buffer = lines.pop() || '';
 
               for (const line of lines) {
-                if (line.startsWith('data:')) {
-                  const data = line.slice(5).trim();
-                  if (data) {
-                    try {
-                      const metadata = JSON.parse(data) as BookMetadata;
-                      subscriber.next(metadata);
-                    } catch (e) {
-                      console.error('Error parsing SSE data:', e);
-                    }
-                  }
-                }
+                emitLine(line);
               }
+            }
+            if (buffer) {
+              emitLine(buffer);
             }
             subscriber.complete();
           } catch (error) {

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
@@ -92,7 +92,7 @@
               <i class="pi pi-list"></i>
               {{ t('searchResults') }}
             </h3>
-            <span class="results-count">{{ t('booksFound', { count: filteredMetadata.length }) }}</span>
+            <span class="results-count">{{ t('booksFound', { count: filteredMetadata().length }) }}</span>
           </div>
           @if (loading) {
             <span class="fetching-badge">
@@ -129,7 +129,7 @@
       </div>
     }
 
-    @if (!searchTriggered && allFetchedMetadata.length === 0) {
+    @if (!searchTriggered && allFetchedMetadata().length === 0) {
       <div class="empty-state">
         <div class="empty-icon">
           <i class="pi pi-search"></i>
@@ -139,7 +139,7 @@
       </div>
     }
 
-    @if (searchTriggered && allFetchedMetadata.length === 0 && !loading) {
+    @if (searchTriggered && allFetchedMetadata().length === 0 && !loading) {
       <div class="empty-state">
         <div class="empty-icon no-results">
           <i class="pi pi-inbox"></i>
@@ -149,10 +149,10 @@
       </div>
     }
 
-    @if (allFetchedMetadata.length > 0) {
+    @if (allFetchedMetadata().length > 0) {
       <div class="results-section">
         <div class="results-grid">
-          @for (metadata of filteredMetadata; track trackByMetadata($index, metadata)) {
+          @for (metadata of filteredMetadata(); track trackByMetadata($index, metadata)) {
             <div
               class="metadata-card"
               role="button"

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
@@ -1,4 +1,4 @@
-import {Component, effect, inject, Input, OnChanges, OnDestroy, signal, SimpleChanges} from '@angular/core';
+import {Component, computed, effect, inject, Input, OnChanges, OnDestroy, signal, SimpleChanges, WritableSignal} from '@angular/core';
 import {FormBuilder, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Button} from 'primeng/button';
 import {InputText} from 'primeng/inputtext';
@@ -34,7 +34,7 @@ import {TranslocoDirective} from '@jsverse/transloco';
 export class MetadataSearcherComponent implements OnDestroy, OnChanges {
   form: FormGroup;
   providers: string[] = [];
-  allFetchedMetadata: BookMetadata[] = [];
+  
   bookId!: number;
   loading: boolean = false;
   searchTriggered = false;
@@ -63,6 +63,15 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
 
   private subscription: Subscription = new Subscription();
   private cancelRequest$ = new Subject<void>();
+  
+  // Signals for state
+  allFetchedMetadata: WritableSignal<BookMetadata[]> = signal([]);
+  metadataByProvider = signal<Map<string, BookMetadata[]>>(new Map());
+  providerCounts = signal<Map<string, number>>(new Map());
+  providerLoading = signal<Map<string, boolean>>(new Map());
+  providerCompletionStatus = signal<Map<string, boolean>>(new Map());
+  selectedProviderFilters = signal<Set<string>>(new Set(['all']));
+
   private syncSettingsEffect = effect(() => {
     const settings = this.appSettingsService.appSettings();
     if (!settings) return;
@@ -82,14 +91,59 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
     this.syncFormFromState();
   });
 
-  providerCounts = new Map<string, number>();
-  providerLoading = new Map<string, boolean>();
-  selectedProviderFilters = new Set<string>(['all']);
-  filteredMetadata: BookMetadata[] = [];
-  providerFilterOptions: { label: string; value: string }[] = [];
+  // Computed properties
+  interleavedMetadata = computed(() => {
+    const interleaved: BookMetadata[] = [];
+    const byProvider = this.metadataByProvider();
+    const providers = Array.from(byProvider.keys());
 
-  private metadataByProvider = new Map<string, BookMetadata[]>();
-  private providerCompletionStatus = new Map<string, boolean>();
+    if (providers.length === 0) return [];
+
+    const maxLength = Math.max(
+      ...Array.from(byProvider.values()).map(list => list.length)
+    );
+
+    for (let i = 0; i < maxLength; i++) {
+      for (const provider of providers) {
+        const providerList = byProvider.get(provider);
+        if (providerList && i < providerList.length) {
+          interleaved.push(providerList[i]);
+        }
+      }
+    }
+
+    return interleaved;
+  });
+
+  filteredMetadata = computed(() => {
+    const all = this.interleavedMetadata();
+    const filters = this.selectedProviderFilters();
+    
+    if (filters.has('all')) {
+      return all;
+    } else {
+      return all.filter(metadata => {
+        const provider = this.getProviderFromMetadata(metadata);
+        return provider && filters.has(provider);
+      });
+    }
+  });
+
+  providerFilterOptions = computed(() => {
+    const allCount = this.interleavedMetadata().length;
+    const counts = this.providerCounts();
+    
+    return [
+      {label: `All (${allCount})`, value: 'all'},
+      ...Array.from(counts.entries())
+        .filter(([, count]) => count > 0)
+        .map(([provider, count]) => ({
+          label: `${provider.charAt(0).toUpperCase() + provider.slice(1)} (${count})`,
+          value: provider
+        }))
+    ];
+  });
+
   private pendingAutoSearch = false;
   private providerInitialized = false;
 
@@ -139,13 +193,14 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
     this.loading = false;
     this.detailLoading = false;
     this.selectedFetchedMetadata.set(null);
-    this.allFetchedMetadata = [];
-    this.filteredMetadata = [];
-    this.providerCounts.clear();
-    this.providerLoading.clear();
-    this.providerCompletionStatus.clear();
-    this.metadataByProvider.clear();
-    this.selectedProviderFilters = new Set(['all']);
+    this.allFetchedMetadata.set([]);
+    
+    this.providerCounts.set(new Map());
+    this.providerLoading.set(new Map());
+    this.providerCompletionStatus.set(new Map());
+    this.metadataByProvider.set(new Map());
+    
+    this.selectedProviderFilters.set(new Set(['all']));
     this.bookId = book.id;
 
     const formUpdate: Record<'title' | 'author' | 'isbn', string> & {provider?: string[] | null} = {
@@ -198,24 +253,28 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
       };
 
       this.loading = true;
-      this.allFetchedMetadata = [];
-      this.filteredMetadata = [];
-      this.providerCounts.clear();
-      this.providerLoading.clear();
-      this.providerCompletionStatus.clear();
-      this.metadataByProvider.clear();
-      this.selectedProviderFilters = new Set(['all']);
-      this.cancelRequest$.next();
-
+      this.allFetchedMetadata.set([]);
+      
+      const initialCounts = new Map<string, number>();
+      const initialLoading = new Map<string, boolean>();
+      const initialCompletion = new Map<string, boolean>();
+      const initialByProvider = new Map<string, BookMetadata[]>();
+      
       providerKeys.forEach((provider: string) => {
         const providerLower = provider.toLowerCase();
-        this.providerCounts.set(providerLower, 0);
-        this.providerLoading.set(providerLower, true);
-        this.providerCompletionStatus.set(providerLower, false);
-        this.metadataByProvider.set(providerLower, []);
+        initialCounts.set(providerLower, 0);
+        initialLoading.set(providerLower, true);
+        initialCompletion.set(providerLower, false);
+        initialByProvider.set(providerLower, []);
       });
-
-      this.updateProviderFilterOptions();
+      
+      this.providerCounts.set(initialCounts);
+      this.providerLoading.set(initialLoading);
+      this.providerCompletionStatus.set(initialCompletion);
+      this.metadataByProvider.set(initialByProvider);
+      
+      this.selectedProviderFilters.set(new Set(['all']));
+      this.cancelRequest$.next();
 
       const activeProviders = new Set<string>(providerKeys.map((p: string) => p.toLowerCase()));
 
@@ -223,41 +282,37 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
         .pipe(takeUntil(this.cancelRequest$))
         .subscribe({
           next: (metadata) => {
-            const metadataWithThumbnail = {
-              ...metadata,
-              thumbnailUrl: metadata.thumbnailUrl
-            };
-
             const provider = this.getProviderFromMetadata(metadata);
             if (provider) {
-              const providerList = this.metadataByProvider.get(provider) || [];
-              providerList.push(metadataWithThumbnail);
-              this.metadataByProvider.set(provider, providerList);
+              this.metadataByProvider.update(map => {
+                const list = map.get(provider) || [];
+                return new Map(map).set(provider, [...list, metadata]);
+              });
 
-              this.providerCounts.set(provider, providerList.length);
+              this.providerCounts.update(map => {
+                const count = (this.metadataByProvider().get(provider)?.length) || 0;
+                return new Map(map).set(provider, count);
+              });
 
-              if (!this.providerCompletionStatus.get(provider)) {
-                this.providerLoading.set(provider, false);
-                this.providerCompletionStatus.set(provider, true);
+              if (!this.providerCompletionStatus().get(provider)) {
+                this.providerLoading.update(map => new Map(map).set(provider, false));
+                this.providerCompletionStatus.update(map => new Map(map).set(provider, true));
               }
             }
-
-            this.allFetchedMetadata = this.interleaveResults();
-
-            this.applyFilter();
-            this.updateProviderFilterOptions();
+            
+            this.allFetchedMetadata.update(all => [...all, metadata]);
           },
           error: (error) => {
             console.error('Error fetching metadata:', error);
             this.loading = false;
-            this.providerLoading.clear();
+            this.providerLoading.set(new Map());
           },
           complete: () => {
             this.loading = false;
             activeProviders.forEach((provider: string) => {
-              if (!this.providerCompletionStatus.get(provider)) {
-                this.providerLoading.set(provider, false);
-                this.providerCompletionStatus.set(provider, true);
+              if (!this.providerCompletionStatus().get(provider)) {
+                this.providerLoading.update(map => new Map(map).set(provider, false));
+                this.providerCompletionStatus.update(map => new Map(map).set(provider, true));
               }
             });
           }
@@ -267,30 +322,8 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
     }
   }
 
-  private interleaveResults(): BookMetadata[] {
-    const interleaved: BookMetadata[] = [];
-    const providers = Array.from(this.metadataByProvider.keys());
-
-    if (providers.length === 0) return [];
-
-    const maxLength = Math.max(
-      ...Array.from(this.metadataByProvider.values()).map(list => list.length)
-    );
-
-    for (let i = 0; i < maxLength; i++) {
-      for (const provider of providers) {
-        const providerList = this.metadataByProvider.get(provider);
-        if (providerList && i < providerList.length) {
-          interleaved.push(providerList[i]);
-        }
-      }
-    }
-
-    return interleaved;
-  }
-
   private getProviderFromMetadata(metadata: BookMetadata): string | null {
-    if (metadata.audibleId) return 'audible'; // Audible has to come before Amazon because they both have an ASIN.
+    if (metadata.audibleId) return 'audible'; 
     if (metadata.asin) return 'amazon';
     if (metadata.goodreadsId) return 'goodreads';
     if (metadata.googleId) return 'google';
@@ -306,67 +339,47 @@ export class MetadataSearcherComponent implements OnDestroy, OnChanges {
     return this.getProviderFromMetadata(metadata) || 'unknown';
   }
 
-  private updateProviderFilterOptions(): void {
-    this.providerFilterOptions = [
-      {label: `All (${this.allFetchedMetadata.length})`, value: 'all'},
-      ...Array.from(this.providerCounts.entries())
-        .filter(([, count]) => count > 0)
-        .map(([provider, count]) => ({
-          label: `${provider.charAt(0).toUpperCase() + provider.slice(1)} (${count})`,
-          value: provider
-        }))
-    ];
-  }
-
   onProviderPillClick(provider: string, event: Event): void {
     const providerLower = provider.toLowerCase();
 
     const isModifierClick = (event instanceof MouseEvent || event instanceof KeyboardEvent) && (event.ctrlKey || event.metaKey);
-    if (isModifierClick) {
-      if (this.selectedProviderFilters.has(providerLower)) {
-        this.selectedProviderFilters.delete(providerLower);
-      } else {
-        this.selectedProviderFilters.add(providerLower);
-        this.selectedProviderFilters.delete('all');
-      }
+    
+    this.selectedProviderFilters.update(filters => {
+      const newFilters = new Set(filters);
+      if (isModifierClick) {
+        if (newFilters.has(providerLower)) {
+          newFilters.delete(providerLower);
+        } else {
+          newFilters.add(providerLower);
+          newFilters.delete('all');
+        }
 
-      if (this.selectedProviderFilters.size === 0) {
-        this.selectedProviderFilters.add('all');
-      }
-    } else {
-      if (this.selectedProviderFilters.has(providerLower) && this.selectedProviderFilters.size === 1) {
-        this.selectedProviderFilters.clear();
-        this.selectedProviderFilters.add('all');
+        if (newFilters.size === 0) {
+          newFilters.add('all');
+        }
       } else {
-        this.selectedProviderFilters.clear();
-        this.selectedProviderFilters.add(providerLower);
+        if (newFilters.has(providerLower) && newFilters.size === 1) {
+          newFilters.clear();
+          newFilters.add('all');
+        } else {
+          newFilters.clear();
+          newFilters.add(providerLower);
+        }
       }
-    }
-
-    this.applyFilter();
+      return newFilters;
+    });
   }
 
   isProviderPillActive(provider: string): boolean {
-    return this.selectedProviderFilters.has(provider.toLowerCase());
+    return this.selectedProviderFilters().has(provider.toLowerCase());
   }
 
   isProviderLoading(provider: string): boolean {
-    return this.providerLoading.get(provider.toLowerCase()) ?? false;
-  }
-
-  private applyFilter(): void {
-    if (this.selectedProviderFilters.has('all')) {
-      this.filteredMetadata = [...this.allFetchedMetadata];
-    } else {
-      this.filteredMetadata = this.allFetchedMetadata.filter(metadata => {
-        const provider = this.getProviderFromMetadata(metadata);
-        return provider && this.selectedProviderFilters.has(provider);
-      });
-    }
+    return this.providerLoading().get(provider.toLowerCase()) ?? false;
   }
 
   getProviderTabs(): { provider: string; count: number }[] {
-    return Array.from(this.providerCounts.entries()).map(([provider, count]) => ({
+    return Array.from(this.providerCounts().entries()).map(([provider, count]) => ({
       provider: provider.charAt(0).toUpperCase() + provider.slice(1),
       count
     }));

--- a/frontend/src/app/features/metadata/component/cover-search/cover-search.component.ts
+++ b/frontend/src/app/features/metadata/component/cover-search/cover-search.component.ts
@@ -82,6 +82,7 @@ export class CoverSearchComponent implements OnInit {
       this.loading = true;
       this.coverImages = [];
       const request: CoverFetchRequest = {
+        bookId: this.bookId,
         title: this.searchForm.value.title,
         author: this.searchForm.value.author,
         coverType: this.coverType

--- a/frontend/src/app/features/metadata/component/cover-search/cover-search.component.ts
+++ b/frontend/src/app/features/metadata/component/cover-search/cover-search.component.ts
@@ -80,6 +80,7 @@ export class CoverSearchComponent implements OnInit {
   onSearch() {
     if (this.searchForm.valid) {
       this.loading = true;
+      this.coverImages = [];
       const request: CoverFetchRequest = {
         title: this.searchForm.value.title,
         author: this.searchForm.value.author,
@@ -87,16 +88,17 @@ export class CoverSearchComponent implements OnInit {
       };
 
       this.bookCoverService.fetchBookCovers(request)
-        .pipe(finalize(() => this.loading = false))
+        .pipe(finalize(() => {
+          this.loading = false;
+          this.hasSearched = true;
+        }))
         .subscribe({
-          next: (images) => {
-            this.coverImages = images.sort((a, b) => a.index - b.index);
-            this.hasSearched = true;
+          next: (image) => {
+            this.coverImages.push(image);
+            this.coverImages.sort((a, b) => a.index - b.index);
           },
           error: (error) => {
             console.error('Error fetching covers:', error);
-            this.coverImages = [];
-            this.hasSearched = true;
           }
         });
     } else {

--- a/frontend/src/app/shared/services/book-cover.service.spec.ts
+++ b/frontend/src/app/shared/services/book-cover.service.spec.ts
@@ -35,6 +35,7 @@ describe('BookCoverService', () => {
 
   it('streams covers over SSE with auth headers', async () => {
     const requestBody: CoverFetchRequest = {
+      bookId: 123,
       title: 'Dune',
       author: 'Frank Herbert',
       coverType: 'ebook',
@@ -69,7 +70,7 @@ describe('BookCoverService', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/\/api\/v1\/books\/1\/metadata\/covers$/),
+      expect.stringMatching(/\/api\/v1\/books\/123\/metadata\/covers$/),
       expect.objectContaining({
         method: 'POST',
         headers: {

--- a/frontend/src/app/shared/services/book-cover.service.spec.ts
+++ b/frontend/src/app/shared/services/book-cover.service.spec.ts
@@ -1,53 +1,84 @@
 import {provideHttpClient} from '@angular/common/http';
-import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
 import {TestBed} from '@angular/core/testing';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {BookCoverService, CoverFetchRequest, CoverImage} from './book-cover.service';
+import {AuthService} from '../service/auth.service';
 
 describe('BookCoverService', () => {
   let service: BookCoverService;
-  let httpTestingController: HttpTestingController;
+  let authService: {getInternalAccessToken: ReturnType<typeof vi.fn>};
 
   beforeEach(() => {
+    authService = {
+      getInternalAccessToken: vi.fn(() => 'token-123'),
+    };
+
     TestBed.configureTestingModule({
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
         BookCoverService,
+        {provide: AuthService, useValue: authService},
       ],
     });
 
     service = TestBed.inject(BookCoverService);
-    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
-    httpTestingController.verify();
     TestBed.resetTestingModule();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
-  it('posts the cover fetch request and returns the backend response', () => {
+  it('streams covers over SSE with auth headers', async () => {
     const requestBody: CoverFetchRequest = {
       title: 'Dune',
       author: 'Frank Herbert',
       coverType: 'ebook',
     };
-    const response: CoverImage[] = [
-      {url: 'https://example.test/cover-1.jpg', source: 'google', width: 600, height: 900, index: 0},
-      {url: 'https://example.test/cover-2.jpg', source: 'openlibrary', index: 1},
-    ];
+    const mockImage = {url: 'https://example.test/cover-1.jpg', index: 1};
+    const encoder = new TextEncoder();
+    const dataChunk = encoder.encode(`data: ${JSON.stringify(mockImage)}\n`);
 
-    let result: CoverImage[] | undefined;
+    const mockReader = {
+      read: vi.fn()
+        .mockResolvedValueOnce({done: false, value: dataChunk})
+        .mockResolvedValueOnce({done: true, value: undefined}),
+      releaseLock: vi.fn()
+    };
+
+    const mockResponse = {
+      ok: true,
+      body: {
+        getReader: () => mockReader
+      }
+    };
+
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    let result: CoverImage | undefined;
     service.fetchBookCovers(requestBody).subscribe(value => {
       result = value;
     });
 
-    const request = httpTestingController.expectOne(req => req.url.endsWith('/api/v1/books/1/metadata/covers'));
-    expect(request.request.method).toBe('POST');
-    expect(request.request.body).toEqual(requestBody);
-    request.flush(response);
+    // Wait for the stream to process
+    await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(result).toEqual(response);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/v1\/books\/1\/metadata\/covers$/),
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer token-123'
+        },
+        body: JSON.stringify(requestBody)
+      })
+    );
+    expect(result).toEqual(mockImage);
   });
 });

--- a/frontend/src/app/shared/services/book-cover.service.ts
+++ b/frontend/src/app/shared/services/book-cover.service.ts
@@ -13,6 +13,7 @@ export interface CoverImage {
 }
 
 export interface CoverFetchRequest {
+  bookId?: number;
   title?: string;
   author?: string;
   coverType?: 'ebook' | 'audiobook';
@@ -31,9 +32,14 @@ export class BookCoverService {
     const token = this.authService.getInternalAccessToken();
 
     return new Observable<CoverImage>(subscriber => {
+      if (!request.bookId) {
+        subscriber.error(new Error('bookId is required for fetching covers'));
+        return;
+      }
+
       const abortController = new AbortController();
 
-      fetch(`${this.baseUrl}/1/metadata/covers`, {
+      fetch(`${this.baseUrl}/${request.bookId}/metadata/covers`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/app/shared/services/book-cover.service.ts
+++ b/frontend/src/app/shared/services/book-cover.service.ts
@@ -62,6 +62,23 @@ export class BookCoverService {
 
           const decoder = new TextDecoder();
           let buffer = '';
+          const emitLine = (line: string) => {
+            if (!line.startsWith('data:')) {
+              return;
+            }
+
+            const data = line.slice(5).trim();
+            if (!data) {
+              return;
+            }
+
+            try {
+              const image = JSON.parse(data) as CoverImage;
+              subscriber.next(image);
+            } catch (e) {
+              console.error('Error parsing SSE data:', e);
+            }
+          };
 
           try {
             while (true) {
@@ -73,18 +90,11 @@ export class BookCoverService {
               buffer = lines.pop() || '';
 
               for (const line of lines) {
-                if (line.startsWith('data:')) {
-                  const data = line.slice(5).trim();
-                  if (data) {
-                    try {
-                      const image = JSON.parse(data) as CoverImage;
-                      subscriber.next(image);
-                    } catch (e) {
-                      console.error('Error parsing SSE data:', e);
-                    }
-                  }
-                }
+                emitLine(line);
               }
+            }
+            if (buffer) {
+              emitLine(buffer);
             }
             subscriber.complete();
           } catch (error) {

--- a/frontend/src/app/shared/services/book-cover.service.ts
+++ b/frontend/src/app/shared/services/book-cover.service.ts
@@ -2,6 +2,7 @@ import {inject, Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {API_CONFIG} from '../../core/config/api-config';
+import {AuthService} from '../service/auth.service';
 
 export interface CoverImage {
   url: string;
@@ -24,9 +25,83 @@ export class BookCoverService {
   private readonly baseUrl = `${API_CONFIG.BASE_URL}/api/v1/books`;
 
   private http = inject(HttpClient);
+  private authService = inject(AuthService);
 
-  fetchBookCovers(request: CoverFetchRequest): Observable<CoverImage[]> {
-    return this.http.post<CoverImage[]>(`${this.baseUrl}/1/metadata/covers`, request);
+  fetchBookCovers(request: CoverFetchRequest): Observable<CoverImage> {
+    const token = this.authService.getInternalAccessToken();
+
+    return new Observable<CoverImage>(subscriber => {
+      const abortController = new AbortController();
+
+      fetch(`${this.baseUrl}/1/metadata/covers`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify(request),
+        signal: abortController.signal
+      })
+        .then(async response => {
+          if (!response.ok) {
+            subscriber.error(new Error(`HTTP error! status: ${response.status}`));
+            return;
+          }
+
+          const reader = response.body?.getReader();
+          if (!reader) {
+            subscriber.error(new Error('Response body is null'));
+            return;
+          }
+
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          try {
+            while (true) {
+              const {done, value} = await reader.read();
+              if (done) break;
+
+              buffer += decoder.decode(value, {stream: true});
+              const lines = buffer.split('\n');
+              buffer = lines.pop() || '';
+
+              for (const line of lines) {
+                if (line.startsWith('data:')) {
+                  const data = line.slice(5).trim();
+                  if (data) {
+                    try {
+                      const image = JSON.parse(data) as CoverImage;
+                      subscriber.next(image);
+                    } catch (e) {
+                      console.error('Error parsing SSE data:', e);
+                    }
+                  }
+                }
+              }
+            }
+            subscriber.complete();
+          } catch (error) {
+            if (error instanceof Error && error.name === 'AbortError') {
+              // Silently handle abort
+            } else {
+              subscriber.error(error);
+            }
+          } finally {
+            reader.releaseLock();
+          }
+        })
+        .catch(error => {
+          if (error instanceof Error && error.name === 'AbortError') {
+            return;
+          }
+          subscriber.error(error);
+        });
+
+      return () => {
+        abortController.abort();
+      };
+    });
   }
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request refactors the book metadata fetching flow to use reactive streams (Flux) end-to-end, improves frontend state management with Angular signals and computed properties, and updates the frontend to use native Fetch for SSE-like streaming instead of a third-party library. These changes enable more efficient, real-time metadata updates from multiple providers and simplify the frontend's state logic.

**Backend: Move to Reactive Streams for Metadata Fetching**
- Changed the `BookMetadataService` and `BookParser` interface to use `Flux<BookMetadata>` for streaming metadata results, replacing the previous synchronous and list-based fetching. This allows incremental delivery of metadata as it is retrieved from providers.
- Refactored `GoodReadsParser` to implement `fetchMetadataStream`, emitting metadata items as they are fetched, and adapted all synchronous methods to use the new stream-based approach. 

**Frontend: Streaming & State Management Improvements**
- Replaced the use of `ngx-sse-client` with a native Fetch-based implementation for handling server-sent events (SSE), allowing the frontend to process streamed metadata updates as they arrive. 
- Migrated metadata and provider state management in `MetadataSearcherComponent` to Angular signals and computed properties, enabling more reactive UI updates and simplifying the logic for filtering, interleaving, and displaying metadata from multiple providers. 

**Frontend: Template and Reactive State Usage**
- Updated the component template to use the new signal-based state (e.g., `allFetchedMetadata()` and `filteredMetadata()`) for rendering, ensuring the UI stays in sync with the reactive data model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Backend endpoints and providers now stream results progressively (server-sent events / reactive streams) so sources emit incrementally and failures isolate per-source.
  * Metadata UI rewritten to use signals and computed state for reactive filtering and provider status; templates updated to consume signals.

* **New Features**
  * Frontend now consumes incremental server streams via fetch/ReadableStream for metadata, covers, and author photos with cancellation.

* **Tests**
  * Unit tests updated to stub global fetch and validate streaming behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->