### PR TITLE
chore(github): update bug report template with build selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,6 +69,19 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: build
+    attributes:
+      label: What Build of Grimmory are you on?
+      description: Stable is the default build in most cases.
+      options:
+        - Stable
+        - Nightly
+        - Release Candidate
+      default: 0
+    validations:
+      required: true
+
   - type: checkboxes
     id: prerequisites
     attributes:
@@ -77,3 +90,5 @@ body:
       options:
         - label: I've searched existing issues and confirmed this bug hasn't been reported yet
           required: true
+
+


### PR DESCRIPTION
## Description

Added a build version option in the bug template for GitHub
Options between Stable, Nightly, and Release Candidate 
https://i.imgur.com/C8UGufM.png

**Linked Issue:** Fixes #471

## Changes
Adds a dropdown to issue template with options for build version. It must be selected but defaults to Stable. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a required build version field to the bug report template, allowing users to specify whether they are using Stable, Nightly, or Release Candidate builds when submitting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->