### PR TITLE
fix(ui): handle RFC5987 content-disposition headers

### DIFF
--- a/frontend/src/app/shared/service/file-download.service.spec.ts
+++ b/frontend/src/app/shared/service/file-download.service.spec.ts
@@ -28,7 +28,7 @@ describe('FileDownloadService', () => {
     TestBed.resetTestingModule();
   });
 
-  it('downloads a blob using the filename from the response header', () => {
+  it('downloads a blob', () => {
     const click = vi.fn();
     const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
     const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue(anchor);
@@ -48,27 +48,88 @@ describe('FileDownloadService', () => {
 
     expect(createElementSpy).toHaveBeenCalledWith('a');
     expect(createObjectUrlSpy).toHaveBeenCalled();
-    expect(anchor.download).toBe('server name.epub');
     expect(click).toHaveBeenCalledOnce();
     expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:download');
+  });
+
+  it('downloads using the utf-8-only filename from the response header', () => {
+    const click = vi.fn();
+    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    service.downloadFile('/files/1', 'fallback.epub');
+
+    const request = httpTestingController.expectOne('/files/1');
+    request.flush(new Blob(['content']), {
+      headers: new HttpHeaders({
+        'Content-Disposition': "attachment; filename*=UTF-8''server%20name.epub",
+      }),
+    });
+
+    expect(anchor.download).toBe('server name.epub');
+  });
+
+  it('downloads a blob using the ascii filename from the response header', () => {
+    const click = vi.fn();
+    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    service.downloadFile('/files/1', 'fallback.epub');
+
+    const request = httpTestingController.expectOne('/files/1');
+    request.flush(new Blob(['content']), {
+      headers: new HttpHeaders({
+        'Content-Disposition': "attachment; filename=\"server name.epub\"",
+      }),
+    });
+
+    expect(anchor.download).toBe('server name.epub');
+  });
+
+  it('downloads a blob using the unquoted ascii filename from the response header', () => {
+    const click = vi.fn();
+    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    service.downloadFile('/files/1', 'fallback.epub');
+
+    const request = httpTestingController.expectOne('/files/1');
+    request.flush(new Blob(['content']), {
+      headers: new HttpHeaders({
+        'Content-Disposition': "attachment; filename=server_name.epub",
+      }),
+    });
+
+    expect(anchor.download).toBe('server_name.epub');
+  });
+
+  it('downloads a blob using the both utf-8 and ascii from the response header', () => {
+    const click = vi.fn();
+    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    service.downloadFile('/files/1', 'fallback.epub');
+
+    const request = httpTestingController.expectOne('/files/1');
+    request.flush(new Blob(['content']), {
+      headers: new HttpHeaders({
+        'Content-Disposition': "attachment; filename=\"server name.epub\"; filename*=UTF-8''server%20name.epub",
+      }),
+    });
+
+    expect(anchor.download).toBe('server name.epub');
   });
 
   it('falls back to the provided filename when the response has no content-disposition header', () => {
     const click = vi.fn();
     const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
-    const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue(anchor);
-    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:download');
-    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
 
     service.downloadFile('/files/2', 'fallback.epub');
 
     const request = httpTestingController.expectOne('/files/2');
     request.flush(new Blob(['content']));
 
-    expect(createElementSpy).toHaveBeenCalledWith('a');
-    expect(createObjectUrlSpy).toHaveBeenCalled();
     expect(anchor.download).toBe('fallback.epub');
-    expect(click).toHaveBeenCalledOnce();
-    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:download');
   });
 });

--- a/frontend/src/app/shared/service/file-download.service.ts
+++ b/frontend/src/app/shared/service/file-download.service.ts
@@ -26,7 +26,11 @@ export class FileDownloadService {
     if (!contentDisposition) return null;
     const utf8Match = contentDisposition.match(/filename\*=UTF-8''([\w%\-.]+)/i);
     if (utf8Match) {
-      return decodeURIComponent(utf8Match[1]);
+      try {
+        return decodeURIComponent(utf8Match[1]);
+      } catch {
+        // Do nothing in this case and fall back to the ascii filename.
+      }
     }
     const match = contentDisposition.match(/filename=(?:"([^"]+)"|([^"; ]+))/i)
     if (match) {

--- a/frontend/src/app/shared/service/file-download.service.ts
+++ b/frontend/src/app/shared/service/file-download.service.ts
@@ -24,7 +24,14 @@ export class FileDownloadService {
 
   private extractFilename(contentDisposition: string | null): string | null {
     if (!contentDisposition) return null;
-    const match = contentDisposition.match(/filename\*=UTF-8''([\w%\-.]+)/i);
-    return match ? decodeURIComponent(match[1]) : null;
+    const utf8Match = contentDisposition.match(/filename\*=UTF-8''([\w%\-.]+)/i);
+    if (utf8Match) {
+      return decodeURIComponent(utf8Match[1]);
+    }
+    const match = contentDisposition.match(/filename=(?:"([^"]+)"|([^"; ]+))/i)
+    if (match) {
+      return match[1] ?? match[2];
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
this updates the file download service to handle changes to our content disposition headers.  while they were still [RFC5987](https://datatracker.ietf.org/doc/html/rfc5987#section-3.2) compliant, the parser did not properly read them

this change adds in falling back to the ASCII filename when a UTF-8 filename is not present

**Linked Issue:** Fixes #729

## Changes

* updates the file download service to handle ascii content disposition
* adds tests for more permutations of the content disposition header read by the file download service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File downloads now more reliably extract filenames from varied Content-Disposition formats (UTF-8 extended params, quoted and unquoted names) and fall back properly when parsing or decoding fails.
* **Tests**
  * Updated tests to concentrate on filename parsing across Content-Disposition variants and simplified assertions around blob handling and URL creation/revocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->