### PR TITLE
chore(helm): switch MariaDB chart to CloudPirate

### DIFF
--- a/deploy/helm/grimmory/Chart.yaml
+++ b/deploy/helm/grimmory/Chart.yaml
@@ -21,5 +21,5 @@ version: 0.1.0
 appVersion: "v3.0.0"
 dependencies:
   - name: mariadb
-    version: 22.0.*
-    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 0.16.*
+    repository: oci://registry-1.docker.io/cloudpirates

--- a/deploy/helm/grimmory/Chart.yaml
+++ b/deploy/helm/grimmory/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.38.2"
+appVersion: "v3.0.0"
 dependencies:
   - name: mariadb
     version: 22.0.*

--- a/deploy/helm/grimmory/Chart.yaml
+++ b/deploy/helm/grimmory/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.0.0"
+appVersion: "v0.38.2"
 dependencies:
   - name: mariadb
     version: 0.16.0

--- a/deploy/helm/grimmory/Chart.yaml
+++ b/deploy/helm/grimmory/Chart.yaml
@@ -21,5 +21,5 @@ version: 0.1.0
 appVersion: "v3.0.0"
 dependencies:
   - name: mariadb
-    version: 0.16.*
+    version: 0.16.0
     repository: oci://registry-1.docker.io/cloudpirates

--- a/deploy/helm/grimmory/templates/deployment.yaml
+++ b/deploy/helm/grimmory/templates/deployment.yaml
@@ -36,8 +36,8 @@ spec:
             - /bin/sh
             - -c
             - |
-              echo "Waiting for database on port {{ .Values.mariadb.primary.service.ports.mysql }}..."
-              until nc -z -v -w5 {{ .Release.Name }}-mariadb {{ .Values.mariadb.primary.service.ports.mysql }}; do
+              echo "Waiting for database on port {{ .Values.mariadb.service.port }}..."
+              until nc -z -v -w5 {{ .Release.Name }}-mariadb {{ .Values.mariadb.service.port }}; do
                 echo "Waiting for database..."
                 sleep 2
               done
@@ -63,7 +63,7 @@ spec:
               #protocol: TCP
           env:
             - name: DATABASE_URL
-              value: jdbc:mariadb://{{ .Release.Name }}-mariadb:{{ .Values.mariadb.primary.service.ports.mysql }}/{{ .Values.mariadb.auth.database }}
+              value: jdbc:mariadb://{{ .Release.Name }}-mariadb:{{ .Values.mariadb.service.port }}/{{ .Values.mariadb.auth.database }}
             - name: DATABASE_USERNAME
               value: {{ .Values.mariadb.auth.username }}
             - name: DATABASE_PASSWORD

--- a/deploy/helm/grimmory/values.yaml
+++ b/deploy/helm/grimmory/values.yaml
@@ -9,6 +9,10 @@ mariadb:
   auth:
     database: grimmory
     username: grimmory
+    # existingSecret: mariadb-credentials
+    # secretKeys:
+    #   rootPasswordKey: mariadb-root-password
+    #   userPasswordKey: mariadb-password
   service:
     port: 3306
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/

--- a/deploy/helm/grimmory/values.yaml
+++ b/deploy/helm/grimmory/values.yaml
@@ -5,10 +5,12 @@
 mariadb:
   enabled: true
   image:
-    tag: 11.8.3
+    tag: 12.2.2
   auth:
     database: grimmory
     username: grimmory
+  service:
+    port: 3306
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   repository: grimmory/grimmory


### PR DESCRIPTION
## Description

This PR updates the helm charts to the current version of Grimmory.
It also updates the subchart of MariaDB from the Bitnami chart to the one maintained by CloudPirates.

**Linked Issue:** Fixes #872

## Changes

- Bump `appVersion` to `v3.0.0` (the latest release) so the chart pulls `grimmory-tools/grimmory:v3.0.0`
- Migrate the dependency from Bitmani's MariaDB chart to CloudPirate's MariaDB chart
  - Change the chart itself in the dependencies
  - Update the `Deployment` template and default `values.yaml` to use the values structure of CloudPirate's chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated database dependency to a new repository and pinned a specific version for more predictable installs.
  * Bumped bundled database image to 12.2.2 and added an explicit service port (3306) to improve deployment stability.
  * Adjusted deployment configuration to use the new database service port for readiness checks and connection URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->