### PR TITLE
fix(file-move): clean up emptied source folders after sidecar move

### DIFF
--- a/backend/src/main/java/org/booklore/service/file/FileMoveService.java
+++ b/backend/src/main/java/org/booklore/service/file/FileMoveService.java
@@ -236,14 +236,14 @@ public class FileMoveService {
             // Also protect the source library root so cleanup doesn't traverse above it
             libraryRoots.add(Paths.get(bookEntity.getLibraryPath().getPath()).toAbsolutePath().normalize());
 
-            for (Path sourceParent : sourceParentsToCleanup) {
-                fileMoveHelper.deleteEmptyParentDirsUpToLibraryFolders(sourceParent, libraryRoots);
-            }
-
             try {
                 sidecarMetadataWriter.moveSidecarFiles(currentPrimaryFilePath, newFilePath);
             } catch (Exception e) {
                 log.warn("Failed to move sidecar files for book ID {}: {}", bookId, e.getMessage());
+            }
+
+            for (Path sourceParent : sourceParentsToCleanup) {
+                fileMoveHelper.deleteEmptyParentDirsUpToLibraryFolders(sourceParent, libraryRoots);
             }
 
             entityManager.clear();
@@ -417,14 +417,14 @@ public class FileMoveService {
             // Also protect the source library root so cleanup doesn't traverse above it
             libraryRoots.add(Paths.get(bookWithFiles.getLibraryPath().getPath()).toAbsolutePath().normalize());
 
-            for (Path sourceParent : sourceParentsToCleanup) {
-                fileMoveHelper.deleteEmptyParentDirsUpToLibraryFolders(sourceParent, libraryRoots);
-            }
-
             try {
                 sidecarMetadataWriter.moveSidecarFiles(currentPrimaryFilePath, expectedPrimaryFilePath);
             } catch (Exception e) {
                 log.warn("Failed to move sidecar files for book ID {}: {}", bookEntity.getId(), e.getMessage());
+            }
+
+            for (Path sourceParent : sourceParentsToCleanup) {
+                fileMoveHelper.deleteEmptyParentDirsUpToLibraryFolders(sourceParent, libraryRoots);
             }
 
             if (isLibraryMonitoredWhenCalled) {

--- a/backend/src/test/java/org/booklore/service/file/FileMoveServiceOrderingTest.java
+++ b/backend/src/test/java/org/booklore/service/file/FileMoveServiceOrderingTest.java
@@ -188,11 +188,12 @@ class FileMoveServiceOrderingTest {
 
         assertThat(result.isMoved()).isTrue();
 
-        InOrder inOrder = inOrder(fileMoveHelper, monitoringRegistrationService, service);
+        InOrder inOrder = inOrder(fileMoveHelper, sidecarMetadataWriter, monitoringRegistrationService, service);
         inOrder.verify(fileMoveHelper).unregisterLibrary(1L);
         inOrder.verify(monitoringRegistrationService).waitForEventsDrainedByPaths(anySet(), anyLong());
         inOrder.verify(fileMoveHelper).moveFileWithBackup(any());
         inOrder.verify(fileMoveHelper).commitMove(any(), any());
+        inOrder.verify(sidecarMetadataWriter).moveSidecarFiles(any(), any());
         inOrder.verify(fileMoveHelper).deleteEmptyParentDirsUpToLibraryFolders(any(), anySet());
         inOrder.verify(service).sleep(anyLong());
         inOrder.verify(monitoringRegistrationService).registerLibrary(dto);
@@ -228,8 +229,9 @@ class FileMoveServiceOrderingTest {
 
         service.moveSingleFile(book);
 
-        InOrder inOrder = inOrder(bookFileRepository, fileMoveHelper);
+        InOrder inOrder = inOrder(bookFileRepository, sidecarMetadataWriter, fileMoveHelper);
         inOrder.verify(bookFileRepository).updateFileNameAndSubPath(anyLong(), anyString(), anyString());
+        inOrder.verify(sidecarMetadataWriter).moveSidecarFiles(any(), any());
         inOrder.verify(fileMoveHelper).deleteEmptyParentDirsUpToLibraryFolders(any(), anySet());
     }
 

--- a/backend/src/test/java/org/booklore/service/file/FileMoveServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/file/FileMoveServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -911,6 +912,29 @@ class FileMoveServiceTest {
             service.bulkMoveFiles(request);
 
             verify(entityManager).clear();
+        }
+
+        @Test
+        @DisplayName("moves sidecars before cleaning up empty source directories")
+        void movesSidecarsBeforeCleanup() throws IOException {
+            BookFileEntity epub = createBookFile(1L, "Book.epub", "path", true, false);
+            BookEntity book = createBook(List.of(epub));
+            Path target = Paths.get("/target/new/NewName.epub");
+
+            mockBulkMoveSetup(book, target);
+
+            FileMoveRequest request = new FileMoveRequest();
+            FileMoveRequest.Move move = new FileMoveRequest.Move();
+            move.setBookId(100L);
+            move.setTargetLibraryId(2L);
+            move.setTargetLibraryPathId(20L);
+            request.setMoves(List.of(move));
+
+            service.bulkMoveFiles(request);
+
+            InOrder inOrder = inOrder(sidecarMetadataWriter, fileMoveHelper);
+            inOrder.verify(sidecarMetadataWriter).moveSidecarFiles(any(), any());
+            inOrder.verify(fileMoveHelper).deleteEmptyParentDirsUpToLibraryFolders(any(), anySet());
         }
     }
 


### PR DESCRIPTION
## Description

This fixes an organize file bug where empty source folders could be left behind after a move. The cleanup step ran before sidecar files were moved, so the source directory still technically had content in it during cleanup, and was left behind once sidecars were relocated.

**Linked Issue:** https://github.com/grimmory-tools/grimmory/issues/821

## Changes

- move sidecar relocation ahead of empty directory cleanup in single file/bulk file flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file operation sequencing to ensure metadata files are processed before empty parent directory cleanup, improving data consistency.

* **Tests**
  * Enhanced test coverage to validate the correct sequencing of file operations with metadata handling during bulk file moves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->