### PR TITLE
fix(metadata): support multiple roles for the same creator in EPUB metadata extraction

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -184,7 +184,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
             NodeList children = metadata.getChildNodes();
 
             Map<String, String> creatorsById = new HashMap<>();
-            Map<String, String> creatorRoleById = new HashMap<>();
+            Map<String, List<String>> creatorRolesById = new HashMap<>();
             Map<String, List<String>> creatorsByRole = new HashMap<>();
             creatorsByRole.put("aut", new ArrayList<>());
 
@@ -217,7 +217,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                         }
 
                         if ("role".equals(prop) && StringUtils.isNotBlank(refines)) {
-                            creatorRoleById.put(refines.substring(1), content.toLowerCase());
+                            creatorRolesById.computeIfAbsent(refines.substring(1), k -> new ArrayList<>()).add(content.toLowerCase());
                         }
 
                         if ("rendition:layout".equals(prop) && "pre-paginated".equals(content)) {
@@ -394,8 +394,10 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
             for (Map.Entry<String, String> entry : creatorsById.entrySet()) {
                 String id = entry.getKey();
                 String value = entry.getValue();
-                String role = creatorRoleById.getOrDefault(id, "aut");
-                creatorsByRole.computeIfAbsent(role, k -> new ArrayList<>()).add(value);
+                List<String> roles = creatorRolesById.getOrDefault(id, List.of("aut"));
+                for (String role : roles) {
+                    creatorsByRole.computeIfAbsent(role, k -> new ArrayList<>()).add(value);
+                }
             }
 
             builderMeta.authors(creatorsByRole.get("aut"));

--- a/booklore-api/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -477,6 +477,19 @@ class EpubMetadataExtractorTest {
 
             assertThat(metadata.getAuthors()).containsExactlyInAnyOrder("Author One", "Author Two");
         }
+
+        @Test
+        void multipleRolesForSameCreator() throws IOException {
+            String opf = wrapOpf("""
+                    <dc:title>Book</dc:title>
+                    <dc:creator id="author">Charles Dickens</dc:creator>
+                    <meta property="role" refines="#author">aut</meta>
+                    <meta property="role" refines="#author">waw</meta>
+                    """);
+            BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
+
+            assertThat(metadata.getAuthors()).containsExactly("Charles Dickens");
+        }
     }
 
     @Nested


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request improves the handling of EPUB creator roles in the `EpubMetadataExtractor`, allowing for multiple roles to be associated with a single creator. The main change is updating the internal data structures and logic to support and process creators with multiple roles, rather than just one. A new test ensures this behavior is correctly implemented.

**EPUB creator roles handling:**

* Changed `creatorRoleById` from a `Map<String, String>` to `creatorRolesById` as a `Map<String, List<String>>` to store multiple roles per creator.
* Updated the extraction logic to collect all roles for a creator instead of overwriting previous ones.
* Modified the logic that maps creators to roles to iterate over all roles for each creator, ensuring creators appear under each of their assigned roles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB metadata extraction to properly handle creators with multiple assigned roles, preventing duplicate author entries.

* **Tests**
  * Added test coverage for multi-role creator scenarios in EPUB files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->