### PR TITLE
fix(metadata): improve fallback logic for blank or null titles in metadata extraction, bump pdfium4j to 0.16.0

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -120,7 +120,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.46")
 
     // --- Book & Image Processing ---
-    val pdfium4jVersion = if (useLocalLibs) "+" else "0.15.0"
+    val pdfium4jVersion = if (useLocalLibs) "+" else "0.16.0"
     implementation("org.grimmory:pdfium4j:$pdfium4jVersion")
     runtimeOnly("org.grimmory:pdfium4j:$pdfium4jVersion:${pdfiumNativesClassifier()}")
 

--- a/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
@@ -55,9 +55,7 @@ public class BookdropMetadataService {
         }
         if (initial.getTitle() == null || initial.getTitle().isBlank()) {
             log.warn("Metadata extraction returned empty title for file: {}. Using filename as fallback.", entity.getFileName());
-            initial = initial.toBuilder()
-                    .title(FilenameUtils.getBaseName(entity.getFileName()))
-                    .build();
+            initial.setTitle(FilenameUtils.getBaseName(entity.getFileName()));
         }
         extractAndSaveCover(entity);
         String initialJson = objectMapper.writeValueAsString(initial);

--- a/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
@@ -51,7 +51,11 @@ public class BookdropMetadataService {
         BookMetadata initial = extractInitialMetadata(entity);
         if (initial == null) {
             log.warn("Metadata extraction returned null for file: {}. Using filename as fallback.", entity.getFileName());
-            initial = BookMetadata.builder()
+            initial = BookMetadata.builder().build();
+        }
+        if (initial.getTitle() == null || initial.getTitle().isBlank()) {
+            log.warn("Metadata extraction returned empty title for file: {}. Using filename as fallback.", entity.getFileName());
+            initial = initial.toBuilder()
                     .title(FilenameUtils.getBaseName(entity.getFileName()))
                     .build();
         }

--- a/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
@@ -50,7 +50,7 @@ public class BookdropMetadataService {
         BookdropFileEntity entity = getOrThrow(bookdropFileId);
         BookMetadata initial = extractInitialMetadata(entity);
         if (initial == null) {
-            log.warn("Metadata extraction returned null for file: {}. Using filename as fallback.", entity.getFileName());
+            log.warn("Metadata extraction returned null for file: {}. Using empty metadata as fallback.", entity.getFileName());
             initial = BookMetadata.builder().build();
         }
         if (initial.getTitle() == null || initial.getTitle().isBlank()) {

--- a/backend/src/main/java/org/booklore/util/PathPatternResolver.java
+++ b/backend/src/main/java/org/booklore/util/PathPatternResolver.java
@@ -84,9 +84,11 @@ public class PathPatternResolver {
             }
         }
 
-        String title = sanitize(metadata != null && metadata.getTitle() != null
-                ? metadata.getTitle()
-                : filenameBase);
+        String resolvedTitle = metadata != null ? metadata.getTitle() : null;
+        String title = sanitize(resolvedTitle);
+        if (title.isBlank()) {
+            title = sanitize(filenameBase);
+        }
 
         String subtitle = sanitize(metadata != null ? metadata.getSubtitle() : "");
 
@@ -212,6 +214,13 @@ public class PathPatternResolver {
             usedFallbackFilename = true;
         }
 
+        // Guard against patterns like {title}.{extension} resolving to only ".ext"
+        // when metadata title is blank/missing after sanitization.
+        if (!usedFallbackFilename && isExtensionOnlyFilename(result)) {
+            result = values.getOrDefault("currentFilename", "untitled");
+            usedFallbackFilename = true;
+        }
+
         boolean patternIncludesExtension = pattern.contains("{extension}");
         boolean patternIncludesFullFilename = pattern.contains("{currentFilename}");
 
@@ -282,6 +291,20 @@ public class PathPatternResolver {
             case "lower" -> value.toLowerCase();
             default -> value;
         };
+    }
+
+    private boolean isExtensionOnlyFilename(String value) {
+        if (value == null) {
+            return false;
+        }
+        String trimmed = value.trim();
+        if (!trimmed.startsWith(".")) {
+            return false;
+        }
+        if (trimmed.length() <= 1) {
+            return false;
+        }
+        return trimmed.indexOf('/', 1) < 0;
     }
 
     private String sanitize(String input) {

--- a/backend/src/test/java/org/booklore/PathPatternResolverTest.java
+++ b/backend/src/test/java/org/booklore/PathPatternResolverTest.java
@@ -163,9 +163,9 @@ class PathPatternResolverTest {
         assertThat(PathPatternResolver.resolvePattern(b, "{title}")).isEqualTo("Title");
     }
 
-    @Test void patternWithOnlyExtension_returnsExtensionOnly() {
+    @Test void patternWithOnlyExtension_fallsBackToCurrentFilename() {
         var book = createBook(null, null, null, null, null, null, null, null, null, "sample.pdf");
-        assertThat(PathPatternResolver.resolvePattern(book, ".{extension}")).isEqualTo(".pdf");
+        assertThat(PathPatternResolver.resolvePattern(book, ".{extension}")).isEqualTo("sample.pdf");
     }
 
     @Test void patternWithExtensionAndFilenamePlaceholder_works() {

--- a/backend/src/test/java/org/booklore/service/BookdropMetadataServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/BookdropMetadataServiceTest.java
@@ -133,6 +133,22 @@ class BookdropMetadataServiceTest {
         verify(bookdropFileRepository).save(result);
     }
 
+    @Test
+    void attachInitialMetadata_shouldFallbackToFilenameWhenTitleBlank() throws Exception {
+        BookMetadata metadata = BookMetadata.builder().title("   ").build();
+
+        when(bookdropFileRepository.findById(1L)).thenReturn(Optional.of(sampleFile));
+        when(metadataExtractorFactory.extractMetadata(eq(BookFileExtension.EPUB), any(File.class))).thenReturn(metadata);
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"title\":\"book\"}");
+        when(bookdropFileRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        bookdropMetadataService.attachInitialMetadata(1L);
+
+        ArgumentCaptor<BookMetadata> argument = ArgumentCaptor.forClass(BookMetadata.class);
+        verify(objectMapper).writeValueAsString(argument.capture());
+        assertThat(argument.getValue().getTitle()).isEqualTo("book");
+    }
+
     @Test()
     void attachInitialMetadata_shouldTruncateFields() throws Exception {
         BookMetadata metadata = BookMetadata.builder()

--- a/backend/src/test/java/org/booklore/util/PathPatternResolverTest.java
+++ b/backend/src/test/java/org/booklore/util/PathPatternResolverTest.java
@@ -85,6 +85,17 @@ class PathPatternResolverTest {
     }
 
     @Test
+    void testResolvePattern_blankTitleWithExplicitExtensionPatternFallsBackToFilename() {
+        BookMetadata metadata = BookMetadata.builder()
+                .title("   ")
+                .build();
+
+        String result = PathPatternResolver.resolvePattern(metadata, "{title}.{extension}", "original.pdf");
+
+        assertEquals("original.pdf", result);
+    }
+
+    @Test
     void testResolvePattern_multiplePlaceholders() {
         BookMetadata metadata = BookMetadata.builder()
                 .title("Test Book")
@@ -200,6 +211,17 @@ class PathPatternResolverTest {
                 .build();
 
         String result = PathPatternResolver.resolvePattern(metadata, "{title}", "original.pdf");
+
+        assertEquals("original.pdf", result);
+    }
+
+    @Test
+    void testResolvePattern_nullTitleWithExplicitExtensionPatternFallsBackToFilename() {
+        BookMetadata metadata = BookMetadata.builder()
+                .title(null)
+                .build();
+
+        String result = PathPatternResolver.resolvePattern(metadata, "{title}.{extension}", "original.pdf");
 
         assertEquals("original.pdf", result);
     }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #834<!-- issue number leave empty if none -->

## Changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or blank book titles — now reliably falls back to the filename.
  * More robust filename pattern resolution to avoid producing extension-only or empty names.

* **Tests**
  * Added and updated unit tests covering title fallback and filename-pattern edge cases.

* **Chores**
  * Updated pdfium4j dependency to 0.16.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->