### PR TITLE
fix(reader): enforce CSP in rendered foliate documents

### DIFF
--- a/frontend/src/assets/foliate/epub.js
+++ b/frontend/src/assets/foliate/epub.js
@@ -108,6 +108,17 @@ const resolveURL = (url, relativeTo) => {
 
 const isExternal = uri => /^(?!blob)\w+:/i.test(uri)
 
+const prependScriptBlockingMetaCsp = doc => {
+    const head = doc.querySelector('head')
+    if (!head) return
+    if (head.querySelector('meta[http-equiv="Content-Security-Policy"]')) return
+    const nsURI = doc.documentElement?.namespaceURI
+    const meta = nsURI ? doc.createElementNS(nsURI, 'meta') : doc.createElement('meta')
+    meta.setAttribute('http-equiv', 'Content-Security-Policy')
+    meta.setAttribute('content', "script-src 'none'")
+    head.prepend(meta)
+}
+
 // like `path.relative()` in Node.js
 const pathRelative = (from, to) => {
     if (!from) return to
@@ -923,6 +934,9 @@ class Loader {
             for (const el of doc.querySelectorAll('[style]'))
                 el.setAttribute('style',
                     await this.replaceCSS(el.getAttribute('style'), href, parents))
+            // Keep rendered book documents non-scriptable even when Safari requires
+            // allow-scripts on the iframe for parent-side interaction.
+            prependScriptBlockingMetaCsp(doc)
             // TODO: replace inline scripts? probably not worth the trouble
             const result = new XMLSerializer().serializeToString(doc)
             return this.createURL(href, result, item.mediaType, parent)

--- a/frontend/src/assets/foliate/epub.js
+++ b/frontend/src/assets/foliate/epub.js
@@ -111,7 +111,6 @@ const isExternal = uri => /^(?!blob)\w+:/i.test(uri)
 const prependScriptBlockingMetaCsp = doc => {
     const head = doc.querySelector('head')
     if (!head) return
-    if (head.querySelector('meta[http-equiv="Content-Security-Policy"]')) return
     const nsURI = doc.documentElement?.namespaceURI
     const meta = nsURI ? doc.createElementNS(nsURI, 'meta') : doc.createElement('meta')
     meta.setAttribute('http-equiv', 'Content-Security-Policy')

--- a/frontend/src/assets/foliate/epub.js
+++ b/frontend/src/assets/foliate/epub.js
@@ -108,9 +108,31 @@ const resolveURL = (url, relativeTo) => {
 
 const isExternal = uri => /^(?!blob)\w+:/i.test(uri)
 
+const ensureDocumentRoot = doc => {
+    if (doc.documentElement) return doc.documentElement
+
+    const root = doc.createElementNS(NS.XHTML, 'html')
+    while (doc.firstChild) root.append(doc.firstChild)
+    doc.append(root)
+    return root
+}
+
+const ensureHeadElement = doc => {
+    const root = ensureDocumentRoot(doc)
+    let head = Array.from(root.children)
+        .find(el => el.localName?.toLowerCase() === 'head')
+    if (head) return head
+
+    const nsURI = root.namespaceURI
+    head = nsURI ? doc.createElementNS(nsURI, 'head') : doc.createElement('head')
+    const body = Array.from(root.children)
+        .find(el => el.localName?.toLowerCase() === 'body')
+    root.insertBefore(head, body ?? root.firstChild)
+    return head
+}
+
 const prependScriptBlockingMetaCsp = doc => {
-    const head = doc.querySelector('head')
-    if (!head) return
+    const head = ensureHeadElement(doc)
     const nsURI = doc.documentElement?.namespaceURI
     const meta = nsURI ? doc.createElementNS(nsURI, 'meta') : doc.createElement('meta')
     meta.setAttribute('http-equiv', 'Content-Security-Policy')

--- a/frontend/src/assets/foliate/fixed-layout.js
+++ b/frontend/src/assets/foliate/fixed-layout.js
@@ -81,9 +81,10 @@ export class FixedLayout extends HTMLElement {
             display: 'none',
             overflow: 'hidden',
         })
-        // Foliate recommends disabling scripts for untrusted book content:
-        // https://github.com/johnfactotum/foliate-js#security
-        iframe.setAttribute('sandbox', 'allow-same-origin')
+        // Safari blocks parent-side interaction with sandboxed iframe content without
+        // allow-scripts. We inject CSP into the rendered documents instead:
+        // https://bugs.webkit.org/show_bug.cgi?id=218086
+        iframe.setAttribute('sandbox', 'allow-same-origin allow-scripts')
         iframe.setAttribute('scrolling', 'no')
         iframe.setAttribute('part', 'filter')
         this.#root.append(element)

--- a/frontend/src/assets/foliate/mobi.js
+++ b/frontend/src/assets/foliate/mobi.js
@@ -13,9 +13,30 @@ const MIME = {
     SVG: 'image/svg+xml',
 }
 
+const ensureDocumentRoot = doc => {
+    if (doc.documentElement) return doc.documentElement
+
+    const root = doc.createElement('html')
+    while (doc.firstChild) root.append(doc.firstChild)
+    doc.append(root)
+    return root
+}
+
+const ensureHeadElement = doc => {
+    const root = ensureDocumentRoot(doc)
+    let head = Array.from(root.children)
+        .find(el => el.localName?.toLowerCase() === 'head')
+    if (head) return head
+
+    head = doc.createElement('head')
+    const body = Array.from(root.children)
+        .find(el => el.localName?.toLowerCase() === 'body')
+    root.insertBefore(head, body ?? root.firstChild)
+    return head
+}
+
 const prependScriptBlockingMetaCsp = doc => {
-    const head = doc.querySelector('head')
-    if (!head) return
+    const head = ensureHeadElement(doc)
     const meta = doc.createElement('meta')
     meta.setAttribute('http-equiv', 'Content-Security-Policy')
     meta.setAttribute('content', "script-src 'none'")

--- a/frontend/src/assets/foliate/mobi.js
+++ b/frontend/src/assets/foliate/mobi.js
@@ -16,7 +16,6 @@ const MIME = {
 const prependScriptBlockingMetaCsp = doc => {
     const head = doc.querySelector('head')
     if (!head) return
-    if (head.querySelector('meta[http-equiv="Content-Security-Policy"]')) return
     const meta = doc.createElement('meta')
     meta.setAttribute('http-equiv', 'Content-Security-Policy')
     meta.setAttribute('content', "script-src 'none'")

--- a/frontend/src/assets/foliate/mobi.js
+++ b/frontend/src/assets/foliate/mobi.js
@@ -13,6 +13,16 @@ const MIME = {
     SVG: 'image/svg+xml',
 }
 
+const prependScriptBlockingMetaCsp = doc => {
+    const head = doc.querySelector('head')
+    if (!head) return
+    if (head.querySelector('meta[http-equiv="Content-Security-Policy"]')) return
+    const meta = doc.createElement('meta')
+    meta.setAttribute('http-equiv', 'Content-Security-Policy')
+    meta.setAttribute('content', "script-src 'none'")
+    head.prepend(meta)
+}
+
 const PDB_HEADER = {
     name: [0, 32, 'string'],
     type: [60, 4, 'string'],
@@ -862,6 +872,9 @@ class MOBI6 {
         }`))
 
         await this.replaceResources(doc)
+        // Keep rendered book documents non-scriptable even when Safari requires
+        // allow-scripts on the iframe for parent-side interaction.
+        prependScriptBlockingMetaCsp(doc)
         const result = this.serializer.serializeToString(doc)
         const url = URL.createObjectURL(new Blob([result], { type: this.#type }))
         this.#cache.set(section, url)

--- a/frontend/src/assets/foliate/paginator.js
+++ b/frontend/src/assets/foliate/paginator.js
@@ -239,9 +239,10 @@ class View {
             display: 'none',
             width: '100%', height: '100%',
         })
-        // Foliate recommends disabling scripts for untrusted book content:
-        // https://github.com/johnfactotum/foliate-js#security
-        this.#iframe.setAttribute('sandbox', 'allow-same-origin')
+        // Safari blocks parent-side interaction with sandboxed iframe content without
+        // allow-scripts. We inject CSP into the rendered documents instead:
+        // https://bugs.webkit.org/show_bug.cgi?id=218086
+        this.#iframe.setAttribute('sandbox', 'allow-same-origin allow-scripts')
         this.#iframe.setAttribute('scrolling', 'no')
     }
     get element() {


### PR DESCRIPTION
## Description

Restores EPUB reader usability on iOS Safari while keeping script execution blocked for rendered book content.

This changes the Foliate reader back to using `allow-scripts` in the iframe sandbox so Safari can properly handle reader tap and touch interactions again, and moves the script-blocking control into the actual rendered Foliate documents by injecting a `Content-Security-Policy` meta tag before they are serialized to `blob:` URLs

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/793

## Changes

- restore `allow-scripts` in Foliate paginator and `fixed-layout` iframe sandboxes
- inject `Content-Security-Policy: script-src 'none'` into rendered EPUB/MOBI documents in `epub.js` + `mobi.js`
- document the Safari/WebKit limitation in the Foliate iframe sandbox comments

## Testing

- Performed a red/green test using sample EPUBs that use scripted content to verify no regression in blocking scripts. Test coverage included sample EPUBs w/ scripted content in the body, as well as files with no head and scripted content within an SVG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Rendered book content now includes a Content Security Policy that blocks script execution, preventing embedded scripts from running.

* **Compatibility**
  * Improved Safari and iframe interaction by adjusting sandbox behavior while preserving script blocking via the injected CSP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->