### PR TITLE
fix(auth): fix authentication request handling to exclude specific endpoints from authorization checks leading to permission denied errors

### DIFF
--- a/booklore-api/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/booklore-api/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -57,7 +57,10 @@ public class SecurityConfig {
             "/kobo/**",                // Kobo API requests (auth handled in KoboAuthFilter)
             "/api/docs",               // API documentation UI
             "/api/openapi.json",       // OpenAPI spec (used by API documentation UI)
-            "/api/v1/auth/**",         // Login and token refresh endpoints (must remain public)
+            "/api/v1/auth/login",      // Login endpoint (must remain public)
+            "/api/v1/auth/refresh",    // Token refresh endpoint (must remain public)
+            "/api/v1/auth/remote",     // Remote auth endpoint (must remain public)
+            "/api/v1/auth/oidc/**",    // OIDC authentication endpoints
             "/api/v1/public-settings", // Public endpoint for checking OIDC or other app settings
             "/api/v1/setup/**",        // Setup wizard endpoints (must remain accessible before initial setup)
             "/api/v1/healthcheck/**"   // Healthcheck endpoints (must remain accessible for Docker healthchecks)

--- a/frontend/src/app/core/security/auth-interceptor.service.spec.ts
+++ b/frontend/src/app/core/security/auth-interceptor.service.spec.ts
@@ -176,4 +176,58 @@ describe('AuthInterceptorService', () => {
     expect((firstResponse as HttpResponse<string>).body).toBe('Bearer refreshed-token');
     expect((secondResponse as HttpResponse<string>).body).toBe('Bearer refreshed-token');
   });
+
+  describe('isExcludedAuthRequest', () => {
+    const next = vi.fn((request: HttpRequest<unknown>) =>
+      of(new HttpResponse({status: 200, body: request.headers.has('Authorization')}))
+    );
+
+    it('excludes /api/v1/auth/login', async () => {
+      authService.getInternalAccessToken.mockReturnValue('token-123');
+      const response = await firstValueFrom(interceptor(new HttpRequest('POST', `${API_CONFIG.BASE_URL}/api/v1/auth/login`, null), next));
+      expect((response as HttpResponse<boolean>).body).toBe(false);
+    });
+
+    it('excludes /api/v1/auth/refresh', async () => {
+      authService.getInternalAccessToken.mockReturnValue('token-123');
+      const response = await firstValueFrom(interceptor(new HttpRequest('POST', `${API_CONFIG.BASE_URL}/api/v1/auth/refresh`, null), next));
+      expect((response as HttpResponse<boolean>).body).toBe(false);
+    });
+
+    it('excludes /api/v1/auth/remote', async () => {
+      authService.getInternalAccessToken.mockReturnValue('token-123');
+      const response = await firstValueFrom(interceptor(new HttpRequest('GET', `${API_CONFIG.BASE_URL}/api/v1/auth/remote`), next));
+      expect((response as HttpResponse<boolean>).body).toBe(false);
+    });
+
+    it('excludes /api/v1/auth/oidc/state', async () => {
+      authService.getInternalAccessToken.mockReturnValue('token-123');
+      const response = await firstValueFrom(interceptor(new HttpRequest('GET', `${API_CONFIG.BASE_URL}/api/v1/auth/oidc/state`), next));
+      expect((response as HttpResponse<boolean>).body).toBe(false);
+    });
+
+    it('excludes /api/v1/auth/oidc/callback', async () => {
+      authService.getInternalAccessToken.mockReturnValue('token-123');
+      const response = await firstValueFrom(interceptor(new HttpRequest('POST', `${API_CONFIG.BASE_URL}/api/v1/auth/oidc/callback`, null), next));
+      expect((response as HttpResponse<boolean>).body).toBe(false);
+    });
+
+    it('does NOT exclude /api/v1/auth/login-history (exact match test)', async () => {
+      authService.getInternalAccessToken.mockReturnValue('token-123');
+      const response = await firstValueFrom(interceptor(new HttpRequest('GET', `${API_CONFIG.BASE_URL}/api/v1/auth/login-history`), next));
+      expect((response as HttpResponse<boolean>).body).toBe(true);
+    });
+
+    it('does NOT exclude /api/v1/auth/login?query=1 (exact match test)', async () => {
+      authService.getInternalAccessToken.mockReturnValue('token-123');
+      const response = await firstValueFrom(interceptor(new HttpRequest('GET', `${API_CONFIG.BASE_URL}/api/v1/auth/login?query=1`), next));
+      expect((response as HttpResponse<boolean>).body).toBe(false);
+    });
+
+    it('does NOT exclude /api/v1/auth/logout', async () => {
+      authService.getInternalAccessToken.mockReturnValue('token-123');
+      const response = await firstValueFrom(interceptor(new HttpRequest('POST', `${API_CONFIG.BASE_URL}/api/v1/auth/logout`, null), next));
+      expect((response as HttpResponse<boolean>).body).toBe(true);
+    });
+  });
 });

--- a/frontend/src/app/core/security/auth-interceptor.service.ts
+++ b/frontend/src/app/core/security/auth-interceptor.service.ts
@@ -13,7 +13,18 @@ export const AuthInterceptorService: HttpInterceptorFn = (req, next: HttpHandler
 
   const token = authService.getInternalAccessToken();
   const isApiRequest = req.url.startsWith(`${API_CONFIG.BASE_URL}/api/`);
-  const isAuthRequest = req.url.startsWith(`${API_CONFIG.BASE_URL}/api/v1/auth/`);
+  const authExcludePaths = [
+    '/api/v1/auth/login',
+    '/api/v1/auth/refresh',
+    '/api/v1/auth/remote',
+    '/api/v1/auth/oidc/state',
+    '/api/v1/auth/oidc/callback',
+    '/api/v1/auth/oidc/redirect',
+    '/api/v1/auth/oidc/mobile/callback',
+    '/api/v1/auth/oidc/backchannel-logout',
+  ];
+  const urlPath = req.url.split('?')[0];
+  const isAuthRequest = authExcludePaths.some(path => urlPath === `${API_CONFIG.BASE_URL}${path}`);
   const hasAuthHeader = req.headers.has('Authorization');
 
   const authReq = (token && isApiRequest && !isAuthRequest && !hasAuthHeader) ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }) : req;


### PR DESCRIPTION
## Description

Apply the authentication request-handling fixes from #538 directly on this branch to unblock the work after merge conflicts.

This preserves the original behavior change from @balazs-szucs PR: only the specific public auth endpoints remain excluded from authorization header injection and 401 refresh handling, while other auth-related routes like user registration and logout are treated as authenticated requests again

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/562

## Changes

- narrow backend public auth endpoint matching from `/api/v1/auth/**` to the explicit public login, refresh, remote auth, and OIDC routes
- update the frontend auth interceptor to exclude only those exact public auth endpoints from bearer token injection and refresh retry handling
- add frontend tests covering the explicit exclusion list and exact-match behavior for similar auth paths
- apply the #538 logic manually on this branch so the fix can move forward despite PR conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Authentication endpoint access control has been refined. Public access without JWT tokens is now limited to: login, refresh, remote operations, and OIDC flows (state, callback, and related endpoints). Consequently, all remaining authentication-related endpoints now require valid JWT token authentication. This establishes more explicit security boundaries for the authentication system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->