### PR TITLE
chore(deps):  update Spring Boot version to 4.0.6 and adjust testing behavior for new version

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -6,7 +6,7 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
     java
-    id("org.springframework.boot") version "4.0.5"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.hibernate.orm") version "7.3.2.Final"
     id("com.github.ben-manes.versions") version "0.54.0"

--- a/backend/src/test/java/org/booklore/service/book/BookDownloadServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookDownloadServiceTest.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -71,8 +73,6 @@ public class BookDownloadServiceTest {
 
     @Test
     public void downloadBook_includesContentDispositionUTF8() {
-        String expected = "attachment; filename=\"=?UTF-8?Q?=C9=87xample.epub?=\"; filename*=UTF-8''%C9%87xample.epub";
-
         BookEntity bookEntity = getSampleBook("ɇxample.epub");
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
@@ -83,7 +83,9 @@ public class BookDownloadServiceTest {
                 .getHeaders()
                 .getFirst("Content-Disposition");
 
-        assertEquals(expected, actual);
+        assertNotNull(actual);
+        assertTrue(actual.startsWith("attachment;"));
+        assertTrue(actual.contains("filename*=UTF-8''%C9%87xample.epub"));
     }
 
     private BookEntity getSampleBook(String filename) {

--- a/backend/src/test/java/org/booklore/service/book/BookDownloadServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookDownloadServiceTest.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -73,6 +71,8 @@ public class BookDownloadServiceTest {
 
     @Test
     public void downloadBook_includesContentDispositionUTF8() {
+        String expected = "attachment; filename=\"_xample.epub\"; filename*=UTF-8''%C9%87xample.epub";
+
         BookEntity bookEntity = getSampleBook("ɇxample.epub");
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
@@ -83,9 +83,7 @@ public class BookDownloadServiceTest {
                 .getHeaders()
                 .getFirst("Content-Disposition");
 
-        assertNotNull(actual);
-        assertTrue(actual.startsWith("attachment;"));
-        assertTrue(actual.contains("filename*=UTF-8''%C9%87xample.epub"));
+        assertEquals(expected, actual);
     }
 
     private BookEntity getSampleBook(String filename) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Spring Boot Gradle plugin to version 4.0.6.

* **Tests**
  * Adjusted file download tests to accept a simplified UTF‑8 filename header format while retaining encoded filename support, improving robustness of download header validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->