### PR TITLE
fix(ui): enable all OIDC permissions when admin is granted

### DIFF
--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -583,7 +583,10 @@
             <div class="toggle-content">
               <span class="toggle-label">{{ t('groupMapping.adminLabel') }}</span>
             </div>
-            <p-toggleswitch [(ngModel)]="editingGroupMapping.isAdmin"></p-toggleswitch>
+            <p-toggleswitch
+              [(ngModel)]="editingGroupMapping.isAdmin"
+              (onChange)="onAdminCheckboxChange()"
+            />
           </div>
         </div>
         <div class="config-item full-width">
@@ -596,7 +599,12 @@
             <ng-container *transloco="let a; prefix: 'settingsUsers'">
             @for (perm of editingGroupMappingPerms; track perm) {
               <div class="permission-item">
-                <p-checkbox [(ngModel)]="perm.selected" [binary]="true" [inputId]="'gm_' + perm.value"></p-checkbox>
+                <p-checkbox
+                  [(ngModel)]="perm.selected"
+                  [binary]="true"
+                  [inputId]="'gm_' + perm.value"
+                  [disabled]="editingGroupMapping.isAdmin"
+                />
                 <label [for]="'gm_' + perm.value">{{ a(perm.translationKey) }}</label>
               </div>
             }

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -437,6 +437,13 @@ export class AuthenticationSettingsComponent {
     });
   }
 
+  onAdminCheckboxChange(): void {
+    this.editingGroupMappingPerms = this.availablePermissions.map(p => ({
+      ...p,
+      selected: true,
+    }));
+  }
+
   private emptyGroupMapping(): OidcGroupMapping {
     return {oidcGroupClaim: '', isAdmin: false, permissions: [], libraryIds: [], description: ''};
   }

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -438,10 +438,12 @@ export class AuthenticationSettingsComponent {
   }
 
   onAdminCheckboxChange(): void {
-    this.editingGroupMappingPerms = this.availablePermissions.map(p => ({
-      ...p,
-      selected: true,
-    }));
+    if (this.editingGroupMapping.isAdmin) {
+      this.editingGroupMappingPerms = this.availablePermissions.map(p => ({
+        ...p,
+        selected: true,
+      }));
+    }
   }
 
   private emptyGroupMapping(): OidcGroupMapping {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Matches the OIDC group mapping permissions to match the user management permissions UI - when the admin flag is toggled on, all checkboxes are forced "on".

Replaces #486

<img width="713" height="1015" alt="image" src="https://github.com/user-attachments/assets/8516382f-e475-42ab-a942-c1905811c95f" />

**Linked Issue:** Fixes #386 

## Changes

* Updates OIDC group mapping modal so admin flag enables all permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * The admin toggle for group mappings now disables individual permission checkboxes when enabled.
  * Permission selections are automatically set to include all permissions when the admin toggle is activated, and are prevented from being modified while admin is on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->