### PR TITLE
fix(ui): properly scale placeholder artwork text with smaller sizes

### DIFF
--- a/frontend/src/app/shared/components/cover-generator/cover-generator.component.ts
+++ b/frontend/src/app/shared/components/cover-generator/cover-generator.component.ts
@@ -41,6 +41,7 @@ export type CoverPlaceholderSize = 'sm' | 'md' | 'lg';
       display: block;
       width: 100%;
       height: 100%;
+      container-type: size;
     }
 
     .placeholder {
@@ -52,11 +53,12 @@ export type CoverPlaceholderSize = 'sm' | 'md' | 'lg';
       justify-content: center;
       text-align: center;
       border-radius: inherit;
+      overflow: hidden;
     }
 
-    .placeholder.size-sm { padding: 0.5rem; }
-    .placeholder.size-md { padding: 1rem; }
-    .placeholder.size-lg { padding: 1.5rem; }
+    .placeholder.size-sm { padding: min(0.5rem, 4cqi); }
+    .placeholder.size-md { padding: min(1rem, 6cqi); }
+    .placeholder.size-lg { padding: min(1.5rem, 8cqi); }
 
     .placeholder-title {
       color: rgba(255, 255, 255, 0.9);
@@ -66,20 +68,22 @@ export type CoverPlaceholderSize = 'sm' | 'md' | 'lg';
       -webkit-line-clamp: 3;
       -webkit-box-orient: vertical;
       overflow: hidden;
+      word-break: break-word;
+      max-width: 100%;
     }
 
     .size-sm .placeholder-title {
-      font-size: 11px;
+      font-size: min(11px, 10cqi);
       margin-bottom: 2px;
     }
 
     .size-md .placeholder-title {
-      font-size: 13px;
+      font-size: min(13px, 10cqi);
       margin-bottom: 4px;
     }
 
     .size-lg .placeholder-title {
-      font-size: 15px;
+      font-size: min(15px, 10cqi);
       margin-bottom: 8px;
     }
 
@@ -90,11 +94,13 @@ export type CoverPlaceholderSize = 'sm' | 'md' | 'lg';
       -webkit-line-clamp: 1;
       -webkit-box-orient: vertical;
       overflow: hidden;
+      word-break: break-word;
+      max-width: 100%;
     }
 
-    .size-sm .placeholder-author { font-size: 9px; }
-    .size-md .placeholder-author { font-size: 11px; }
-    .size-lg .placeholder-author { font-size: 12px; }
+    .size-sm .placeholder-author { font-size: min(9px, 8cqi); }
+    .size-md .placeholder-author { font-size: min(11px, 8cqi); }
+    .size-lg .placeholder-author { font-size: min(12px, 8cqi); }
   `]
 })
 export class CoverPlaceholderComponent {

--- a/frontend/src/app/shared/components/cover-generator/cover-generator.component.ts
+++ b/frontend/src/app/shared/components/cover-generator/cover-generator.component.ts
@@ -41,7 +41,7 @@ export type CoverPlaceholderSize = 'sm' | 'md' | 'lg';
       display: block;
       width: 100%;
       height: 100%;
-      container-type: size;
+      container-type: inline-size;
     }
 
     .placeholder {


### PR DESCRIPTION
## Description

Forgot to PR this weeks ago! 😅

This fixes an issue with placeholder generated covers in thumbnail environments (e.g. the search results) where placeholder text would overflow beyond the edges of the artwork and generally look bad. Text now scales correctly with the size of the artwork. 

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes
- Placeholder text now scales proportionally to the artwork size, even on small surface areas
- Long titles/author names are clipped and word-wrapped to stay within the cover shape 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced responsive layout handling in the cover generator with improved text overflow prevention and better content wrapping across different screen sizes
  * Refined dynamic padding and typography scaling to adjust intelligently based on container size, maintaining consistent visual appearance across all dimensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->