### PR TITLE
ci: match release automation to desired behavioral workflow

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -62,20 +62,8 @@ jobs:
       - name: Install Release Tooling Dependencies
         run: just release install
 
-      - name: Configure Release Bot Git Identity
-        env:
-          RELEASE_GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN != '' && secrets.RELEASE_BOT_TOKEN || github.token }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${RELEASE_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN != '' && secrets.RELEASE_BOT_TOKEN || github.token }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN != '' && secrets.RELEASE_BOT_TOKEN || github.token }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         run: just release run

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -34,11 +34,6 @@ jobs:
     needs: [migration-check, test-suite]
     runs-on: ubuntu-latest
 
-    outputs:
-      released: ${{ steps.release_state.outputs.released }}
-      release_tag: ${{ steps.release_state.outputs.release_tag }}
-      release_sha: ${{ steps.release_state.outputs.release_sha }}
-
     permissions:
       contents: write
 
@@ -67,11 +62,6 @@ jobs:
       - name: Install Release Tooling Dependencies
         run: just release install
 
-      - name: Record Pre-Release HEAD
-        id: pre_release
-        run: |
-          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Configure Release Bot Git Identity
         env:
           RELEASE_GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN != '' && secrets.RELEASE_BOT_TOKEN || github.token }}
@@ -89,71 +79,3 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         run: just release run
-
-      - name: Capture Release State
-        id: release_state
-        run: |
-          set -eu
-          head_before="${{ steps.pre_release.outputs.head_sha }}"
-          head_after="$(git rev-parse HEAD)"
-
-          echo "release_sha=$head_after" >> "$GITHUB_OUTPUT"
-
-          if [ "$head_after" = "$head_before" ]; then
-            echo "released=false" >> "$GITHUB_OUTPUT"
-            echo "release_tag=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          release_tag="$(git tag --points-at "$head_after" 'v*' | sort -V | tail -n 1)"
-
-          if [ -z "$release_tag" ]; then
-            echo "semantic-release advanced HEAD without creating a release tag" >&2
-            exit 1
-          fi
-
-          echo "released=true" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-
-  backport-release:
-    name: Backport Release Commit to Develop
-    if: ${{ needs.semantic-release.outputs.released == 'true' }}
-    needs: [semantic-release]
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Configure Release Bot Git Identity
-        env:
-          RELEASE_GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN != '' && secrets.RELEASE_BOT_TOKEN || github.token }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${RELEASE_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-      - name: Cherry-pick Release Commit onto Develop
-        env:
-          RELEASE_SHA: ${{ needs.semantic-release.outputs.release_sha }}
-          RELEASE_TAG: ${{ needs.semantic-release.outputs.release_tag }}
-        run: |
-          set -eu
-          release_version="${RELEASE_TAG#v}"
-
-          git fetch origin main develop --tags
-          git checkout -B develop origin/develop
-
-          if git log --format=%s origin/develop | grep -Fxq "chore(release): ${release_version} [skip ci]"; then
-            echo "Develop already contains the release commit for ${RELEASE_TAG}; skipping backport."
-            exit 0
-          fi
-
-          git cherry-pick -x "$RELEASE_SHA"
-          git push origin HEAD:develop

--- a/tools/release/release.config.cjs
+++ b/tools/release/release.config.cjs
@@ -1,7 +1,6 @@
 const releasePolicy = require("./release-policy.cjs");
 
 module.exports = {
-  repositoryUrl: "https://github.com/grimmory-tools/grimmory.git",
   branches: ["main"],
   tagFormat: "v${version}",
   plugins: [

--- a/tools/release/release.config.cjs
+++ b/tools/release/release.config.cjs
@@ -35,19 +35,6 @@ module.exports = {
       }
     ],
     [
-      "@semantic-release/changelog",
-      {
-        changelogFile: "CHANGELOG.md"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        assets: ["CHANGELOG.md"],
-        message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         draftRelease: true,


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Drop the changelog commit during the release creation process, don't push tags automatically, & publish the release as a draft.  Because of this, a backport from main to develop is no longer required.

This change also means that a commit hitting main isn't an AUTOMATIC release - a human still has to go to the releases page and hit "publish".

## Changes

* drop semantic-release plugin `git`
* drop semantic-release plugin `changelog`
* drop `backport` job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the release workflow by removing automated changelog generation and backport processes to the development branch.
  * Removed release state tracking outputs from the release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->