### PR TITLE
fix(metadata): hide sidecar tab when sidecar json is disabled

### DIFF
--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.html
@@ -37,7 +37,7 @@
           {{ t('tabSearch') }}
         </p-tab>
       }
-      @if ((admin || canEditMetadata) && !isPhysical && isLocalStorage) {
+      @if (canShowSidecarTab) {
         <p-tab value="sidecar">
           <i [class]="'pi pi-file'"></i>
           {{ t('tabSidecar') }}
@@ -63,7 +63,7 @@
           <app-metadata-searcher [book]="book()" [isActiveTab]="tab === 'match'"></app-metadata-searcher>
         </p-tabpanel>
       }
-      @if ((admin || canEditMetadata) && !isPhysical && isLocalStorage) {
+      @if (canShowSidecarTab) {
         <p-tabpanel value="sidecar">
           <app-sidecar-viewer [book]="book()"></app-sidecar-viewer>
         </p-tabpanel>

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.spec.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.spec.ts
@@ -1,9 +1,81 @@
-import {describe, expect, it} from 'vitest';
+import {signal, type WritableSignal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {ActivatedRoute, Router} from '@angular/router';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 
-// TODO(seam): This surface combines routed params, dynamic-dialog inputs, TanStack query
-// state, and metadata-host book switching, so it needs a routed integration harness.
-describe.skip('BookMetadataCenterComponent', () => {
-  it('needs a routed dialog harness for tab sync, book switching, and recommendation loading', () => {
-    expect.hasAssertions();
+import {createQueryClientHarness} from '../../../../core/testing/query-testing';
+import {AppSettings, type MetadataPersistenceSettings} from '../../../../shared/model/app-settings.model';
+import {AppSettingsService} from '../../../../shared/service/app-settings.service';
+import {BookMetadataHostService} from '../../../../shared/service/book-metadata-host.service';
+import {BookService} from '../../../book/service/book.service';
+import {UserService} from '../../../settings/user-management/user.service';
+import {BookMetadataCenterComponent} from './book-metadata-center.component';
+
+describe('BookMetadataCenterComponent', () => {
+  let appSettingsSignal: WritableSignal<AppSettings | null>;
+  let currentUserSignal: WritableSignal<{permissions?: {admin?: boolean; canEditMetadata?: boolean}} | null>;
+
+  beforeEach(() => {
+    const queryClientHarness = createQueryClientHarness();
+
+    appSettingsSignal = signal<AppSettings | null>(null);
+    currentUserSignal = signal({permissions: {admin: true, canEditMetadata: true}});
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...queryClientHarness.providers,
+        {provide: ActivatedRoute, useValue: {}},
+        {provide: Router, useValue: {navigate: vi.fn()}},
+        {provide: BookService, useValue: {}},
+        {provide: UserService, useValue: {currentUser: currentUserSignal}},
+        {provide: AppSettingsService, useValue: {appSettings: appSettingsSignal}},
+        {provide: BookMetadataHostService, useValue: {}},
+      ],
+    });
+  });
+
+  it('shows the sidecar tab only when sidecar JSON is enabled', () => {
+    const component = TestBed.runInInjectionContext(() => new BookMetadataCenterComponent());
+    TestBed.flushEffects();
+
+    expect(component.canShowSidecarTab).toBe(false);
+
+    appSettingsSignal.set(buildSettings({sidecarEnabled: true}));
+
+    expect(component.canShowSidecarTab).toBe(true);
+
+    appSettingsSignal.set(buildSettings({sidecarEnabled: false}));
+
+    expect(component.canShowSidecarTab).toBe(false);
   });
 });
+
+function buildSettings({
+  diskType = 'LOCAL',
+  sidecarEnabled,
+}: {
+  diskType?: AppSettings['diskType'];
+  sidecarEnabled: boolean;
+}): AppSettings {
+  const metadataPersistenceSettings: MetadataPersistenceSettings = {
+    moveFilesToLibraryPattern: false,
+    convertCbrCb7ToCbz: false,
+    saveToOriginalFile: {
+      epub: {enabled: false, maxFileSizeInMb: 250},
+      pdf: {enabled: false, maxFileSizeInMb: 250},
+      cbx: {enabled: false, maxFileSizeInMb: 250},
+      audiobook: {enabled: false, maxFileSizeInMb: 1000},
+    },
+    sidecarSettings: {
+      enabled: sidecarEnabled,
+      writeOnUpdate: false,
+      writeOnScan: false,
+      includeCoverFile: false,
+    },
+  };
+
+  return {
+    diskType,
+    metadataPersistenceSettings,
+  } as AppSettings;
+}

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
@@ -86,7 +86,12 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
   });
   get isPhysical(): boolean { return this.book()?.isPhysical ?? false; }
   isLocalStorage: boolean = true;
+  get canShowSidecarTab(): boolean {
+    const settings = this.appSettingsService.appSettings();
+    const sidecarEnabled = settings?.metadataPersistenceSettings?.sidecarSettings?.enabled ?? false;
 
+    return (this.admin || this.canEditMetadata) && !this.isPhysical && this.isLocalStorage && sidecarEnabled;
+  }
   private validTabs = ['view', 'edit', 'match', 'sidecar'];
 
   get tab(): string {


### PR DESCRIPTION
## Description

Currently, Sidecar tab is gated by user permissions, is physical and is local, but not if Sidecar is enabled or not. Hide the Sidecar tab in the book details metadata center when `Enable Sidecar JSON` is disabled.

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/810

## Changes

- hide sidecar tab visibility on existing sidecar logic && `[...].sidecarSettings.enabled`

Note: In testing this, I found that setting the URL param for the view to a view a user doesn't have permissions for just shows an empty screen. Created a follow up outside of this PR on https://github.com/grimmory-tools/grimmory/issues/813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sidecar metadata tab visibility controls using configuration-based logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->