### PR TITLE
fix(phone/mobile): enable pan mode and disable swipe-to-navigate and tap-to-turn-page zones on mobile devices

### DIFF
--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -187,19 +187,28 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   readonly embedPdfBook = inject(EmbedPdfBookService);
   readonly pdfBookmarkService = inject(PdfBookmarkService);
   private readonly ngZone = inject(NgZone);
+  private userPanPreferred = false;
+
 
   ngOnInit(): void {
     const dismissed = localStorage.getItem(this.DOC_VIEWER_DISMISSED_KEY);
     this.isDocViewerInfoVisible.set(dismissed !== 'true');
 
+    let lastIsPhone: boolean | null = null;
     const syncPhoneMode = () => {
-      const isPhone = window.innerWidth < 768;
-      this.isPhone.set(isPhone);
-      this.isPanActive.set(isPhone);
-      if (this.bookViewerInitialized) {
-        this.embedPdfBook.setPanMode(isPhone);
+      const nextIsPhone = window.innerWidth < 768;
+      if (nextIsPhone === lastIsPhone) return;
+
+      lastIsPhone = nextIsPhone;
+      this.isPhone.set(nextIsPhone);
+
+      if (nextIsPhone) {
+        this.applyPanMode(true);
+      } else {
+        this.applyPanMode(this.userPanPreferred);
       }
     };
+
     syncPhoneMode();
     window.addEventListener('resize', syncPhoneMode);
     this.destroyRef.onDestroy(() => window.removeEventListener('resize', syncPhoneMode));
@@ -705,25 +714,36 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
 
   // --- Annotation tools ---
 
+  private applyPanMode(active: boolean): void {
+    this.isPanActive.set(active);
+    if (active) {
+      this.activeAnnotationTool.set(null);
+      this.embedPdfBook.setActiveTool(null);
+    }
+    if (this.bookViewerInitialized) {
+      this.embedPdfBook.setPanMode(active);
+    }
+  }
+
+
   toggleAnnotationTool(toolId: string | null): void {
     if (this.activeAnnotationTool() === toolId) {
       this.activeAnnotationTool.set(null);
     } else {
-      this.isPanActive.set(false);
-      this.embedPdfBook.setPanMode(false);
+      this.userPanPreferred = false;
+      this.applyPanMode(false);
       this.activeAnnotationTool.set(toolId);
     }
     this.embedPdfBook.setActiveTool(this.activeAnnotationTool());
   }
 
+
   togglePanMode(): void {
-    this.isPanActive.update(v => !v);
-    if (this.isPanActive()) {
-      this.activeAnnotationTool.set(null);
-      this.embedPdfBook.setActiveTool(null);
-    }
-    this.embedPdfBook.setPanMode(this.isPanActive());
+    const nextValue = !this.isPanActive();
+    this.userPanPreferred = nextValue;
+    this.applyPanMode(nextValue);
   }
+
 
   setAnnotationColor(color: string): void {
     this.activeAnnotationColor = color;

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -70,6 +70,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   readonly goToPageInput = signal<number | null>(null);
   readonly outline = signal<PdfOutlineItem[]>([]);
   readonly pdfBookmarks = signal<BookMark[]>([]);
+  readonly isPhone = signal(false);
   readonly annotationListItems = signal<PdfAnnotationListItem[]>([]);
 
   readonly isInitialScrollDone = signal(false);
@@ -190,9 +191,20 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     const dismissed = localStorage.getItem(this.DOC_VIEWER_DISMISSED_KEY);
     this.isDocViewerInfoVisible.set(dismissed !== 'true');
-    const isPhone = window.innerWidth < 768;
+
+    const syncPhoneMode = () => {
+      const isPhone = window.innerWidth < 768;
+      this.isPhone.set(isPhone);
+      this.isPanActive.set(isPhone);
+      if (this.bookViewerInitialized) {
+        this.embedPdfBook.setPanMode(isPhone);
+      }
+    };
+    syncPhoneMode();
+    window.addEventListener('resize', syncPhoneMode);
+    this.destroyRef.onDestroy(() => window.removeEventListener('resize', syncPhoneMode));
+
     this.isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-    this.isPanActive.set(isPhone);
 
     setTimeout(() => this.wakeLockService.enable(), 1000);
     this.startChromeAutoHide();
@@ -1183,10 +1195,9 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
     const deltaY = endY - this.touchStartY;
     const elapsed = Date.now() - this.touchStartTime;
 
-    const isPhone = window.innerWidth < 768;
     // Swipe detection: enough horizontal movement, more horizontal than vertical.
     // Skip if pan mode is active OR if on a phone to prevent accidental page turns during selection/navigation.
-    const skipSwipe = isPhone || this.isPanActive();
+    const skipSwipe = this.isPhone() || this.isPanActive();
 
     if (!skipSwipe && this.touchMoveCount >= 3 && Math.abs(deltaX) > this.SWIPE_THRESHOLD && Math.abs(deltaX) > Math.abs(deltaY) * 1.5) {
       this.ngZone.run(() => {
@@ -1207,10 +1218,10 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
       this.ngZone.run(() => {
         // On phones, disable tap-to-change-page zones to prevent accidental navigation.
         // Taps will only toggle the chrome.
-        if (!isPhone && tapX < screenWidth * this.TAP_ZONE_RATIO) {
+        if (!this.isPhone() && tapX < screenWidth * this.TAP_ZONE_RATIO) {
           // Left zone: previous page
           this.goToPreviousPage();
-        } else if (!isPhone && tapX > screenWidth * (1 - this.TAP_ZONE_RATIO)) {
+        } else if (!this.isPhone() && tapX > screenWidth * (1 - this.TAP_ZONE_RATIO)) {
           // Right zone: next page
           this.goToNextPage();
         } else {

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -190,7 +190,9 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     const dismissed = localStorage.getItem(this.DOC_VIEWER_DISMISSED_KEY);
     this.isDocViewerInfoVisible.set(dismissed !== 'true');
+    const isPhone = window.innerWidth < 768;
     this.isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    this.isPanActive.set(isPhone);
 
     setTimeout(() => this.wakeLockService.enable(), 1000);
     this.startChromeAutoHide();
@@ -434,6 +436,10 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
         this.t.getActiveLang()
       );
       this.bookViewerInitialized = true;
+
+      if (this.isPanActive()) {
+        this.embedPdfBook.setPanMode(true);
+      }
 
       // Cache the raw PDF bytes so the doc-viewer switch never needs a network request
       if (!this.cachedPdfBuffer) {
@@ -1177,8 +1183,12 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
     const deltaY = endY - this.touchStartY;
     const elapsed = Date.now() - this.touchStartTime;
 
-    // Swipe detection: enough horizontal movement, more horizontal than vertical
-    if (this.touchMoveCount >= 3 && Math.abs(deltaX) > this.SWIPE_THRESHOLD && Math.abs(deltaX) > Math.abs(deltaY) * 1.5) {
+    const isPhone = window.innerWidth < 768;
+    // Swipe detection: enough horizontal movement, more horizontal than vertical.
+    // Skip if pan mode is active OR if on a phone to prevent accidental page turns during selection/navigation.
+    const skipSwipe = isPhone || this.isPanActive();
+
+    if (!skipSwipe && this.touchMoveCount >= 3 && Math.abs(deltaX) > this.SWIPE_THRESHOLD && Math.abs(deltaX) > Math.abs(deltaY) * 1.5) {
       this.ngZone.run(() => {
         if (deltaX < 0) {
           this.goToNextPage();
@@ -1195,14 +1205,16 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
       const tapX = this.touchStartX;
 
       this.ngZone.run(() => {
-        if (tapX < screenWidth * this.TAP_ZONE_RATIO) {
+        // On phones, disable tap-to-change-page zones to prevent accidental navigation.
+        // Taps will only toggle the chrome.
+        if (!isPhone && tapX < screenWidth * this.TAP_ZONE_RATIO) {
           // Left zone: previous page
           this.goToPreviousPage();
-        } else if (tapX > screenWidth * (1 - this.TAP_ZONE_RATIO)) {
+        } else if (!isPhone && tapX > screenWidth * (1 - this.TAP_ZONE_RATIO)) {
           // Right zone: next page
           this.goToNextPage();
         } else {
-          // Center zone: toggle chrome
+          // Center zone (or any zone on phone): toggle chrome
           if (this.headerVisible() || this.footerVisible()) {
             this.hideChrome();
           } else {


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

This pull request improves the mobile usability of the `PdfReaderComponent` by adjusting gesture handling and navigation to prevent accidental page turns and interactions on phones. The main changes ensure that swipe and tap gestures behave differently on phones, prioritizing document selection and navigation over page turning.

**Mobile gesture and navigation improvements:**

* In `ngOnInit`, the component now detects if the device is a phone (screen width < 768px) and automatically enables pan mode for a better touch experience.
* During PDF viewer initialization, pan mode is activated if the device is detected as a phone, ensuring smoother navigation and preventing accidental page turns.

**Gesture handling changes:**

* Swipe-to-change-page gestures are now disabled on phones and when pan mode is active, reducing accidental page turns during document selection or navigation.
* Tap-to-change-page zones (left/right screen tap for previous/next page) are disabled on phones; taps only toggle the UI chrome, further preventing unintended navigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic pan mode on narrow screens (phones) for smoother PDF navigation; remembers user pan preference when resizing.

* **Bug Fixes**
  * Reduced accidental page turns by disabling swipe and tap-to-navigate zones when pan mode is active or on phones; taps on phones now primarily toggle viewer chrome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->