### PR TITLE
ci: use env vars for input to scripts

### DIFF
--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -37,23 +37,26 @@ jobs:
 
       - name: Normalize Diff Refs
         id: normalize_refs
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+          HEAD_REF: ${{ inputs.head_ref }}
         run: |
-          base_ref="${{ inputs.base_ref }}"
-          head_ref="${{ inputs.head_ref }}"
-
-          if [ "$base_ref" = "0000000000000000000000000000000000000000" ]; then
+          if [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
             echo "base_ref is the all-zero sentinel; callers must supply a real comparison base for migration checks." >&2
             exit 1
           fi
 
-          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
 
       - name: Detect Flyway Migration Changes
         id: check_migrations
+        env:
+          BASE_REF: ${{ steps.normalize_refs.outputs.base_ref }}
+          HEAD_REF: ${{ steps.normalize_refs.outputs.head_ref }}
         run: |
-          echo "Comparing ${{ steps.normalize_refs.outputs.base_ref }}...${{ steps.normalize_refs.outputs.head_ref }}"
-          if git diff --name-only "${{ steps.normalize_refs.outputs.base_ref }}...${{ steps.normalize_refs.outputs.head_ref }}" | grep -Eq "^booklore-api/src/main/resources/db/migration/V.*\\.sql$"; then
+          echo "Comparing ${BASE_REF}...${HEAD_REF}"
+          if git diff --name-only "${BASE_REF}...${HEAD_REF}" | grep -Eq "^booklore-api/src/main/resources/db/migration/V.*\\.sql$"; then
             echo "Migration file changes detected. Proceeding with migration preview."
             echo "has_migrations=true" >> "$GITHUB_OUTPUT"
           else
@@ -88,10 +91,13 @@ jobs:
           fetch-depth: 0
 
       - name: Apply Migrations from Base Branch
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          BASE_REF: ${{ needs.check-for-migrations.outputs.base_ref }}
         run: |
-          echo "Applying migrations from base ref (${{ needs.check-for-migrations.outputs.base_ref }})..."
+          echo "Applying migrations from base ref (${BASE_REF})..."
           docker run --network host \
-            -v ${{ github.workspace }}:/flyway/sql \
+            -v ${GITHUB_WORKSPACE}:/flyway/sql \
             flyway/flyway:12.1.0 \
             -url=jdbc:mariadb://127.0.0.1:3306/booklore_test \
             -user=root -password=root \
@@ -105,10 +111,13 @@ jobs:
           fetch-depth: 0
 
       - name: Apply Migrations from Head Branch
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          HEAD_REF: ${{ needs.check-for-migrations.outputs.head_ref }}
         run: |
-          echo "Applying new migrations from head ref (${{ needs.check-for-migrations.outputs.head_ref }})..."
+          echo "Applying new migrations from head ref (${HEAD_REF})..."
           docker run --network host \
-            -v ${{ github.workspace }}:/flyway/sql \
+            -v ${GITHUB_WORKSPACE}:/flyway/sql \
             flyway/flyway:12.1.0 \
             -url=jdbc:mariadb://127.0.0.1:3306/booklore_test \
             -user=root -password=root \

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -82,11 +82,13 @@ jobs:
 
       - name: Record Nightly Build Metadata
         id: record
+        env:
+          NIGHTLY_TAG: ${{ needs.resolve_ref.outputs.nightly_tag }}
         run: |
-          echo "image_tag=${{ needs.resolve_ref.outputs.nightly_tag }}" >> "$GITHUB_OUTPUT"
-          echo "nightly_tag=${{ needs.resolve_ref.outputs.nightly_tag }}" >> "$GITHUB_ENV"
+          echo "image_tag=${NIGHTLY_TAG}" >> "$GITHUB_OUTPUT"
+          echo "nightly_tag=${NIGHTLY_TAG}" >> "$GITHUB_ENV"
           echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
-          echo "Nightly tag: ${{ needs.resolve_ref.outputs.nightly_tag }}"
+          echo "Nightly tag: ${NIGHTLY_TAG}"
 
       - name: Set Up QEMU for Multi-Arch Builds
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -41,10 +41,12 @@ jobs:
           ref: ${{ inputs.commit_sha != '' && inputs.commit_sha || format('refs/tags/{0}', inputs.release_tag) }}
 
       - name: Record Release Tag and Commit
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          echo "release_tag=${{ inputs.release_tag }}" >> "$GITHUB_ENV"
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_ENV"
           echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
-          echo "Stable release tag: ${{ inputs.release_tag }}"
+          echo "Stable release tag: ${RELEASE_TAG}"
 
       - name: Set Up QEMU for Multi-Arch Builds
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -92,5 +94,6 @@ jobs:
       - name: Publish Draft GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN != '' && secrets.RELEASE_BOT_TOKEN || github.token }}
+          RELEASE_TAG: ${{ env.release_tag }}
         run: |
-          gh release edit "${{ env.release_tag }}" --draft=false
+          gh release edit "${RELEASE_TAG}" --draft=false


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
using github actions vars directly in the script for scripts allows for intentional or unintentional errors in scripts and allows for unexpected values to be injected as script commands.  this updates all cases where we're doing that with env vars instead which do not suffer from this issue

## Changes

* use env var in GHA run scripts instead of variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored GitHub Actions workflow configurations to streamline and improve automation consistency across the development pipeline. Enhanced environment variable handling in migrations check, nightly build, and release workflows. These updates improve clarity and reliability of the automated build and release processes, making the development workflow more maintainable and robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->