### PR TITLE
fix(api): use configurable upload limit for author photo / book cover

### DIFF
--- a/backend/src/main/java/org/booklore/service/AuthorMetadataService.java
+++ b/backend/src/main/java/org/booklore/service/AuthorMetadataService.java
@@ -12,11 +12,13 @@ import org.booklore.model.dto.CoverImage;
 import org.booklore.model.dto.Library;
 import org.booklore.model.dto.request.AuthorMatchRequest;
 import org.booklore.model.dto.request.AuthorUpdateRequest;
+import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.entity.AuthorEntity;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.enums.AuditAction;
 import org.booklore.model.enums.AuthorMetadataSource;
 import org.booklore.repository.AuthorRepository;
+import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.service.audit.AuditService;
 import org.booklore.service.metadata.DuckDuckGoCoverService;
 import org.booklore.service.metadata.parser.AuthorParser;
@@ -52,6 +54,7 @@ public class AuthorMetadataService {
     private final FileService fileService;
     private final DuckDuckGoCoverService duckDuckGoCoverService;
     private final AuthenticationService authenticationService;
+    private final AppSettingService appSettingService;
 
     public List<AuthorSummary> getAllAuthors() {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
@@ -211,10 +214,36 @@ public class AuthorMetadataService {
         }
     }
 
+    private long getMaxFileUploadSizeMb() {
+        AppSettings appSettings = this.appSettingService.getAppSettings();
+
+        Integer maxFileUploadSizeMb = appSettings.getMaxFileUploadSizeInMb();
+
+        if (maxFileUploadSizeMb == null) {
+            log.warn("Max File Upload Size is unset, defaulting to 0");
+            return 0L;
+        }
+
+        return maxFileUploadSizeMb.longValue();
+    }
+
+    private void validatePhoto(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw ApiError.INVALID_INPUT.createException("Uploaded file is empty");
+        }
+        long maxSizeMb = getMaxFileUploadSizeMb();
+        long maxFileSize = maxSizeMb * 1024 * 1024;
+        if (file.getSize() > maxFileSize) {
+            throw ApiError.FILE_TOO_LARGE.createException(maxSizeMb);
+        }
+    }
+
     @Transactional
     public void uploadAuthorPhoto(Long authorId, MultipartFile file) {
         AuthorEntity author = authorRepository.findById(authorId)
                 .orElseThrow(() -> ApiError.AUTHOR_NOT_FOUND.createException(authorId));
+
+        validatePhoto(file);
 
         try {
             java.awt.image.BufferedImage image = FileService.readImage(file.getInputStream());

--- a/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
@@ -509,8 +509,8 @@ public class BookCoverService {
         Integer maxFileUploadSizeMb = appSettings.getMaxFileUploadSizeInMb();
 
         if (maxFileUploadSizeMb == null) {
-            log.warn("Max File Upload Size is unset, defaulting to 0");
-            return 0L;
+            log.warn("Max File Upload Size is unset, cannot continue");
+            throw ApiError.INTERNAL_SERVER_ERROR.createException("Max File Upload Size is Unset");
         }
 
         return maxFileUploadSizeMb.longValue();

--- a/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
@@ -3,6 +3,7 @@ package org.booklore.service.metadata;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.exception.ApiError;
+import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.settings.MetadataPersistenceSettings;
 import org.booklore.model.entity.AuthorEntity;
 import org.booklore.model.entity.BookEntity;
@@ -502,13 +503,27 @@ public class BookCoverService {
     // SECTION: INTERNAL HELPERS
     // =========================
 
+    private long getMaxFileUploadSizeMb() {
+        AppSettings appSettings = this.appSettingService.getAppSettings();
+
+        Integer maxFileUploadSizeMb = appSettings.getMaxFileUploadSizeInMb();
+
+        if (maxFileUploadSizeMb == null) {
+            log.warn("Max File Upload Size is unset, defaulting to 0");
+            return 0L;
+        }
+
+        return maxFileUploadSizeMb.longValue();
+    }
+
     private void validateCoverFile(MultipartFile file) {
         if (file.isEmpty()) {
             throw ApiError.INVALID_INPUT.createException("Uploaded file is empty");
         }
-        long maxFileSize = 5L * 1024 * 1024;
+        long maxSizeMb = getMaxFileUploadSizeMb();
+        long maxFileSize = maxSizeMb * 1024 * 1024;
         if (file.getSize() > maxFileSize) {
-            throw ApiError.FILE_TOO_LARGE.createException(5);
+            throw ApiError.FILE_TOO_LARGE.createException(maxSizeMb);
         }
         // Detect MIME from content byte never trust the client-supplied Content-Type header
         try (var inputStream = file.getInputStream()) {

--- a/backend/src/main/java/org/booklore/util/FileService.java
+++ b/backend/src/main/java/org/booklore/util/FileService.java
@@ -216,7 +216,7 @@ public class FileService {
         long maxSizeMb = getMaxFileUploadSizeMb();
         long maxFileSize = maxSizeMb * 1024 * 1024;
         if (file.getSize() > maxFileSize) {
-            throw new IllegalArgumentException("File size must not exceed 5 MB");
+            throw ApiError.FILE_TOO_LARGE.createException(maxSizeMb);
         }
     }
 

--- a/backend/src/main/java/org/booklore/util/FileService.java
+++ b/backend/src/main/java/org/booklore/util/FileService.java
@@ -2,6 +2,7 @@ package org.booklore.util;
 
 import org.booklore.config.AppProperties;
 import org.booklore.exception.ApiError;
+import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.settings.CoverCroppingSettings;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.service.appsettings.AppSettingService;
@@ -187,7 +188,20 @@ public class FileService {
     // VALIDATION
     // ========================================
 
-    private static void validateCoverFile(MultipartFile file) {
+    private long getMaxFileUploadSizeMb() {
+        AppSettings appSettings = this.appSettingService.getAppSettings();
+
+        Integer maxFileUploadSizeMb = appSettings.getMaxFileUploadSizeInMb();
+
+        if (maxFileUploadSizeMb == null) {
+            log.warn("Max File Upload Size is unset, defaulting to 0");
+            return 0L;
+        }
+
+        return maxFileUploadSizeMb.longValue();
+    }
+
+    private void validateCoverFile(MultipartFile file) {
         if (file.isEmpty()) {
             throw new IllegalArgumentException("Uploaded file is empty");
         }
@@ -199,7 +213,9 @@ public class FileService {
         if (!lowerType.startsWith(JPEG_MIME_TYPE) && !lowerType.startsWith(PNG_MIME_TYPE)) {
             throw new IllegalArgumentException("Only JPEG and PNG files are allowed");
         }
-        if (file.getSize() > MAX_FILE_SIZE_BYTES) {
+        long maxSizeMb = getMaxFileUploadSizeMb();
+        long maxFileSize = maxSizeMb * 1024 * 1024;
+        if (file.getSize() > maxFileSize) {
             throw new IllegalArgumentException("File size must not exceed 5 MB");
         }
     }

--- a/backend/src/main/java/org/booklore/util/FileService.java
+++ b/backend/src/main/java/org/booklore/util/FileService.java
@@ -194,8 +194,8 @@ public class FileService {
         Integer maxFileUploadSizeMb = appSettings.getMaxFileUploadSizeInMb();
 
         if (maxFileUploadSizeMb == null) {
-            log.warn("Max File Upload Size is unset, defaulting to 0");
-            return 0L;
+            log.warn("Max File Upload Size is unset, cannot continue");
+            throw ApiError.INTERNAL_SERVER_ERROR.createException("Max File Upload Size is Unset");
         }
 
         return maxFileUploadSizeMb.longValue();

--- a/backend/src/test/java/org/booklore/service/AuthorMetadataServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/AuthorMetadataServiceTest.java
@@ -10,6 +10,7 @@ import org.booklore.model.entity.AuthorEntity;
 import org.booklore.model.enums.AuditAction;
 import org.booklore.model.enums.AuthorMetadataSource;
 import org.booklore.repository.AuthorRepository;
+import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.service.audit.AuditService;
 import org.booklore.service.metadata.DuckDuckGoCoverService;
 import org.booklore.service.metadata.parser.AuthorParser;
@@ -41,6 +42,7 @@ class AuthorMetadataServiceTest {
     @Mock private FileService fileService;
     @Mock private DuckDuckGoCoverService duckDuckGoCoverService;
     @Mock private AuthenticationService authenticationService;
+    @Mock private AppSettingService appSettingService;
 
     private AuthorMetadataService service;
 
@@ -49,7 +51,16 @@ class AuthorMetadataServiceTest {
         Map<AuthorMetadataSource, AuthorParser> authorParserMap = Map.of(
                 AuthorMetadataSource.AUDNEXUS, authorParser
         );
-        service = new AuthorMetadataService(authorRepository, authorParserMap, auditService, fileService, duckDuckGoCoverService, authenticationService);
+
+        service = new AuthorMetadataService(
+                authorRepository,
+                authorParserMap,
+                auditService,
+                fileService,
+                duckDuckGoCoverService,
+                authenticationService,
+                appSettingService
+        );
 
         BookLoreUser.UserPermissions adminPermissions = new BookLoreUser.UserPermissions();
         adminPermissions.setAdmin(true);

--- a/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
@@ -57,6 +57,7 @@ class BookCoverServiceTest {
     @Mock private TransactionTemplate transactionTemplate;
     @Mock private Executor taskExecutor;
     @Mock private AuthenticationService authenticationService;
+    @Mock private AppSettings appSettings;
 
     @InjectMocks
     private BookCoverService service;
@@ -396,6 +397,9 @@ class BookCoverServiceTest {
 
         @Test
         void filtersOutLockedBooksForBulkOperations() {
+            when(appSettingService.getAppSettings()).thenReturn(appSettings);
+            when(appSettings.getMaxFileUploadSizeInMb()).thenReturn(5);
+
             BookEntity unlocked = buildBook(1L, false);
             BookEntity locked = buildBook(2L, true);
 
@@ -431,6 +435,9 @@ class BookCoverServiceTest {
 
         @Test
         void rejectsNonImageContentType() throws Exception {
+            when(appSettingService.getAppSettings()).thenReturn(appSettings);
+            when(appSettings.getMaxFileUploadSizeInMb()).thenReturn(5);
+
             MultipartFile file = mock(MultipartFile.class);
             when(file.isEmpty()).thenReturn(false);
             when(file.getSize()).thenReturn(1024L);
@@ -442,7 +449,10 @@ class BookCoverServiceTest {
         }
 
         @Test
-        void rejectsFileLargerThan5MB() {
+        void rejectsFileLargerThanLimit() {
+            when(appSettingService.getAppSettings()).thenReturn(appSettings);
+            when(appSettings.getMaxFileUploadSizeInMb()).thenReturn(5);
+
             MultipartFile file = mock(MultipartFile.class);
             when(file.isEmpty()).thenReturn(false);
             when(file.getSize()).thenReturn(6L * 1024 * 1024);
@@ -454,6 +464,9 @@ class BookCoverServiceTest {
 
         @Test
         void acceptsJpegFile() {
+            when(appSettingService.getAppSettings()).thenReturn(appSettings);
+            when(appSettings.getMaxFileUploadSizeInMb()).thenReturn(5);
+
             MultipartFile file = mock(MultipartFile.class);
             when(file.isEmpty()).thenReturn(false);
             when(file.getSize()).thenReturn(1024L);
@@ -469,6 +482,9 @@ class BookCoverServiceTest {
 
         @Test
         void acceptsPngFile() {
+            when(appSettingService.getAppSettings()).thenReturn(appSettings);
+            when(appSettings.getMaxFileUploadSizeInMb()).thenReturn(5);
+
             MultipartFile file = mock(MultipartFile.class);
             when(file.isEmpty()).thenReturn(false);
             when(file.getSize()).thenReturn(1024L);
@@ -484,6 +500,9 @@ class BookCoverServiceTest {
 
         @Test
         void rejectsIOExceptionOnRead() throws Exception {
+            when(appSettingService.getAppSettings()).thenReturn(appSettings);
+            when(appSettings.getMaxFileUploadSizeInMb()).thenReturn(5);
+
             MultipartFile file = mock(MultipartFile.class);
             when(file.isEmpty()).thenReturn(false);
             when(file.getSize()).thenReturn(1024L);
@@ -712,6 +731,9 @@ class BookCoverServiceTest {
 
         @Test
         void processesOnlyUnlockedBooks() throws Exception {
+            when(appSettingService.getAppSettings()).thenReturn(appSettings);
+            when(appSettings.getMaxFileUploadSizeInMb()).thenReturn(5);
+
             BookEntity unlocked = buildBook(1L, false);
             BookEntity locked = buildBook(2L, true);
 
@@ -959,7 +981,6 @@ class BookCoverServiceTest {
             book.setLibrary(LibraryEntity.builder().build());
             book.setLibraryPath(LibraryPathEntity.builder().path("/lib").build());
 
-            AppSettings appSettings = mock(AppSettings.class);
             MetadataPersistenceSettings persistSettings = mock(MetadataPersistenceSettings.class);
             when(appSettingService.getAppSettings()).thenReturn(appSettings);
             when(appSettings.getMetadataPersistenceSettings()).thenReturn(persistSettings);

--- a/backend/src/test/java/org/booklore/util/FileServiceTest.java
+++ b/backend/src/test/java/org/booklore/util/FileServiceTest.java
@@ -1033,6 +1033,12 @@ class FileServiceTest {
 
             @Test
             void fileTooLarge_throwsRuntimeException() {
+                when(appSettingService.getAppSettings()).thenReturn(
+                        AppSettings.builder()
+                                .maxFileUploadSizeInMb(5)
+                                .build()
+                );
+
                 byte[] largeData = new byte[6 * 1024 * 1024]; // 6MB
                 MockMultipartFile largeFile = new MockMultipartFile(
                         "file", "large.jpg", "image/jpeg", largeData);

--- a/backend/src/test/java/org/booklore/util/FileServiceTest.java
+++ b/backend/src/test/java/org/booklore/util/FileServiceTest.java
@@ -972,6 +972,12 @@ class FileServiceTest {
 
             @Test
             void validJpegFile_succeeds() throws IOException {
+                when(appSettingService.getAppSettings()).thenReturn(
+                        AppSettings.builder()
+                                .maxFileUploadSizeInMb(5)
+                                .build()
+                );
+
                 BufferedImage image = createTestImage(300, 400);
                 byte[] imageBytes = imageToBytes(image);
                 MockMultipartFile file = new MockMultipartFile(
@@ -984,6 +990,12 @@ class FileServiceTest {
 
             @Test
             void validPngFile_succeeds() throws IOException {
+                when(appSettingService.getAppSettings()).thenReturn(
+                        AppSettings.builder()
+                                .maxFileUploadSizeInMb(5)
+                                .build()
+                );
+
                 BufferedImage image = createTestImage(300, 400);
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 ImageIO.write(image, "PNG", baos);
@@ -1035,6 +1047,12 @@ class FileServiceTest {
 
             @Test
             void fileExactlyAtSizeLimit_succeeds() throws IOException {
+                when(appSettingService.getAppSettings()).thenReturn(
+                        AppSettings.builder()
+                                .maxFileUploadSizeInMb(5)
+                                .build()
+                );
+
                 BufferedImage image = createTestImage(100, 100);
                 byte[] imageBytes = imageToBytes(image);
                 // Ensure it's under 5MB
@@ -1049,6 +1067,12 @@ class FileServiceTest {
 
             @Test
             void caseInsensitiveMimeType_succeeds() throws IOException {
+                when(appSettingService.getAppSettings()).thenReturn(
+                        AppSettings.builder()
+                                .maxFileUploadSizeInMb(5)
+                                .build()
+                );
+
                 BufferedImage image = createTestImage(100, 100);
                 byte[] imageBytes = imageToBytes(image);
                 MockMultipartFile file = new MockMultipartFile(
@@ -1083,6 +1107,12 @@ class FileServiceTest {
 
             @Test
             void mimeTypeWithExtraParameters_succeeds() throws IOException {
+                when(appSettingService.getAppSettings()).thenReturn(
+                        AppSettings.builder()
+                                .maxFileUploadSizeInMb(5)
+                                .build()
+                );
+
                 BufferedImage image = createTestImage(100, 100);
                 byte[] imageBytes = imageToBytes(image);
                 MockMultipartFile file = new MockMultipartFile(


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Previously, the file upload limit for author photos and book covers defaulted to 5mb.  However, some users (for some reason) want humongous book covers and requested to have this limit increased.

This change updates the author photo and book cover systems to use the server setting `maxFileUploadSizeInMb` to determine the expected maximum file size for an upload.

**Linked Issue:** Fixes #781<!-- issue number leave empty if none -->

## Changes

* adds a file size limit to the author photo upload based on the `maxFileUploadSizeInMb` setting
* updates the file size limit in book cover upload to use the `maxFileUploadSizeInMb` setting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Upload size limits for author photos, book covers and other file uploads are now configurable via app settings; missing settings log a warning and cause uploads to be blocked. Empty uploads are rejected and oversized files are refused with a clear error referencing the configured limit.
* **Tests**
  * Test suites updated to enforce and validate the new configurable upload-size behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->