### PR TITLE
fix(table-view): table-view to also actually select all when users select press all

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.html
@@ -335,7 +335,7 @@
                         [onBookSelect]="onBookCardSelect"
                         [isSeriesCollapsed]="seriesCollapseFilter.seriesCollapsed()"
                         (checkboxClick)="onCheckboxClicked($event)"
-                        [isSelected]="selectedBooks().has(book.id)"
+                        [isSelected]="bookSelectionService.isBookSelected(book)"
                         [useSquareCovers]="isAudiobookOnlyLibrary()"
                         [overlayPreferenceService]="bookCardOverlayPreferenceService">
                       </app-book-card>

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.html
@@ -313,6 +313,7 @@
               [books]="books"
               [preselectedBookIds]="selectedBooks()"
               (selectedBooksChange)="onSelectedBooksChange($event)"
+              (selectAllRequested)="selectAllBooks()"
               [sortOption]="this.bookSorter.selectedSort!"
               [visibleColumns]="visibleColumns()"
             ></app-book-table>

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -851,15 +851,9 @@ export class BookBrowserComponent implements AfterViewInit {
     this.appBooksApi.fetchAllBookIds().pipe(take(1)).subscribe({
       next: (allIds) => {
         this.bookSelectionService.selectAll(allIds);
-        if (this.bookTableComponent) {
-          this.bookTableComponent.selectAllBooks();
-        }
       },
       error: () => {
         this.bookSelectionService.selectAll();
-        if (this.bookTableComponent) {
-          this.bookTableComponent.selectAllBooks();
-        }
       }
     });
   }

--- a/frontend/src/app/features/book/components/book-browser/book-selection.service.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-selection.service.ts
@@ -87,7 +87,7 @@ export class BookSelectionService {
     this._selectedBooks.update(current => {
       const next = new Set(current);
       for (const book of this.currentBooks) {
-        next.add(book.id);
+        this.getSelectableBookIds(book).forEach(bookId => next.add(bookId));
       }
       return next;
     });

--- a/frontend/src/app/features/book/components/book-browser/book-selection.service.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-selection.service.ts
@@ -21,14 +21,22 @@ export class BookSelectionService {
     this.currentBooks = books;
   }
 
+  getSelectableBookIds(book: Book): number[] {
+    return book.seriesBooks?.length
+      ? book.seriesBooks.map(seriesBook => seriesBook.id)
+      : [book.id];
+  }
+
+  isBookSelected(book: Book): boolean {
+    const selectedIds = this._selectedBooks();
+    const ids = this.getSelectableBookIds(book);
+    return ids.every(id => selectedIds.has(id));
+  }
+
   selectBook(book: Book): void {
     this._selectedBooks.update(current => {
       const next = new Set(current);
-      if (book.seriesBooks) {
-        book.seriesBooks.forEach(seriesBook => next.add(seriesBook.id));
-      } else {
-        next.add(book.id);
-      }
+      this.getSelectableBookIds(book).forEach(bookId => next.add(bookId));
       return next;
     });
   }
@@ -36,11 +44,7 @@ export class BookSelectionService {
   deselectBook(book: Book): void {
     this._selectedBooks.update(current => {
       const next = new Set(current);
-      if (book.seriesBooks) {
-        book.seriesBooks.forEach(seriesBook => next.delete(seriesBook.id));
-      } else {
-        next.delete(book.id);
-      }
+      this.getSelectableBookIds(book).forEach(bookId => next.delete(bookId));
       return next;
     });
   }

--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.ts
@@ -122,7 +122,17 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
   private syncSelectedBooks(): void {
     // Only include in 'selectedBooks' the objects that are actually in 'this.books'
     // so that p-table correctly shows them as selected in the UI.
-    this.selectedBooks = this.books.filter(book => this.selectedBookIds.has(book.id));
+    this.selectedBooks = this.books.filter(book => this.isBookSelected(book));
+  }
+
+  private getSelectableBookIds(book: Book): number[] {
+    return book.seriesBooks?.length
+      ? book.seriesBooks.map(seriesBook => seriesBook.id)
+      : [book.id];
+  }
+
+  private isBookSelected(book: Book): boolean {
+    return this.getSelectableBookIds(book).every(bookId => this.selectedBookIds.has(bookId));
   }
 
   scrollToTop(): void {
@@ -146,22 +156,14 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
 
   onRowSelect(event: { data?: Book | Book[] }): void {
     if (event.data && !Array.isArray(event.data)) {
-      if (event.data.seriesBooks) {
-        event.data.seriesBooks.forEach(book => this.selectedBookIds.add(book.id));
-      } else {
-        this.selectedBookIds.add(event.data.id);
-      }
+      this.getSelectableBookIds(event.data).forEach(bookId => this.selectedBookIds.add(bookId));
       this.selectedBooksChange.emit(new Set(this.selectedBookIds));
     }
   }
 
   onRowUnselect(event: { data?: Book | Book[] }): void {
     if (event.data && !Array.isArray(event.data)) {
-      if (event.data.seriesBooks) {
-        event.data.seriesBooks.forEach(book => this.selectedBookIds.delete(book.id));
-      } else {
-        this.selectedBookIds.delete(event.data.id);
-      }
+      this.getSelectableBookIds(event.data).forEach(bookId => this.selectedBookIds.delete(bookId));
       this.selectedBooksChange.emit(new Set(this.selectedBookIds));
     }
   }

--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.ts
@@ -40,6 +40,7 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
   selectedBookIds = new Set<number>();
 
   @Output() selectedBooksChange = new EventEmitter<Set<number>>();
+  @Output() selectAllRequested = new EventEmitter<void>();
   @Input() books: Book[] = [];
   @Input() sortOption: SortOption | null = null;
   @Input() visibleColumns: { field: string; header: string }[] = [];
@@ -91,8 +92,8 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
       this.metadataCenterViewMode = user.userSettings.metadataCenterViewMode ?? 'route';
     }
 
-    this.selectedBookIds = this.preselectedBookIds;
-    this.selectedBooks = this.bookService.getBooksByIds([...this.selectedBookIds]);
+    this.selectedBookIds = new Set(this.preselectedBookIds);
+    this.syncSelectedBooks();
     this.setScrollHeight();
     window.addEventListener('resize', this.resizeListener);
   }
@@ -104,13 +105,24 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
       : 'calc(100dvh - 150px)';
   }
 
