### PR TITLE
refactor(jwt): remove Jackson 2 compatibility note and add unit tests for JWT utilities 

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -171,11 +171,8 @@ dependencies {
     implementation(platform("tools.jackson:jackson-bom:3.1.2"))
     implementation("tools.jackson.core:jackson-core")
     implementation("tools.jackson.core:jackson-databind")
-    implementation("tools.jackson.module:jackson-module-blackbird")
-
-    // --- Jackson 2 (Compatibility) ---
-    // jackson-annotations version is managed by Jackson 3 BOM (requires 2.20+)
     implementation("com.fasterxml.jackson.core:jackson-annotations")
+    implementation("tools.jackson.module:jackson-module-blackbird")
 
     // --- Caching ---
     implementation("org.springframework.boot:spring-boot-starter-cache")

--- a/backend/src/test/java/org/booklore/config/security/JwtUtilsTest.java
+++ b/backend/src/test/java/org/booklore/config/security/JwtUtilsTest.java
@@ -1,0 +1,68 @@
+package org.booklore.config.security;
+
+import io.jsonwebtoken.Claims;
+import org.booklore.model.entity.BookLoreUserEntity;
+import org.booklore.service.security.JwtSecretService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtUtilsTest {
+
+    @Mock
+    private JwtSecretService jwtSecretService;
+
+    @InjectMocks
+    private JwtUtils jwtUtils;
+
+    private BookLoreUserEntity user;
+    private final String SECRET = "mySuperSecretKeyThatNeedsToBeVeryLongForHS256Algorithm1234567890";
+
+    @BeforeEach
+    void setUp() {
+        user = new BookLoreUserEntity();
+        user.setId(123L);
+        user.setUsername("testuser");
+        user.setDefaultPassword(false);
+    }
+
+    @Test
+    void testGenerateAndValidateAccessToken() {
+        when(jwtSecretService.getSecret()).thenReturn(SECRET);
+
+        String token = jwtUtils.generateAccessToken(user);
+        assertThat(token).isNotBlank();
+
+        boolean isValid = jwtUtils.validateToken(token);
+        assertThat(isValid).isTrue();
+
+        String username = jwtUtils.extractUsername(token);
+        assertThat(username).isEqualTo("testuser");
+
+        Long userId = jwtUtils.extractUserId(token);
+        assertThat(userId).isEqualTo(123L);
+    }
+
+    @Test
+    void testGenerateAndValidateRefreshToken() {
+        when(jwtSecretService.getSecret()).thenReturn(SECRET);
+
+        String token = jwtUtils.generateRefreshToken(user);
+        assertThat(token).isNotBlank();
+
+        boolean isValid = jwtUtils.validateToken(token);
+        assertThat(isValid).isTrue();
+
+        Claims claims = jwtUtils.extractClaims(token);
+        assertThat(claims.getSubject()).isEqualTo("testuser");
+        assertThat(claims.get("userId", Long.class)).isEqualTo(123L);
+        assertThat(claims.get("isDefaultPassword", Boolean.class)).isFalse();
+    }
+}


### PR DESCRIPTION


## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

This pull request introduces a new unit test class for the JWT utility logic and makes a minor dependency ordering adjustment in the build configuration. The main focus is on improving test coverage for JWT-related functionality.

**Testing improvements:**

* Added a new test class `JwtUtilsTest` to verify access and refresh token generation, validation, and claims extraction for the `JwtUtils` class. This includes tests for extracting the username, user ID, and custom claims from tokens.

**Build configuration:**

* Reordered the `jackson-module-blackbird` dependency in `backend/build.gradle.kts` to be consistent with other Jackson dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added authentication token generation and validation tests.

* **Chores**
  * Updated dependency configuration for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->