### PR TITLE
fix(api): use correct field for `lastReadTime`

### DIFF
--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -1061,7 +1061,7 @@ public class AppBookService {
             case "publisher" -> "metadata.publisher";
             case "language" -> "metadata.language";
             case "publisheddate" -> "metadata.publishedDate";
-            case "lastreadtime" -> "lastReadTime";
+            case "lastreadtime" -> "userBookProgress.lastReadTime";
             case "pagecount" -> "metadata.pageCount";
             default -> "addedOn";
         };


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
For the sort order `lastreadtime` we current try to use the field `lastReadTime` off of `BookEntity`.  this does not exist which leads to an exception and a failure

Instead, we can use `progress.lastReadTime`

**Linked Issue:** Fixes #776

## Changes

* Update the sort order `lastreadtime` to use `progress.lastReadTime` under the hood


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the sort order when filtering by "last read time" to ensure books are displayed in the accurate sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->