### PR TITLE
fix(api): improve sort feature parity of `AppBookService`

### DIFF
--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -1069,7 +1069,15 @@ public class AppBookService {
             case "language" -> "metadata.language";
             case "publisher" -> "metadata.publisher";
             case "publisheddate" -> "metadata.publishedDate";
+            case "amazonrating" -> "metadata.amazonRating";
+            case "amazonreviewcount" -> "metadata.amazonReviewCount";
+            case "goodreadsrating" -> "metadata.goodreadsRating";
+            case "goodreadsreviewcount" -> "metadata.goodreadsReviewCount";
+            case "hardcoverrating" -> "metadata.hardcoverRating";
+            case "hardcoverreviewcount" -> "metadata.hardcoverReviewCount";
+            case "ranobedbrating" -> "metadata.ranobedbRating";
             case "lastreadtime" -> "userBookProgress.lastReadTime";
+            case "readstatus" -> "userBookProgress.readStatus";
             case "datefinished" -> "userBookProgress.dateFinished";
             case "personalrating" -> "userBookProgress.personalRating";
             default -> "addedOn";

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -1045,22 +1045,17 @@ public class AppBookService {
             }
         }
 
-        // For `lastReadTime` sorting we need to filter to only the current user's progress.
-        if ("lastreadtime".equalsIgnoreCase(req.sort())) {
+        // Any of the user book progress sorting we need to filter to only the current user's progress.
+        String field = getSortField(req.sort());
+        if (field.startsWith("userBookProgress.")) {
             specs.add(AppBookSpecification.withProgress(userId, true));
         }
 
         return AppBookSpecification.combine(specs.toArray(new Specification[0]));
     }
 
-    private Sort buildSort(String sortBy, String sortDir) {
-        Sort.Direction direction = "asc".equalsIgnoreCase(sortDir)
-                ? Sort.Direction.ASC
-                : Sort.Direction.DESC;
-
-        // "author" needs a join to the authors collection, which can't be expressed
-        // as a simple property path, fall through to the default (addedOn) for now.
-        String field = switch (sortBy != null ? sortBy.toLowerCase() : DEFAULT_SORT) {
+    private String getSortField(String sortBy) {
+        return switch (sortBy != null ? sortBy.toLowerCase() : DEFAULT_SORT) {
             case "addedon" -> "addedOn";
             case "title" -> "metadata.title";
             case "seriesname", "series" -> "metadata.seriesName";
@@ -1083,6 +1078,14 @@ public class AppBookService {
             case "personalrating" -> "userBookProgress.personalRating";
             default -> throw ApiError.INVALID_INPUT.createException("Invalid sort");
         };
+    }
+
+    private Sort buildSort(String sortBy, String sortDir) {
+        Sort.Direction direction = "asc".equalsIgnoreCase(sortDir)
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+
+        String field = getSortField(sortBy);
 
         return Sort.by(direction, field);
     }

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -53,6 +53,7 @@ public class AppBookService {
 
     private static final int DEFAULT_PAGE_SIZE = 50;
     private static final int MAX_PAGE_SIZE = 50;
+    private static final String DEFAULT_SORT = "addedon";
 
     private final BookRepository bookRepository;
     private final UserBookProgressRepository userBookProgressRepository;
@@ -1059,7 +1060,8 @@ public class AppBookService {
 
         // "author" needs a join to the authors collection, which can't be expressed
         // as a simple property path, fall through to the default (addedOn) for now.
-        String field = switch (sortBy != null ? sortBy.toLowerCase() : "") {
+        String field = switch (sortBy != null ? sortBy.toLowerCase() : DEFAULT_SORT) {
+            case "addedon" -> "addedOn";
             case "title" -> "metadata.title";
             case "seriesname", "series" -> "metadata.seriesName";
             case "seriesnumber" -> "metadata.seriesNumber";

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -1065,11 +1065,13 @@ public class AppBookService {
             case "title" -> "metadata.title";
             case "seriesname", "series" -> "metadata.seriesName";
             case "seriesnumber" -> "metadata.seriesNumber";
-            case "publisher" -> "metadata.publisher";
+            case "pagecount" -> "metadata.pageCount";
             case "language" -> "metadata.language";
+            case "publisher" -> "metadata.publisher";
             case "publisheddate" -> "metadata.publishedDate";
             case "lastreadtime" -> "userBookProgress.lastReadTime";
-            case "pagecount" -> "metadata.pageCount";
+            case "datefinished" -> "userBookProgress.dateFinished";
+            case "personalrating" -> "userBookProgress.personalRating";
             default -> "addedOn";
         };
 

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -1076,11 +1076,12 @@ public class AppBookService {
             case "hardcoverrating" -> "metadata.hardcoverRating";
             case "hardcoverreviewcount" -> "metadata.hardcoverReviewCount";
             case "ranobedbrating" -> "metadata.ranobedbRating";
+            case "narrator" -> "metadata.narrator";
             case "lastreadtime" -> "userBookProgress.lastReadTime";
             case "readstatus" -> "userBookProgress.readStatus";
             case "datefinished" -> "userBookProgress.dateFinished";
             case "personalrating" -> "userBookProgress.personalRating";
-            default -> "addedOn";
+            default -> throw ApiError.INVALID_INPUT.createException("Invalid sort");
         };
 
         return Sort.by(direction, field);

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -1076,7 +1076,7 @@ public class AppBookService {
             case "readstatus" -> "userBookProgress.readStatus";
             case "datefinished" -> "userBookProgress.dateFinished";
             case "personalrating" -> "userBookProgress.personalRating";
-            default -> throw ApiError.INVALID_INPUT.createException("Invalid sort");
+            default -> "addedOn";
         };
     }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Adds support for sorting fields:

* `addedon` (explicitly, it was implicitly there before)
* `amazonrating`
* `amazonreviewcount`
* `goodreadsrating`
* `goodreadsreviewcount`
* `hardcoverrating`
* `hardcoverreviewcount`
* `ranobedbrating`
* `narrator`
* `readstatus`
* `datefinished`
* `personalrating`

This brings us closer parity to the non-paginated sorting

**Linked Issue:** Related to #797 

## Changes

* Adds some of the easier sort fields to AppBookService


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded sorting options for books to include additional metadata fields (ratings, review counts) and personal reading progress information (read status, completion date, personal ratings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->