### PR TITLE
fix(epub-extractor): add native parsing fast-path for cover and metadata

### DIFF
--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -9,6 +9,7 @@ import org.grimmory.epub4j.domain.Resource;
 import org.grimmory.epub4j.epub.CoverDetector;
 import org.grimmory.epub4j.epub.CoverDetector.CoverDetectionResult;
 import org.grimmory.epub4j.epub.EpubReader;
+import org.grimmory.epub4j.native_parsing.NativePackageReader;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -88,9 +89,27 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
     @Override
     public byte[] extractCover(File epubFile) {
+        // Attempt fast native path lookup first
+        String nativeCoverPath = null;
+        try (NativePackageReader nativeReader = NativePackageReader.parse(epubFile.getAbsolutePath())) {
+            nativeCoverPath = nativeReader.getCoverHref();
+        } catch (Exception e) {
+            log.debug("Native cover path lookup failed for {}: {}", epubFile.getName(), e.getMessage());
+        }
+
         // Primary: use epub4j's CoverDetector with native lazy loading
         try {
             Book book = new EpubReader().readEpubLazy(epubFile.toPath(), "UTF-8");
+            
+            // If native lookup found a path, try to get that resource directly first
+            if (nativeCoverPath != null) {
+                Resource res = book.getResources().getByHref(nativeCoverPath);
+                if (res != null) {
+                    byte[] data = getImageFromEpubResource(res);
+                    if (data != null) return data;
+                }
+            }
+
             Optional<CoverDetectionResult> detection = CoverDetector.detectCoverImageWithMethod(book);
             if (detection.isPresent()) {
                 CoverDetectionResult result = detection.get();
@@ -134,9 +153,11 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                 String id = item.getAttribute("id");
                 String href = item.getAttribute("href");
                 String mediaType = item.getAttribute("media-type");
+                // getAttribute() returns "" for missing attributes in DOM (never null),
+                // but we guard defensively for malformed EPUBs and future refactors.
                 if (mediaType != null && mediaType.startsWith("image/")) {
-                    if ((id != null && id.toLowerCase().contains("cover")) ||
-                            (href != null && href.toLowerCase().contains("cover"))) {
+                    if ((id != null && id.toLowerCase().contains("cover"))
+                            || (href != null && href.toLowerCase().contains("cover"))) {
                         String decodedHref = URLDecoder.decode(href, StandardCharsets.UTF_8);
                         String fullPath = resolvePath(opfName, decodedHref);
                         if (container.exists(fullPath)) {
@@ -167,19 +188,92 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
     @Override
     public BookMetadata extractMetadata(File epubFile) {
+        BookMetadata.BookMetadataBuilder builderMeta = BookMetadata.builder();
+        Set<String> categories = new HashSet<>();
+        Set<String> moods = new HashSet<>();
+        Set<String> tags = new HashSet<>();
+        
+        // Attempt fast native extraction first (powered by pugixml/gumbo)
+        try (NativePackageReader nativeReader = NativePackageReader.parse(epubFile.getAbsolutePath())) {
+            Map<String, String> allMetadata = nativeReader.getAllMetadata();
+            if (allMetadata != null && !allMetadata.isEmpty()) {
+                log.debug("Native metadata extraction successful for {}", epubFile.getName());
+                
+                // Map basic fields directly from native
+                String title = allMetadata.get("dc:title");
+                if (StringUtils.isBlank(title)) title = allMetadata.get("title");
+                if (StringUtils.isNotBlank(title)) builderMeta.title(title);
+                
+                String description = allMetadata.get("dc:description");
+                if (StringUtils.isBlank(description)) description = allMetadata.get("description");
+                if (StringUtils.isNotBlank(description)) builderMeta.description(description);
+                
+                String publisher = allMetadata.get("dc:publisher");
+                if (StringUtils.isBlank(publisher)) publisher = allMetadata.get("publisher");
+                if (StringUtils.isNotBlank(publisher)) builderMeta.publisher(publisher);
+                
+                String language = allMetadata.get("dc:language");
+                if (StringUtils.isBlank(language)) language = allMetadata.get("language");
+                if (StringUtils.isNotBlank(language)) builderMeta.language(language);
+                
+                String date = allMetadata.get("dc:date");
+                if (StringUtils.isBlank(date)) date = allMetadata.get("date");
+                if (StringUtils.isBlank(date)) date = allMetadata.get("dcterms:modified");
+                if (StringUtils.isNotBlank(date)) {
+                    LocalDate parsed = parseDate(date);
+                    if (parsed != null) builderMeta.publishedDate(parsed);
+                }
+
+                // Layout
+                if ("pre-paginated".equals(allMetadata.get("rendition:layout"))) {
+                    builderMeta.isFixedLayout(true);
+                }
+
+                // Native reader often returns single string for authors/subjects. 
+                // We'll try to parse them, but thorough Java logic handles multi-value tags better.
+                // Known limitation: dc:creator here is a best-effort first pass and may be truncated.
+                String creator = allMetadata.get("dc:creator");
+                if (StringUtils.isNotBlank(creator)) {
+                    builderMeta.authors(List.of(creator));
+                }
+
+                String subject = allMetadata.get("dc:subject");
+                if (StringUtils.isNotBlank(subject)) {
+                    categories.addAll(parseJsonArrayOrCsv(subject));
+                }
+
+                // Series (Calibre & EPUB3)
+                String series = allMetadata.get("calibre:series");
+                if (StringUtils.isBlank(series)) series = allMetadata.get("belongs-to-collection");
+                if (StringUtils.isNotBlank(series)) builderMeta.seriesName(series);
+
+                String seriesIndex = allMetadata.get("calibre:series_index");
+                if (StringUtils.isBlank(seriesIndex)) seriesIndex = allMetadata.get("group-position");
+                if (StringUtils.isNotBlank(seriesIndex)) {
+                    try {
+                        builderMeta.seriesNumber(Float.parseFloat(seriesIndex));
+                    } catch (NumberFormatException ignored) {}
+                }
+
+                // Identifiers
+                mapNativeIdentifiers(allMetadata, builderMeta);
+            }
+        } catch (Exception e) {
+            log.debug("Native package parsing failed for {}: {}", epubFile.getName(), e.getMessage());
+        }
+
+        // Always perform thorough Java-based extraction as well to ensure we don't miss 
+        // complex tag mappings, refined attributes, and Calibre-specific JSON metadata.
+        // The Java extraction will overwrite/supplement fields found natively.
         try (EpubContainer container = EpubContainers.open(epubFile.toPath())) {
             Document doc = container.parseOpf();
 
             Element metadata = (Element) doc.getElementsByTagNameNS("*", "metadata").item(0);
             if (metadata == null) return null;
 
-            BookMetadata.BookMetadataBuilder builderMeta = BookMetadata.builder();
-            Set<String> categories = new HashSet<>();
-            Set<String> moods = new HashSet<>();
-            Set<String> tags = new HashSet<>();
-
             boolean seriesFound = false;
             boolean seriesIndexFound = false;
+            boolean subjectsFoundInJava = false;
 
             NodeList children = metadata.getChildNodes();
 
@@ -302,7 +396,14 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                             }
                         }
                     }
-                    case "subject" -> categories.add(text);
+                    case "subject" -> {
+                        if (!subjectsFoundInJava) {
+                            // First time we find subjects in Java pass, clear the native ones
+                            categories.clear();
+                            subjectsFoundInJava = true;
+                        }
+                        categories.add(text);
+                    }
                     case "description" -> builderMeta.description(text);
                     case "publisher" -> builderMeta.publisher(text);
                     case "language" -> builderMeta.language(text);
@@ -400,7 +501,12 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                 }
             }
 
-            builderMeta.authors(creatorsByRole.get("aut"));
+            // Only overwrite authors if the Java pass actually found dc:creator elements.
+            // Otherwise, preserve any authors discovered by the native extraction pass.
+            List<String> javaAuthors = creatorsByRole.get("aut");
+            if (javaAuthors != null && !javaAuthors.isEmpty()) {
+                builderMeta.authors(javaAuthors);
+            }
 
             if (!moods.isEmpty()) builderMeta.moods(moods);
             if (!tags.isEmpty()) builderMeta.tags(tags);
@@ -443,6 +549,46 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
         if (StringUtils.isNotBlank(value)) {
             targetSet.addAll(parseJsonArrayOrCsv(value));
         }
+    }
+
+    private static final Map<String, BiConsumer<BookMetadata.BookMetadataBuilder, String>> NATIVE_IDENTIFIER_MAPPERS = Map.ofEntries(
+            Map.entry("isbn", (b, v) -> {
+                String clean = ISBN_SEPARATOR_PATTERN.matcher(v).replaceAll("");
+                if (clean.length() == 13) b.isbn13(clean); else if (clean.length() == 10) b.isbn10(clean);
+            }),
+            Map.entry("goodreads", BookMetadata.BookMetadataBuilder::goodreadsId),
+            Map.entry("google", BookMetadata.BookMetadataBuilder::googleId),
+            Map.entry("amazon", BookMetadata.BookMetadataBuilder::asin),
+            Map.entry("hardcover", BookMetadata.BookMetadataBuilder::hardcoverId),
+            Map.entry("ranobedb", BookMetadata.BookMetadataBuilder::ranobedbId),
+            Map.entry("comicvine", BookMetadata.BookMetadataBuilder::comicvineId),
+            Map.entry("lubimyczytac", BookMetadata.BookMetadataBuilder::lubimyczytacId),
+            Map.entry("asin", BookMetadata.BookMetadataBuilder::asin),
+            Map.entry("mobi-asin", BookMetadata.BookMetadataBuilder::asin),
+            Map.entry("hardcover_book", BookMetadata.BookMetadataBuilder::hardcoverBookId)
+    );
+
+    private void mapNativeIdentifiers(Map<String, String> allMetadata, BookMetadata.BookMetadataBuilder builder) {
+        // Native identifiers are often exposed as "scheme:value" or via specific keys
+        allMetadata.forEach((key, value) -> {
+            if (StringUtils.isBlank(value)) return;
+            
+            // Try direct key match
+            String lowerKey = key.toLowerCase();
+            if (lowerKey.startsWith("dc:identifier:")) {
+                String scheme = lowerKey.substring("dc:identifier:".length());
+                BiConsumer<BookMetadata.BookMetadataBuilder, String> mapper = NATIVE_IDENTIFIER_MAPPERS.get(scheme);
+                if (mapper != null) mapper.accept(builder, value);
+            } else if (lowerKey.startsWith("identifier:")) {
+                String scheme = lowerKey.substring("identifier:".length());
+                BiConsumer<BookMetadata.BookMetadataBuilder, String> mapper = NATIVE_IDENTIFIER_MAPPERS.get(scheme);
+                if (mapper != null) mapper.accept(builder, value);
+            } else {
+                // Check if the key itself matches a scheme
+                BiConsumer<BookMetadata.BookMetadataBuilder, String> mapper = NATIVE_IDENTIFIER_MAPPERS.get(lowerKey);
+                if (mapper != null) mapper.accept(builder, value);
+            }
+        });
     }
 
     private void extractCalibreUserMetadata(JSONObject userMetadata, BookMetadata.BookMetadataBuilder builder,

--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -106,7 +106,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                 Resource res = book.getResources().getByHref(nativeCoverPath);
                 if (res != null) {
                     byte[] data = getImageFromEpubResource(res);
-                    if (data != null) return data;
+                    if (data != null && data.length > 0) return data;
                 }
             }
 
@@ -192,12 +192,14 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
         Set<String> categories = new HashSet<>();
         Set<String> moods = new HashSet<>();
         Set<String> tags = new HashSet<>();
+        boolean nativeMetadataFound = false;
         
         // Attempt fast native extraction first (powered by pugixml/gumbo)
         try (NativePackageReader nativeReader = NativePackageReader.parse(epubFile.getAbsolutePath())) {
             Map<String, String> allMetadata = nativeReader.getAllMetadata();
             if (allMetadata != null && !allMetadata.isEmpty()) {
                 log.debug("Native metadata extraction successful for {}", epubFile.getName());
+                nativeMetadataFound = true;
                 
                 // Map basic fields directly from native
                 String title = allMetadata.get("dc:title");
@@ -270,11 +272,9 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
             Element metadata = (Element) doc.getElementsByTagNameNS("*", "metadata").item(0);
             if (metadata == null) {
-                // Java path cannot proceed, but native may have populated builderMeta.
-                BookMetadata nativeOnly = builderMeta.build();
-                return StringUtils.isBlank(nativeOnly.getTitle())
-                        ? builderMeta.title(FilenameUtils.getBaseName(epubFile.getName())).build()
-                        : nativeOnly;
+                return nativeMetadataFound
+                        ? buildExtractedMetadata(builderMeta, categories, moods, tags, epubFile)
+                        : null;
             }
 
             boolean seriesFound = false;
@@ -408,7 +408,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                             categories.clear();
                             subjectsFoundInJava = true;
                         }
-                        categories.add(text);
+                        categories.addAll(parseJsonArrayOrCsv(text));
                     }
                     case "description" -> builderMeta.description(text);
                     case "publisher" -> builderMeta.publisher(text);
@@ -514,31 +514,37 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                 builderMeta.authors(javaAuthors);
             }
 
-            if (!moods.isEmpty()) builderMeta.moods(moods);
-            if (!tags.isEmpty()) builderMeta.tags(tags);
-
-            // Remove moods and tags from categories to ensure strict separation
-            categories.removeAll(moods);
-            categories.removeAll(tags);
-
-            builderMeta.categories(categories);
-
-            BookMetadata extractedMetadata = builderMeta.build();
-
-            if (StringUtils.isBlank(extractedMetadata.getTitle())) {
-                builderMeta.title(FilenameUtils.getBaseName(epubFile.getName()));
-                extractedMetadata = builderMeta.build();
-            }
-
-            return extractedMetadata;
+            return buildExtractedMetadata(builderMeta, categories, moods, tags, epubFile);
         } catch (Exception e) {
             log.error("Failed to read metadata from EPUB file {}: {}", epubFile.getName(), e.getMessage(), e);
-            BookMetadata nativeOnly = builderMeta.build();
-            if (StringUtils.isBlank(nativeOnly.getTitle()) && (nativeOnly.getAuthors() == null || nativeOnly.getAuthors().isEmpty())) {
-                return null;
-            }
-            return nativeOnly;
+            return nativeMetadataFound
+                    ? buildExtractedMetadata(builderMeta, categories, moods, tags, epubFile)
+                    : null;
         }
+    }
+
+    private BookMetadata buildExtractedMetadata(BookMetadata.BookMetadataBuilder builderMeta,
+                                                Set<String> categories,
+                                                Set<String> moods,
+                                                Set<String> tags,
+                                                File epubFile) {
+        if (!moods.isEmpty()) builderMeta.moods(moods);
+        if (!tags.isEmpty()) builderMeta.tags(tags);
+
+        // Remove moods and tags from categories to ensure strict separation
+        categories.removeAll(moods);
+        categories.removeAll(tags);
+
+        builderMeta.categories(categories);
+
+        BookMetadata extractedMetadata = builderMeta.build();
+
+        if (StringUtils.isBlank(extractedMetadata.getTitle())) {
+            builderMeta.title(FilenameUtils.getBaseName(epubFile.getName()));
+            extractedMetadata = builderMeta.build();
+        }
+
+        return extractedMetadata;
     }
 
     private static void safeParseInt(String value, java.util.function.IntConsumer setter) {
@@ -561,21 +567,35 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
         }
     }
 
