### PR TITLE
fix(release): always publish nightly images on manual runs

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -4,12 +4,6 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
-    inputs:
-      publish_image:
-        description: 'Publish the nightly container image'
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   resolve_ref:
@@ -69,7 +63,6 @@ jobs:
 
   build-and-push:
     name: Build and Push Nightly Image
-    if: ${{ github.event_name == 'schedule' || inputs.publish_image }}
     needs: [resolve_ref, test-suite]
     runs-on: ubuntu-latest
 
@@ -170,7 +163,7 @@ jobs:
 
   notify-discord:
     name: Notify Discord (Nightly)
-    if: ${{ always() && needs.generate-notes.result == 'success' && (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'skipped') }}
+    if: ${{ always() && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' }}
     needs: [resolve_ref, build-and-push, generate-notes]
     permissions: {}
     uses: ./.github/workflows/notify-discord-release-notes.yml


### PR DESCRIPTION
## Description

Remove the manual nightly smoke-test path that skipped image publishing.

Nightly runs should now behave consistently regardless of how they are triggered: both scheduled and manually dispatched runs will build, publish, and notify using the same flow

## Changes

- remove the `publish_image` workflow dispatch input from the nightly workflow
- make `Build and Push Nightly Image` run for all nightly executions, including manual runs
- require a successful nightly image publish before sending the Discord notification
- remove the remaining workflow logic that supported the old “notes only” nightly path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Streamlined nightly publish workflow: Removed manual publish toggle feature to simplify scheduled execution paths.
* Refined publish notifications: Discord alerts now require successful completion of both note generation and image build stages before dispatching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->