### PR TITLE
chore(deps): drop deprecated npm package @types/dompurify

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,7 +74,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/user-event": "^14.6.1",
-    "@types/dompurify": "^3.2.0",
     "@types/node": "^25.6.0",
     "@types/showdown": "^2.0.6",
     "@vitest/coverage-v8": "^4.1.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4017,15 +4017,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/dompurify@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@types/dompurify@npm:3.2.0"
-  dependencies:
-    dompurify: "npm:*"
-  checksum: 10c0/e83fec586ffbb1b43f7c8479f2a99c223814d240db912d53fb126aaeea52a4091deceeb75632b5d76004d88ef0fbf444984887b121dece6fa69f4172ed4b2b07
-  languageName: node
-  linkType: hard
-
 "@types/esrecurse@npm:^4.3.1":
   version: 4.3.1
   resolution: "@types/esrecurse@npm:4.3.1"
@@ -5300,18 +5291,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:*":
-  version: 3.3.3
-  resolution: "dompurify@npm:3.3.3"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
-  languageName: node
-  linkType: hard
-
 "dompurify@npm:^3.4.1":
   version: 3.4.1
   resolution: "dompurify@npm:3.4.1"
@@ -6321,7 +6300,6 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/user-event": "npm:^14.6.1"
     "@tweenjs/tween.js": "npm:^25.0.0"
-    "@types/dompurify": "npm:^3.2.0"
     "@types/node": "npm:^25.6.0"
     "@types/showdown": "npm:^2.0.6"
     "@vitest/coverage-v8": "npm:^4.1.5"


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

[Per npm](https://www.npmjs.com/package/@types/dompurify), dompurify now provides its own types.  This package is currently preventing dompurify from updating - something we need because the current version has reported vulnerabilities.

## Changes

* drops the `@types/dompurify` package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused TypeScript type package for DOM sanitization from developer dependencies to streamline and simplify the project’s dev setup. This reduces maintenance for type-only packages and slightly trims dev dependency surface area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->