### PR TITLE
fix(api): use correct field for lastReadTime

### DIFF
--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -1061,7 +1061,7 @@ public class AppBookService {
             case "publisher" -> "metadata.publisher";
             case "language" -> "metadata.language";
             case "publisheddate" -> "metadata.publishedDate";
-            case "lastreadtime" -> "lastReadTime";
+            case "lastreadtime" -> "userBookProgress.lastReadTime";
             case "pagecount" -> "metadata.pageCount";
             default -> "addedOn";
         };

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -1044,6 +1044,11 @@ public class AppBookService {
             }
         }
 
+        // For `lastReadTime` sorting we need to filter to only the current user's progress.
+        if ("lastreadtime".equalsIgnoreCase(req.sort())) {
+            specs.add(AppBookSpecification.withProgress(userId, true));
+        }
+
         return AppBookSpecification.combine(specs.toArray(new Specification[0]));
     }
 

--- a/backend/src/main/java/org/booklore/app/specification/AppBookSpecification.java
+++ b/backend/src/main/java/org/booklore/app/specification/AppBookSpecification.java
@@ -131,6 +131,28 @@ public class AppBookSpecification {
         };
     }
 
+    /**
+     * Filter books that have any progress for a specific user.
+     * If `optional` is true, allow books without user progress to be included
+     * but omit other user's progress.
+     */
+    public static Specification<BookEntity> withProgress(Long userId, boolean optional) {
+        return (root, query, cb) -> {
+            if (userId == null) {
+                return cb.conjunction();
+            }
+
+            Join<BookEntity, UserBookProgressEntity> progressJoin = root.join("userBookProgress", JoinType.LEFT);
+            progressJoin = progressJoin.on(cb.equal(progressJoin.get("user").get("id"), userId));
+
+            if (optional) {
+                return cb.conjunction();
+            }
+
+            return cb.equal(progressJoin.get("user").get("id"), userId);
+        };
+    }
+
     public static Specification<BookEntity> addedWithinDays(int days) {
         return (root, query, cb) -> {
             Instant cutoff = Instant.now().minus(days, ChronoUnit.DAYS);


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
For the sort order `lastreadtime` we current try to use the field `lastReadTime` off of `BookEntity`.  this does not exist which leads to an exception and a failure

Instead, we can use `progress.lastReadTime`

**Linked Issue:** Fixes #776

## Changes

* Update the sort order `lastreadtime` to use `progress.lastReadTime`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced 'last read time' sorting to exclusively display your books with accurate filtering based on your reading progress. This improvement ensures that when sorting by this criteria, you see only books from your personal library, with proper timestamps accurately reflecting your reading history and recent access moments for each title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->