### PR TITLE
docs: add AI usage policy for contributors

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,86 @@
+# AI Usage Policy
+
+The Grimmory project has strict rules for AI usage:
+
+- **All AI usage in any form must be disclosed.** You must state
+  the tool you used (e.g. Claude, Codex, Copilot, Cursor, etc.)
+  along with the extent that the work was AI-assisted.
+
+- **The human-in-the-loop must fully understand all code.** If you
+  can't explain what your changes do and how they interact with the
+  greater system without the aid of AI tools, consider finding other
+  ways to contribute — documentation, testing, discussion, and
+  feedback are all genuinely valuable.
+
+- **When contributing via pull requests, AI is a tool — not a
+  substitute for understanding.** All AI-assisted code must be
+  fully tested and verified by you before submission. If you don't
+  have enough familiarity with the affected area of the codebase
+  to identify what could go wrong, ask questions first.
+
+- **When contributing via issues and discussions, AI assistance is
+  welcome but you must remain in the loop.** Any AI-generated
+  content must be reviewed and edited by you before submission.
+  AI tends toward verbosity and noise — trim it, focus it, and
+  make sure it reflects your actual intent.
+
+- **No AI-generated media is allowed (art, images, videos, audio, etc.).**
+  Text and code are the only acceptable AI-generated content, per the
+  other rules in this policy.
+
+- **Submissions that are clearly unreviewed AI output will be closed
+  without further engagement.** Repeated offences will result in
+  being blocked from the project. We love to help people learn and
+  grow — if that's your goal, slow down, ask questions, and we'll
+  help you.
+
+These rules apply only to outside contributions to Grimmory. Maintainers
+are exempt from these rules and may use AI tools at their discretion;
+they are accountable for the quality of the project and apply their
+own judgment accordingly.
+
+## There are Humans Here
+
+Please remember that Grimmory is maintained by humans.
+
+Every discussion, issue, and pull request is read and reviewed by
+humans (and sometimes machines, too). It is a boundary point at which
+people interact with each other and the work done. It is rude and
+disrespectful to approach this boundary with low-effort, unqualified
+work, since it puts the burden of validation on the maintainer.
+
+## Our Philosophy on AI
+
+Parts of Grimmory has been written with AI assistance, and many maintainers
+embrace AI tools as a productive part of their workflow, in their own different
+and personal ways. As a project, we welcome AI as a tool.
+
+**Our reason for the strict AI policy is not due to an anti-AI stance**,
+but instead due to the gap between what AI can produce and what
+contributors can confidently stand behind. It's not the tools that
+are the problem, but it's when it's used to leapfrog past understanding.
+
+AI tooling has opened the door for more people to participate in
+software projects than ever before — and that's genuinely exciting.
+
+But as Ian Malcolm put it in Jurassic Park: _[they] were so
+preoccupied with whether or not they could, they didn't stop to think
+if they should_.
+
+The same applies here. The ability to produce something
+with AI doesn't automatically bring with it the understanding to judge
+whether that something is correct, safe, or right for the codebase
+it's entering.
+
+That judgment — of side effects, edge cases, architectural fit,
+conventions — still belongs to a human who knows what they're looking
+at. We're here to help you become that human, if you want to be.
+
+We include this section to be transparent about the project's usage of
+AI for people who may disagree with it, and to address the misconception
+that this policy is anti-AI in nature.
+
+---
+
+_This policy is adapted from the [Ghostty AI Usage Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md),
+with thanks to the Ghostty project._

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -51,7 +51,7 @@ work, since it puts the burden of validation on the maintainer.
 
 ## Our Philosophy on AI
 
-Parts of Grimmory has been written with AI assistance, and many maintainers
+Parts of Grimmory have been written with AI assistance, and many maintainers
 embrace AI tools as a productive part of their workflow, in their own different
 and personal ways. As a project, we welcome AI as a tool.
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -58,7 +58,7 @@ and personal ways. As a project, we welcome AI as a tool.
 **Our reason for the strict AI policy is not due to an anti-AI stance**,
 but instead due to the gap between what AI can produce and what
 contributors can confidently stand behind. It's not the tools that
-are the problem, but it's when it's used to leapfrog past understanding.
+are the problem, but when they're used to leapfrog past understanding.
 
 AI tooling has opened the door for more people to participate in
 software projects than ever before — and that's genuinely exciting.


### PR DESCRIPTION
## Description

This PR adds a repo-level AI usage policy for contributors. This policy was formed by reflecting on the AI policies instituted by other popular FOSS projects. This specific policy is adapted from the [Ghostty AI Usage Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).

The new policy sets expectations for disclosure, review, testing, and human accountability
when AI tools are used in discussions, issues, or pull requests. It also explicitly
disallows AI-generated media in contributions, and gives maintainers a clear set of rules for
handling low-effort or unreviewed AI submissions.

## Changes

- Add a root AI_POLICY.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an AI Usage Policy requiring contributors to disclose AI assistance (tool and extent), verify and understand AI-assisted submissions, and ensure testing/verification for PRs; mandates human review/editing for AI-generated issue/discussion content; prohibits AI-generated non-text media; unreviewed submissions may be closed and repeated violations blocked; policy targets external contributions and outlines enforcement and project AI philosophy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->