### PR TITLE
fix(metadata): update book retrieval methods to fix lazy init exception when removing some authors/retrieving metadata from file

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/email/SendEmailV2Service.java
+++ b/booklore-api/src/main/java/org/booklore/service/email/SendEmailV2Service.java
@@ -71,13 +71,15 @@ public class SendEmailV2Service {
 
     private void sendEmailInVirtualThread(EmailProviderV2Entity emailProvider, String recipientEmail, BookEntity book, BookFileEntity bookFile) {
         String bookTitle = book.getMetadata().getTitle();
+        File bookFileOnDisk = FileUtils.getBookFullPath(book, bookFile).toFile();
+        long bookId = book.getId();
         String logMessage = "Email dispatch initiated for book: " + bookTitle + " to " + recipientEmail;
         notificationService.sendMessage(Topic.LOG, LogNotification.info(logMessage));
         log.info(logMessage);
         taskExecutor.execute(() -> {
             try {
-                sendEmail(emailProvider, recipientEmail, book, bookFile);
-                auditService.log(AuditAction.BOOK_SENT, "Book", book.getId(), "Sent book: " + bookTitle + " to " + recipientEmail);
+                sendEmail(emailProvider, recipientEmail, bookTitle, bookFileOnDisk);
+                auditService.log(AuditAction.BOOK_SENT, "Book", bookId, "Sent book: " + bookTitle + " to " + recipientEmail);
                 String successMessage = "The book: " + bookTitle + " has been successfully sent to " + recipientEmail;
                 notificationService.sendMessage(Topic.LOG, LogNotification.info(successMessage));
                 log.info(successMessage);
@@ -89,15 +91,14 @@ public class SendEmailV2Service {
         });
     }
 
-    private void sendEmail(EmailProviderV2Entity emailProvider, String recipientEmail, BookEntity book, BookFileEntity bookFileEntity) throws MessagingException {
+    private void sendEmail(EmailProviderV2Entity emailProvider, String recipientEmail, String bookTitle, File bookFile) throws MessagingException {
         JavaMailSenderImpl dynamicMailSender = setupMailSender(emailProvider);
         MimeMessage message = dynamicMailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
         helper.setFrom(StringUtils.firstNonEmpty(emailProvider.getFromAddress(), emailProvider.getUsername()));
         helper.setTo(recipientEmail);
-        helper.setSubject("Your Book from Grimmory: " + book.getMetadata().getTitle());
-        helper.setText(generateEmailBody(book.getMetadata().getTitle()));
-        File bookFile = FileUtils.getBookFullPath(book, bookFileEntity).toFile();
+        helper.setSubject("Your Book from Grimmory: " + bookTitle);
+        helper.setText(generateEmailBody(bookTitle));
         helper.addAttachment(bookFile.getName(), bookFile);
         dynamicMailSender.send(message);
         log.info("Book sent successfully to {}", recipientEmail);

--- a/booklore-api/src/main/java/org/booklore/service/email/SendEmailV2Service.java
+++ b/booklore-api/src/main/java/org/booklore/service/email/SendEmailV2Service.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 
@@ -71,7 +72,11 @@ public class SendEmailV2Service {
 
     private void sendEmailInVirtualThread(EmailProviderV2Entity emailProvider, String recipientEmail, BookEntity book, BookFileEntity bookFile) {
         String bookTitle = book.getMetadata().getTitle();
-        File bookFileOnDisk = FileUtils.getBookFullPath(book, bookFile).toFile();
+        Path bookPath = FileUtils.getBookFullPath(book, bookFile);
+        if (bookPath == null) {
+            throw ApiError.FILE_NOT_FOUND.createException(bookTitle);
+        }
+        File bookFileOnDisk = bookPath.toFile();
         long bookId = book.getId();
         String logMessage = "Email dispatch initiated for book: " + bookTitle + " to " + recipientEmail;
         notificationService.sendMessage(Topic.LOG, LogNotification.info(logMessage));

--- a/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/BookMetadataService.java
@@ -223,7 +223,7 @@ public class BookMetadataService {
 
     public BookMetadata getFileMetadata(long bookId) {
         log.info("Extracting file metadata for book ID: {}", bookId);
-        BookEntity bookEntity = bookRepository.findById(bookId).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
+        BookEntity bookEntity = bookRepository.findByIdWithBookFiles(bookId).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
         var primaryFile = bookEntity.getPrimaryBookFile();
         if (primaryFile == null) {
             throw ApiError.GENERIC_BAD_REQUEST.createException("Book has no file to extract metadata from");

--- a/booklore-api/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
@@ -298,11 +298,11 @@ class SendEmailV2ServiceTest {
 
         try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
             fileUtilsMock.when(() -> FileUtils.getBookFullPath(book, bookFile))
-                    .thenThrow(new IllegalStateException("Book file not found"));
+                    .thenReturn(Path.of("/library/books/test-book.epub"));
 
             sendEmailV2Service.emailBookQuick(10L);
 
-            // Error is caught and logged, not rethrown
+            // Error is caught inside async thread and logged, not rethrown
             verify(notificationService, atLeastOnce()).sendMessage(any(), any());
         }
     }

--- a/booklore-api/src/test/java/org/booklore/service/metadata/BookMetadataServiceTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/BookMetadataServiceTest.java
@@ -483,7 +483,7 @@ class BookMetadataServiceTest {
 
         @Test
         void throwsWhenBookNotFound() {
-            when(bookRepository.findById(1L)).thenReturn(Optional.empty());
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> service.getFileMetadata(1L))
                     .isInstanceOf(APIException.class);
@@ -492,7 +492,7 @@ class BookMetadataServiceTest {
         @Test
         void throwsWhenPrimaryFileIsNull() {
             BookEntity bookEntity = BookEntity.builder().id(1L).bookFiles(new ArrayList<>()).build();
-            when(bookRepository.findById(1L)).thenReturn(Optional.of(bookEntity));
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
             assertThatThrownBy(() -> service.getFileMetadata(1L))
                     .isInstanceOf(APIException.class);


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request fixes a lazy init bug + improves reliability, and code clarity. The main changes include refactoring the email sending method to accept simpler parameters, updating metadata extraction to eagerly load book files, and adjusting related tests to match these changes.

**Metadata extraction enhancements:**
- Changed `getFileMetadata` to use `findByIdWithBookFiles`, ensuring all necessary book file data is loaded in one query and preventing lazy-loading issues. 


**Email sending improvements:**
- Refactored `sendEmail` to accept a book title and `File` object instead of full entity objects, simplifying the interface and reducing the risk of lazy-loading issues. 
- Updated the async email dispatch logic to prepare the file path and book title before launching the background thread, ensuring all required data is available. )


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of email sending so messages include correct book title and attachment handling and report file-missing errors earlier.
  * Fixed metadata retrieval so book file information is consistently available when fetching file metadata.

* **Tests**
  * Updated tests to reflect the service behavior changes and ensure async error handling and metadata lookups are exercised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->