### PR TITLE
refactor(kobo): create endpoints for non-catchall

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/KoboController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/KoboController.java
@@ -40,7 +40,6 @@ import java.util.regex.Pattern;
 @Tag(name = "Kobo Integration", description = "Endpoints for Kobo device and library integration")
 public class KoboController {
 
-    private static final Pattern KOBO_V1_PRODUCTS_NEXTREAD_PATTERN = Pattern.compile(".*/v1/products/\\d+/nextread.*");
     private String token;
     private final AppSettingService appSettingService;
     private final KoboServerProxy koboServerProxy;
@@ -178,6 +177,15 @@ public class KoboController {
                 .build());
     }
 
+    @Operation(summary = "Publish analytics event", description = "Publish an analytics event for Kobo.")
+    @ApiResponse(responseCode = "200", description = "Analytics event pushed successfully")
+    @PostMapping("/v1/analytics/event")
+    public ResponseEntity<?> pushEvent() {
+        // Never pass along analytics events.
+        return ResponseEntity.ok().build();
+    }
+
+
     @Operation(summary = "Download Kobo book", description = "Download a book from the Kobo library.")
     @ApiResponse(responseCode = "200", description = "Book downloaded successfully")
     @GetMapping("/v1/books/{bookId}/download")
@@ -206,21 +214,24 @@ public class KoboController {
         }
     }
 
+    @Operation(summary = "Get Kobo Next to Read", description = "Retrieves the next book to read after the specified book, such as with a series.")
+    @ApiResponse(responseCode = "200", description = "The next book in a series to read.")
+    @PostMapping(".*/v1/products/{bookId}/nextread")
+    public ResponseEntity<?> getNextRead(@Parameter(description = "Book ID") @PathVariable String bookId) {
+        if (!StringUtils.isNumeric(bookId)) {
+            if (isForwardingToKoboStore()) {
+                return koboServerProxy.proxyCurrentRequest();
+            }
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
+
     @Operation(summary = "Catch-all for Kobo API", description = "Catch-all endpoint for unhandled Kobo API requests.")
     @ApiResponse(responseCode = "200", description = "Request proxied successfully")
     @RequestMapping(value = "/**", method = {RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE, RequestMethod.PATCH})
     public ResponseEntity<JsonNode> catchAll(HttpServletRequest request, @RequestBody(required = false) Object body) {
-        String path = request.getRequestURI();
-
-        if (path.contains("/v1/analytics/event")) {
-            // Never pass along analytics events.
-            return ResponseEntity.ok().build();
-        }
-
-        if (KOBO_V1_PRODUCTS_NEXTREAD_PATTERN.matcher(path).matches()) {
-            return ResponseEntity.ok().build();
-        }
-
         if (isForwardingToKoboStore()) {
             return koboServerProxy.proxyCurrentRequest(body, false);
         }

--- a/booklore-api/src/main/java/org/booklore/controller/KoboController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/KoboController.java
@@ -216,7 +216,7 @@ public class KoboController {
 
     @Operation(summary = "Get Kobo Next to Read", description = "Retrieves the next book to read after the specified book, such as with a series.")
     @ApiResponse(responseCode = "200", description = "The next book in a series to read.")
-    @PostMapping(".*/v1/products/{bookId}/nextread")
+    @PostMapping("/v1/products/{bookId}/nextread")
     public ResponseEntity<?> getNextRead(@Parameter(description = "Book ID") @PathVariable String bookId) {
         if (!StringUtils.isNumeric(bookId)) {
             if (isForwardingToKoboStore()) {

--- a/booklore-api/src/main/java/org/booklore/service/kobo/KoboServerProxy.java
+++ b/booklore-api/src/main/java/org/booklore/service/kobo/KoboServerProxy.java
@@ -54,6 +54,10 @@ public class KoboServerProxy {
         return headerName.toLowerCase().startsWith("x-kobo-");
     }
 
+    public ResponseEntity<JsonNode> proxyCurrentRequest() {
+        return proxyCurrentRequest(null, false);
+    }
+
     public ResponseEntity<JsonNode> proxyCurrentRequest(Object body, boolean includeSyncToken) {
         HttpServletRequest request = RequestUtils.getCurrentRequest();
         String path = KOBO_API_PREFIX_PATTERN.matcher(request.getRequestURI()).replaceFirst("");


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
this cleans up the catchall so it really the catch all rather than odds-and-ends.  this means we create a publish analytics events endpoint and a next-read endpoint

**Linked Issue:** Related to #365

## Changes

* adds a kobo proxy helper method with no parameters
* creates a kobo post analytics event endpoint (no-op)
* creates a kobo get-next-read endpoint
* drop extra code paths from the catch all endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated endpoints for analytics event submissions and product "next read" requests; by default they return 200 OK, with optional proxying when request forwarding is enabled.

* **Refactor**
  * Simplified request-forwarding so proxying happens only when explicitly enabled; otherwise requests consistently return 200 OK.
  * Added a simpler proxy entrypoint that forwards the current request without body or sync-token handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->