### PR TITLE
chore: drop `booklore-ui` symlink

### DIFF
--- a/booklore-ui
+++ b/booklore-ui
@@ -1,1 +1,0 @@
-frontend


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
drops the `booklore-ui` symlink because we no longer require this for CI or build scripts

**Linked Issue:** Related to #750

## Changes

* drops the `booklore-ui` symlink

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused configuration and dependencies to streamline the project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->