### PR TITLE
fix(kobo): proxy the `/v1/auth/device` endpoint

### DIFF
--- a/booklore-api/src/main/java/org/booklore/controller/KoboController.java
+++ b/booklore-api/src/main/java/org/booklore/controller/KoboController.java
@@ -115,7 +115,11 @@ public class KoboController {
     @Operation(summary = "Authenticate Kobo device", description = "Authenticate a Kobo device.")
     @ApiResponse(responseCode = "200", description = "Device authenticated successfully")
     @PostMapping("/v1/auth/device")
-    public ResponseEntity<KoboAuthentication> authenticateDevice(@Parameter(description = "Authentication request body") @RequestBody JsonNode body) {
+    public ResponseEntity<?> authenticateDevice(@Parameter(description = "Authentication request body") @RequestBody JsonNode body) {
+        if (isForwardingToKoboStore()) {
+            return koboServerProxy.proxyCurrentRequest(body, false);
+        }
+
         return koboDeviceAuthService.authenticateDevice(body);
     }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
without this it's impossible to set up a kobo device from factory reset since we won't have a userkey yet.  this also helps in some situations with the forward-to-store flows for sync

**Linked Issue:** Fixes #509

## Changes

* add kobo proxy for `/v1/auth/device` when store proxy is enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication endpoint now supports optional request forwarding to external authentication services when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->