### PR TITLE
ci: temp disable dependabot typescript updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,9 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "typescript"
+
 
   # Release tooling – npm (semantic-release)
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,6 @@ updates:
     ignore:
       - dependency-name: "typescript"
 
-
   # Release tooling – npm (semantic-release)
   - package-ecosystem: "npm"
     directory: "/tools/release"


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Configure dependabot to ignore typescript because it's incompatible to upgrade with our angular version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->