### PR TITLE
fix(kobo): default kobo forward to store setting "on"

### DIFF
--- a/booklore-api/src/main/java/org/booklore/model/dto/settings/KoboSettings.java
+++ b/booklore-api/src/main/java/org/booklore/model/dto/settings/KoboSettings.java
@@ -1,5 +1,6 @@
 package org.booklore.model.dto.settings;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import lombok.AllArgsConstructor;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(onConstructor_ = @JsonCreator)
 public class KoboSettings {
     @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
     private boolean convertToKepub = false;
@@ -25,5 +26,5 @@ public class KoboSettings {
     @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
     private int conversionImageCompressionPercentage = 85;
     @Builder.Default @JsonSetter(nulls = Nulls.SKIP)
-    private boolean forwardToKoboStore = false;
+    private boolean forwardToKoboStore = true;
 }

--- a/booklore-api/src/main/java/org/booklore/service/appsettings/SettingPersistenceHelper.java
+++ b/booklore-api/src/main/java/org/booklore/service/appsettings/SettingPersistenceHelper.java
@@ -317,6 +317,7 @@ public class SettingPersistenceHelper {
                 .conversionLimitInMbForCbx(100)
                 .conversionImageCompressionPercentage(85)
                 .forceEnableHyphenation(false)
+                .forwardToKoboStore(true)
                 .build();
     }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
defaults the kobo store proxy to "on" because most users today will need it for the sync to work

**Linked Issue:** Fixes #510

## Changes

* updates the kobo settings DTO so the kobo forward to store setting is "on" when not specified
* updates the settings persistence helper with a default "on" value for the kobo store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kobo Store forwarding is now enabled by default, ensuring newly created or missing-pref settings forward to Kobo.

* **Chores**
  * Improved loading of Kobo-related settings so default preferences are consistently applied when absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->