-  ngOnChanges() {
+  ngOnChanges(changes: import('@angular/core').SimpleChanges) {
+    if (changes['preselectedBookIds'] || changes['books']) {
+      this.selectedBookIds = new Set(this.preselectedBookIds);
+      this.syncSelectedBooks();
+    }
+
     const wrapperElements = this.elementRef.nativeElement.querySelectorAll('.p-virtualscroller');
     wrapperElements.forEach((wrapperElement: Element) => {
       if (wrapperElement instanceof HTMLElement) {
         wrapperElement.style.height = 'calc(100dvh - 160px)';
       }
     });
+  }
+
+  private syncSelectedBooks(): void {
+    // Only include in 'selectedBooks' the objects that are actually in 'this.books'
+    // so that p-table correctly shows them as selected in the UI.
+    this.selectedBooks = this.books.filter(book => this.selectedBookIds.has(book.id));
   }
 
   scrollToTop(): void {
@@ -121,9 +133,9 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   selectAllBooks(): void {
-    this.selectedBookIds = new Set(this.books.map(book => book.id));
-    this.selectedBooks = [...this.books];
-    this.selectedBooksChange.emit(this.selectedBookIds);
+    // We delegate the "Select All" logic to the parent component
+    // which can fetch all book IDs from the API.
+    this.selectAllRequested.emit();
   }
 
   clearSelectedBooks(): void {
@@ -134,26 +146,32 @@ export class BookTableComponent implements OnInit, OnDestroy, OnChanges {
 
   onRowSelect(event: { data?: Book | Book[] }): void {
     if (event.data && !Array.isArray(event.data)) {
-      this.selectedBookIds.add(event.data.id);
-      this.selectedBooksChange.emit(this.selectedBookIds);
+      if (event.data.seriesBooks) {
+        event.data.seriesBooks.forEach(book => this.selectedBookIds.add(book.id));
+      } else {
+        this.selectedBookIds.add(event.data.id);
+      }
+      this.selectedBooksChange.emit(new Set(this.selectedBookIds));
     }
   }
 
   onRowUnselect(event: { data?: Book | Book[] }): void {
     if (event.data && !Array.isArray(event.data)) {
-      this.selectedBookIds.delete(event.data.id);
-      this.selectedBooksChange.emit(this.selectedBookIds);
+      if (event.data.seriesBooks) {
+        event.data.seriesBooks.forEach(book => this.selectedBookIds.delete(book.id));
+      } else {
+        this.selectedBookIds.delete(event.data.id);
+      }
+      this.selectedBooksChange.emit(new Set(this.selectedBookIds));
     }
   }
 
   onHeaderCheckboxToggle(event: { checked: boolean }): void {
     if (event.checked) {
-      this.selectedBooks = [...this.books];
-      this.selectedBookIds = new Set(this.books.map(book => book.id));
+      this.selectAllRequested.emit();
     } else {
       this.clearSelectedBooks();
     }
-    this.selectedBooksChange.emit(this.selectedBookIds);
   }
 
   getStarColor(rating: number): string {

--- a/frontend/src/app/features/book/components/series-page/series-page.component.html
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.html
@@ -288,7 +288,7 @@
                           [index]="i"
                           [book]="book"
                           [isCheckboxEnabled]="true"
-                          [isSelected]="selectedBooks.has(book.id)"
+                          [isSelected]="isBookSelected(book)"
                           (checkboxClick)="onCheckboxClicked($event)"
                           [onBookSelect]="handleBookSelect.bind(this)"
                           [isSeriesCollapsed]="false"

--- a/frontend/src/app/features/book/components/series-page/series-page.component.ts
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.ts
@@ -564,7 +564,7 @@ export class SeriesPageComponent implements AfterViewChecked {
 
   selectAllBooks(): void {
     for (const book of this.filteredBooks()) {
-      this.selectedBooks.add(book.id);
+      this.getSelectableBookIds(book).forEach(id => this.selectedBooks.add(id));
     }
     this.moreActionsMenuItems = this.bookMenuService.getMoreActionsMenu(this.selectedBooks, this.user());
   }

--- a/frontend/src/app/features/book/components/series-page/series-page.component.ts
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.ts
@@ -519,21 +519,22 @@ export class SeriesPageComponent implements AfterViewChecked {
     return Math.round((rating / 5) * 100);
   }
 
+  private getSelectableBookIds(book: Book): number[] {
+    return book.seriesBooks?.length
+      ? book.seriesBooks.map(seriesBook => seriesBook.id)
+      : [book.id];
+  }
+
+  isBookSelected(book: Book): boolean {
+    return this.getSelectableBookIds(book).every(id => this.selectedBooks.has(id));
+  }
+
   handleBookSelection(book: Book, selected: boolean) {
+    const ids = this.getSelectableBookIds(book);
     if (selected) {
-      if (book.seriesBooks) {
-        this.selectedBooks = new Set([...this.selectedBooks, ...book.seriesBooks.map(book => book.id)]);
-      } else {
-        this.selectedBooks.add(book.id);
-      }
+      ids.forEach(id => this.selectedBooks.add(id));
     } else {
-      if (book.seriesBooks) {
-        book.seriesBooks.forEach(book => {
-          this.selectedBooks.delete(book.id);
-        });
-      } else {
-        this.selectedBooks.delete(book.id);
-      }
+      ids.forEach(id => this.selectedBooks.delete(id));
     }
   }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

See title. Again. Just for table-view. For context see: #533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Select-all and row selection now include all books in a series and keep UI selection consistent across table, grid, and series views.
  * Grid and card selection correctly reflect current selection state.

* **Refactor**
  * Centralized selection logic into shared helpers and moved select-all coordination to parent-driven events for clearer component communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->