### PR TITLE
fix: properly handle single-file audiobooks

### DIFF
--- a/backend/src/main/java/org/booklore/service/library/LibraryFileHelper.java
+++ b/backend/src/main/java/org/booklore/service/library/LibraryFileHelper.java
@@ -23,9 +23,9 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,54 +55,86 @@ public class LibraryFileHelper {
     }
 
     public List<Long> detectDeletedAdditionalFiles(List<LibraryFile> libraryFiles, List<BookFileEntity> allAdditionalFiles) {
-        Set<String> currentFileKeys = libraryFiles.stream()
-                .map(this::generateUniqueKey)
+        Set<Path> currentFileKeys = libraryFiles.stream()
+                .map(LibraryFile::getFullPath)
                 .collect(Collectors.toSet());
 
         return allAdditionalFiles.stream()
                 .filter(BookFileEntity::isBookFormat)
-                .filter(additionalFile -> !currentFileKeys.contains(generateUniqueKey(additionalFile)))
+                .filter(additionalFile -> !currentFileKeys.contains(additionalFile.getFullFilePath()))
                 .map(BookFileEntity::getId)
                 .collect(Collectors.toList());
     }
 
     public List<LibraryFile> detectNewBookPaths(List<LibraryFile> libraryFiles, List<BookEntity> books, List<BookFileEntity> allAdditionalFiles) {
-        Set<String> existingKeys = books.stream()
-                .filter(book -> book.getBookFiles() != null && !book.getBookFiles().isEmpty())
-                .map(this::generateUniqueKey)
+        Set<Path> existingFilePaths = books.stream()
+                .map(BookEntity::getPrimaryBookFile)
+                .filter(Objects::nonNull)
+                .filter(b -> !b.isFolderBased())
+                .map(BookFileEntity::getFullFilePath)
                 .collect(Collectors.toSet());
 
-        Set<String> additionalFileKeys = allAdditionalFiles.stream()
-                .map(this::generateUniqueKey)
+        existingFilePaths.addAll(
+                allAdditionalFiles.stream()
+                        .filter(b -> !b.isFolderBased())
+                        .map(BookFileEntity::getFullFilePath)
+                        .collect(Collectors.toSet())
+        );
+
+        Set<Path> existingFolderPaths = books.stream()
+                .map(BookEntity::getPrimaryBookFile)
+                .filter(Objects::nonNull)
+                .filter(BookFileEntity::isFolderBased)
+                .map(BookFileEntity::getFullFilePath)
                 .collect(Collectors.toSet());
 
-        existingKeys.addAll(additionalFileKeys);
+        existingFolderPaths.addAll(
+                allAdditionalFiles.stream()
+                        .filter(BookFileEntity::isFolderBased)
+                        .map(BookFileEntity::getFullFilePath)
+                        .collect(Collectors.toSet())
+        );
 
         return libraryFiles.stream()
-                .filter(file -> !existingKeys.contains(generateUniqueKey(file)))
+                .filter(file -> {
+                    Path filePath = file.getFullPath();
+
+                    if (file.isFolderBased()) {
+                        // If there's an exact match for existing folder paths bail early.
+                        if (existingFolderPaths.contains(filePath)) {
+                            return false;
+                        }
+
+                        // Next check if there are any book existing files which are
+                        // contained by this folder.
+
+                        // Next check if there are any book folders which contain this file.
+                        for (Path existingFile : existingFilePaths) {
+                            if (existingFile.startsWith(filePath)) {
+                                return false;
+                            }
+                        }
+
+                        // If none of that matches then this is a new folder.
+                        return true;
+                    }
+
+                    // If there's an exact match for existing file paths bail early.
+                    if (existingFilePaths.contains(filePath)) {
+                        return false;
+                    }
+
+                    // Next check if there are any book folders which contain this file.
+                    for (Path existingFolder : existingFolderPaths) {
+                        if (filePath.startsWith(existingFolder)) {
+                            return false;
+                        }
+                    }
+
+                    // If none of that matches then this is a new file.
+                    return true;
+                })
                 .collect(Collectors.toList());
-    }
-
-    private String generateUniqueKey(BookEntity book) {
-        BookFileEntity primaryFile = book.getPrimaryBookFile();
-        if (primaryFile == null) {
-            // Fileless book - use a unique key that won't match any file
-            return "fileless:" + book.getId();
-        }
-        return generateKey(book.getLibraryPath().getId(), primaryFile.getFileSubPath(), primaryFile.getFileName());
-    }
-
-    private String generateUniqueKey(BookFileEntity file) {
-        return generateKey(file.getBook().getLibraryPath().getId(), file.getFileSubPath(), file.getFileName());
-    }
-
-    private String generateUniqueKey(LibraryFile file) {
-        return generateKey(file.getLibraryPathEntity().getId(), file.getFileSubPath(), file.getFileName());
-    }
-
-    private String generateKey(Long libraryPathId, String subPath, String fileName) {
-        String safeSubPath = (subPath == null) ? "" : subPath;
-        return libraryPathId + ":" + safeSubPath + ":" + fileName;
     }
 
     public List<LibraryFile> getAllLibraryFiles(LibraryEntity libraryEntity) throws IOException {
@@ -237,7 +269,6 @@ public class LibraryFileHelper {
         // Track directories that contain audio files for folder-based audiobook detection
         Map<Path, List<Path>> dirAudioFiles = new HashMap<>();
         Map<Path, Boolean> dirHasNonAudioBooks = new HashMap<>();
-        Set<Path> processedAsFolderAudiobook = new HashSet<>();
 
         Files.walkFileTree(libraryPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new SimpleFileVisitor<>() {
             @Override
@@ -263,16 +294,15 @@ public class LibraryFileHelper {
                 } else {
                     // Track that this directory has non-audio book files
                     dirHasNonAudioBooks.put(parentDir, true);
-
-                    // Add non-audio files immediately
-                    libraryFiles.add(LibraryFile.builder()
-                            .libraryEntity(libraryEntity)
-                            .libraryPathEntity(pathEntity)
-                            .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), file))
-                            .fileName(fileName)
-                            .bookFileType(fileType)
-                            .build());
                 }
+
+                libraryFiles.add(LibraryFile.builder()
+                        .libraryEntity(libraryEntity)
+                        .libraryPathEntity(pathEntity)
+                        .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), file))
+                        .fileName(fileName)
+                        .bookFileType(fileType)
+                        .build());
 
                 return FileVisitResult.CONTINUE;
             }
