### PR TITLE
fix(epub-writer): rewrite EPUB metadata writer

### DIFF
--- a/booklore-api/src/main/java/org/booklore/config/RestClientConfig.java
+++ b/booklore-api/src/main/java/org/booklore/config/RestClientConfig.java
@@ -10,6 +10,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.concurrent.Executors;
 
 @Configuration
 public class RestClientConfig {
@@ -33,6 +34,27 @@ public class RestClientConfig {
         var factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(10));
         factory.setReadTimeout(Duration.ofSeconds(10));
+        return new RestTemplate(factory);
+    }
+
+    /**
+     * RestTemplate dedicated to downloading user-supplied cover URLs.
+     *
+     * <p>Redirects are explicitly disabled so that a remote host cannot bounce a request to an
+     * internal/metadata address after the caller has performed its private-IP guard (SSRF defence
+     * in depth). Callers are expected to revalidate any {@code Location} header themselves if they
+     * choose to follow a redirect manually.
+     */
+    @Bean
+    public RestTemplate coverDownloadRestTemplate() {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .connectTimeout(Duration.ofSeconds(10))
+                .executor(Executors.newVirtualThreadPerTaskExecutor())
+                .build();
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+        factory.setReadTimeout(Duration.ofSeconds(30));
         return new RestTemplate(factory);
     }
 }

--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -9,6 +9,7 @@ import org.grimmory.epub4j.domain.Resource;
 import org.grimmory.epub4j.epub.CoverDetector;
 import org.grimmory.epub4j.epub.CoverDetector.CoverDetectionResult;
 import org.grimmory.epub4j.epub.EpubReader;
