### PR TITLE
fix(ci): skip nightly Discord notifications when no release is predicted

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -165,7 +165,7 @@ jobs:
 
   notify-discord:
     name: Notify Discord (Nightly)
-    if: ${{ always() && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' }}
+    if: ${{ always() && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' && needs.generate-notes.outputs.predicted_version != '' }}
     needs: [resolve_ref, build-and-push, generate-notes]
     permissions: {}
     uses: ./.github/workflows/notify-discord-release-notes.yml


### PR DESCRIPTION
## Description

Skips the nightly Discord notification when the generated release notes do not predict a release version.

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/769

## Changes

- gate the nightly Discord job on `predicted_version`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved notification reliability in release pipeline by refining trigger conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->