@@ -284,16 +314,17 @@ public class LibraryFileHelper {
                 List<Path> audioFiles = dirAudioFiles.get(dir);
                 boolean hasNonAudioBooks = dirHasNonAudioBooks.getOrDefault(dir, false);
 
-                if (audioFiles != null && audioFiles.size() >= MIN_AUDIO_FILES_FOR_FOLDER_AUDIOBOOK && !hasNonAudioBooks) {
+                if (audioFiles == null) {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                if (audioFiles.size() >= MIN_AUDIO_FILES_FOR_FOLDER_AUDIOBOOK && !hasNonAudioBooks) {
                     // Don't treat library root as audiobook folder
                     if (!dir.equals(libraryPath)) {
                         if (FileUtils.isSeriesFolder(audioFiles)) {
                             log.info("Detected series folder: {} ({} audio files with distinct titles)", dir.getFileName(), audioFiles.size());
-                            addIndividualAudioFiles(audioFiles, libraryEntity, pathEntity, libraryFiles);
                         } else {
                             log.info("Detected folder-based audiobook: {} ({} audio files)", dir.getFileName(), audioFiles.size());
-
-                            processedAsFolderAudiobook.add(dir);
 
                             libraryFiles.add(LibraryFile.builder()
                                     .libraryEntity(libraryEntity)
@@ -304,45 +335,10 @@ public class LibraryFileHelper {
                                     .folderBased(true)
                                     .build());
                         }
-                    } else {
-                        // Library root - add individual audio files
-                        addIndividualAudioFiles(audioFiles, libraryEntity, pathEntity, libraryFiles);
-                    }
-                } else if (audioFiles != null) {
-                    // Not a folder-based audiobook - add individual audio files
-                    // But skip if parent was already processed as folder-based audiobook
-                    boolean parentIsAudiobookFolder = false;
-                    Path parent = dir.getParent();
-                    while (parent != null && parent.startsWith(libraryPath)) {
-                        if (processedAsFolderAudiobook.contains(parent)) {
-                            parentIsAudiobookFolder = true;
-                            break;
-                        }
-                        parent = parent.getParent();
-                    }
-
-                    if (!parentIsAudiobookFolder) {
-                        addIndividualAudioFiles(audioFiles, libraryEntity, pathEntity, libraryFiles);
                     }
                 }
 
                 return FileVisitResult.CONTINUE;
-            }
-
-            private void addIndividualAudioFiles(List<Path> audioFiles, LibraryEntity libraryEntity,
-                    LibraryPathEntity pathEntity, List<LibraryFile> libraryFiles) {
-                for (Path audioFile : audioFiles) {
-                    String fileName = audioFile.getFileName().toString();
-                    Optional<BookFileExtension> ext = BookFileExtension.fromFileName(fileName);
-
-                    libraryFiles.add(LibraryFile.builder()
-                            .libraryEntity(libraryEntity)
-                            .libraryPathEntity(pathEntity)
-                            .fileSubPath(FileUtils.getRelativeSubPath(pathEntity.getPath(), audioFile))
-                            .fileName(fileName)
-                            .bookFileType(ext.map(BookFileExtension::getType).orElse(BookFileType.AUDIOBOOK))
-                            .build());
-                }
             }
 
             @Override

--- a/backend/src/test/java/org/booklore/service/library/LibraryFileHelperTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryFileHelperTest.java
@@ -67,7 +67,9 @@ class LibraryFileHelperTest {
 
         List<String> expected = List.of(
                 "author/other/c.mp3",
-                "author/title"
+                "author/title",
+                "author/title/a.mp3",
+                "author/title/b.mp3"
         );
 
         assertEquals(expected, actual);
@@ -370,8 +372,8 @@ class LibraryFileHelperTest {
 
         List<LibraryFile> files = libraryFileHelper.getLibraryFiles(createLibraryWithMode(tempDir, LibraryOrganizationMode.AUTO_DETECT));
 
-        assertThat(files).hasSize(1);
-        assertThat(files.getFirst().isFolderBased()).isTrue();
+        assertThat(files).hasSize(6);
+        assertThat(files.getLast().isFolderBased()).isTrue();
     }
 
     @Test
@@ -435,6 +437,12 @@ class LibraryFileHelperTest {
                 .fileName("a")
                 .build();
 
+        LibraryFile bookLibraryFile = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .fileSubPath("example/a")
+                .fileName("file.mp3")
+                .build();
+
         BookFileEntity existing = BookFileEntity.builder()
                 .folderBased(true)
                 .fileSubPath("example")
@@ -450,7 +458,7 @@ class LibraryFileHelperTest {
         existing.setBook(book);
 
         List<Long> actual = libraryFileHelper.detectDeletedBookIds(
-                List.of(bookLibraryFolder),
+                List.of(bookLibraryFolder, bookLibraryFile),
                 List.of(book)
         );
 
@@ -580,6 +588,12 @@ class LibraryFileHelperTest {
                 .fileName("a")
                 .build();
 
+        LibraryFile fileA = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .fileSubPath("example/a")
+                .fileName("file.mp3")
+                .build();
+
         LibraryFile fileB = LibraryFile.builder()
                 .libraryPathEntity(libraryPathEntity)
                 .fileSubPath("example")
@@ -600,7 +614,7 @@ class LibraryFileHelperTest {
         audiobookFolder.setBook(audiobook);
 
         List<LibraryFile> actual = libraryFileHelper.detectNewBookPaths(
-                List.of(folderA, fileB),
+                List.of(folderA, fileA, fileB),
                 List.of(audiobook),
                 Collections.emptyList()
         );
@@ -608,6 +622,116 @@ class LibraryFileHelperTest {
         assertThat(actual).isEqualTo(List.of(fileB));
     }
 
+    @Test
+    void detectNewBooks_shouldHandleFolderAudiobooksWithNameOverlap() {
+        LibraryPathEntity libraryPathEntity = LibraryPathEntity.builder()
+                .path("/books")
+                .build();
+
+        LibraryFile folderA = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .folderBased(true)
+                .fileSubPath("example")
+                .fileName("a")
+                .build();
+
+        LibraryFile fileA = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .fileSubPath("example/a")
+                .fileName("file.mp3")
+                .build();
+
+        LibraryFile fileB = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .fileSubPath("example")
+                .fileName("a.epub")
+                .build();
+
+        BookFileEntity audiobookFolder = BookFileEntity.builder()
+                .folderBased(true)
+                .fileSubPath("example")
+                .fileName("a")
+                .build();
+
+        BookEntity audiobook = BookEntity.builder()
+                .libraryPath(libraryPathEntity)
+                .bookFiles(List.of(audiobookFolder))
+                .build();
+
+        audiobookFolder.setBook(audiobook);
+
+        List<LibraryFile> actual = libraryFileHelper.detectNewBookPaths(
+                List.of(folderA, fileA, fileB),
+                List.of(audiobook),
+                Collections.emptyList()
+        );
+
+        assertThat(actual).isEqualTo(List.of(fileB));
+    }
+
+    @Test
+    void detectNewBooks_shouldHandleFileAudiobooksInSameFolder() {
+        LibraryPathEntity libraryPathEntity = LibraryPathEntity.builder()
+                .path("/books")
+                .build();
+
+        LibraryFile folder = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .folderBased(true)
+                .fileSubPath("audiobooks")
+                .fileName("example")
+                .build();
+
+        LibraryFile fileA = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .fileSubPath("audiobooks/example")
+                .fileName("a.mp3")
+                .build();
+
+        LibraryFile fileB = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .fileSubPath("audiobooks/example")
+                .fileName("b.mp3")
+                .build();
+
+        LibraryFile fileC = LibraryFile.builder()
+                .libraryPathEntity(libraryPathEntity)
+                .fileSubPath("audiobooks/example")
+                .fileName("c.mp3")
+                .build();
+
+        BookFileEntity audiobookAFile = BookFileEntity.builder()
+                .fileSubPath("audiobooks/example")
+                .fileName("a.mp3")
+                .build();
+
+        BookEntity audiobookA = BookEntity.builder()
+                .libraryPath(libraryPathEntity)
+                .bookFiles(List.of(audiobookAFile))
+                .build();
+
+        audiobookAFile.setBook(audiobookA);
+
+        BookFileEntity audiobookBFile = BookFileEntity.builder()
+                .fileSubPath("audiobooks/example")
+                .fileName("b.mp3")
+                .build();
+
+        BookEntity audiobookB = BookEntity.builder()
+                .libraryPath(libraryPathEntity)
+                .bookFiles(List.of(audiobookBFile))
+                .build();
+
+        audiobookBFile.setBook(audiobookB);
+
+        List<LibraryFile> actual = libraryFileHelper.detectNewBookPaths(
+                List.of(folder, fileA, fileB, fileC),
+                List.of(audiobookA, audiobookB),
+                Collections.emptyList()
+        );
+
+        assertThat(actual).isEqualTo(List.of(fileC));
+    }
 
     @Test
     void detectNewBooks_shouldHandleAdditionalFiles() {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
in some cases, single file audio books are being removed when the library scan is being done.  this is because of ambiguity in our audiobook detection.  often, multiple single file audiobooks gets detected as a folder-based audiobook which leads to us not finding those single files

this change updates the algorithm for detecting files so we check for both folder & file based audiobooks

**Linked Issue:** Fixes #446<!-- issue number leave empty if none -->

## Changes

* switches away from the "key" system to paths
* ensures audiobooks get both folder & file based paths when scanning the library for new / deleted files
* handles both of these cases during a scan to allow for improperly detected books to be found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal file path comparison logic for more reliable library file detection.

* **Tests**
  * Expanded test coverage for library file management, including folder-based audiobook handling and file detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->