### PR TITLE
fix(reader): use CSP for protecting foliate instead of iframe sandbox

### DIFF
--- a/frontend/src/assets/foliate/fixed-layout.js
+++ b/frontend/src/assets/foliate/fixed-layout.js
@@ -83,7 +83,7 @@ export class FixedLayout extends HTMLElement {
         })
         // Foliate recommends disabling scripts for untrusted book content:
         // https://github.com/johnfactotum/foliate-js#security
-        iframe.setAttribute('sandbox', 'allow-same-origin')
+        iframe.setAttribute('sandbox', 'allow-same-origin allow-scripts')
         iframe.setAttribute('scrolling', 'no')
         iframe.setAttribute('part', 'filter')
         this.#root.append(element)

--- a/frontend/src/assets/foliate/paginator.js
+++ b/frontend/src/assets/foliate/paginator.js
@@ -241,7 +241,7 @@ class View {
         })
         // Foliate recommends disabling scripts for untrusted book content:
         // https://github.com/johnfactotum/foliate-js#security
-        this.#iframe.setAttribute('sandbox', 'allow-same-origin')
+        this.#iframe.setAttribute('sandbox', 'allow-same-origin allow-scripts')
         this.#iframe.setAttribute('scrolling', 'no')
     }
     get element() {

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,6 +6,7 @@
   <title>Grimmory</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; worker-src blob:; frame-src blob: data:; object-src 'none'; form-action 'none';">
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg"/>
   <link rel="manifest" href="manifest.webmanifest">
 </head>


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
The iframe sandbox approach causes issues with iOS safari readers and has been affecting some users.

This PR switches to a `Content-Security-Policy` approach to fix GHSA-frv6-5wq5-9p24 using a specific CSP for the entire web UI, set in the `meta` of the HTML document

I used this approach as an epub document can be crafted to have items without a `head` such as SVG making it difficult to inject the headers to protect users within the iframe.

* `script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval';` - allow scripts that we host, and WASM needed by foliate
* `worker-src blob:;` - needed for the reader - I think to run the WASM
* `frame-src blob: data:;` - limit iframes to just the kinds we use for the reader
* `object-src 'none';` - prevent loading of `object` or `embed` defined within iframes or anywhere else.  we don't use this
* `form-action 'none';` - as far as I can tell we do not use raw forms within our application, but a form in the epub could be used to perform malicious actions

**Linked Issue:** Fixes #793, closes #794

Tested using the test case epubs we have for #794 & another I had crafted which runs scripts within an SVG in an epub.

## Changes

* add back `allow-scripts` to the foliate iframes
* adds a `Content-Security-Policy` to the web UI `index.html`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Infrastructure**
  * Added Content-Security-Policy meta tag to enforce resource loading restrictions and improve application security with controls for scripts, workers, forms, and embedded frames.

* **Improvements**
  * Updated embedded content rendering components to allow JavaScript execution, enhancing page rendering and improving interaction capabilities for book display features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->