### PR TITLE
fix(kobo): add library to entityGraph when fetching books for download

### DIFF
--- a/booklore-api/src/main/java/org/booklore/repository/BookRepository.java
+++ b/booklore-api/src/main/java/org/booklore/repository/BookRepository.java
@@ -42,7 +42,7 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
     @Query("SELECT b FROM BookEntity b WHERE b.id = :id AND (b.deleted IS NULL OR b.deleted = false)")
     Optional<BookEntity> findByIdFull(@Param("id") Long id);
 
-    @EntityGraph(attributePaths = { "metadata", "metadata.authors", "metadata.categories", "metadata.tags", "metadata.comicMetadata", "libraryPath", "bookFiles" })
+    @EntityGraph(attributePaths = { "metadata", "metadata.authors", "metadata.categories", "metadata.tags", "metadata.comicMetadata", "libraryPath", "library", "bookFiles" })
     @Query("SELECT b FROM BookEntity b WHERE b.id = :id AND (b.deleted IS NULL OR b.deleted = false)")
     Optional<BookEntity> findByIdForKoboDownload(@Param("id") Long id);
 

--- a/booklore-api/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
+++ b/booklore-api/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
@@ -1,0 +1,133 @@
+package org.booklore.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.booklore.BookloreApplication;
+import org.booklore.model.entity.*;
+import org.booklore.model.enums.BookFileType;
+import org.booklore.service.task.TaskCronService;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest(classes = {
+        BookloreApplication.class
+})
+@Transactional
+@TestPropertySource(properties = {
+        "logging.level.root=debug",
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "app.path-config=build/tmp/test-config",
+        "app.bookdrop-folder=build/tmp/test-bookdrop",
+        "spring.main.allow-bean-definition-overriding=true",
+        "spring.task.scheduling.enabled=false",
+        "app.task.scan-library-cron=*/1 * * * * *",
+        "app.task.process-bookdrop-cron=*/1 * * * * *",
+        "app.features.oidc-enabled=false",
+        "spring.jpa.properties.hibernate.connection.provider_disables_autocommit=false",
+        "spring.jpa.properties.hibernate.enable_lazy_load_no_trans=false"
+})
+@Import(BookRepositoryDataJpaTest.TestConfig.class)
+class BookRepositoryDataJpaTest {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @org.springframework.boot.test.context.TestConfiguration
+    public static class TestConfig {
+        @Bean("flyway")
+        @Primary
+        public Flyway flyway() {
+            return mock(Flyway.class);
+        }
+
+        @Bean
+        @Primary
+        public TaskCronService taskCronService() {
+            return mock(TaskCronService.class);
+        }
+    }
+
+    @Test
+    void contextLoads() {
+        assertThat(bookRepository).isNotNull();
+    }
+
+    @Test
+    void findAllWithMetadataByIds_executesAgainstJpaMetamodel() {
+        LibraryEntity library = LibraryEntity.builder()
+                .name("Test Library")
+                .icon("book")
+                .watch(false)
+                .formatPriority(List.of(BookFileType.EPUB, BookFileType.PDF))
+                .build();
+        entityManager.persist(library);
+        entityManager.flush();
+
+        LibraryPathEntity libraryPath = LibraryPathEntity.builder()
+                .library(library)
+                .path("/test/path")
+                .build();
+        entityManager.persist(libraryPath);
+        entityManager.flush();
+
+        BookEntity book = BookEntity.builder()
+                .library(library)
+                .libraryPath(libraryPath)
+                .addedOn(Instant.now())
+                .deleted(false)
+                .build();
+        entityManager.persist(book);
+        entityManager.flush();
+
+        BookFileEntity bookFile = BookFileEntity.builder()
+                .book(book)
+                .fileName("test.epub")
+                .fileSubPath("")
+                .isBookFormat(true)
+                .bookType(BookFileType.EPUB)
+                .fileSizeKb(500L)
+                .initialHash("hash1")
+                .currentHash("hash1")
+                .addedOn(Instant.now())
+                .build();
+        entityManager.persist(bookFile);
+        entityManager.flush();
+
+        entityManager.clear();
+
+        Optional<BookEntity> result = bookRepository.findByIdForKoboDownload(1L);
+
+        TestTransaction.end();
+
+        assertThat(result).isPresent();
+
+        BookEntity bookEntity = result.get();
+        assertThat(bookEntity.getId()).isEqualTo(book.getId());
+        assertThat(bookEntity.getPrimaryBookFile()).isNotNull();
+    }
+}


### PR DESCRIPTION
## Description

**Linked Issue:** Fixes #644

## Changes

Prevent LazyInitializationException by including Library in the EntityGraph when fetching books for Kobo downloads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kobo download now fetches complete book data including associated library details, improving download reliability.
* **Tests**
  * Added an integration test that verifies the repository returns full book information for Kobo downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->