### PR TITLE
fix(pdf-writer): use same-dir temp files and harden cleanup

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/writer/PdfMetadataWriter.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/writer/PdfMetadataWriter.java
@@ -43,13 +43,13 @@ public class PdfMetadataWriter implements MetadataWriter {
         }
 
         Path filePath = file.toPath();
+        Path parentDir = filePath.getParent();
         Path backupPath = null;
         boolean backupCreated = false;
-        File tempFile = null;
+        Path tempPath = null;
 
         try {
-            String prefix = "pdfBackup-" + UUID.randomUUID() + "-";
-            backupPath = Files.createTempFile(prefix, ".pdf");
+            backupPath = Files.createTempFile(parentDir, ".pdfBackup-", ".pdf");
             Files.copy(filePath, backupPath, StandardCopyOption.REPLACE_EXISTING);
             backupCreated = true;
         } catch (IOException e) {
@@ -58,10 +58,10 @@ public class PdfMetadataWriter implements MetadataWriter {
 
         try (PdfDocument doc = PdfDocument.open(filePath)) {
             applyMetadataToDocument(doc, metadataEntity, clear);
-            tempFile = File.createTempFile("pdfmeta-", ".pdf");
-            doc.save(tempFile.toPath(), SaveOptions.SKIP_VALIDATION);
-            Files.move(tempFile.toPath(), filePath, StandardCopyOption.REPLACE_EXISTING);
-            tempFile = null; // Prevent deletion in finally block after successful move
+            tempPath = Files.createTempFile(parentDir, ".pdfmeta-", ".pdf");
+            doc.save(tempPath, SaveOptions.SKIP_VALIDATION);
+            Files.move(tempPath, filePath, StandardCopyOption.REPLACE_EXISTING);
+            tempPath = null;
             log.info("Successfully embedded metadata into PDF: {}", file.getName());
         } catch (Exception e) {
             log.warn("Failed to write metadata to PDF {}: {}", file.getName(), e.getMessage(), e);
@@ -74,8 +74,12 @@ public class PdfMetadataWriter implements MetadataWriter {
                 }
             }
         } finally {
-            if (tempFile != null && tempFile.exists()) {
-                tempFile.delete();
+            if (tempPath != null) {
+                try {
+                    Files.deleteIfExists(tempPath);
+                } catch (IOException e) {
+                    log.warn("Could not delete PDF temp file: {}", e.getMessage());
+                }
             }
             if (backupCreated) {
                 try {
@@ -418,18 +422,17 @@ public class PdfMetadataWriter implements MetadataWriter {
             return null;
         }
         
-        // Extract numeric ID from slug format "12345678-book-title"
-        int dashIndex = goodreadsId.indexOf('-');
-        if (dashIndex > 0) {
-            String numericPart = goodreadsId.substring(0, dashIndex);
-            // Validate it's actually numeric
+        // Extract numeric ID from slug format "12345678-book-title" or "12345678.Book_Title"
+        int sep = goodreadsId.indexOf('-');
+        if (sep < 0) sep = goodreadsId.indexOf('.');
+        if (sep > 0) {
+            String numericPart = goodreadsId.substring(0, sep);
             if (numericPart.matches("\\d+")) {
                 return numericPart;
             }
         }
         
-        // Already just the ID, or return as-is if it's all numeric
-        return goodreadsId.matches("\\d+") ? goodreadsId : goodreadsId;
+        return goodreadsId;
     }
 
 }

--- a/booklore-api/src/test/java/org/booklore/service/metadata/writer/PdfMetadataWriterTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/writer/PdfMetadataWriterTest.java
@@ -88,7 +88,7 @@ class PdfMetadataWriterTest {
         meta.setPublishedDate(LocalDate.of(2022, 11, 22));
         meta.setLanguage("en");
         meta.setPageCount(754);
-        
+
         List<AuthorEntity> authors = new ArrayList<>();
         AuthorEntity author = new AuthorEntity();
         author.setName("Jason C McDonald");
@@ -197,7 +197,7 @@ class PdfMetadataWriterTest {
         writer.saveMetadataToFile(pdf, meta, null, null);
 
         BookMetadata result = extractor.extractMetadata(pdf);
-        assertEquals("52555538", result.getGoodreadsId(), 
+        assertEquals("52555538", result.getGoodreadsId(),
                 "Goodreads ID should be normalized to just the numeric part");
     }
 
@@ -287,17 +287,21 @@ class PdfMetadataWriterTest {
         File pdf = createEmptyPdf("tags-moods.pdf");
 
         BookMetadataEntity meta = createBasicMetadata();
-        
+
         Set<TagEntity> tags = new HashSet<>();
-        TagEntity tag1 = new TagEntity(); tag1.setName("Python");
-        TagEntity tag2 = new TagEntity(); tag2.setName("Programming");
+        TagEntity tag1 = new TagEntity();
+        tag1.setName("Python");
+        TagEntity tag2 = new TagEntity();
+        tag2.setName("Programming");
         tags.add(tag1);
         tags.add(tag2);
         meta.setTags(tags);
-        
+
         Set<MoodEntity> moods = new HashSet<>();
-        MoodEntity mood1 = new MoodEntity(); mood1.setName("Educational");
-        MoodEntity mood2 = new MoodEntity(); mood2.setName("Technical");
+        MoodEntity mood1 = new MoodEntity();
+        mood1.setName("Educational");
+        MoodEntity mood2 = new MoodEntity();
+        mood2.setName("Technical");
         moods.add(mood1);
         moods.add(mood2);
         meta.setMoods(moods);


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request improves the reliability and maintainability of the `PdfMetadataWriter` class by updating how temporary and backup files are handled, and by refining the normalization of Goodreads IDs. It also includes minor code style improvements in the related test class.

**File handling improvements:**

* Temporary and backup PDF files are now created in the same directory as the original file, reducing the risk of cross-device file move errors and improving cleanup reliability. The code now uses `Path` and `Files.createTempFile()` with the parent directory for both backup and temp files, and ensures temp files are deleted using `Files.deleteIfExists()` in a try-catch block. 

**Metadata normalization:**

* The `normalizeGoodreadsId` method now supports extracting the numeric Goodreads ID from both dash (`-`) and dot (`.`) separators, making it more robust for different slug formats. The method no longer returns the original string if it is not numeric, but simply returns it as-is. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Goodreads ID extraction to support multiple separator formats
  * Enhanced file write reliability during metadata embedding with better temporary file management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->