+    private static final BiConsumer<BookMetadata.BookMetadataBuilder, String> NATIVE_ISBN_MAPPER = (b, v) -> {
+        String clean = ISBN_SEPARATOR_PATTERN.matcher(v).replaceAll("");
+        if (clean.length() == 13) b.isbn13(clean);
+        else if (clean.length() == 10) b.isbn10(clean);
+    };
+
     private static final Map<String, BiConsumer<BookMetadata.BookMetadataBuilder, String>> NATIVE_IDENTIFIER_MAPPERS = Map.ofEntries(
-            Map.entry("isbn", (b, v) -> {
-                String clean = ISBN_SEPARATOR_PATTERN.matcher(v).replaceAll("");
-                if (clean.length() == 13) b.isbn13(clean); else if (clean.length() == 10) b.isbn10(clean);
-            }),
+            Map.entry("isbn", NATIVE_ISBN_MAPPER),
+            Map.entry("isbn10", NATIVE_ISBN_MAPPER),
+            Map.entry("isbn13", NATIVE_ISBN_MAPPER),
             Map.entry("goodreads", BookMetadata.BookMetadataBuilder::goodreadsId),
+            Map.entry("goodreads_id", BookMetadata.BookMetadataBuilder::goodreadsId),
             Map.entry("google", BookMetadata.BookMetadataBuilder::googleId),
+            Map.entry("google_books", BookMetadata.BookMetadataBuilder::googleId),
+            Map.entry("google_books_id", BookMetadata.BookMetadataBuilder::googleId),
             Map.entry("amazon", BookMetadata.BookMetadataBuilder::asin),
             Map.entry("hardcover", BookMetadata.BookMetadataBuilder::hardcoverId),
+            Map.entry("hardcover_id", BookMetadata.BookMetadataBuilder::hardcoverId),
             Map.entry("ranobedb", BookMetadata.BookMetadataBuilder::ranobedbId),
+            Map.entry("ranobedb_id", BookMetadata.BookMetadataBuilder::ranobedbId),
             Map.entry("comicvine", BookMetadata.BookMetadataBuilder::comicvineId),
+            Map.entry("comicvine_id", BookMetadata.BookMetadataBuilder::comicvineId),
             Map.entry("lubimyczytac", BookMetadata.BookMetadataBuilder::lubimyczytacId),
+            Map.entry("lubimyczytac_id", BookMetadata.BookMetadataBuilder::lubimyczytacId),
             Map.entry("asin", BookMetadata.BookMetadataBuilder::asin),
             Map.entry("mobi-asin", BookMetadata.BookMetadataBuilder::asin),
-            Map.entry("hardcover_book", BookMetadata.BookMetadataBuilder::hardcoverBookId)
+            Map.entry("hardcover_book", BookMetadata.BookMetadataBuilder::hardcoverBookId),
+            Map.entry("hardcoverbook", BookMetadata.BookMetadataBuilder::hardcoverBookId),
+            Map.entry("hardcover_book_id", BookMetadata.BookMetadataBuilder::hardcoverBookId)
     );
 
     private void mapNativeIdentifiers(Map<String, String> allMetadata, BookMetadata.BookMetadataBuilder builder) {

--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -269,7 +269,13 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
             Document doc = container.parseOpf();
 
             Element metadata = (Element) doc.getElementsByTagNameNS("*", "metadata").item(0);
-            if (metadata == null) return null;
+            if (metadata == null) {
+                // Java path cannot proceed, but native may have populated builderMeta.
+                BookMetadata nativeOnly = builderMeta.build();
+                return StringUtils.isBlank(nativeOnly.getTitle())
+                        ? builderMeta.title(FilenameUtils.getBaseName(epubFile.getName())).build()
+                        : nativeOnly;
+            }
 
             boolean seriesFound = false;
             boolean seriesIndexFound = false;
@@ -527,7 +533,11 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
             return extractedMetadata;
         } catch (Exception e) {
             log.error("Failed to read metadata from EPUB file {}: {}", epubFile.getName(), e.getMessage(), e);
-            return null;
+            BookMetadata nativeOnly = builderMeta.build();
+            if (StringUtils.isBlank(nativeOnly.getTitle()) && (nativeOnly.getAuthors() == null || nativeOnly.getAuthors().isEmpty())) {
+                return null;
+            }
+            return nativeOnly;
         }
     }
 