+import org.grimmory.epub4j.native_parsing.NativePackageReader;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -88,9 +89,27 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
     @Override
     public byte[] extractCover(File epubFile) {
+        // Attempt fast native path lookup first
+        String nativeCoverPath = null;
+        try (NativePackageReader nativeReader = NativePackageReader.parse(epubFile.getAbsolutePath())) {
+            nativeCoverPath = nativeReader.getCoverHref();
+        } catch (Exception e) {
+            log.debug("Native cover path lookup failed for {}: {}", epubFile.getName(), e.getMessage());
+        }
+
         // Primary: use epub4j's CoverDetector with native lazy loading
         try {
             Book book = new EpubReader().readEpubLazy(epubFile.toPath(), "UTF-8");
+            
+            // If native lookup found a path, try to get that resource directly first
+            if (nativeCoverPath != null) {
+                Resource res = book.getResources().getByHref(nativeCoverPath);
+                if (res != null) {
+                    byte[] data = getImageFromEpubResource(res);
+                    if (data != null) return data;
+                }
+            }
+
             Optional<CoverDetectionResult> detection = CoverDetector.detectCoverImageWithMethod(book);
             if (detection.isPresent()) {
                 CoverDetectionResult result = detection.get();
@@ -134,9 +153,11 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                 String id = item.getAttribute("id");
                 String href = item.getAttribute("href");
                 String mediaType = item.getAttribute("media-type");
+                // getAttribute() returns "" for missing attributes in DOM (never null),
+                // but we guard defensively for malformed EPUBs and future refactors.
                 if (mediaType != null && mediaType.startsWith("image/")) {
-                    if ((id != null && id.toLowerCase().contains("cover")) ||
-                            (href != null && href.toLowerCase().contains("cover"))) {
+                    if ((id != null && id.toLowerCase().contains("cover"))
+                            || (href != null && href.toLowerCase().contains("cover"))) {
                         String decodedHref = URLDecoder.decode(href, StandardCharsets.UTF_8);
                         String fullPath = resolvePath(opfName, decodedHref);
                         if (container.exists(fullPath)) {
@@ -167,19 +188,92 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
     @Override
     public BookMetadata extractMetadata(File epubFile) {
+        BookMetadata.BookMetadataBuilder builderMeta = BookMetadata.builder();
+        Set<String> categories = new HashSet<>();
+        Set<String> moods = new HashSet<>();
+        Set<String> tags = new HashSet<>();
+        
+        // Attempt fast native extraction first (powered by pugixml/gumbo)
+        try (NativePackageReader nativeReader = NativePackageReader.parse(epubFile.getAbsolutePath())) {
+            Map<String, String> allMetadata = nativeReader.getAllMetadata();
+            if (allMetadata != null && !allMetadata.isEmpty()) {
+                log.debug("Native metadata extraction successful for {}", epubFile.getName());
+                
+                // Map basic fields directly from native
+                String title = allMetadata.get("dc:title");
+                if (StringUtils.isBlank(title)) title = allMetadata.get("title");
+                if (StringUtils.isNotBlank(title)) builderMeta.title(title);
+                
+                String description = allMetadata.get("dc:description");
+                if (StringUtils.isBlank(description)) description = allMetadata.get("description");
+                if (StringUtils.isNotBlank(description)) builderMeta.description(description);
+                
+                String publisher = allMetadata.get("dc:publisher");
+                if (StringUtils.isBlank(publisher)) publisher = allMetadata.get("publisher");
+                if (StringUtils.isNotBlank(publisher)) builderMeta.publisher(publisher);
+                
+                String language = allMetadata.get("dc:language");
+                if (StringUtils.isBlank(language)) language = allMetadata.get("language");
+                if (StringUtils.isNotBlank(language)) builderMeta.language(language);
+                
+                String date = allMetadata.get("dc:date");
+                if (StringUtils.isBlank(date)) date = allMetadata.get("date");
+                if (StringUtils.isBlank(date)) date = allMetadata.get("dcterms:modified");
+                if (StringUtils.isNotBlank(date)) {
+                    LocalDate parsed = parseDate(date);
+                    if (parsed != null) builderMeta.publishedDate(parsed);
+                }
+
+                // Layout
+                if ("pre-paginated".equals(allMetadata.get("rendition:layout"))) {
+                    builderMeta.isFixedLayout(true);
+                }
+
+                // Native reader often returns single string for authors/subjects. 
+                // We'll try to parse them, but thorough Java logic handles multi-value tags better.
+                // Known limitation: dc:creator here is a best-effort first pass and may be truncated.
+                String creator = allMetadata.get("dc:creator");
+                if (StringUtils.isNotBlank(creator)) {
+                    builderMeta.authors(List.of(creator));
+                }
+
+                String subject = allMetadata.get("dc:subject");
+                if (StringUtils.isNotBlank(subject)) {
+                    categories.addAll(parseJsonArrayOrCsv(subject));
+                }
+
+                // Series (Calibre & EPUB3)
+                String series = allMetadata.get("calibre:series");
+                if (StringUtils.isBlank(series)) series = allMetadata.get("belongs-to-collection");
+                if (StringUtils.isNotBlank(series)) builderMeta.seriesName(series);
+
+                String seriesIndex = allMetadata.get("calibre:series_index");
+                if (StringUtils.isBlank(seriesIndex)) seriesIndex = allMetadata.get("group-position");
+                if (StringUtils.isNotBlank(seriesIndex)) {
+                    try {
+                        builderMeta.seriesNumber(Float.parseFloat(seriesIndex));
+                    } catch (NumberFormatException ignored) {}
+                }
+
+                // Identifiers
+                mapNativeIdentifiers(allMetadata, builderMeta);
+            }
+        } catch (Exception e) {
+            log.debug("Native package parsing failed for {}: {}", epubFile.getName(), e.getMessage());
+        }
+
+        // Always perform thorough Java-based extraction as well to ensure we don't miss 
+        // complex tag mappings, refined attributes, and Calibre-specific JSON metadata.
+        // The Java extraction will overwrite/supplement fields found natively.
         try (EpubContainer container = EpubContainers.open(epubFile.toPath())) {
             Document doc = container.parseOpf();
 
             Element metadata = (Element) doc.getElementsByTagNameNS("*", "metadata").item(0);
             if (metadata == null) return null;
 
-            BookMetadata.BookMetadataBuilder builderMeta = BookMetadata.builder();
-            Set<String> categories = new HashSet<>();
-            Set<String> moods = new HashSet<>();
-            Set<String> tags = new HashSet<>();
-
             boolean seriesFound = false;
             boolean seriesIndexFound = false;
+            boolean subjectsFoundInJava = false;
 
             NodeList children = metadata.getChildNodes();
 
@@ -302,7 +396,14 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                             }
                         }
                     }
-                    case "subject" -> categories.add(text);
+                    case "subject" -> {
+                        if (!subjectsFoundInJava) {
+                            // First time we find subjects in Java pass, clear the native ones
+                            categories.clear();
+                            subjectsFoundInJava = true;
+                        }
+                        categories.add(text);
+                    }
                     case "description" -> builderMeta.description(text);
                     case "publisher" -> builderMeta.publisher(text);
                     case "language" -> builderMeta.language(text);
@@ -400,7 +501,12 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                 }
             }
 
-            builderMeta.authors(creatorsByRole.get("aut"));
+            // Only overwrite authors if the Java pass actually found dc:creator elements.
+            // Otherwise, preserve any authors discovered by the native extraction pass.
+            List<String> javaAuthors = creatorsByRole.get("aut");
+            if (javaAuthors != null && !javaAuthors.isEmpty()) {
+                builderMeta.authors(javaAuthors);
+            }
 
             if (!moods.isEmpty()) builderMeta.moods(moods);
             if (!tags.isEmpty()) builderMeta.tags(tags);
@@ -443,6 +549,46 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
         if (StringUtils.isNotBlank(value)) {
             targetSet.addAll(parseJsonArrayOrCsv(value));
         }
+    }
+
+    private static final Map<String, BiConsumer<BookMetadata.BookMetadataBuilder, String>> NATIVE_IDENTIFIER_MAPPERS = Map.ofEntries(
+            Map.entry("isbn", (b, v) -> {
+                String clean = ISBN_SEPARATOR_PATTERN.matcher(v).replaceAll("");
+                if (clean.length() == 13) b.isbn13(clean); else if (clean.length() == 10) b.isbn10(clean);
+            }),
+            Map.entry("goodreads", BookMetadata.BookMetadataBuilder::goodreadsId),
+            Map.entry("google", BookMetadata.BookMetadataBuilder::googleId),
+            Map.entry("amazon", BookMetadata.BookMetadataBuilder::asin),
+            Map.entry("hardcover", BookMetadata.BookMetadataBuilder::hardcoverId),
+            Map.entry("ranobedb", BookMetadata.BookMetadataBuilder::ranobedbId),
+            Map.entry("comicvine", BookMetadata.BookMetadataBuilder::comicvineId),
+            Map.entry("lubimyczytac", BookMetadata.BookMetadataBuilder::lubimyczytacId),
+            Map.entry("asin", BookMetadata.BookMetadataBuilder::asin),
+            Map.entry("mobi-asin", BookMetadata.BookMetadataBuilder::asin),
+            Map.entry("hardcover_book", BookMetadata.BookMetadataBuilder::hardcoverBookId)
+    );
+
+    private void mapNativeIdentifiers(Map<String, String> allMetadata, BookMetadata.BookMetadataBuilder builder) {
+        // Native identifiers are often exposed as "scheme:value" or via specific keys
+        allMetadata.forEach((key, value) -> {
+            if (StringUtils.isBlank(value)) return;
+            
+            // Try direct key match
+            String lowerKey = key.toLowerCase();
+            if (lowerKey.startsWith("dc:identifier:")) {
+                String scheme = lowerKey.substring("dc:identifier:".length());
+                BiConsumer<BookMetadata.BookMetadataBuilder, String> mapper = NATIVE_IDENTIFIER_MAPPERS.get(scheme);
+                if (mapper != null) mapper.accept(builder, value);
+            } else if (lowerKey.startsWith("identifier:")) {
+                String scheme = lowerKey.substring("identifier:".length());
+                BiConsumer<BookMetadata.BookMetadataBuilder, String> mapper = NATIVE_IDENTIFIER_MAPPERS.get(scheme);
+                if (mapper != null) mapper.accept(builder, value);
+            } else {
+                // Check if the key itself matches a scheme
+                BiConsumer<BookMetadata.BookMetadataBuilder, String> mapper = NATIVE_IDENTIFIER_MAPPERS.get(lowerKey);
+                if (mapper != null) mapper.accept(builder, value);
+            }
+        });
     }
 
     private void extractCalibreUserMetadata(JSONObject userMetadata, BookMetadata.BookMetadataBuilder builder,

--- a/booklore-api/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -9,283 +9,444 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.service.appsettings.AppSettingService;
-import org.booklore.util.SecureXmlUtils;
+import org.booklore.util.MimeDetector;
+import org.grimmory.epub4j.native_parsing.NativeImageProcessor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-
-import org.grimmory.epub4j.archive.EpubContainer;
-import org.grimmory.epub4j.archive.EpubContainers;
+import java.util.zip.ZipFile;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class EpubMetadataWriter implements MetadataWriter {
 
     private static final String OPF_NS = "http://www.idpf.org/2007/opf";
+    private static final String DC_NS = "http://purl.org/dc/elements/1.1/";
+    private static final Map<String, String> LANGUAGE_NAME_TO_CODE;
+    private static final Set<String> ISO_LANGUAGES;
+    private static final DateTimeFormatter EPUB_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+    private static final Set<String> SUPPORTED_EPUB_IMAGE_TYPES =
+            Set.of("image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml");
+    private static final Pattern PREFIX = Pattern.compile("calibre:\\s*https?://\\S+");
+
+    static {
+        Map<String, String> map = new HashMap<>();
+        for (Locale locale : Locale.getAvailableLocales()) {
+            String language = locale.getLanguage();
+            if (language.isEmpty()) continue;
+            map.putIfAbsent(locale.getDisplayLanguage(Locale.ENGLISH).toLowerCase(), language);
+            map.putIfAbsent(locale.getDisplayLanguage(locale).toLowerCase(), language);
+        }
+        LANGUAGE_NAME_TO_CODE = Collections.unmodifiableMap(map);
+
+        Set<String> langs = new HashSet<>();
+        for (String iso : Locale.getISOLanguages()) {
+            langs.add(iso.toLowerCase());
+        }
+        ISO_LANGUAGES = Collections.unmodifiableSet(langs);
+    }
+
+    private static final int MAX_COVER_BYTES = 20 * 1024 * 1024; // 20 MiB
+
     private final AppSettingService appSettingService;
+
+    private final RestTemplate coverRestTemplate;
+
+    public EpubMetadataWriter(
+            AppSettingService appSettingService,
+            @Qualifier("coverDownloadRestTemplate") RestTemplate coverRestTemplate) {
+        this.appSettingService = appSettingService;
+        this.coverRestTemplate = coverRestTemplate;
+    }
 
     @Override
     public void saveMetadataToFile(File epubFile, BookMetadataEntity metadata, String thumbnailUrl, MetadataClearFlags clear) {
-        if (!shouldSaveMetadataToFile(epubFile)) {
-            return;
-        }
+        if (!shouldSaveMetadataToFile(epubFile)) return;
 
-        File backupFile = new File(epubFile.getParentFile(), epubFile.getName() + ".bak");
         try {
-            Files.copy(epubFile.toPath(), backupFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException ex) {
-            log.warn("Failed to create backup of EPUB {}: {}", epubFile.getName(), ex.getMessage());
-            return;
-        }
-        Path tempDir = null;
-        try {
-            tempDir = Files.createTempDirectory("epub_edit_" + UUID.randomUUID());
-            extractZipToDirectory(epubFile, tempDir);
+            // Track whether any pass actually wrote changes
+            boolean[] anyChanges = {false};
 
-            File opfFile = findOpfFile(tempDir.toFile());
-            if (opfFile == null) {
-                log.warn("Could not locate OPF file in EPUB");
-                return;
-            }
-
-            DocumentBuilder builder = SecureXmlUtils.createSecureDocumentBuilder(true);
-            Document opfDoc = builder.parse(opfFile);
-
-            NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
-            Element metadataElement = (Element) metadataList.item(0);
-            final String DC_NS = "http://purl.org/dc/elements/1.1/";
-
-            boolean[] hasChanges = {false};
-            MetadataCopyHelper helper = new MetadataCopyHelper(metadata);
-
-            helper.copyTitle(clear != null && clear.isTitle(), val -> {
-                replaceAndTrackChange(opfDoc, metadataElement, "title", DC_NS, val, hasChanges);
-                if (StringUtils.isNotBlank(metadata.getSubtitle())) {
-                    addSubtitleToTitle(metadataElement, opfDoc, metadata.getSubtitle());
-                }
-            });
-            helper.copyDescription(clear != null && clear.isDescription(), val -> replaceAndTrackChange(opfDoc, metadataElement, "description", DC_NS, val, hasChanges));
-            helper.copyPublisher(clear != null && clear.isPublisher(), val -> replaceAndTrackChange(opfDoc, metadataElement, "publisher", DC_NS, val, hasChanges));
-            helper.copyPublishedDate(clear != null && clear.isPublishedDate(), val -> replaceAndTrackChange(opfDoc, metadataElement, "date", DC_NS, val != null ? val.toString() : null, hasChanges));
-            helper.copyLanguage(clear != null && clear.isLanguage(), val -> replaceAndTrackChange(opfDoc, metadataElement, "language", DC_NS, val, hasChanges));
-
-            helper.copyAuthors(clear != null && clear.isAuthors(), names -> {
-                removeCreatorsByRole(metadataElement, "");
-                removeCreatorsByRole(metadataElement, "aut");
-                if (names != null) {
-                    for (String name : names) {
-                        String[] parts = name.split(" ", 2);
-                        String first = parts.length > 1 ? parts[0] : "";
-                        String last = parts.length > 1 ? parts[1] : parts[0];
-                        String fileAs = last + ", " + first;
-                        metadataElement.appendChild(createCreatorElement(opfDoc, metadataElement, name, fileAs, "aut"));
-                    }
-                }
-                hasChanges[0] = true;
-            });
-
-            helper.copyCategories(clear != null && clear.isCategories(), categories -> {
-                removeElementsByTagNameNS(metadataElement, DC_NS, "subject");
-                if (categories != null) {
-                    for (String cat : categories.stream().map(String::trim).distinct().toList()) {
-                        metadataElement.appendChild(createSubjectElement(opfDoc, cat));
-                    }
-                }
-                hasChanges[0] = true;
-            });
-
-            helper.copySeriesName(clear != null && clear.isSeriesName(), val -> {
-                replaceBelongsToCollection(metadataElement, opfDoc, metadata.getSeriesName(), metadata.getSeriesNumber(), hasChanges);
-            });
-
-            helper.copySeriesNumber(clear != null && clear.isSeriesNumber(), val -> {
-                replaceBelongsToCollection(metadataElement, opfDoc, metadata.getSeriesName(), metadata.getSeriesNumber(), hasChanges);
-            });
-
-            helper.copyIsbn13(clear != null && clear.isIsbn13(), val -> {
-                removeIdentifierByUrn(metadataElement, "isbn");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "isbn", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyIsbn10(clear != null && clear.isIsbn10(), val -> {
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "isbn", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyAsin(clear != null && clear.isAsin(), val -> {
-                removeIdentifierByUrn(metadataElement, "amazon");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "amazon", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyGoodreadsId(clear != null && clear.isGoodreadsId(), val -> {
-                removeIdentifierByUrn(metadataElement, "goodreads");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "goodreads", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyGoogleId(clear != null && clear.isGoogleId(), val -> {
-                removeIdentifierByUrn(metadataElement, "google");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "google", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyComicvineId(clear != null && clear.isComicvineId(), val -> {
-                removeIdentifierByUrn(metadataElement, "comicvine");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "comicvine", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyHardcoverId(clear != null && clear.isHardcoverId(), val -> {
-                removeIdentifierByUrn(metadataElement, "hardcover");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "hardcover", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyHardcoverBookId(clear != null && clear.isHardcoverBookId(), val -> {
-                removeIdentifierByUrn(metadataElement, "hardcoverbook");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "hardcoverbook", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyLubimyczytacId(clear != null && clear.isLubimyczytacId(), val -> {
-                removeIdentifierByUrn(metadataElement, "lubimyczytac");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "lubimyczytac", val));
-                }
-                hasChanges[0] = true;
-            });
-            helper.copyRanobedbId(clear != null && clear.isRanobedbId(), val -> {
-                removeIdentifierByUrn(metadataElement, "ranobedb");
-                if (val != null && !val.isBlank()) {
-                    metadataElement.appendChild(createIdentifierElement(opfDoc, "ranobedb", val));
-                }
-                hasChanges[0] = true;
-            });
-
+            // PRE-FETCH COVER
+            byte[] rawCoverData = null;
             if (StringUtils.isNotBlank(thumbnailUrl)) {
-                byte[] coverData = loadImage(thumbnailUrl);
-                if (coverData != null) {
-                    applyCoverImageToEpub(tempDir, opfDoc, coverData);
+                rawCoverData = loadImage(thumbnailUrl);
+            }
+            final byte[] finalCoverData = rawCoverData != null ? optimizeCoverImage(rawCoverData) : null;
+            final String newCoverMediaType = finalCoverData != null ? detectMediaType(finalCoverData) : null;
+
+            org.grimmory.epub4j.epub.EpubMetadataWriter.updateMetadata(epubFile.toPath(), opfDoc -> {
+                Element metadataElement = getMetadataElement(opfDoc);
+                if (metadataElement == null) return;
+
+                boolean[] hasChanges = {false};
+                MetadataCopyHelper helper = new MetadataCopyHelper(metadata);
+
+                applyDcMetadata(opfDoc, metadataElement, metadata, helper, clear, hasChanges);
+                applyAuthors(opfDoc, metadataElement, helper, clear, hasChanges);
+                applyCategories(opfDoc, metadataElement, helper, clear, hasChanges);
+                applySeries(opfDoc, metadataElement, metadata, helper, clear, hasChanges);
+                applyIdentifiers(opfDoc, metadataElement, helper, clear, hasChanges);
+
+                if (finalCoverData != null) {
                     hasChanges[0] = true;
                 }
+
+                if (!hasChanges[0] && hasBookloreMetadataChanges(metadataElement, metadata)) {
+                    hasChanges[0] = true;
+                }
+
+                if (!hasChanges[0] && hasOrphanedRefines(metadataElement)) {
+                    hasChanges[0] = true;
+                }
+
+                if (hasChanges[0]) {
+                    addBookloreMetadata(metadataElement, opfDoc, metadata);
+                    cleanupCalibreArtifacts(metadataElement, opfDoc);
+                    organizeMetadataElements(metadataElement);
+                    removeEmptyTextNodes(opfDoc);
+                    anyChanges[0] = true;
+                }
+
+                // If we have cover data, update manifest
+                if (newCoverMediaType != null) {
+                    updateCoverManifestEntry(opfDoc, newCoverMediaType);
+                }
+            });
+
+            if (finalCoverData != null) {
+                org.grimmory.epub4j.epub.EpubMetadataWriter.replaceCoverImage(epubFile.toPath(), finalCoverData);
+                anyChanges[0] = true;
             }
 
-            if (!hasChanges[0] && hasBookloreMetadataChanges(metadataElement, metadata)) {
-                hasChanges[0] = true;
+            // Normalize cover media-type to match actual image content
+            if (fixCoverMediaTypeMismatch(epubFile)) {
+                anyChanges[0] = true;
             }
 
-            if (hasChanges[0]) {
-                addBookloreMetadata(metadataElement, opfDoc, metadata);
-                cleanupCalibreArtifacts(metadataElement, opfDoc);
-                organizeMetadataElements(metadataElement);
-                removeEmptyTextNodes(opfDoc);
-                Transformer transformer = TransformerFactory.newInstance().newTransformer();
-                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-                transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-                transformer.transform(new DOMSource(opfDoc), new StreamResult(opfFile));
-
-                File tempEpub = new File(epubFile.getParentFile(), epubFile.getName() + ".tmp");
-                createEpubZipFromDirectory(tempDir, tempEpub.toPath());
-
-                if (!epubFile.delete()) throw new IOException("Could not delete original EPUB");
-                if (!tempEpub.renameTo(epubFile)) throw new IOException("Could not rename temp EPUB");
-
+            if (anyChanges[0]) {
                 log.info("Metadata updated in EPUB: {}", epubFile.getName());
             } else {
                 log.info("No changes detected. Skipping EPUB write for: {}", epubFile.getName());
             }
         } catch (Exception e) {
             log.warn("Failed to write metadata to EPUB file {}: {}", epubFile.getName(), e.getMessage(), e);
-            if (backupFile.exists()) {
-                try {
-                    Files.copy(backupFile.toPath(), epubFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                    log.info("Restored EPUB from backup: {}", epubFile.getName());
-                } catch (IOException io) {
-                    log.error("Failed to restore EPUB from backup for {}: {}", epubFile.getName(), io.getMessage(), io);
-                }
-            }
-        } finally {
-            if (tempDir != null) {
-                deleteDirectoryRecursively(tempDir);
-            }
-            if (backupFile.exists()) {
-                try {
-                    Files.delete(backupFile.toPath());
-                } catch (IOException ex) {
-                    log.warn("Failed to delete backup for {}: {}", epubFile.getName(), ex.getMessage());
-                }
-            }
         }
     }
 
-    private void updateIdentifier(Element metadataElement, Document opfDoc, String scheme, String idValue, boolean[] hasChanges) {
-        removeIdentifierByScheme(metadataElement, scheme);
-        if (idValue != null && !idValue.isBlank()) {
-            metadataElement.appendChild(createIdentifierElement(opfDoc, scheme, idValue));
+    public void replaceCoverImageFromBytes(BookEntity bookEntity, byte[] file) {
+        if (!shouldSaveMetadataToFile(bookEntity.getFullFilePath().toFile())) return;
+        if (file == null || file.length == 0) {
+            log.warn("Cover update failed: empty or null byte array.");
+            return;
         }
-        hasChanges[0] = true;
+        replaceCoverImageInternal(bookEntity, file, "byte array");
+    }
+
+    public void replaceCoverImageFromUpload(BookEntity bookEntity, MultipartFile multipartFile) {
+        if (!shouldSaveMetadataToFile(bookEntity.getFullFilePath().toFile())) return;
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            log.warn("Cover upload failed: empty or null file.");
+            return;
+        }
+        try {
+            replaceCoverImageInternal(bookEntity, multipartFile.getBytes(), "upload");
+        } catch (IOException e) {
+            log.warn("Failed to read uploaded cover image: {}", e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void replaceCoverImageFromUrl(BookEntity bookEntity, String url) {
+        if (!shouldSaveMetadataToFile(bookEntity.getFullFilePath().toFile())) return;
+        if (url == null || url.isBlank()) {
+            log.warn("Cover update via URL failed: empty or null URL.");
+            return;
+        }
+        byte[] coverData = loadImage(url);
+        if (coverData == null) {
+            log.warn("Failed to load image from URL: {}", url);
+            return;
+        }
+        replaceCoverImageInternal(bookEntity, coverData, "URL");
+    }
+
+    @Override
+    public BookFileType getSupportedBookType() {
+        return BookFileType.EPUB;
+    }
+
+    private void replaceCoverImageInternal(BookEntity bookEntity, byte[] coverData, String source) {
+        try {
+            Path epubPath = Path.of(bookEntity.getFullFilePath().toUri());
+            byte[] optimized = optimizeCoverImage(coverData);
+            String newMediaType = detectMediaType(optimized);
+
+            // First pass: replace the cover image bytes in the ZIP
+            // not FQN, for some reason complain when i import this
+            org.grimmory.epub4j.epub.EpubMetadataWriter.replaceCoverImage(epubPath, optimized);
+
+            // Second pass: update manifest media-type/href and dcterms:modified
+            org.grimmory.epub4j.epub.EpubMetadataWriter.updateMetadata(epubPath, opfDoc -> {
+                // Update manifest media-type and href if image format changed
+                if (newMediaType != null) {
+                    updateCoverManifestEntry(opfDoc, newMediaType);
+                }
+
+                Element metadataElement = getMetadataElement(opfDoc);
+                if (metadataElement != null && isEpub3(opfDoc)) {
+                    removeDctermsModifiedMeta(metadataElement);
+                    removeCalibreTimestampMeta(metadataElement);
+
+                    Element modified = opfDoc.createElementNS(OPF_NS, "meta");
+                    modified.setAttribute("property", "dcterms:modified");
+                    modified.setTextContent(ZonedDateTime.now().format(EPUB_DATE_FORMATTER));
+                    metadataElement.appendChild(modified);
+                    removeEmptyTextNodes(opfDoc);
+                }
+            });
+
+            log.info("Cover image updated in EPUB from {}: {}", source, epubPath.getFileName());
+        } catch (Exception e) {
+            log.warn("Failed to update EPUB cover image from {}: {}", source, e.getMessage(), e);
+        }
+    }
+
+    private void updateCoverManifestEntry(Document opfDoc, String newMediaType) {
+        NodeList manifestList = opfDoc.getElementsByTagNameNS(OPF_NS, "manifest");
+        if (manifestList.getLength() == 0) return;
+
+        Element manifest = (Element) manifestList.item(0);
+        Element coverItem = findCoverItem(opfDoc, manifest);
+        if (coverItem == null) return;
+
+        String currentMediaType = coverItem.getAttribute("media-type");
+        if (!newMediaType.equals(currentMediaType)) {
+            coverItem.setAttribute("media-type", newMediaType);
+        }
+    }
+
+    private Element findCoverItem(Document opfDoc, Element manifest) {
+        // Check metadata <meta name="cover" content="item-id"/>
+        Element metadataElement = getMetadataElement(opfDoc);
+        if (metadataElement != null) {
+            String coverItemId = getMetaContentByName(metadataElement);
+            if (coverItemId != null && !coverItemId.isBlank()) {
+                NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
+                for (int i = 0; i < items.getLength(); i++) {
+                    Element item = (Element) items.item(i);
+                    if (coverItemId.equals(item.getAttribute("id"))) return item;
+                }
+            }
+        }
+
+        // Check properties="cover-image" (EPUB 3)
+        NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
+        for (int i = 0; i < items.getLength(); i++) {
+            Element item = (Element) items.item(i);
+            if (item.getAttribute("properties").contains("cover-image")) return item;
+        }
+
+        // Fallback: common cover id values
+        for (int i = 0; i < items.getLength(); i++) {
+            Element item = (Element) items.item(i);
+            String id = item.getAttribute("id");
+            if ("cover-image".equals(id) || "cover".equals(id) || "coverimg".equals(id)) return item;
+        }
+
+        return null;
+    }
+
+    private byte[] optimizeCoverImage(byte[] coverData) {
+        if (!NativeImageProcessor.isAvailable()) return coverData;
+
+        String mediaType = detectMediaType(coverData);
+        if ("image/jpeg".equals(mediaType)) {
+            try (NativeImageProcessor.ImageData optimized = NativeImageProcessor.compressJpeg(coverData, 85, true)) {
+                byte[] result = optimized.toByteArray();
+                if (result.length < coverData.length) {
+                    log.debug("Native JPEG optimization: {} → {} bytes", coverData.length, result.length);
+                    return result;
+                }
+            } catch (Exception e) {
+                log.warn("Native JPEG optimization failed: {}", e.getMessage());
+            }
+        } else if ("image/png".equals(mediaType)) {
+            try (NativeImageProcessor.ImageData optimized = NativeImageProcessor.optimizePng(coverData, true)) {
+                byte[] result = optimized.toByteArray();
+                if (result.length < coverData.length) {
+                    log.debug("Native PNG optimization: {} → {} bytes", coverData.length, result.length);
+                    return result;
+                }
+            } catch (Exception e) {
+                log.warn("Native PNG optimization failed: {}", e.getMessage());
+            }
+        }
+        return coverData;
+    }
+
+    private void applyDcMetadata(Document opfDoc, Element metadataElement, BookMetadataEntity metadata,
+                                 MetadataCopyHelper helper, MetadataClearFlags clear, boolean[] hasChanges) {
+        helper.copyTitle(flagSet(clear, MetadataClearFlags::isTitle), val -> {
+            replaceAndTrackChange(opfDoc, metadataElement, "title", DC_NS, val, hasChanges);
+            if (StringUtils.isNotBlank(metadata.getSubtitle())) {
+                addSubtitleToTitle(metadataElement, opfDoc, metadata.getSubtitle());
+            }
+        });
+        helper.copyDescription(flagSet(clear, MetadataClearFlags::isDescription),
+                val -> replaceAndTrackChange(opfDoc, metadataElement, "description", DC_NS, val, hasChanges));
+        helper.copyPublisher(flagSet(clear, MetadataClearFlags::isPublisher),
+                val -> replaceAndTrackChange(opfDoc, metadataElement, "publisher", DC_NS, val, hasChanges));
+        helper.copyPublishedDate(flagSet(clear, MetadataClearFlags::isPublishedDate),
+                val -> replaceAndTrackChange(opfDoc, metadataElement, "date", DC_NS, val != null ? val.toString() : null, hasChanges));
+        helper.copyLanguage(flagSet(clear, MetadataClearFlags::isLanguage), val -> {
+            String normalized = normalizeLanguage(val);
+            replaceAndTrackChange(opfDoc, metadataElement, "language", DC_NS, normalized, hasChanges);
+        });
+    }
+
+    private void applyAuthors(Document opfDoc, Element metadataElement,
+                              MetadataCopyHelper helper, MetadataClearFlags clear, boolean[] hasChanges) {
+        helper.copyAuthors(flagSet(clear, MetadataClearFlags::isAuthors), names -> {
+            removeCreatorsByRole(metadataElement, "");
+            removeCreatorsByRole(metadataElement, "aut");
+            if (names != null) {
+                for (String name : names) {
+                    int sp = name.lastIndexOf(' ');
+                    String fileAs;
+                    if (sp <= 0) {
+                        fileAs = name; // single-token or leading-space names
+                    } else {
+                        fileAs = name.substring(sp + 1) + ", " + name.substring(0, sp);
+                    }
+                    metadataElement.appendChild(createCreatorElement(opfDoc, metadataElement, name, fileAs));
+                }
+            }
+            hasChanges[0] = true;
+        });
+    }
+
+    private void applyCategories(Document opfDoc, Element metadataElement,
+                                 MetadataCopyHelper helper, MetadataClearFlags clear, boolean[] hasChanges) {
+        helper.copyCategories(flagSet(clear, MetadataClearFlags::isCategories), categories -> {
+            removeElementsByTagNameNS(metadataElement);
+            if (categories != null) {
+                categories.stream().map(String::trim).distinct()
+                        .forEach(cat -> metadataElement.appendChild(createSubjectElement(opfDoc, cat)));
+            }
+            hasChanges[0] = true;
+        });
+    }
+
+    private void applySeries(Document opfDoc, Element metadataElement, BookMetadataEntity metadata,
+                             MetadataCopyHelper helper, MetadataClearFlags clear, boolean[] hasChanges) {
+        helper.copySeriesName(flagSet(clear, MetadataClearFlags::isSeriesName),
+                val -> replaceBelongsToCollection(metadataElement, opfDoc, metadata.getSeriesName(), metadata.getSeriesNumber(), hasChanges));
+        helper.copySeriesNumber(flagSet(clear, MetadataClearFlags::isSeriesNumber),
+                val -> replaceBelongsToCollection(metadataElement, opfDoc, metadata.getSeriesName(), metadata.getSeriesNumber(), hasChanges));
+    }
+
+    private void applyIdentifiers(Document opfDoc, Element metadataElement,
+                                  MetadataCopyHelper helper, MetadataClearFlags clear, boolean[] hasChanges) {
+        copyIdentifier(helper::copyIsbn13, flagSet(clear, MetadataClearFlags::isIsbn13), opfDoc, metadataElement, "isbn", hasChanges);
+        copyIdentifier(helper::copyIsbn10, flagSet(clear, MetadataClearFlags::isIsbn10), opfDoc, metadataElement, null, hasChanges);
+        copyIdentifier(helper::copyAsin, flagSet(clear, MetadataClearFlags::isAsin), opfDoc, metadataElement, "amazon", hasChanges);
+        copyIdentifier(helper::copyGoodreadsId, flagSet(clear, MetadataClearFlags::isGoodreadsId), opfDoc, metadataElement, "goodreads", hasChanges);
+        copyIdentifier(helper::copyGoogleId, flagSet(clear, MetadataClearFlags::isGoogleId), opfDoc, metadataElement, "google", hasChanges);
+        copyIdentifier(helper::copyComicvineId, flagSet(clear, MetadataClearFlags::isComicvineId), opfDoc, metadataElement, "comicvine", hasChanges);
+        copyIdentifier(helper::copyHardcoverId, flagSet(clear, MetadataClearFlags::isHardcoverId), opfDoc, metadataElement, "hardcover", hasChanges);
+        copyIdentifier(helper::copyHardcoverBookId, flagSet(clear, MetadataClearFlags::isHardcoverBookId), opfDoc, metadataElement, "hardcoverbook", hasChanges);
+        copyIdentifier(helper::copyLubimyczytacId, flagSet(clear, MetadataClearFlags::isLubimyczytacId), opfDoc, metadataElement, "lubimyczytac", hasChanges);
+        copyIdentifier(helper::copyRanobedbId, flagSet(clear, MetadataClearFlags::isRanobedbId), opfDoc, metadataElement, "ranobedb", hasChanges);
+    }
+
+    @FunctionalInterface
+    private interface IdentifierCopyMethod {
+        void copy(boolean clear, Consumer<String> consumer);
+    }
+
+    private void copyIdentifier(IdentifierCopyMethod method, boolean clearFlag,
+                                Document opfDoc, Element metadataElement, String scheme, boolean[] hasChanges) {
+        method.copy(clearFlag, val -> {
+            if (scheme != null) removeIdentifierByUrn(metadataElement, scheme);
+            if (val != null && !val.isBlank()) {
+                String urnScheme = scheme != null ? scheme : "isbn";
+                metadataElement.appendChild(createIdentifierElement(opfDoc, urnScheme, val));
+            }
+            hasChanges[0] = true;
+        });
+    }
+
+    private static boolean flagSet(MetadataClearFlags clear, Predicate<MetadataClearFlags> getter) {
+        return clear != null && getter.test(clear);
     }
 
     private void replaceAndTrackChange(Document doc, Element parent, String tag, String ns, String val, boolean[] flag) {
-        if (replaceElementText(doc, parent, tag, ns, val, false)) flag[0] = true;
+        if (replaceElementText(doc, parent, tag, ns, val)) flag[0] = true;
     }
 
-    private void replaceMetaElement(Element metadataElement, Document doc, String name, String newVal, boolean[] flag) {
-        String existing = getMetaContentByName(metadataElement, name);
-        if (!Objects.equals(existing, newVal)) {
-            removeMetaByName(metadataElement, name);
-            if (newVal != null) metadataElement.appendChild(createMetaElement(doc, name, newVal));
-            flag[0] = true;
-        }
-    }
-
-    private boolean replaceElementText(Document doc, Element parent, String tagName, String namespaceURI, String newValue, boolean restoreMode) {
+    private boolean replaceElementText(Document doc, Element parent, String tagName, String namespaceURI, String newValue) {
         NodeList nodes = parent.getElementsByTagNameNS(namespaceURI, tagName);
         String currentValue = null;
+        List<Node> preservedAttributes = new ArrayList<>();
+        boolean epub3 = isEpub3(doc);
+
         if (nodes.getLength() > 0) {
-            currentValue = nodes.item(0).getTextContent();
+            Element existing = (Element) nodes.item(0);
+            currentValue = existing.getTextContent();
+            var attrMap = existing.getAttributes();
+            for (int i = 0; i < attrMap.getLength(); i++) {
+                Node attr = attrMap.item(i);
+                // Skip opf: namespace attributes when targeting EPUB3, they are EPUB2-only
+                // and would produce invalid metadata if carried over to an EPUB3 document.
+                if (epub3 && OPF_NS.equals(attr.getNamespaceURI())) continue;
+                // Skip xmlns declarations, they are managed by the DOM serializer automatically.
+                if (attr.getNodeName().startsWith("xmlns")) continue;
+                preservedAttributes.add(attr);
+            }
         }
 
         boolean changed = !Objects.equals(currentValue, newValue);
@@ -298,294 +459,48 @@ public class EpubMetadataWriter implements MetadataWriter {
             Element newElem = doc.createElementNS(namespaceURI, tagName);
             newElem.setPrefix("dc");
             newElem.setTextContent(newValue);
+            for (Node attr : preservedAttributes) {
+                if (attr.getNamespaceURI() != null) {
+                    newElem.setAttributeNS(attr.getNamespaceURI(), attr.getNodeName(), attr.getNodeValue());
+                } else {
+                    newElem.setAttribute(attr.getNodeName(), attr.getNodeValue());
+                }
+            }
             parent.appendChild(newElem);
-        } else if (restoreMode) {
-            changed = true;
         }
 
         return changed;
     }
 
-
-    public void replaceCoverImageFromBytes(BookEntity bookEntity, byte[] file) {
-        if (!shouldSaveMetadataToFile(bookEntity.getFullFilePath().toFile())) {
-            return;
-        }
-        if (file == null || file.length == 0) {
-            log.warn("Cover update failed: empty or null byte array.");
-            return;
-        }
-
-        replaceCoverImageInternal(bookEntity, file, "byte array");
-    }
-
-    public void replaceCoverImageFromUpload(BookEntity bookEntity, MultipartFile multipartFile) {
-        if (!shouldSaveMetadataToFile(bookEntity.getFullFilePath().toFile())) {
-            return;
-        }
-        if (multipartFile == null || multipartFile.isEmpty()) {
-            log.warn("Cover upload failed: empty or null file.");
-            return;
-        }
-
-        try {
-            byte[] coverData = multipartFile.getBytes();
-            replaceCoverImageInternal(bookEntity, coverData, "upload");
-        } catch (IOException e) {
-            log.warn("Failed to read uploaded cover image: {}", e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public void replaceCoverImageFromUrl(BookEntity bookEntity, String url) {
-        if (!shouldSaveMetadataToFile(bookEntity.getFullFilePath().toFile())) {
-            return;
-        }
-        if (url == null || url.isBlank()) {
-            log.warn("Cover update via URL failed: empty or null URL.");
-            return;
-        }
-
-        byte[] coverData = loadImage(url);
-        if (coverData == null) {
-            log.warn("Failed to load image from URL: {}", url);
-            return;
-        }
-
-        replaceCoverImageInternal(bookEntity, coverData, "URL");
-    }
-
-    private void replaceCoverImageInternal(BookEntity bookEntity, byte[] coverData, String source) {
-        Path tempDir = null;
-        try {
-            File epubFile = new File(bookEntity.getFullFilePath().toUri());
-            tempDir = Files.createTempDirectory("epub_cover_" + UUID.randomUUID());
-
-            extractZipToDirectory(epubFile, tempDir);
-
-            File opfFile = findOpfFile(tempDir.toFile());
-            if (opfFile == null) {
-                log.warn("OPF file not found in EPUB: {}", epubFile.getName());
-                return;
+    private void removeElementsByTagNameNS(Element parent) {
+        NodeList nodes = parent.getElementsByTagNameNS(EpubMetadataWriter.DC_NS, "subject");
+        for (int i = nodes.getLength() - 1; i >= 0; i--) {
+            Element subject = (Element) nodes.item(i);
+            String id = subject.getAttribute("id");
+            if (StringUtils.isNotBlank(id)) {
+                removeMetaByRefines(parent, "#" + id);
             }
-
-            DocumentBuilder builder = SecureXmlUtils.createSecureDocumentBuilder(true);
-            Document opfDoc = builder.parse(opfFile);
-
-            applyCoverImageToEpub(tempDir, opfDoc, coverData);
-
-            removeEmptyTextNodes(opfDoc);
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-            transformer.transform(new DOMSource(opfDoc), new StreamResult(opfFile));
-
-            File tempEpub = new File(epubFile.getParentFile(), epubFile.getName() + ".tmp");
-            createEpubZipFromDirectory(tempDir, tempEpub.toPath());
-
-            if (!epubFile.delete()) throw new IOException("Could not delete original EPUB");
-            if (!tempEpub.renameTo(epubFile)) throw new IOException("Could not rename temp EPUB");
-
-            log.info("Cover image updated in EPUB from {}: {}", source, epubFile.getName());
-
-        } catch (Exception e) {
-            log.warn("Failed to update EPUB cover image from {}: {}", source, e.getMessage(), e);
-        } finally {
-            if (tempDir != null) {
-                deleteDirectoryRecursively(tempDir);
-            }
+            parent.removeChild(subject);
         }
     }
 
-    @Override
-    public BookFileType getSupportedBookType() {
-        return BookFileType.EPUB;
-    }
-
-    private void applyCoverImageToEpub(Path tempDir, Document opfDoc, byte[] coverData) throws IOException {
-        NodeList manifestList = opfDoc.getElementsByTagNameNS(OPF_NS, "manifest");
-        if (manifestList.getLength() == 0) {
-            throw new IOException("No <manifest> element found in OPF document.");
-        }
-
-        Element manifest = (Element) manifestList.item(0);
-        Element existingCoverItem = null;
-
-        // First, try to find cover via metadata reference (EPUB 3 style)
-        NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
-        if (metadataList.getLength() > 0) {
-            Element metadataElement = (Element) metadataList.item(0);
-            String coverItemId = getMetaContentByName(metadataElement, "cover");
-
-            if (coverItemId != null && !coverItemId.isBlank()) {
-                // Find the item with this id
-                NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
-                for (int i = 0; i < items.getLength(); i++) {
-                    Element item = (Element) items.item(i);
-                    if (coverItemId.equals(item.getAttribute("id"))) {
-                        existingCoverItem = item;
-                        break;
-                    }
-                }
-            }
-        }
-
-        // If not found, try looking for properties="cover-image" (EPUB 3)
-        if (existingCoverItem == null) {
-            NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
-            for (int i = 0; i < items.getLength(); i++) {
-                Element item = (Element) items.item(i);
-                String properties = item.getAttribute("properties");
-                if (properties != null && properties.contains("cover-image")) {
-                    existingCoverItem = item;
-                    break;
-                }
-            }
-        }
-
-        // If still not found, try common id values (EPUB 2 fallback)
-        if (existingCoverItem == null) {
-            NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
-            for (int i = 0; i < items.getLength(); i++) {
-                Element item = (Element) items.item(i);
-                String itemId = item.getAttribute("id");
-                if ("cover-image".equals(itemId) || "cover".equals(itemId) || "coverimg".equals(itemId)) {
-                    existingCoverItem = item;
-                    break;
-                }
-            }
-        }
-
-        if (existingCoverItem == null) {
-            throw new IOException("No cover item found in manifest");
-        }
-
-        String coverHref = existingCoverItem.getAttribute("href");
-        String decodedCoverHref = URLDecoder.decode(coverHref, StandardCharsets.UTF_8);
-        if (decodedCoverHref == null || decodedCoverHref.isBlank()) {
-            throw new IOException("Cover item has no href attribute");
-        }
-
-        Path opfPath;
-        try {
-            opfPath = findOpfPath(tempDir);
-        } catch (ParserConfigurationException | SAXException e) {
-            throw new IOException("Failed to parse container.xml to locate OPF path", e);
-        }
-
-        Path opfDir = opfPath.getParent();
-        Path coverFilePath = opfDir.resolve(decodedCoverHref).normalize();
-
-        Files.createDirectories(coverFilePath.getParent());
-        Files.write(coverFilePath, coverData);
-    }
-
-    private Path findOpfPath(Path tempDir) throws IOException, ParserConfigurationException, SAXException {
-        Path containerXml = tempDir.resolve("META-INF/container.xml");
-        if (!Files.exists(containerXml)) {
-            throw new IOException("container.xml not found at expected location: " + containerXml);
-        }
-
-        DocumentBuilder builder = SecureXmlUtils.createSecureDocumentBuilder(false);
-        Document containerDoc = builder.parse(containerXml.toFile());
-        Node rootfile = containerDoc.getElementsByTagName("rootfile").item(0);
-        if (rootfile == null) {
-            throw new IOException("No <rootfile> found in container.xml");
-        }
-
-        String opfPath = ((Element) rootfile).getAttribute("full-path");
-        if (opfPath.isBlank()) {
-            throw new IOException("Missing or empty 'full-path' attribute in <rootfile>");
-        }
-
-        return tempDir.resolve(opfPath).normalize();
-    }
-
-    private File findOpfFile(File rootDir) {
-        File[] matches = rootDir.listFiles(path -> path.isFile() && path.getName().endsWith(".opf"));
-        if (matches != null && matches.length > 0) return matches[0];
-        for (File file : Objects.requireNonNull(rootDir.listFiles())) {
-            if (file.isDirectory()) {
-                File child = findOpfFile(file);
-                if (child != null) return child;
-            }
-        }
-        return null;
-    }
-
-    private byte[] loadImage(String pathOrUrl) {
-        try (InputStream stream = pathOrUrl.startsWith("http") ? URI.create(pathOrUrl).toURL().openStream() : new FileInputStream(pathOrUrl)) {
-            return stream.readAllBytes();
-        } catch (IOException e) {
-            log.warn("Failed to load image from {}: {}", pathOrUrl, e.getMessage());
-            return null;
-        }
-    }
-
-    private void extractZipToDirectory(File zipSource, Path targetDir) throws IOException {
-        try (EpubContainer container = EpubContainers.open(zipSource.toPath())) {
-            for (String name : container.listAllFiles()) {
-                Path entryPath = targetDir.resolve(name).normalize();
-                if (!entryPath.startsWith(targetDir)) {
-                    throw new IOException("ZIP entry outside target directory: " + name);
-                }
-                Files.createDirectories(entryPath.getParent());
-                try (OutputStream out = Files.newOutputStream(entryPath)) {
-                    container.streamTo(name, out);
-                }
-            }
-        }
-    }
-
-    private void createEpubZipFromDirectory(Path sourceDir, Path targetZip) throws IOException {
-        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(targetZip))) {
-            // EPUB spec requires mimetype to be the first entry in the ZIP, uncompressed (STORED)
-            Path mimetypeFile = sourceDir.resolve("mimetype");
-            if (Files.exists(mimetypeFile)) {
-                byte[] mimetypeData = Files.readAllBytes(mimetypeFile);
-                ZipEntry mimetypeEntry = new ZipEntry("mimetype");
-                mimetypeEntry.setMethod(ZipEntry.STORED);
-                mimetypeEntry.setSize(mimetypeData.length);
-                mimetypeEntry.setCompressedSize(mimetypeData.length);
-                CRC32 crc = new CRC32();
-                crc.update(mimetypeData);
-                mimetypeEntry.setCrc(crc.getValue());
-                zos.putNextEntry(mimetypeEntry);
-                zos.write(mimetypeData);
-                zos.closeEntry();
-            } else {
-                log.warn("EPUB mimetype file not found in extracted directory — output may be spec-invalid");
-            }
-
-            try (var pathStream = Files.walk(sourceDir)) {
-                pathStream
-                    .filter(path -> !path.equals(sourceDir))
-                    .filter(path -> !path.equals(mimetypeFile))
-                    .sorted()
-                    .forEach(path -> {
-                        try {
-                            String relativePath = sourceDir.relativize(path).toString().replace(File.separatorChar, '/');
-                            if (Files.isDirectory(path)) {
-                                zos.putNextEntry(new ZipEntry(relativePath + "/"));
-                                zos.closeEntry();
-                            } else {
-                                zos.putNextEntry(new ZipEntry(relativePath));
-                                Files.copy(path, zos);
-                                zos.closeEntry();
-                            }
-                        } catch (IOException e) {
-                            throw new java.io.UncheckedIOException(e);
-                        }
-                    });
-            }
-        }
-    }
-
-    private void removeMetaByName(Element metadataElement, String name) {
+    /** Removes {@code <meta name="calibre:timestamp" .../>} elements from metadata. */
+    private void removeCalibreTimestampMeta(Element metadataElement) {
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
         for (int i = metas.getLength() - 1; i >= 0; i--) {
             Element meta = (Element) metas.item(i);
-            if (name.equals(meta.getAttribute("name"))) {
+            if ("calibre:timestamp".equals(meta.getAttribute("name"))) {
+                metadataElement.removeChild(meta);
+            }
+        }
+    }
+
+    /** Removes {@code <meta property="dcterms:modified" .../>} elements from metadata. */
+    private void removeDctermsModifiedMeta(Element metadataElement) {
+        NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
+        for (int i = metas.getLength() - 1; i >= 0; i--) {
+            Element meta = (Element) metas.item(i);
+            if ("dcterms:modified".equals(meta.getAttribute("property"))) {
                 metadataElement.removeChild(meta);
             }
         }
@@ -601,47 +516,38 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
     }
 
-    private Element createMetaElement(Document doc, String name, String content) {
-        Element meta = doc.createElementNS(doc.getDocumentElement().getNamespaceURI(), "meta");
-        meta.setAttribute("name", name);
-        meta.setAttribute("content", content);
-        return meta;
+    private Element findMetaElement(Element metadataElement, Predicate<Element> filter) {
+        NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
+        for (int i = 0; i < metas.getLength(); i++) {
+            Element meta = (Element) metas.item(i);
+            if (filter.test(meta)) return meta;
+        }
+        return null;
     }
 
-    private void removeIdentifierByScheme(Element metadataElement, String scheme) {
-        NodeList identifiers = metadataElement.getElementsByTagNameNS("*", "identifier");
-        for (int i = identifiers.getLength() - 1; i >= 0; i--) {
-            Element idElement = (Element) identifiers.item(i);
-            if (scheme.equalsIgnoreCase(idElement.getAttributeNS(OPF_NS, "scheme"))) {
-                metadataElement.removeChild(idElement);
-            }
-        }
+    private String getMetaContentByName(Element metadataElement) {
+        Element meta = findMetaElement(metadataElement, el -> "cover".equals(el.getAttribute("name")));
+        return meta != null ? meta.getAttribute("content") : null;
     }
+
     private void removeIdentifierByUrn(Element metadataElement, String urnScheme) {
         NodeList identifiers = metadataElement.getElementsByTagNameNS("*", "identifier");
         String urnPrefix = "urn:" + urnScheme.toLowerCase() + ":";
-        String oldPrefix = urnScheme.toLowerCase() + ":";
+        String barePrefix = urnScheme.toLowerCase() + ":";
         for (int i = identifiers.getLength() - 1; i >= 0; i--) {
             Element idElement = (Element) identifiers.item(i);
             String content = idElement.getTextContent().trim().toLowerCase();
-            if (content.startsWith(urnPrefix) || content.startsWith(oldPrefix)) {
+            if (content.startsWith(urnPrefix) || content.startsWith(barePrefix)) {
                 metadataElement.removeChild(idElement);
             }
         }
     }
 
     private Element createIdentifierElement(Document doc, String scheme, String value) {
-        Element id = doc.createElementNS("http://purl.org/dc/elements/1.1/", "identifier");
+        Element id = doc.createElementNS(DC_NS, "identifier");
         id.setPrefix("dc");
         id.setTextContent("urn:" + scheme.toLowerCase() + ":" + value);
         return id;
-    }
-
-    private void removeElementsByTagNameNS(Element parent, String namespaceURI, String localName) {
-        NodeList nodes = parent.getElementsByTagNameNS(namespaceURI, localName);
-        for (int i = nodes.getLength() - 1; i >= 0; i--) {
-            parent.removeChild(nodes.item(i));
-        }
     }
 
     private void removeCreatorsByRole(Element metadataElement, String role) {
@@ -651,8 +557,8 @@ public class EpubMetadataWriter implements MetadataWriter {
             String id = creatorElement.getAttribute("id");
             String creatorRole = creatorElement.getAttributeNS(OPF_NS, "role");
             if (StringUtils.isNotBlank(id) && StringUtils.isBlank(creatorRole)) {
-                // Finds any matching role meta tags for this creator ID
-                Element meta = getMetaElementByFilter(metadataElement, el -> ("role".equals(el.getAttribute("property")) && "#".concat(id).equals(el.getAttribute("refines"))));
+                Element meta = findMetaElement(metadataElement,
+                        el -> "role".equals(el.getAttribute("property")) && ("#" + id).equals(el.getAttribute("refines")));
                 if (meta != null) {
                     creatorRole = meta.hasAttribute("content") ? meta.getAttribute("content").trim() : meta.getTextContent().trim();
                 }
@@ -660,231 +566,54 @@ public class EpubMetadataWriter implements MetadataWriter {
             if (role.equalsIgnoreCase(creatorRole)) {
                 metadataElement.removeChild(creatorElement);
                 if (StringUtils.isNotBlank(id)) {
-                    removeMetaByRefines(metadataElement, "#".concat(id));
+                    removeMetaByRefines(metadataElement, "#" + id);
                 }
             }
         }
     }
 
-    private Element createCreatorElement(Document doc, Element metadataElement, String fullName, String fileAs, String role) {
-        Element creator = doc.createElementNS("http://purl.org/dc/elements/1.1/", "creator");
+    private Element createCreatorElement(Document doc, Element metadataElement, String fullName, String fileAs) {
+        Element creator = doc.createElementNS(DC_NS, "creator");
         creator.setPrefix("dc");
         creator.setTextContent(fullName);
 
-        boolean isEpub3 = isEpub3(doc);
-
-        if (isEpub3) {
-            // EPUB3: use <meta refines="#id"> elements instead of opf: attributes
+        if (isEpub3(doc)) {
             String creatorId = "creator-" + UUID.randomUUID().toString().substring(0, 8);
             creator.setAttribute("id", creatorId);
 
             if (fileAs != null) {
                 Element fileAsMeta = doc.createElementNS(OPF_NS, "meta");
-                fileAsMeta.setPrefix("opf");
                 fileAsMeta.setAttribute("refines", "#" + creatorId);
                 fileAsMeta.setAttribute("property", "file-as");
                 fileAsMeta.setTextContent(fileAs);
                 metadataElement.appendChild(fileAsMeta);
             }
-            if (role != null) {
-                Element roleMeta = doc.createElementNS(OPF_NS, "meta");
-                roleMeta.setPrefix("opf");
-                roleMeta.setAttribute("refines", "#" + creatorId);
-                roleMeta.setAttribute("property", "role");
-                roleMeta.setAttribute("scheme", "marc:relators");
-                roleMeta.setTextContent(role);
-                metadataElement.appendChild(roleMeta);
-            }
+
+            Element roleMeta = doc.createElementNS(OPF_NS, "meta");
+            roleMeta.setAttribute("refines", "#" + creatorId);
+            roleMeta.setAttribute("property", "role");
+            roleMeta.setAttribute("scheme", "marc:relators");
+            roleMeta.setTextContent("aut");
+            metadataElement.appendChild(roleMeta);
         } else {
-            // EPUB2: use opf: attributes directly on dc:creator
-            if (fileAs != null) {
-                creator.setAttributeNS(OPF_NS, "opf:file-as", fileAs);
-            }
-            if (role != null) {
-                creator.setAttributeNS(OPF_NS, "opf:role", role);
-            }
+            if (fileAs != null) creator.setAttributeNS(OPF_NS, "opf:file-as", fileAs);
+            creator.setAttributeNS(OPF_NS, "opf:role", "aut");
         }
         return creator;
     }
 
     private Element createSubjectElement(Document doc, String subject) {
-        Element subj = doc.createElementNS("http://purl.org/dc/elements/1.1/", "subject");
+        Element subj = doc.createElementNS(DC_NS, "subject");
         subj.setPrefix("dc");
         subj.setTextContent(subject);
         return subj;
     }
 
-    private Element getMetaElementByFilter(Element metadataElement, java.util.function.Predicate<Element> filter) {
-        NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
-        for (int i = 0; i < metas.getLength(); i++) {
-            Element meta = (Element) metas.item(i);
-            if (filter.test(meta)) {
-                return meta;
-            }
-        }
-        return null;
-    }
-
-    private String getMetaContentByName(Element metadataElement, String name) {
-        Element meta = getMetaElementByFilter(metadataElement, el -> name.equals(el.getAttribute("name")));
-        if (meta != null) {
-            return meta.getAttribute("content");
-        }
-        return null;
-    }
-
-    private void deleteDirectoryRecursively(Path dir) {
-        try (var pathStream = Files.walk(dir)) {
-            pathStream
-                    .sorted(Comparator.reverseOrder())
-                    .forEach(path -> {
-                        try {
-                            Files.delete(path);
-                        } catch (IOException e) {
-                            log.warn("Failed to delete temp file/directory: {}", path, e);
-                        }
-                    });
-        } catch (IOException e) {
-            log.warn("Failed to clean up temporary directory: {}", dir, e);
-        }
-    }
-
-    public boolean shouldSaveMetadataToFile(File epubFile) {
-        MetadataPersistenceSettings.SaveToOriginalFile settings = appSettingService.getAppSettings().getMetadataPersistenceSettings().getSaveToOriginalFile();
-
-        MetadataPersistenceSettings.FormatSettings epubSettings = settings.getEpub();
-        if (epubSettings == null || !epubSettings.isEnabled()) {
-            log.debug("EPUB metadata writing is disabled. Skipping: {}", epubFile.getName());
-            return false;
-        }
-
-        long fileSizeInMb = epubFile.length() / (1024 * 1024);
-        if (fileSizeInMb > epubSettings.getMaxFileSizeInMb()) {
-            log.info("EPUB file {} ({} MB) exceeds max size limit ({} MB). Skipping metadata write.", epubFile.getName(), fileSizeInMb, epubSettings.getMaxFileSizeInMb());
-            return false;
-        }
-
-        return true;
-    }
-
-    private void removeEmptyTextNodes(Document doc) {
-        try {
-            XPath xpath = XPathFactory.newInstance().newXPath();
-            NodeList emptyTextNodes = (NodeList) xpath.evaluate("//text()[normalize-space(.)='']", doc, XPathConstants.NODESET);
-
-            for (int i = 0; i < emptyTextNodes.getLength(); i++) {
-                Node emptyTextNode = emptyTextNodes.item(i);
-                emptyTextNode.getParentNode().removeChild(emptyTextNode);
-            }
-        } catch (Exception e) {
-            log.warn("Failed to remove empty text nodes", e);
-        }
-    }
-
-    private boolean isEpub3(Document doc) {
-        String version = doc.getDocumentElement().getAttribute("version");
-        return version != null && version.trim().startsWith("3");
-    }
-
-    private boolean hasBookloreMetadataChanges(Element metadataElement, BookMetadataEntity metadata) {
-        Map<String, String> existing = new TreeMap<>();
-        NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
-        for (int i = 0; i < metas.getLength(); i++) {
-            Element meta = (Element) metas.item(i);
-            String property = meta.getAttribute("property");
-            String name = meta.getAttribute("name");
-            String key = property.startsWith("booklore:") ? property : (name.startsWith("booklore:") ? name : null);
-            if (key != null) {
-                String value = meta.getAttribute("content").isEmpty() ? meta.getTextContent() : meta.getAttribute("content");
-                if (!isEffectivelyZeroOrBlank(value)) {
-                    existing.put(key, value);
-                }
-            }
-        }
-
-        Map<String, String> expected = new TreeMap<>();
-        if (StringUtils.isNotBlank(metadata.getSubtitle())) {
-            expected.put("booklore:subtitle", metadata.getSubtitle());
-        }
-        if (metadata.getPageCount() != null && metadata.getPageCount() > 0) {
-            expected.put("booklore:page_count", String.valueOf(metadata.getPageCount()));
-        }
-        if (metadata.getSeriesTotal() != null && metadata.getSeriesTotal() > 0) {
-            expected.put("booklore:series_total", String.valueOf(metadata.getSeriesTotal()));
-        }
-        if (metadata.getAmazonRating() != null && metadata.getAmazonRating() > 0) {
-            expected.put("booklore:amazon_rating", String.valueOf(metadata.getAmazonRating()));
-        }
-        if (metadata.getAmazonReviewCount() != null && metadata.getAmazonReviewCount() > 0) {
-            expected.put("booklore:amazon_review_count", String.valueOf(metadata.getAmazonReviewCount()));
-        }
-        if (metadata.getGoodreadsRating() != null && metadata.getGoodreadsRating() > 0) {
-            expected.put("booklore:goodreads_rating", String.valueOf(metadata.getGoodreadsRating()));
-        }
-        if (metadata.getGoodreadsReviewCount() != null && metadata.getGoodreadsReviewCount() > 0) {
-            expected.put("booklore:goodreads_review_count", String.valueOf(metadata.getGoodreadsReviewCount()));
-        }
-        if (metadata.getHardcoverRating() != null && metadata.getHardcoverRating() > 0) {
-            expected.put("booklore:hardcover_rating", String.valueOf(metadata.getHardcoverRating()));
-        }
-        if (metadata.getHardcoverReviewCount() != null && metadata.getHardcoverReviewCount() > 0) {
-            expected.put("booklore:hardcover_review_count", String.valueOf(metadata.getHardcoverReviewCount()));
-        }
-        if (metadata.getLubimyczytacRating() != null && metadata.getLubimyczytacRating() > 0) {
-            expected.put("booklore:lubimyczytac_rating", String.valueOf(metadata.getLubimyczytacRating()));
-        }
-        if (metadata.getRanobedbRating() != null && metadata.getRanobedbRating() > 0) {
-            expected.put("booklore:ranobedb_rating", String.valueOf(metadata.getRanobedbRating()));
-        }
-        if (metadata.getMoods() != null && !metadata.getMoods().isEmpty()) {
-            String moodsJson = "[" + metadata.getMoods().stream()
-                .map(mood -> "\"" + mood.getName().replace("\"", "\\\"") + "\"")
-                .sorted()
-                .collect(Collectors.joining(", ")) + "]";
-            expected.put("booklore:moods", moodsJson);
-        }
-        if (metadata.getTags() != null && !metadata.getTags().isEmpty()) {
-            String tagsJson = "[" + metadata.getTags().stream()
-                .map(tag -> "\"" + tag.getName().replace("\"", "\\\"") + "\"")
-                .sorted()
-                .collect(Collectors.joining(", ")) + "]";
-            expected.put("booklore:tags", tagsJson);
-        }
-        if (metadata.getAgeRating() != null) {
-            expected.put("booklore:age_rating", String.valueOf(metadata.getAgeRating()));
-        }
-        if (StringUtils.isNotBlank(metadata.getContentRating())) {
-            expected.put("booklore:content_rating", metadata.getContentRating());
-        }
-
-        return !existing.equals(expected);
-    }
-
-    private static boolean isEffectivelyZeroOrBlank(String value) {
-        if (value == null || value.isBlank()) return true;
-        try {
-            return Double.parseDouble(value) <= 0;
-        } catch (NumberFormatException e) {
-            return false;
-        }
-    }
-
-    private void removeAllBookloreMetadata(Element metadataElement) {
-        NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
-        for (int i = metas.getLength() - 1; i >= 0; i--) {
-            Element meta = (Element) metas.item(i);
-            String property = meta.getAttribute("property");
-            String name = meta.getAttribute("name");
-            if (property.startsWith("booklore:") || name.startsWith("booklore:")) {
-                metadataElement.removeChild(meta);
-            }
-        }
-    }
-
-    private void replaceBelongsToCollection(Element metadataElement, Document doc, String seriesName, Float seriesNumber, boolean[] hasChanges) {
+    private void replaceBelongsToCollection(Element metadataElement, Document doc,
+                                            String seriesName, Float seriesNumber, boolean[] hasChanges) {
         boolean epub3 = isEpub3(doc);
 
-        // Remove existing EPUB3 collection metas
+        // Remove existing series metadata (both EPUB3 and EPUB2 forms)
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
         for (int i = metas.getLength() - 1; i >= 0; i--) {
             Element meta = (Element) metas.item(i);
@@ -893,75 +622,62 @@ public class EpubMetadataWriter implements MetadataWriter {
             if ("belongs-to-collection".equals(property) || "collection-type".equals(property) || "group-position".equals(property)) {
                 String id = meta.getAttribute("id");
                 metadataElement.removeChild(meta);
-                if (StringUtils.isNotBlank(id)) {
-                    removeMetaByRefines(metadataElement, "#" + id);
-                }
+                if (StringUtils.isNotBlank(id)) removeMetaByRefines(metadataElement, "#" + id);
             }
-            // Also remove EPUB2-style series metas
             if ("calibre:series".equals(name) || "calibre:series_index".equals(name)) {
                 metadataElement.removeChild(meta);
             }
         }
-        
-        if (StringUtils.isNotBlank(seriesName)) {
-            if (epub3) {
-                // EPUB3: use belongs-to-collection with refines
-                String collectionId = "collection-" + UUID.randomUUID().toString().substring(0, 8);
 
-                Element collectionMeta = doc.createElementNS(OPF_NS, "meta");
-                collectionMeta.setPrefix("opf");
-                collectionMeta.setAttribute("id", collectionId);
-                collectionMeta.setAttribute("property", "belongs-to-collection");
-                collectionMeta.setTextContent(seriesName);
-                metadataElement.appendChild(collectionMeta);
+        if (StringUtils.isBlank(seriesName)) return;
 
-                Element typeMeta = doc.createElementNS(OPF_NS, "meta");
-                typeMeta.setPrefix("opf");
-                typeMeta.setAttribute("property", "collection-type");
-                typeMeta.setAttribute("refines", "#" + collectionId);
-                typeMeta.setTextContent("series");
-                metadataElement.appendChild(typeMeta);
+        if (epub3) {
+            String collectionId = "collection-" + UUID.randomUUID().toString().substring(0, 8);
 
-                if (seriesNumber != null && seriesNumber > 0) {
-                    Element positionMeta = doc.createElementNS(OPF_NS, "meta");
-                    positionMeta.setPrefix("opf");
-                    positionMeta.setAttribute("property", "group-position");
-                    positionMeta.setAttribute("refines", "#" + collectionId);
-                    if (seriesNumber % 1.0f == 0) {
-                        positionMeta.setTextContent(String.format("%.0f", seriesNumber));
-                    } else {
-                        positionMeta.setTextContent(String.valueOf(seriesNumber));
-                    }
-                    metadataElement.appendChild(positionMeta);
-                }
-            } else {
-                // EPUB2: use calibre:series convention (widely supported by e-readers)
-                Element seriesMeta = doc.createElementNS(doc.getDocumentElement().getNamespaceURI(), "meta");
-                seriesMeta.setAttribute("name", "calibre:series");
-                seriesMeta.setAttribute("content", seriesName);
-                metadataElement.appendChild(seriesMeta);
+            Element collectionMeta = doc.createElementNS(OPF_NS, "meta");
+            collectionMeta.setAttribute("id", collectionId);
+            collectionMeta.setAttribute("property", "belongs-to-collection");
+            collectionMeta.setTextContent(seriesName);
+            metadataElement.appendChild(collectionMeta);
 
-                if (seriesNumber != null && seriesNumber > 0) {
-                    Element indexMeta = doc.createElementNS(doc.getDocumentElement().getNamespaceURI(), "meta");
-                    indexMeta.setAttribute("name", "calibre:series_index");
-                    if (seriesNumber % 1.0f == 0) {
-                        indexMeta.setAttribute("content", String.format("%.0f", seriesNumber));
-                    } else {
-                        indexMeta.setAttribute("content", String.valueOf(seriesNumber));
-                    }
-                    metadataElement.appendChild(indexMeta);
-                }
+            Element typeMeta = doc.createElementNS(OPF_NS, "meta");
+            typeMeta.setAttribute("property", "collection-type");
+            typeMeta.setAttribute("refines", "#" + collectionId);
+            typeMeta.setTextContent("series");
+            metadataElement.appendChild(typeMeta);
+
+            if (seriesNumber != null && seriesNumber > 0) {
+                Element positionMeta = doc.createElementNS(OPF_NS, "meta");
+                positionMeta.setAttribute("property", "group-position");
+                positionMeta.setAttribute("refines", "#" + collectionId);
+                positionMeta.setTextContent(formatSeriesNumber(seriesNumber));
+                metadataElement.appendChild(positionMeta);
             }
-            
-            hasChanges[0] = true;
+        } else {
+            Element seriesMeta = doc.createElementNS(doc.getDocumentElement().getNamespaceURI(), "meta");
+            seriesMeta.setAttribute("name", "calibre:series");
+            seriesMeta.setAttribute("content", seriesName);
+            metadataElement.appendChild(seriesMeta);
+
+            if (seriesNumber != null && seriesNumber > 0) {
+                Element indexMeta = doc.createElementNS(doc.getDocumentElement().getNamespaceURI(), "meta");
+                indexMeta.setAttribute("name", "calibre:series_index");
+                indexMeta.setAttribute("content", formatSeriesNumber(seriesNumber));
+                metadataElement.appendChild(indexMeta);
+            }
         }
+
+        hasChanges[0] = true;
+    }
+
+    private static String formatSeriesNumber(float seriesNumber) {
+        return seriesNumber % 1.0f == 0 ? String.format("%.0f", seriesNumber) : String.valueOf(seriesNumber);
     }
 
     private void addSubtitleToTitle(Element metadataElement, Document doc, String subtitle) {
-        final String DC_NS = "http://purl.org/dc/elements/1.1/";
         boolean epub3 = isEpub3(doc);
 
-        // Remove existing subtitle elements (both EPUB2 and EPUB3 forms)
+        // Remove existing subtitle elements
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
         for (int i = metas.getLength() - 1; i >= 0; i--) {
             Element meta = (Element) metas.item(i);
@@ -983,7 +699,6 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
 
         if (epub3) {
-            // EPUB3: add subtitle as separate dc:title with title-type refinement
             String subtitleId = "subtitle-" + UUID.randomUUID().toString().substring(0, 8);
             Element subtitleElement = doc.createElementNS(DC_NS, "title");
             subtitleElement.setPrefix("dc");
@@ -992,14 +707,11 @@ public class EpubMetadataWriter implements MetadataWriter {
             metadataElement.appendChild(subtitleElement);
 
             Element typeMeta = doc.createElementNS(OPF_NS, "meta");
-            typeMeta.setPrefix("opf");
             typeMeta.setAttribute("refines", "#" + subtitleId);
             typeMeta.setAttribute("property", "title-type");
             typeMeta.setTextContent("subtitle");
             metadataElement.appendChild(typeMeta);
         }
-        // EPUB2: subtitle is stored only via booklore:subtitle metadata (written in addBookloreMetadata).
-        // No modification to dc:title is needed — this preserves round-trip fidelity.
     }
 
     private void addBookloreMetadata(Element metadataElement, Document doc, BookMetadataEntity metadata) {
@@ -1011,94 +723,72 @@ public class EpubMetadataWriter implements MetadataWriter {
             String bookloreNamespace = "booklore: http://booklore.org/metadata/1.0/";
 
             if (!existingPrefix.contains("booklore:")) {
-                if (existingPrefix.isEmpty()) {
-                    packageElement.setAttribute("prefix", bookloreNamespace);
-                } else {
-                    packageElement.setAttribute("prefix", existingPrefix.trim() + " " + bookloreNamespace);
-                }
+                packageElement.setAttribute("prefix",
+                        existingPrefix.isEmpty() ? bookloreNamespace : existingPrefix.trim() + " " + bookloreNamespace);
             }
+
+            removeDctermsModifiedMeta(metadataElement);
+            removeCalibreTimestampMeta(metadataElement);
+
+            Element modified = doc.createElementNS(OPF_NS, "meta");
+            modified.setAttribute("property", "dcterms:modified");
+            modified.setTextContent(ZonedDateTime.now().format(EPUB_DATE_FORMATTER));
+            metadataElement.appendChild(modified);
         }
-        
+
         removeAllBookloreMetadata(metadataElement);
-        
-        if (StringUtils.isNotBlank(metadata.getSubtitle())) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "subtitle", metadata.getSubtitle(), epub3));
-        }
-        
-        if (metadata.getPageCount() != null && metadata.getPageCount() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "page_count", String.valueOf(metadata.getPageCount()), epub3));
-        }
-        
-        if (metadata.getSeriesTotal() != null && metadata.getSeriesTotal() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "series_total", String.valueOf(metadata.getSeriesTotal()), epub3));
-        }
-        
-        if (metadata.getAmazonRating() != null && metadata.getAmazonRating() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "amazon_rating", String.valueOf(metadata.getAmazonRating()), epub3));
-        }
-        
-        if (metadata.getAmazonReviewCount() != null && metadata.getAmazonReviewCount() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "amazon_review_count", String.valueOf(metadata.getAmazonReviewCount()), epub3));
-        }
-        
-        if (metadata.getGoodreadsRating() != null && metadata.getGoodreadsRating() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "goodreads_rating", String.valueOf(metadata.getGoodreadsRating()), epub3));
-        }
-        
-        if (metadata.getGoodreadsReviewCount() != null && metadata.getGoodreadsReviewCount() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "goodreads_review_count", String.valueOf(metadata.getGoodreadsReviewCount()), epub3));
-        }
-        
-        if (metadata.getHardcoverRating() != null && metadata.getHardcoverRating() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "hardcover_rating", String.valueOf(metadata.getHardcoverRating()), epub3));
-        }
-        
-        if (metadata.getHardcoverReviewCount() != null && metadata.getHardcoverReviewCount() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "hardcover_review_count", String.valueOf(metadata.getHardcoverReviewCount()), epub3));
-        }
-        
-        if (metadata.getLubimyczytacRating() != null && metadata.getLubimyczytacRating() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "lubimyczytac_rating", String.valueOf(metadata.getLubimyczytacRating()), epub3));
-        }
-        
-        if (metadata.getRanobedbRating() != null && metadata.getRanobedbRating() > 0) {
-            metadataElement.appendChild(createBookloreMetaElement(doc, "ranobedb_rating", String.valueOf(metadata.getRanobedbRating()), epub3));
-        }
-        
+
+        appendBookloreMeta(metadataElement, doc, epub3, "subtitle", metadata.getSubtitle());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "page_count", metadata.getPageCount());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "series_total", metadata.getSeriesTotal());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "amazon_rating", metadata.getAmazonRating());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "amazon_review_count", metadata.getAmazonReviewCount());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "goodreads_rating", metadata.getGoodreadsRating());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "goodreads_review_count", metadata.getGoodreadsReviewCount());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "hardcover_rating", metadata.getHardcoverRating());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "hardcover_review_count", metadata.getHardcoverReviewCount());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "lubimyczytac_rating", metadata.getLubimyczytacRating());
+        appendBookloreMetaPositive(metadataElement, doc, epub3, "ranobedb_rating", metadata.getRanobedbRating());
+
         if (metadata.getMoods() != null && !metadata.getMoods().isEmpty()) {
-            String moodsJson = "[" + metadata.getMoods().stream()
-                .map(mood -> "\"" + mood.getName().replace("\"", "\\\"") + "\"")
-                .sorted()
-                .collect(Collectors.joining(", ")) + "]";
-            metadataElement.appendChild(createBookloreMetaElement(doc, "moods", moodsJson, epub3));
+            String json = "[" + metadata.getMoods().stream()
+                    .map(m -> "\"" + m.getName().replace("\"", "\\\"") + "\"")
+                    .sorted().collect(Collectors.joining(", ")) + "]";
+            metadataElement.appendChild(createBookloreMetaElement(doc, "moods", json, epub3));
         }
-
         if (metadata.getTags() != null && !metadata.getTags().isEmpty()) {
-            String tagsJson = "[" + metadata.getTags().stream()
-                .map(tag -> "\"" + tag.getName().replace("\"", "\\\"") + "\"")
-                .sorted()
-                .collect(Collectors.joining(", ")) + "]";
-            metadataElement.appendChild(createBookloreMetaElement(doc, "tags", tagsJson, epub3));
+            String json = "[" + metadata.getTags().stream()
+                    .map(t -> "\"" + t.getName().replace("\"", "\\\"") + "\"")
+                    .sorted().collect(Collectors.joining(", ")) + "]";
+            metadataElement.appendChild(createBookloreMetaElement(doc, "tags", json, epub3));
         }
-
         if (metadata.getAgeRating() != null) {
             metadataElement.appendChild(createBookloreMetaElement(doc, "age_rating", String.valueOf(metadata.getAgeRating()), epub3));
         }
-
         if (StringUtils.isNotBlank(metadata.getContentRating())) {
             metadataElement.appendChild(createBookloreMetaElement(doc, "content_rating", metadata.getContentRating(), epub3));
+        }
+    }
+
+    private void appendBookloreMeta(Element metadataElement, Document doc, boolean epub3, String property, String value) {
+        if (StringUtils.isNotBlank(value)) {
+            metadataElement.appendChild(createBookloreMetaElement(doc, property, value, epub3));
+        }
+    }
+
+    private void appendBookloreMetaPositive(Element metadataElement, Document doc, boolean epub3, String property, Number value) {
+        if (value != null && value.doubleValue() > 0) {
+            metadataElement.appendChild(createBookloreMetaElement(doc, property, String.valueOf(value), epub3));
         }
     }
 
     private Element createBookloreMetaElement(Document doc, String property, String value, boolean epub3) {
         if (epub3) {
             Element meta = doc.createElementNS(OPF_NS, "meta");
-            meta.setPrefix("opf");
             meta.setAttribute("property", "booklore:" + property);
             meta.setTextContent(value);
             return meta;
         } else {
-            // EPUB2: use name/content attribute form
             Element meta = doc.createElementNS(doc.getDocumentElement().getNamespaceURI(), "meta");
             meta.setAttribute("name", "booklore:" + property);
             meta.setAttribute("content", value);
@@ -1106,25 +796,85 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
     }
 
+    private void removeAllBookloreMetadata(Element metadataElement) {
+        NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
+        for (int i = metas.getLength() - 1; i >= 0; i--) {
+            Element meta = (Element) metas.item(i);
+            if (meta.getAttribute("property").startsWith("booklore:") || meta.getAttribute("name").startsWith("booklore:")) {
+                metadataElement.removeChild(meta);
+            }
+        }
+    }
+
+    private boolean hasBookloreMetadataChanges(Element metadataElement, BookMetadataEntity metadata) {
+        Map<String, String> existing = new TreeMap<>();
+        NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
+        for (int i = 0; i < metas.getLength(); i++) {
+            Element meta = (Element) metas.item(i);
+            String property = meta.getAttribute("property");
+            String name = meta.getAttribute("name");
+            String key = property.startsWith("booklore:") ? property : (name.startsWith("booklore:") ? name : null);
+            if (key != null) {
+                String value = meta.getAttribute("content").isEmpty() ? meta.getTextContent() : meta.getAttribute("content");
+                if (!isEffectivelyZeroOrBlank(value)) existing.put(key, value);
+            }
+        }
+
+        Map<String, String> expected = new TreeMap<>();
+        if (StringUtils.isNotBlank(metadata.getSubtitle())) expected.put("booklore:subtitle", metadata.getSubtitle());
+        if (metadata.getPageCount() != null && metadata.getPageCount() > 0) expected.put("booklore:page_count", String.valueOf(metadata.getPageCount()));
+        if (metadata.getSeriesTotal() != null && metadata.getSeriesTotal() > 0) expected.put("booklore:series_total", String.valueOf(metadata.getSeriesTotal()));
+        if (metadata.getAmazonRating() != null && metadata.getAmazonRating() > 0) expected.put("booklore:amazon_rating", String.valueOf(metadata.getAmazonRating()));
+        if (metadata.getAmazonReviewCount() != null && metadata.getAmazonReviewCount() > 0) expected.put("booklore:amazon_review_count", String.valueOf(metadata.getAmazonReviewCount()));
+        if (metadata.getGoodreadsRating() != null && metadata.getGoodreadsRating() > 0) expected.put("booklore:goodreads_rating", String.valueOf(metadata.getGoodreadsRating()));
+        if (metadata.getGoodreadsReviewCount() != null && metadata.getGoodreadsReviewCount() > 0) expected.put("booklore:goodreads_review_count", String.valueOf(metadata.getGoodreadsReviewCount()));
+        if (metadata.getHardcoverRating() != null && metadata.getHardcoverRating() > 0) expected.put("booklore:hardcover_rating", String.valueOf(metadata.getHardcoverRating()));
+        if (metadata.getHardcoverReviewCount() != null && metadata.getHardcoverReviewCount() > 0) expected.put("booklore:hardcover_review_count", String.valueOf(metadata.getHardcoverReviewCount()));
+        if (metadata.getLubimyczytacRating() != null && metadata.getLubimyczytacRating() > 0) expected.put("booklore:lubimyczytac_rating", String.valueOf(metadata.getLubimyczytacRating()));
+        if (metadata.getRanobedbRating() != null && metadata.getRanobedbRating() > 0) expected.put("booklore:ranobedb_rating", String.valueOf(metadata.getRanobedbRating()));
+        if (metadata.getMoods() != null && !metadata.getMoods().isEmpty()) {
+            String json = "[" + metadata.getMoods().stream()
+                    .map(m -> "\"" + m.getName().replace("\"", "\\\"") + "\"")
+                    .sorted().collect(Collectors.joining(", ")) + "]";
+            expected.put("booklore:moods", json);
+        }
+        if (metadata.getTags() != null && !metadata.getTags().isEmpty()) {
+            String json = "[" + metadata.getTags().stream()
+                    .map(t -> "\"" + t.getName().replace("\"", "\\\"") + "\"")
+                    .sorted().collect(Collectors.joining(", ")) + "]";
+            expected.put("booklore:tags", json);
+        }
+        if (metadata.getAgeRating() != null) expected.put("booklore:age_rating", String.valueOf(metadata.getAgeRating()));
+        if (StringUtils.isNotBlank(metadata.getContentRating())) expected.put("booklore:content_rating", metadata.getContentRating());
+
+        return !existing.equals(expected);
+    }
+
+    private static boolean isEffectivelyZeroOrBlank(String value) {
+        if (value == null || value.isBlank()) return true;
+        try {
+            return Double.parseDouble(value) <= 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+
     private void cleanupCalibreArtifacts(Element metadataElement, Document doc) {
         Element packageElement = doc.getDocumentElement();
         if (packageElement.hasAttribute("prefix")) {
             String prefix = packageElement.getAttribute("prefix");
             if (prefix.contains("calibre:")) {
-                prefix = prefix.replaceAll("calibre:\\s*https?://[^\\s]+", "").trim();
-                if (prefix.isEmpty()) {
-                    packageElement.removeAttribute("prefix");
-                } else {
-                    packageElement.setAttribute("prefix", prefix);
-                }
+                prefix = PREFIX.matcher(prefix).replaceAll("").trim();
+                if (prefix.isEmpty()) packageElement.removeAttribute("prefix");
+                else packageElement.setAttribute("prefix", prefix);
             }
         }
-        
+
         if (metadataElement.hasAttribute("xmlns:calibre")) {
             metadataElement.removeAttribute("xmlns:calibre");
         }
-        
-        final String DC_NS = "http://purl.org/dc/elements/1.1/";
+
         NodeList identifiers = metadataElement.getElementsByTagNameNS(DC_NS, "identifier");
         for (int i = identifiers.getLength() - 1; i >= 0; i--) {
             Element idElement = (Element) identifiers.item(i);
@@ -1133,26 +883,22 @@ public class EpubMetadataWriter implements MetadataWriter {
                 metadataElement.removeChild(idElement);
             }
         }
-        
+
         NodeList contributors = metadataElement.getElementsByTagNameNS(DC_NS, "contributor");
         for (int i = contributors.getLength() - 1; i >= 0; i--) {
             Element contributor = (Element) contributors.item(i);
-            String text = contributor.getTextContent().toLowerCase();
-            if (text.contains("calibre")) {
+            if (contributor.getTextContent().toLowerCase().contains("calibre")) {
                 String id = contributor.getAttribute("id");
                 metadataElement.removeChild(contributor);
-                if (StringUtils.isNotBlank(id)) {
-                    removeMetaByRefines(metadataElement, "#" + id);
-                }
+                if (StringUtils.isNotBlank(id)) removeMetaByRefines(metadataElement, "#" + id);
             }
         }
-        
+
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
         for (int i = metas.getLength() - 1; i >= 0; i--) {
             Element meta = (Element) metas.item(i);
             String property = meta.getAttribute("property");
             String name = meta.getAttribute("name");
-            
             boolean isCalibreSeries = !isEpub3(doc) && ("calibre:series".equals(name) || "calibre:series_index".equals(name));
             if (!isCalibreSeries && (property.startsWith("calibre:") || name.startsWith("calibre:"))) {
                 metadataElement.removeChild(meta);
@@ -1160,74 +906,334 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
     }
 
+    private String normalizeLanguage(String lang) {
+        if (lang == null || lang.isBlank()) return lang;
+
+        String trimmed = lang.trim();
+
+        String code = LANGUAGE_NAME_TO_CODE.get(trimmed.toLowerCase());
+        if (code != null) return code;
+
+        Locale tagLocale = Locale.forLanguageTag(trimmed);
+        String tagLang = tagLocale.getLanguage();
+        if (!tagLang.isEmpty() && ISO_LANGUAGES.contains(tagLang.toLowerCase())) {
+            return tagLocale.toLanguageTag();
+        }
+
+        return trimmed;
+    }
+
+    public boolean shouldSaveMetadataToFile(File epubFile) {
+        MetadataPersistenceSettings.SaveToOriginalFile settings =
+                appSettingService.getAppSettings().getMetadataPersistenceSettings().getSaveToOriginalFile();
+        MetadataPersistenceSettings.FormatSettings epubSettings = settings.getEpub();
+        if (epubSettings == null || !epubSettings.isEnabled()) {
+            log.debug("EPUB metadata writing is disabled. Skipping: {}", epubFile.getName());
+            return false;
+        }
+        long fileSizeInMb = epubFile.length() / (1024 * 1024);
+        if (fileSizeInMb > epubSettings.getMaxFileSizeInMb()) {
+            log.info("EPUB file {} ({} MB) exceeds max size limit ({} MB). Skipping.",
+                    epubFile.getName(), fileSizeInMb, epubSettings.getMaxFileSizeInMb());
+            return false;
+        }
+        return true;
+    }
+
+    byte[] loadImage(String url) {
+        if (url == null || url.isBlank()) return null;
+
+        URI uri;
+        try {
+            uri = URI.create(url);
+        } catch (IllegalArgumentException e) {
+            log.warn("Rejected malformed cover URL: {}", e.getMessage());
+            return null;
+        }
+
+        String scheme = uri.getScheme();
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            log.warn("Rejected cover URL with disallowed scheme: {}", scheme);
+            return null;
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            log.warn("Rejected cover URL with missing host");
+            return null;
+        }
+        InetAddress resolvedAddress;
+        try {
+            resolvedAddress = InetAddress.getByName(host);
+            if (resolvedAddress.isLoopbackAddress() || resolvedAddress.isLinkLocalAddress() || resolvedAddress.isSiteLocalAddress()) {
+                log.warn("Rejected cover URL targeting private/internal address for host: {}", host);
+                return null;
+            }
+        } catch (Exception e) {
+            log.warn("Rejected cover URL — hostname could not be resolved: {}", host);
+            return null;
+        }
+        URI safeUri;
+        try {
+            safeUri = new URI(
+                    scheme.toLowerCase(),
+                    null,
+                    resolvedAddress.getHostAddress(),
+                    uri.getPort(),
+                    uri.getPath(),
+                    uri.getQuery(),
+                    null
+            );
+        } catch (Exception e) {
+            log.warn("Rejected cover URL — could not reconstruct safe URI: {}", e.getMessage());
+            return null;
+        }
+
+        try {
+            return coverRestTemplate.execute(safeUri, HttpMethod.GET, null, response -> {
+                MediaType contentType = response.getHeaders().getContentType();
+                if (contentType == null || !contentType.getType().equalsIgnoreCase("image")) {
+                    log.warn("Rejected cover response with non-image Content-Type: {}", contentType);
+                    return null;
+                }
+                try (InputStream in = response.getBody()) {
+                    byte[] data = in.readNBytes(MAX_COVER_BYTES + 1);
+                    if (data.length > MAX_COVER_BYTES) {
+                        log.warn("Rejected cover response exceeding {} MiB size cap", MAX_COVER_BYTES / (1024 * 1024));
+                        return null;
+                    }
+                    return data;
+                }
+            });
+        } catch (Exception e) {
+            log.warn("Failed to fetch cover image from URL: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private String detectMediaType(byte[] data) {
+        if (data == null || data.length == 0) return null;
+        try {
+            String mimeType = MimeDetector.detect(new ByteArrayInputStream(data));
+            if (mimeType != null && SUPPORTED_EPUB_IMAGE_TYPES.contains(mimeType)) return mimeType;
+        } catch (IOException e) {
+            log.warn("Failed to detect media type: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private Element getMetadataElement(Document opfDoc) {
+        NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
+        return metadataList.getLength() > 0 ? (Element) metadataList.item(0) : null;
+    }
+
+    private boolean isEpub3(Document doc) {
+        String version = doc.getDocumentElement().getAttribute("version");
+        return !version.trim().isEmpty() && version.trim().charAt(0) == '3';
+    }
+
+    private void removeEmptyTextNodes(Document doc) {
+        try {
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            NodeList emptyTextNodes = (NodeList) xpath.evaluate("//text()[normalize-space(.)='']", doc, XPathConstants.NODESET);
+            for (int i = 0; i < emptyTextNodes.getLength(); i++) {
+                Node node = emptyTextNodes.item(i);
+                node.getParentNode().removeChild(node);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to remove empty text nodes", e);
+        }
+    }
+
+    private boolean hasOrphanedRefines(Element metadataElement) {
+        Set<String> ids = new HashSet<>();
+        NodeList children = metadataElement.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            if (children.item(i).getNodeType() != Node.ELEMENT_NODE) continue;
+            String id = ((Element) children.item(i)).getAttribute("id");
+            if (!id.isEmpty()) ids.add(id);
+        }
+        for (int i = 0; i < children.getLength(); i++) {
+            if (children.item(i).getNodeType() != Node.ELEMENT_NODE) continue;
+            Element elem = (Element) children.item(i);
+            if (!"meta".equals(elem.getLocalName())) continue;
+            String refines = elem.getAttribute("refines");
+            if (!refines.isEmpty() && refines.charAt(0) == '#' && !ids.contains(refines.substring(1))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean fixCoverMediaTypeMismatch(File epubFile) {
+        String actualType;
+        String declaredType;
+
+        try (ZipFile zip = new ZipFile(epubFile)) {
+            ZipEntry containerEntry = zip.getEntry("META-INF/container.xml");
+            if (containerEntry == null) return false;
+
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DocumentBuilder db = dbf.newDocumentBuilder();
+
+            Document containerDoc;
+            try (InputStream is = zip.getInputStream(containerEntry)) {
+                containerDoc = db.parse(is);
+            }
+            NodeList rootfiles = containerDoc.getElementsByTagName("rootfile");
+            if (rootfiles.getLength() == 0) return false;
+            String opfPath = ((Element) rootfiles.item(0)).getAttribute("full-path");
+            if (opfPath == null || opfPath.isEmpty()) return false;
+
+            ZipEntry opfEntry = zip.getEntry(opfPath);
+            if (opfEntry == null) return false;
+            Document opfDoc;
+            try (InputStream is = zip.getInputStream(opfEntry)) {
+                opfDoc = db.parse(is);
+            }
+
+            NodeList manifestList = opfDoc.getElementsByTagNameNS(OPF_NS, "manifest");
+            if (manifestList.getLength() == 0) return false;
+            Element manifest = (Element) manifestList.item(0);
+            Element coverItem = findCoverItem(opfDoc, manifest);
+            if (coverItem == null) return false;
+
+            declaredType = coverItem.getAttribute("media-type");
+            String href = coverItem.getAttribute("href");
+            if (href.isEmpty() || declaredType.isEmpty()) return false;
+            if (!declaredType.startsWith("image/")) return false;
+
+            String basePath = opfPath.contains("/") ? opfPath.substring(0, opfPath.lastIndexOf('/') + 1) : "";
+            String coverPath = basePath + URLDecoder.decode(href, StandardCharsets.UTF_8);
+
+            ZipEntry coverEntry = zip.getEntry(coverPath);
+            if (coverEntry == null) return false;
+
+            byte[] coverBytes;
+            try (InputStream is = zip.getInputStream(coverEntry)) {
+                coverBytes = is.readAllBytes();
+            }
+
+            actualType = detectMediaType(coverBytes);
+            if (actualType == null || actualType.equals(declaredType)) return false;
+        } catch (Exception e) {
+            log.debug("Cover media-type check skipped for {}: {}", epubFile.getName(), e.getMessage());
+            return false;
+        }
+
+        try {
+            org.grimmory.epub4j.epub.EpubMetadataWriter.updateMetadata(epubFile.toPath(), doc -> {
+                updateCoverManifestEntry(doc, actualType);
+                removeEmptyTextNodes(doc);
+            });
+            log.info("Fixed cover media-type mismatch in {}: {} → {}", epubFile.getName(), declaredType, actualType);
+            return true;
+        } catch (Exception e) {
+            log.warn("Failed to fix cover media-type in {}: {}", epubFile.getName(), e.getMessage());
+            return false;
+        }
+    }
+
     private void organizeMetadataElements(Element metadataElement) {
-        final String DC_NS = "http://purl.org/dc/elements/1.1/";
-        java.util.List<Element> identifiers = new java.util.ArrayList<>();
-        java.util.List<Element> titles = new java.util.ArrayList<>();
-        java.util.List<Element> creators = new java.util.ArrayList<>();
-        java.util.List<Element> contributors = new java.util.ArrayList<>();
-        java.util.List<Element> languages = new java.util.ArrayList<>();
-        java.util.List<Element> dates = new java.util.ArrayList<>();
-        java.util.List<Element> publishers = new java.util.ArrayList<>();
-        java.util.List<Element> descriptions = new java.util.ArrayList<>();
-        java.util.List<Element> subjects = new java.util.ArrayList<>();
-        java.util.List<Element> seriesMetas = new java.util.ArrayList<>();
-        java.util.List<Element> bookloreMetas = new java.util.ArrayList<>();
-        java.util.List<Element> modifiedMetas = new java.util.ArrayList<>();
-        java.util.List<Element> otherMetas = new java.util.ArrayList<>();
-        
+        // Canonical DC ordering per EPUB specification
+        List<String> DC_ORDER = List.of(
+                "identifier", "title", "creator", "contributor", "language",
+                "date", "publisher", "description", "subject");
+
+        Map<String, List<Element>> dcBuckets = new LinkedHashMap<>();
+        for (String tag : DC_ORDER) dcBuckets.put(tag, new ArrayList<>());
+        List<Element> otherDcElements = new ArrayList<>();
+        List<Element> seriesMetas = new ArrayList<>();
+        List<Element> bookloreMetas = new ArrayList<>();
+        List<Element> modifiedMetas = new ArrayList<>();
+        List<Element> otherMetas = new ArrayList<>();
+        List<Element> linkElements = new ArrayList<>();
+        List<Element> uncategorized = new ArrayList<>();
+
+        // Build ID refines-meta lookup
+        Set<String> allIds = new HashSet<>();
+        Map<String, List<Element>> refinesMap = new HashMap<>();
+
         NodeList allChildren = metadataElement.getChildNodes();
         for (int i = 0; i < allChildren.getLength(); i++) {
-            Node node = allChildren.item(i);
-            if (node.getNodeType() != Node.ELEMENT_NODE) continue;
-            Element elem = (Element) node;
+            if (allChildren.item(i).getNodeType() != Node.ELEMENT_NODE) continue;
+            String id = ((Element) allChildren.item(i)).getAttribute("id");
+            if (!id.isEmpty()) allIds.add(id);
+        }
+
+        // First pass: identify refines metas
+        for (int i = 0; i < allChildren.getLength(); i++) {
+            if (allChildren.item(i).getNodeType() != Node.ELEMENT_NODE) continue;
+            Element elem = (Element) allChildren.item(i);
+            if ("meta".equals(elem.getLocalName())) {
+                String refines = elem.getAttribute("refines");
+                if (!refines.isEmpty() && refines.charAt(0) == '#' && allIds.contains(refines.substring(1))) {
+                    refinesMap.computeIfAbsent(refines.substring(1), k -> new ArrayList<>()).add(elem);
+                }
+            }
+        }
+
+        // Second pass: categorize
+        Set<Element> handledRefines = new HashSet<>();
+        for (int i = 0; i < allChildren.getLength(); i++) {
+            if (allChildren.item(i).getNodeType() != Node.ELEMENT_NODE) continue;
+            Element elem = (Element) allChildren.item(i);
             String localName = elem.getLocalName();
             String ns = elem.getNamespaceURI();
-            
+
             if (DC_NS.equals(ns)) {
-                switch (localName) {
-                    case "identifier" -> identifiers.add(elem);
-                    case "title" -> titles.add(elem);
-                    case "creator" -> creators.add(elem);
-                    case "contributor" -> contributors.add(elem);
-                    case "language" -> languages.add(elem);
-                    case "date" -> dates.add(elem);
-                    case "publisher" -> publishers.add(elem);
-                    case "description" -> descriptions.add(elem);
-                    case "subject" -> subjects.add(elem);
-                }
+                dcBuckets.getOrDefault(localName, otherDcElements).add(elem);
             } else if ("meta".equals(localName)) {
+                String refines = elem.getAttribute("refines");
+                if (!refines.isEmpty() && refines.charAt(0) == '#') {
+                    if (allIds.contains(refines.substring(1))) {
+                        handledRefines.add(elem);
+                    }
+                    // Either handled with parent or orphaned, skip either way
+                    continue;
+                }
                 String property = elem.getAttribute("property");
                 String name = elem.getAttribute("name");
                 if (property.startsWith("booklore:") || name.startsWith("booklore:")) {
                     bookloreMetas.add(elem);
-                } else if (property.equals("dcterms:modified") || property.equals("calibre:timestamp")) {
+                } else if ("dcterms:modified".equals(property) || "calibre:timestamp".equals(property)) {
                     modifiedMetas.add(elem);
-                } else if (property.equals("belongs-to-collection") || property.equals("collection-type") || property.equals("group-position")
-                        || "calibre:series".equals(name) || "calibre:series_index".equals(name)) {
+                } else if ("belongs-to-collection".equals(property) || "collection-type".equals(property)
+                        || "group-position".equals(property) || "calibre:series".equals(name) || "calibre:series_index".equals(name)) {
                     seriesMetas.add(elem);
                 } else {
                     otherMetas.add(elem);
                 }
+            } else if ("link".equals(localName)) {
+                linkElements.add(elem);
+            } else {
+                uncategorized.add(elem);
             }
         }
-        
+
+        // Clear and re-append in canonical order
         while (metadataElement.hasChildNodes()) {
             metadataElement.removeChild(metadataElement.getFirstChild());
         }
-        
-        identifiers.forEach(metadataElement::appendChild);
-        titles.forEach(metadataElement::appendChild);
-        creators.forEach(metadataElement::appendChild);
-        contributors.forEach(metadataElement::appendChild);
-        languages.forEach(metadataElement::appendChild);
-        dates.forEach(metadataElement::appendChild);
-        publishers.forEach(metadataElement::appendChild);
-        descriptions.forEach(metadataElement::appendChild);
-        subjects.forEach(metadataElement::appendChild);
-        seriesMetas.forEach(metadataElement::appendChild);
+
+        Consumer<Element> appendWithRefines = elem -> {
+            metadataElement.appendChild(elem);
+            String id = elem.getAttribute("id");
+            if (!id.isEmpty()) {
+                List<Element> refs = refinesMap.get(id);
+                if (refs != null) refs.forEach(metadataElement::appendChild);
+            }
+        };
+
+        dcBuckets.values().forEach(list -> list.forEach(appendWithRefines));
+        otherDcElements.forEach(appendWithRefines);
+        seriesMetas.forEach(appendWithRefines);
         modifiedMetas.forEach(metadataElement::appendChild);
         otherMetas.forEach(metadataElement::appendChild);
+        linkElements.forEach(metadataElement::appendChild);
         bookloreMetas.forEach(metadataElement::appendChild);
+        uncategorized.forEach(metadataElement::appendChild);
     }
 }

--- a/booklore-api/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -66,7 +67,7 @@ class EpubMetadataWriterTest {
         when(appSettings.getMetadataPersistenceSettings()).thenReturn(metadataPersistenceSettings);
         when(appSettingService.getAppSettings()).thenReturn(appSettings);
 
-        writer = new EpubMetadataWriter(appSettingService);
+        writer = new EpubMetadataWriter(appSettingService, mock(RestTemplate.class));
         metadata = new BookMetadataEntity();
         metadata.setTitle("Test Book");
         AuthorEntity author = new AuthorEntity();


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request introduces significant improvements to EPUB metadata extraction and cover handling, with a focus on performance, accuracy, and security. The main changes include implementing a fast native metadata extraction path, enhancing cover extraction logic

**EPUB Metadata Extraction Enhancements:**

- Added a fast native extraction path using `NativePackageReader` for both cover image path and metadata, falling back to the Java-based approach for completeness and correctness. The native pass quickly populates basic fields and identifiers, while the Java pass overwrites or supplements as needed for complex cases.
- Improved handling of subjects/categories: ensures that if subjects are found in the Java pass, they replace any found natively, preventing duplicate or conflicting entries.
- Added better mapping for identifiers (ISBN, Goodreads, Amazon, etc.) from native metadata, using a dedicated mapping method and defensive parsing.

**Cover Extraction Improvements:**

- Optimized cover extraction to first attempt a direct lookup using the native cover path, if available, before falling back to `epub4j`'s cover detection logic. This speeds up extraction for well-formed EPUBs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native parsing fast path for improved EPUB metadata extraction, including cover image and metadata retrieval.
  * Implemented HTTP/2 support with optimized timeouts for cover downloads.

* **Bug Fixes**
  * Enhanced metadata reconciliation to prevent duplicate or conflicting data from multiple parsing sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->