### PR TITLE
fix(devex): add GitHub sign-in note to rc and nightly Discord posts

### DIFF
--- a/.github/workflows/notify-discord-release-notes.yml
+++ b/.github/workflows/notify-discord-release-notes.yml
@@ -109,6 +109,11 @@ jobs:
             description="${description}\n- Candidate SHA: \`${short_sha}\`"
           fi
 
+          note_text=""
+          if [ "$CHANNEL" = "rc" ] || [ "$CHANNEL" = "nightly" ]; then
+            note_text="*Note: You must be signed into GitHub to view the changelog*"
+          fi
+
           {
             echo 'content<<EOF'
             printf '%s\n' "$content"
@@ -117,6 +122,9 @@ jobs:
             echo 'description<<EOF'
             printf '%b\n' "$description"
             echo 'EOF'
+            echo 'note_text<<EOF'
+            printf '%s\n' "$note_text"
+            echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Send Discord Webhook
@@ -124,6 +132,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.discord_webhook }}
           CONTENT: ${{ steps.compose.outputs.content }}
           DESCRIPTION: ${{ steps.compose.outputs.description }}
+          NOTE_TEXT: ${{ steps.compose.outputs.note_text }}
           TITLE_URL: ${{ steps.compose.outputs.title_url }}
         run: |
           set -eu
@@ -131,17 +140,31 @@ jobs:
           payload="$(jq -n \
             --arg content "$CONTENT" \
             --arg description "$DESCRIPTION" \
+            --arg note_text "$NOTE_TEXT" \
             --arg title_url "$TITLE_URL" \
             '
               {
                 content: $content,
-                embeds: [
-                  {
-                    title: "Build Details",
-                    description: $description,
-                    color: 5763719
-                  }
-                ]
+                embeds: (
+                  [
+                    {
+                      title: "Build Details",
+                      description: $description,
+                      color: 5763719
+                    }
+                  ]
+                  + (
+                    if $note_text != "" then
+                      [
+                        {
+                          description: $note_text
+                        }
+                      ]
+                    else
+                      []
+                    end
+                  )
+                )
               }
               + (
                 if $title_url != "" then

--- a/.github/workflows/notify-discord-release-notes.yml
+++ b/.github/workflows/notify-discord-release-notes.yml
@@ -112,18 +112,16 @@ jobs:
           note_text=""
           if [ "$CHANNEL" = "rc" ] || [ "$CHANNEL" = "nightly" ]; then
             note_text="*Note: You must be signed into GitHub to view the changelog*"
+            content="${content}\n${note_text}"
           fi
 
           {
             echo 'content<<EOF'
-            printf '%s\n' "$content"
+            printf '%b\n' "$content"
             echo 'EOF'
             echo "title_url=${title_url}"
             echo 'description<<EOF'
             printf '%b\n' "$description"
-            echo 'EOF'
-            echo 'note_text<<EOF'
-            printf '%s\n' "$note_text"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
@@ -132,7 +130,6 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.discord_webhook }}
           CONTENT: ${{ steps.compose.outputs.content }}
           DESCRIPTION: ${{ steps.compose.outputs.description }}
-          NOTE_TEXT: ${{ steps.compose.outputs.note_text }}
           TITLE_URL: ${{ steps.compose.outputs.title_url }}
         run: |
           set -eu
@@ -140,31 +137,17 @@ jobs:
           payload="$(jq -n \
             --arg content "$CONTENT" \
             --arg description "$DESCRIPTION" \
-            --arg note_text "$NOTE_TEXT" \
             --arg title_url "$TITLE_URL" \
             '
               {
                 content: $content,
-                embeds: (
-                  [
-                    {
-                      title: "Build Details",
-                      description: $description,
-                      color: 5763719
-                    }
-                  ]
-                  + (
-                    if $note_text != "" then
-                      [
-                        {
-                          description: $note_text
-                        }
-                      ]
-                    else
-                      []
-                    end
-                  )
-                )
+                embeds: [
+                  {
+                    title: "Build Details",
+                    description: $description,
+                    color: 5763719
+                  }
+                ]
               }
               + (
                 if $title_url != "" then


### PR DESCRIPTION
## Description

Add a short GitHub sign-in note to nightly and release candidate Discord notifications so users know the changelog link requires authentication.

**Linked Issue:** Fixes #

## Changes

- Add note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord release notifications for rc and nightly channels now include a note reminding users to sign into GitHub to view the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->