### PR TITLE
fix(author-sort): implement the author sort on the backend

### DIFF
--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -103,9 +103,6 @@ public class AppBookService {
 
         // Handle magic shelf: compose the DB-side specification directly (no IN-list)
         if (req.magicShelfId() != null) {
-            Sort sort = buildSort(req.sort(), req.dir());
-            Pageable pageable = PageRequest.of(pageNum, pageSize, sort);
-
             Specification<BookEntity> spec = buildSpecification(
                     accessibleLibraryIds, userId, req);
             spec = spec.and(magicShelfBookService.toSpecification(userId, req.magicShelfId()));
@@ -113,6 +110,14 @@ public class AppBookService {
             if (Boolean.TRUE.equals(req.unshelved())) {
                 spec = spec.and(AppBookSpecification.unshelved());
             }
+
+            if (isAuthorSort(req.sort())) {
+                Page<BookEntity> bookPage = getAuthorSortedPage(spec, req.sort(), req.dir(), pageNum, pageSize);
+                return buildPageResponse(bookPage, userId, pageNum, pageSize);
+            }
+
+            Sort sort = buildSort(req.sort(), req.dir());
+            Pageable pageable = PageRequest.of(pageNum, pageSize, sort);
 
             Page<BookEntity> bookPage = bookRepository.findAll(spec, pageable);
             return buildPageResponse(bookPage, userId, pageNum, pageSize);
@@ -1107,15 +1112,19 @@ public class AppBookService {
         Collator collator = Collator.getInstance(Locale.ROOT);
         collator.setStrength(Collator.PRIMARY);
 
+        Comparator<Object> keyOrder = ascending ? collator : collator.reversed();
+        Comparator<Instant> addedOnOrder = ascending
+                ? Comparator.naturalOrder()
+                : Comparator.reverseOrder();
+        Comparator<Long> idOrder = ascending
+                ? Comparator.naturalOrder()
+                : Comparator.reverseOrder();
+
         Comparator<BookEntity> comparator = Comparator
                 .comparing((BookEntity book) -> buildAuthorSortKey(book, surnameMode),
-                        Comparator.nullsLast(collator))
-                .thenComparing(BookEntity::getAddedOn, Comparator.nullsLast(Comparator.naturalOrder()))
-                .thenComparing(BookEntity::getId, Comparator.nullsLast(Comparator.naturalOrder()));
-
-        if (!ascending) {
-            comparator = comparator.reversed();
-        }
+                        Comparator.nullsLast(keyOrder))
+                .thenComparing(BookEntity::getAddedOn, Comparator.nullsLast(addedOnOrder))
+                .thenComparing(BookEntity::getId, Comparator.nullsLast(idOrder));
 
         List<BookEntity> sorted = books.stream()
                 .sorted(comparator)

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -29,6 +29,7 @@ import org.booklore.repository.UserBookProgressRepository;
 import org.booklore.service.book.BookService;
 import org.booklore.service.opds.MagicShelfBookService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -116,9 +117,6 @@ public class AppBookService {
             return buildPageResponse(bookPage, userId, pageNum, pageSize);
         }
 
-        Sort sort = buildSort(req.sort(), req.dir());
-        Pageable pageable = PageRequest.of(pageNum, pageSize, sort);
-
         Specification<BookEntity> spec = buildSpecification(
                 accessibleLibraryIds, userId, req);
 
@@ -126,6 +124,13 @@ public class AppBookService {
             spec = spec.and(AppBookSpecification.unshelved());
         }
 
+        if (isAuthorSort(req.sort())) {
+            Page<BookEntity> bookPage = getAuthorSortedPage(spec, req.sort(), req.dir(), pageNum, pageSize);
+            return buildPageResponse(bookPage, userId, pageNum, pageSize);
+        }
+
+        Sort sort = buildSort(req.sort(), req.dir());
+        Pageable pageable = PageRequest.of(pageNum, pageSize, sort);
         Page<BookEntity> bookPage = bookRepository.findAll(spec, pageable);
         return buildPageResponse(bookPage, userId, pageNum, pageSize);
     }
@@ -1078,6 +1083,84 @@ public class AppBookService {
             case "personalrating" -> "userBookProgress.personalRating";
             default -> "addedOn";
         };
+    }
+
+    private boolean isAuthorSort(String sortBy) {
+        if (sortBy == null) {
+            return false;
+        }
+        String normalized = sortBy.toLowerCase(Locale.ROOT);
+        return "author".equals(normalized) || "authorsurnamevorname".equals(normalized);
+    }
+
+    private Page<BookEntity> getAuthorSortedPage(
+            Specification<BookEntity> spec,
+            String sortBy,
+            String sortDir,
+            int pageNum,
+            int pageSize) {
+        List<BookEntity> books = bookRepository.findAll(spec);
+        boolean surnameMode = "authorsurnamevorname".equalsIgnoreCase(sortBy);
+        boolean ascending = "asc".equalsIgnoreCase(sortDir);
+
+        Comparator<BookEntity> comparator = Comparator
+                .comparing((BookEntity book) -> buildAuthorSortKey(book, surnameMode),
+                        Comparator.nullsLast(String::compareTo))
+                .thenComparing(BookEntity::getAddedOn, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(BookEntity::getId, Comparator.nullsLast(Comparator.naturalOrder()));
+
+        if (!ascending) {
+            comparator = comparator.reversed();
+        }
+
+        List<BookEntity> sorted = books.stream()
+                .sorted(comparator)
+                .toList();
+
+        int fromIndex = pageNum * pageSize;
+        if (fromIndex >= sorted.size()) {
+            return new PageImpl<>(List.of(), PageRequest.of(pageNum, pageSize), sorted.size());
+        }
+
+        int toIndex = Math.min(fromIndex + pageSize, sorted.size());
+        List<BookEntity> pageContent = sorted.subList(fromIndex, toIndex);
+        return new PageImpl<>(pageContent, PageRequest.of(pageNum, pageSize), sorted.size());
+    }
+
+    private String buildAuthorSortKey(BookEntity book, boolean surnameMode) {
+        if (book.getMetadata() == null || book.getMetadata().getAuthors() == null || book.getMetadata().getAuthors().isEmpty()) {
+            return null;
+        }
+
+        return book.getMetadata().getAuthors().stream()
+                .map(AuthorEntity::getName)
+                .map(name -> normalizeAuthorName(name, surnameMode))
+                .filter(name -> !name.isBlank())
+                .collect(Collectors.joining(", "));
+    }
+
+    private String normalizeAuthorName(String authorName, boolean surnameMode) {
+        if (authorName == null) {
+            return "";
+        }
+
+        String cleaned = authorName.trim();
+        if (cleaned.isBlank()) {
+            return "";
+        }
+
+        if (!surnameMode) {
+            return cleaned.toLowerCase(Locale.ROOT);
+        }
+
+        String[] parts = cleaned.split("\\s+");
+        if (parts.length < 2) {
+            return cleaned.toLowerCase(Locale.ROOT);
+        }
+
+        String surname = parts[parts.length - 1];
+        String firstNames = String.join(" ", Arrays.copyOf(parts, parts.length - 1));
+        return (surname + ", " + firstNames).toLowerCase(Locale.ROOT);
     }
 
     private Sort buildSort(String sortBy, String sortDir) {

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -39,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Tuple;
+import java.text.Collator;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
@@ -1103,9 +1104,12 @@ public class AppBookService {
         boolean surnameMode = "authorsurnamevorname".equalsIgnoreCase(sortBy);
         boolean ascending = "asc".equalsIgnoreCase(sortDir);
 
+        Collator collator = Collator.getInstance(Locale.ROOT);
+        collator.setStrength(Collator.PRIMARY);
+
         Comparator<BookEntity> comparator = Comparator
                 .comparing((BookEntity book) -> buildAuthorSortKey(book, surnameMode),
-                        Comparator.nullsLast(String::compareTo))
+                        Comparator.nullsLast(collator))
                 .thenComparing(BookEntity::getAddedOn, Comparator.nullsLast(Comparator.naturalOrder()))
                 .thenComparing(BookEntity::getId, Comparator.nullsLast(Comparator.naturalOrder()));
 
@@ -1132,11 +1136,12 @@ public class AppBookService {
             return null;
         }
 
-        return book.getMetadata().getAuthors().stream()
+        String key = book.getMetadata().getAuthors().stream()
                 .map(AuthorEntity::getName)
                 .map(name -> normalizeAuthorName(name, surnameMode))
                 .filter(name -> !name.isBlank())
                 .collect(Collectors.joining(", "));
+        return key.isEmpty() ? null : key;
     }
 
     private String normalizeAuthorName(String authorName, boolean surnameMode) {
@@ -1150,17 +1155,17 @@ public class AppBookService {
         }
 
         if (!surnameMode) {
-            return cleaned.toLowerCase(Locale.ROOT);
+            return cleaned;
         }
 
         String[] parts = cleaned.split("\\s+");
         if (parts.length < 2) {
-            return cleaned.toLowerCase(Locale.ROOT);
+            return cleaned;
         }
 
         String surname = parts[parts.length - 1];
         String firstNames = String.join(" ", Arrays.copyOf(parts, parts.length - 1));
-        return (surname + ", " + firstNames).toLowerCase(Locale.ROOT);
+        return (surname + ", " + firstNames);
     }
 
     private Sort buildSort(String sortBy, String sortDir) {

--- a/backend/src/test/java/org/booklore/app/service/AppBookServiceSortingTest.java
+++ b/backend/src/test/java/org/booklore/app/service/AppBookServiceSortingTest.java
@@ -1,0 +1,157 @@
+package org.booklore.app.service;
+
+import jakarta.persistence.EntityManager;
+import org.booklore.app.dto.AppBookSummary;
+import org.booklore.app.dto.AppPageResponse;
+import org.booklore.app.dto.BookListRequest;
+import org.booklore.app.mapper.AppBookMapper;
+import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.entity.AuthorEntity;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.repository.BookRepository;
+import org.booklore.repository.ShelfRepository;
+import org.booklore.repository.UserBookFileProgressRepository;
+import org.booklore.repository.UserBookProgressRepository;
+import org.booklore.service.book.BookService;
+import org.booklore.service.opds.MagicShelfBookService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AppBookServiceSortingTest {
+
+    @Mock private BookRepository bookRepository;
+    @Mock private UserBookProgressRepository userBookProgressRepository;
+    @Mock private UserBookFileProgressRepository userBookFileProgressRepository;
+    @Mock private ShelfRepository shelfRepository;
+    @Mock private AuthenticationService authenticationService;
+    @Mock private AppBookMapper appBookMapper;
+    @Mock private BookService bookService;
+    @Mock private MagicShelfBookService magicShelfBookService;
+    @Mock private EntityManager entityManager;
+
+    private AppBookService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AppBookService(
+                bookRepository, userBookProgressRepository, userBookFileProgressRepository,
+                shelfRepository, authenticationService, appBookMapper,
+                bookService, magicShelfBookService, entityManager
+        );
+        mockAdminUser();
+        when(appBookMapper.toSummary(any(BookEntity.class), any()))
+                .thenAnswer(invocation -> AppBookSummary.builder()
+                        .id(((BookEntity) invocation.getArgument(0)).getId())
+                        .build());
+    }
+
+    @Test
+    void getBooks_sortByAuthor_ascending_joinsAllAuthorsInOrder() {
+        List<BookEntity> unsorted = List.of(
+                book(1L, Instant.parse("2024-01-02T00:00:00Z"), "Jane Zee", "Adam Zoo"),
+                book(2L, Instant.parse("2024-01-03T00:00:00Z"), "Adam Alpha"),
+                book(3L, Instant.parse("2024-01-01T00:00:00Z"), "Jane Zee")
+        );
+        when(bookRepository.findAll(any(Specification.class))).thenReturn(unsorted);
+
+        AppPageResponse<AppBookSummary> response = service.getBooks(baseRequest("author", "asc"));
+
+        assertEquals(List.of(2L, 3L, 1L), response.getContent().stream().map(AppBookSummary::getId).toList());
+    }
+
+    @Test
+    void getBooks_sortByAuthorSurnameVorname_descending_appliesSurnameParsing() {
+        List<BookEntity> unsorted = List.of(
+                book(1L, Instant.parse("2024-01-02T00:00:00Z"), "Jane Zee"),
+                book(2L, Instant.parse("2024-01-03T00:00:00Z"), "Bob Alpha"),
+                book(3L, Instant.parse("2024-01-01T00:00:00Z"), "Mary Anne Smith")
+        );
+        when(bookRepository.findAll(any(Specification.class))).thenReturn(unsorted);
+
+        AppPageResponse<AppBookSummary> response = service.getBooks(baseRequest("authorSurnameVorname", "desc"));
+
+        assertEquals(List.of(1L, 3L, 2L), response.getContent().stream().map(AppBookSummary::getId).toList());
+    }
+
+    @Test
+    void getBooks_sortByAuthor_usesStableTiebreakersForEqualAuthorKeys() {
+        List<BookEntity> unsorted = List.of(
+                book(2L, Instant.parse("2024-01-03T00:00:00Z"), "Jane Zee"),
+                book(1L, Instant.parse("2024-01-01T00:00:00Z"), "Jane Zee")
+        );
+        when(bookRepository.findAll(any(Specification.class))).thenReturn(unsorted);
+
+        AppPageResponse<AppBookSummary> response = service.getBooks(baseRequest("author", "asc"));
+
+        assertEquals(List.of(1L, 2L), response.getContent().stream().map(AppBookSummary::getId).toList());
+    }
+
+    @Test
+    void getBooks_unknownSortKey_fallsBackToDefaultPagedQuery() {
+        Page<BookEntity> page = new PageImpl<>(
+                List.of(book(10L, Instant.parse("2024-01-01T00:00:00Z"), "Author One")),
+                PageRequest.of(0, 50),
+                1
+        );
+        when(bookRepository.findAll(any(Specification.class), any(PageRequest.class))).thenReturn(page);
+
+        AppPageResponse<AppBookSummary> response = service.getBooks(baseRequest("notARealSort", "asc"));
+
+        assertEquals(List.of(10L), response.getContent().stream().map(AppBookSummary::getId).toList());
+        verify(bookRepository).findAll(any(Specification.class), any(PageRequest.class));
+    }
+
+    private BookListRequest baseRequest(String sort, String dir) {
+        return new BookListRequest(
+                0, 50, sort, dir,
+                null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null
+        );
+    }
+
+    private BookEntity book(Long id, Instant addedOn, String... authorNames) {
+        List<AuthorEntity> authors = List.of(authorNames).stream()
+                .map(name -> AuthorEntity.builder().name(name).build())
+                .toList();
+        BookMetadataEntity metadata = BookMetadataEntity.builder()
+                .bookId(id)
+                .title("Book " + id)
+                .authors(authors)
+                .build();
+        return BookEntity.builder()
+                .id(id)
+                .addedOn(addedOn)
+                .metadata(metadata)
+                .build();
+    }
+
+    private void mockAdminUser() {
+        var permissions = new BookLoreUser.UserPermissions();
+        permissions.setAdmin(true);
+        BookLoreUser user = BookLoreUser.builder()
+                .id(1L)
+                .permissions(permissions)
+                .build();
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+    }
+}

--- a/backend/src/test/java/org/booklore/app/service/AppBookServiceSortingTest.java
+++ b/backend/src/test/java/org/booklore/app/service/AppBookServiceSortingTest.java
@@ -149,13 +149,6 @@ class AppBookServiceSortingTest {
 
         AppPageResponse<AppBookSummary> response = service.getBooks(baseRequest("author", "asc"));
 
-        // With Collator.PRIMARY, Ö and O are treated as same base letter if it's PRIMARY strength?
-        // Actually, PRIMARY strength usually ignores case and accents.
-        // Let's see what happens. If they are equal, it falls back to addedOn.
-        // Book 2 (Ostlund) added 2024-01-02
-        // Book 1 (Östlund) added 2024-01-01
-        // Expected if PRIMARY treats them same: Adam (3), Östlund (1), Ostlund (2)
-        
         assertEquals(List.of(3L, 1L, 2L), response.getContent().stream().map(AppBookSummary::getId).toList());
     }
 

--- a/backend/src/test/java/org/booklore/app/service/AppBookServiceSortingTest.java
+++ b/backend/src/test/java/org/booklore/app/service/AppBookServiceSortingTest.java
@@ -119,6 +119,62 @@ class AppBookServiceSortingTest {
         verify(bookRepository).findAll(any(Specification.class), any(PageRequest.class));
     }
 
+    @Test
+    void getBooks_sortByAuthor_ascending_putsEmptyAuthorsLast() {
+        List<BookEntity> unsorted = List.of(
+                book(1L, Instant.parse("2024-01-02T00:00:00Z"), "Adam Alpha"),
+                book(2L, Instant.parse("2024-01-03T00:00:00Z")), // No authors
+                book(3L, Instant.parse("2024-01-01T00:00:00Z"), " ") // Blank author name
+        );
+        when(bookRepository.findAll(any(Specification.class))).thenReturn(unsorted);
+
+        AppPageResponse<AppBookSummary> response = service.getBooks(baseRequest("author", "asc"));
+
+        // Adam Alpha (1) should be first, then the empty/blank ones (2 and 3)
+        // Since both 2 and 3 have null sort keys, they should be sorted by addedOn and then ID.
+        // book 3: addedOn 2024-01-01
+        // book 2: addedOn 2024-01-03
+        // So expected order is 1, 3, 2
+        assertEquals(List.of(1L, 3L, 2L), response.getContent().stream().map(AppBookSummary::getId).toList());
+    }
+
+    @Test
+    void getBooks_sortByAuthor_ascending_handlesAccentedCharacters() {
+        List<BookEntity> unsorted = List.of(
+                book(1L, Instant.parse("2024-01-01T00:00:00Z"), "Östlund"),
+                book(2L, Instant.parse("2024-01-02T00:00:00Z"), "Ostlund"),
+                book(3L, Instant.parse("2024-01-03T00:00:00Z"), "Adam")
+        );
+        when(bookRepository.findAll(any(Specification.class))).thenReturn(unsorted);
+
+        AppPageResponse<AppBookSummary> response = service.getBooks(baseRequest("author", "asc"));
+
+        // With Collator.PRIMARY, Ö and O are treated as same base letter if it's PRIMARY strength?
+        // Actually, PRIMARY strength usually ignores case and accents.
+        // Let's see what happens. If they are equal, it falls back to addedOn.
+        // Book 2 (Ostlund) added 2024-01-02
+        // Book 1 (Östlund) added 2024-01-01
+        // Expected if PRIMARY treats them same: Adam (3), Östlund (1), Ostlund (2)
+        
+        assertEquals(List.of(3L, 1L, 2L), response.getContent().stream().map(AppBookSummary::getId).toList());
+    }
+
+    @Test
+    void getBooks_sortByAuthor_ascending_isCaseInsensitive() {
+        List<BookEntity> unsorted = List.of(
+                book(1L, Instant.parse("2024-01-01T00:00:00Z"), "adam"),
+                book(2L, Instant.parse("2024-01-02T00:00:00Z"), "Adam"),
+                book(3L, Instant.parse("2024-01-03T00:00:00Z"), "Bob")
+        );
+        when(bookRepository.findAll(any(Specification.class))).thenReturn(unsorted);
+
+        AppPageResponse<AppBookSummary> response = service.getBooks(baseRequest("author", "asc"));
+
+        // Case insensitive: adam and Adam are same. Falls back to addedOn.
+        // book 1 added earlier than book 2.
+        assertEquals(List.of(1L, 2L, 3L), response.getContent().stream().map(AppBookSummary::getId).toList());
+    }
+
     private BookListRequest baseRequest(String sort, String dir) {
         return new BookListRequest(
                 0, 50, sort, dir,


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

This pull request adds support for sorting books by author name in the `AppBookService`, including both "author" and "authorSurnameVorname" sorting modes. It introduces custom logic for sorting by author, ensures correct pagination of results, and adds comprehensive unit tests to verify the new sorting behavior.

**Author Sorting Enhancements:**

* Added custom sorting logic in `AppBookService` to handle requests that sort by "author" or "authorSurnameVorname", including normalization and surname-first parsing for the latter. This logic sorts all matching books in-memory and paginates the result. 
* Introduced the `isAuthorSort`, `getAuthorSortedPage`, `buildAuthorSortKey`, and `normalizeAuthorName` helper methods to encapsulate the author sorting logic.
* Added necessary import for `PageImpl` to support manual pagination of sorted results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved book sorting by author: surname-first formatting option, stable tie-breakers, locale-aware accent- and case-insensitive ordering, empty/blank authors placed last, and consistent pagination of the sorted results. Other sort modes remain unchanged.

* **Tests**
  * Added unit tests verifying author-sorting behaviors, edge cases (accents, ties, blanks) and fallback to the original retrieval path for unknown sort keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->