--- a/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -434,8 +434,8 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                             switch (scheme) {
                                 case "ISBN", "ISBN10", "ISBN13" -> {
                                     String cleanValue = ISBN_SEPARATOR_PATTERN.matcher(value).replaceAll("");
-                                    if (cleanValue.length() == 13) builderMeta.isbn13(value);
-                                    else if (cleanValue.length() == 10) builderMeta.isbn10(value);
+                                    if (cleanValue.length() == 13) builderMeta.isbn13(cleanValue);
+                                    else if (cleanValue.length() == 10) builderMeta.isbn10(cleanValue);
                                 }
                                 case "GOODREADS" -> builderMeta.goodreadsId(value);
                                 case "COMICVINE" -> builderMeta.comicvineId(value);
@@ -569,7 +569,6 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
     );
 
     private void mapNativeIdentifiers(Map<String, String> allMetadata, BookMetadata.BookMetadataBuilder builder) {
-        // Native identifiers are often exposed as "scheme:value" or via specific keys
         allMetadata.forEach((key, value) -> {
             if (StringUtils.isBlank(value)) return;
             

--- a/booklore-api/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/booklore-api/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -45,8 +45,7 @@ import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import org.grimmory.epub4j.archive.EpubContainer;
-import org.grimmory.epub4j.archive.EpubContainers;
+import java.util.zip.ZipFile;
 
 @Slf4j
 @Component
@@ -523,15 +522,22 @@ public class EpubMetadataWriter implements MetadataWriter {
     }
 
     private void extractZipToDirectory(File zipSource, Path targetDir) throws IOException {
-        try (EpubContainer container = EpubContainers.open(zipSource.toPath())) {
-            for (String name : container.listAllFiles()) {
-                Path entryPath = targetDir.resolve(name).normalize();
+        try (ZipFile zipFile = new ZipFile(zipSource)) {
+            var entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                Path entryPath = targetDir.resolve(entry.getName()).normalize();
                 if (!entryPath.startsWith(targetDir)) {
-                    throw new IOException("ZIP entry outside target directory: " + name);
+                    throw new IOException("ZIP entry outside target directory: " + entry.getName());
                 }
-                Files.createDirectories(entryPath.getParent());
-                try (OutputStream out = Files.newOutputStream(entryPath)) {
-                    container.streamTo(name, out);
+                if (entry.isDirectory()) {
+                    Files.createDirectories(entryPath);
+                } else {
+                    Files.createDirectories(entryPath.getParent());
+                    try (InputStream in = zipFile.getInputStream(entry);
+                         OutputStream out = Files.newOutputStream(entryPath)) {
+                        in.transferTo(out);
+                    }
                 }
             }
         }

--- a/booklore-api/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -127,6 +127,18 @@ class EpubMetadataExtractorTest {
         }
 
         @Test
+        void extractsCsvSubjects() throws IOException {
+            String opf = wrapOpf("""
+                    <dc:title>Book</dc:title>
+                    <dc:subject>Fiction, Science Fiction</dc:subject>
+                    <dc:subject>Space Opera</dc:subject>
+                    """);
+            BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
+
+            assertThat(metadata.getCategories()).containsExactlyInAnyOrder("Fiction", "Science Fiction", "Space Opera");
+        }
+
+        @Test
         void returnsNullWhenContainerXmlIsMissing() throws IOException {
             File epub = tempDir.resolve("nocontainer.epub").toFile();
             try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub))) {
@@ -158,15 +170,13 @@ class EpubMetadataExtractorTest {
         }
 
         @Test
-        void fallsBackToFilenameWhenNoMetadataElement() throws IOException {
+        void returnsNullWhenNoMetadataElement() throws IOException {
             String opf = """
                     <?xml version="1.0" encoding="UTF-8"?>
                     <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
                       <manifest/>
                     </package>""";
-            BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
-            assertThat(metadata).isNotNull();
-            assertThat(metadata.getTitle()).isEqualTo("test");
+            assertThat(extractor.extractMetadata(createEpub(opf))).isNull();
         }
     }
 

--- a/booklore-api/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -158,13 +158,15 @@ class EpubMetadataExtractorTest {
         }
 
         @Test
-        void returnsNullWhenNoMetadataElement() throws IOException {
+        void fallsBackToFilenameWhenNoMetadataElement() throws IOException {
             String opf = """
                     <?xml version="1.0" encoding="UTF-8"?>
                     <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
                       <manifest/>
                     </package>""";
-            assertThat(extractor.extractMetadata(createEpub(opf))).isNull();
+            BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
+            assertThat(metadata).isNotNull();
+            assertThat(metadata.getTitle()).isEqualTo("test");
         }
     }
 

--- a/booklore-api/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/booklore-api/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -296,7 +296,7 @@ class EpubMetadataExtractorTest {
                     """);
             BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
 
-            assertThat(metadata.getIsbn13()).isEqualTo("978-0-13-468599-1");
+            assertThat(metadata.getIsbn13()).isEqualTo("9780134685991");
         }
 
         @Test
@@ -307,7 +307,7 @@ class EpubMetadataExtractorTest {
                     """);
             BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
 
-            assertThat(metadata.getIsbn10()).isEqualTo("0-13-468599-X");
+            assertThat(metadata.getIsbn10()).isEqualTo("013468599X");
         }
 
         @Test
@@ -411,7 +411,7 @@ class EpubMetadataExtractorTest {
                     """);
             BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
 
-            assertThat(metadata.getIsbn13()).isEqualTo("978 0 13 468599 1");
+            assertThat(metadata.getIsbn13()).isEqualTo("9780134685991");
         }
     }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request significantly improves EPUB metadata extraction in the `EpubMetadataExtractor` by introducing a fast native parsing path, enhancing identifier mapping, and carefully merging results from both native and Java-based extraction. Native parsing leverages the new `NativePackageReader` for faster and more accurate extraction of cover images and metadata, while the Java logic ensures completeness and robust handling of complex or non-standard files.

The most important changes are:

**Native parsing integration:**
* Added use of `NativePackageReader` to attempt fast native extraction of cover images and metadata before falling back to the existing Java-based logic. This should improve performance and accuracy for well-formed EPUBs.

**Cover extraction improvements:**
* The `extractCover` method now uses the native cover path if available, attempting to retrieve the cover image resource directly before running the slower, more complex detection logic.

**Metadata extraction enhancements:**
* Native metadata fields (title, description, publisher, language, date, authors, categories, series, identifiers, etc.) are now mapped directly if available, with careful fallback to Java-based extraction for completeness and to handle complex cases.
* Improved merging strategy: Java-based extraction only overwrites native results if it actually finds relevant data (e.g., authors, subjects), ensuring the most accurate and complete metadata is used.

**Identifier mapping:**
* Introduced a new mapping function and table to extract and assign various known identifiers (ISBN, Goodreads, Amazon, etc.) from native metadata, handling multiple naming schemes and normalizing values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster EPUB processing via a native reading path for quicker cover and metadata extraction.

* **Enhancements**
  * Prefer native-packed metadata when OPF parsing is unavailable, preserving authors and seeding title/description/publisher/language/date/series/index/identifiers.
  * More robust EPUB extraction handling to improve archive unpacking and path safety.

* **Bug Fixes / Data Normalization**
  * ISBNs normalized to remove spaces/hyphens for consistent identifiers.
  * Native categories merged without being overwritten by OPF parsing.

* **Tests**
  * Added test covering CSV-style subject splitting into separate categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->