### PR TITLE
refactor(specifications): replace dynamic array creation with static empty arrays for improved performance

### DIFF
--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -55,7 +55,6 @@ public class AppBookService {
     private static final int MAX_PAGE_SIZE = 50;
     private static final String DEFAULT_SORT = "addedon";
 
-    private static final Specification[] EMPTY_SPECIFICATION_ARRAY = new Specification[0];
     private final BookRepository bookRepository;
     private final UserBookProgressRepository userBookProgressRepository;
     private final UserBookFileProgressRepository userBookFileProgressRepository;
@@ -1052,7 +1051,7 @@ public class AppBookService {
             specs.add(AppBookSpecification.withProgress(userId, true));
         }
 
-        return AppBookSpecification.combine(specs.toArray(EMPTY_SPECIFICATION_ARRAY));
+        return AppBookSpecification.combine(specs.toArray(Specification[]::new));
     }
 
     private String getSortField(String sortBy) {
@@ -1119,7 +1118,7 @@ public class AppBookService {
             specs.add(AppBookSpecification.inLibrary(libraryId));
         }
 
-        return AppBookSpecification.combine(specs.toArray(EMPTY_SPECIFICATION_ARRAY));
+        return AppBookSpecification.combine(specs.toArray(Specification[]::new));
     }
 
     private AppPageResponse<AppBookSummary> buildPageResponse(

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -55,6 +55,7 @@ public class AppBookService {
     private static final int MAX_PAGE_SIZE = 50;
     private static final String DEFAULT_SORT = "addedon";
 
+    private static final Specification[] EMPTY_SPECIFICATION_ARRAY = new Specification[0];
     private final BookRepository bookRepository;
     private final UserBookProgressRepository userBookProgressRepository;
     private final UserBookFileProgressRepository userBookFileProgressRepository;
@@ -1051,7 +1052,7 @@ public class AppBookService {
             specs.add(AppBookSpecification.withProgress(userId, true));
         }
 
-        return AppBookSpecification.combine(specs.toArray(new Specification[0]));
+        return AppBookSpecification.combine(specs.toArray(EMPTY_SPECIFICATION_ARRAY));
     }
 
     private String getSortField(String sortBy) {
@@ -1118,7 +1119,7 @@ public class AppBookService {
             specs.add(AppBookSpecification.inLibrary(libraryId));
         }
 
-        return AppBookSpecification.combine(specs.toArray(new Specification[0]));
+        return AppBookSpecification.combine(specs.toArray(EMPTY_SPECIFICATION_ARRAY));
     }
 
     private AppPageResponse<AppBookSummary> buildPageResponse(

--- a/backend/src/main/java/org/booklore/app/service/AppSeriesService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppSeriesService.java
@@ -33,7 +33,6 @@ public class AppSeriesService {
 
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final int MAX_PAGE_SIZE = 50;
-    private static final Specification[] EMPTY_SPECIFICATION_ARRAY = new Specification[0];
 
     private final EntityManager entityManager;
     private final AuthenticationService authenticationService;
@@ -374,7 +373,7 @@ public class AppSeriesService {
             specs.add(AppBookSpecification.inLibrary(libraryId));
         }
 
-        return AppBookSpecification.combine(specs.toArray(EMPTY_SPECIFICATION_ARRAY));
+        return AppBookSpecification.combine(specs.toArray(Specification[]::new));
     }
 
     private Map<Long, UserBookProgressEntity> getProgressMap(Long userId, Set<Long> bookIds) {

--- a/backend/src/main/java/org/booklore/app/service/AppSeriesService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppSeriesService.java
@@ -33,6 +33,7 @@ public class AppSeriesService {
 
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final int MAX_PAGE_SIZE = 50;
+    private static final Specification[] EMPTY_SPECIFICATION_ARRAY = new Specification[0];
 
     private final EntityManager entityManager;
     private final AuthenticationService authenticationService;
@@ -373,7 +374,7 @@ public class AppSeriesService {
             specs.add(AppBookSpecification.inLibrary(libraryId));
         }
 
-        return AppBookSpecification.combine(specs.toArray(new Specification[0]));
+        return AppBookSpecification.combine(specs.toArray(EMPTY_SPECIFICATION_ARRAY));
     }
 
     private Map<Long, UserBookProgressEntity> getProgressMap(Long userId, Set<Long> bookIds) {

--- a/backend/src/main/java/org/booklore/app/specification/AppBookSpecification.java
+++ b/backend/src/main/java/org/booklore/app/specification/AppBookSpecification.java
@@ -18,8 +18,6 @@ import java.util.Objects;
 
 public class AppBookSpecification {
 
-    private static final Predicate[] EMPTY_PREDICATE_ARRAY = new Predicate[0];
-
     private AppBookSpecification() {
     }
 
@@ -276,7 +274,7 @@ public class AppBookSpecification {
                             .where(cb.equal(bfRoot.get("bookType"), ft));
                     predicates.add(root.get("id").in(sub));
                 }
-                return cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+                return cb.and(predicates.toArray(Predicate[]::new));
             }
 
             Subquery<Long> sub = query.subquery(Long.class);
@@ -583,7 +581,7 @@ public class AppBookSpecification {
                     default -> throw new APIException("Invalid ageRating bucket ID: " + id, HttpStatus.BAD_REQUEST);
                 });
             }
-            Predicate combined = cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+            Predicate combined = cb.or(predicates.toArray(Predicate[]::new));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -615,7 +613,7 @@ public class AppBookSpecification {
                     default -> throw new APIException("Invalid matchScore bucket ID: " + id, HttpStatus.BAD_REQUEST);
                 });
             }
-            Predicate combined = cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+            Predicate combined = cb.or(predicates.toArray(Predicate[]::new));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -665,7 +663,7 @@ public class AppBookSpecification {
             
             sub.select(cb.literal(1L))
                .where(cb.equal(bfJoin.get("id"), minIdSub),
-                      cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY)));
+                      cb.or(predicates.toArray(Predicate[]::new)));
 
             return "not".equals(mode) ? cb.not(cb.exists(sub)) : cb.exists(sub);
         };
@@ -730,7 +728,7 @@ public class AppBookSpecification {
                     default -> throw new APIException("Invalid " + fieldName + " bucket ID: " + id, HttpStatus.BAD_REQUEST);
                 });
             }
-            Predicate combined = cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+            Predicate combined = cb.or(predicates.toArray(Predicate[]::new));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -754,7 +752,7 @@ public class AppBookSpecification {
                     default -> throw new APIException("Invalid pageCount bucket ID: " + id, HttpStatus.BAD_REQUEST);
                 });
             }
-            Predicate combined = cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+            Predicate combined = cb.or(predicates.toArray(Predicate[]::new));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -825,7 +823,7 @@ public class AppBookSpecification {
                     sub.select(cb.literal(1L)).where(cb.equal(subShelves.get("id"), id));
                     predicates.add(cb.exists(sub));
                 }
-                return cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+                return cb.and(predicates.toArray(Predicate[]::new));
             }
 
             Subquery<Long> sub = query.subquery(Long.class);
@@ -877,13 +875,13 @@ public class AppBookSpecification {
                     where.add(cb.equal(mappingRoot.get("role"), role));
                 }
 
-                sub.select(cb.literal(1L)).where(where.toArray(EMPTY_PREDICATE_ARRAY));
+                sub.select(cb.literal(1L)).where(where.toArray(Predicate[]::new));
                 predicates.add(cb.exists(sub));
             }
 
             Predicate combined = "and".equals(mode)
-                    ? cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY))
-                    : cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+                    ? cb.and(predicates.toArray(Predicate[]::new))
+                    : cb.or(predicates.toArray(Predicate[]::new));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -955,7 +953,7 @@ public class AppBookSpecification {
                         );
                 predicates.add(cb.exists(sub));
             }
-            return cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+            return cb.and(predicates.toArray(Predicate[]::new));
         }
 
         // OR or NOT: single EXISTS subquery with IN clause

--- a/backend/src/main/java/org/booklore/app/specification/AppBookSpecification.java
+++ b/backend/src/main/java/org/booklore/app/specification/AppBookSpecification.java
@@ -18,6 +18,8 @@ import java.util.Objects;
 
 public class AppBookSpecification {
 
+    private static final Predicate[] EMPTY_PREDICATE_ARRAY = new Predicate[0];
+
     private AppBookSpecification() {
     }
 
@@ -274,7 +276,7 @@ public class AppBookSpecification {
                             .where(cb.equal(bfRoot.get("bookType"), ft));
                     predicates.add(root.get("id").in(sub));
                 }
-                return cb.and(predicates.toArray(new Predicate[0]));
+                return cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY));
             }
 
             Subquery<Long> sub = query.subquery(Long.class);
@@ -581,7 +583,7 @@ public class AppBookSpecification {
                     default -> throw new APIException("Invalid ageRating bucket ID: " + id, HttpStatus.BAD_REQUEST);
                 });
             }
-            Predicate combined = cb.or(predicates.toArray(new Predicate[0]));
+            Predicate combined = cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -613,7 +615,7 @@ public class AppBookSpecification {
                     default -> throw new APIException("Invalid matchScore bucket ID: " + id, HttpStatus.BAD_REQUEST);
                 });
             }
-            Predicate combined = cb.or(predicates.toArray(new Predicate[0]));
+            Predicate combined = cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -663,7 +665,7 @@ public class AppBookSpecification {
             
             sub.select(cb.literal(1L))
                .where(cb.equal(bfJoin.get("id"), minIdSub),
-                      cb.or(predicates.toArray(new Predicate[0])));
+                      cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY)));
 
             return "not".equals(mode) ? cb.not(cb.exists(sub)) : cb.exists(sub);
         };
@@ -728,7 +730,7 @@ public class AppBookSpecification {
                     default -> throw new APIException("Invalid " + fieldName + " bucket ID: " + id, HttpStatus.BAD_REQUEST);
                 });
             }
-            Predicate combined = cb.or(predicates.toArray(new Predicate[0]));
+            Predicate combined = cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -752,7 +754,7 @@ public class AppBookSpecification {
                     default -> throw new APIException("Invalid pageCount bucket ID: " + id, HttpStatus.BAD_REQUEST);
                 });
             }
-            Predicate combined = cb.or(predicates.toArray(new Predicate[0]));
+            Predicate combined = cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -823,7 +825,7 @@ public class AppBookSpecification {
                     sub.select(cb.literal(1L)).where(cb.equal(subShelves.get("id"), id));
                     predicates.add(cb.exists(sub));
                 }
-                return cb.and(predicates.toArray(new Predicate[0]));
+                return cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY));
             }
 
             Subquery<Long> sub = query.subquery(Long.class);
@@ -875,13 +877,13 @@ public class AppBookSpecification {
                     where.add(cb.equal(mappingRoot.get("role"), role));
                 }
 
-                sub.select(cb.literal(1L)).where(where.toArray(new Predicate[0]));
+                sub.select(cb.literal(1L)).where(where.toArray(EMPTY_PREDICATE_ARRAY));
                 predicates.add(cb.exists(sub));
             }
 
             Predicate combined = "and".equals(mode)
-                    ? cb.and(predicates.toArray(new Predicate[0]))
-                    : cb.or(predicates.toArray(new Predicate[0]));
+                    ? cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY))
+                    : cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
             return "not".equals(mode) ? cb.not(combined) : combined;
         };
     }
@@ -953,7 +955,7 @@ public class AppBookSpecification {
                         );
                 predicates.add(cb.exists(sub));
             }
-            return cb.and(predicates.toArray(new Predicate[0]));
+            return cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY));
         }
 
         // OR or NOT: single EXISTS subquery with IN clause

--- a/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -47,7 +47,6 @@ import org.springframework.web.util.pattern.PathPatternParser;
 public class SecurityConfig {
 
     private static final Pattern ALLOWED = Pattern.compile("\\s*,\\s*");
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private final OpdsUserDetailsService opdsUserDetailsService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationCheckFilter authenticationCheckFilter;
@@ -86,7 +85,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(unauthenticatedEndpoints.toArray(EMPTY_STRING_ARRAY)).permitAll()
+                        .requestMatchers(unauthenticatedEndpoints.toArray(String[]::new)).permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(basic -> basic

--- a/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -47,6 +47,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
 public class SecurityConfig {
 
     private static final Pattern ALLOWED = Pattern.compile("\\s*,\\s*");
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private final OpdsUserDetailsService opdsUserDetailsService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationCheckFilter authenticationCheckFilter;
@@ -85,7 +86,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(unauthenticatedEndpoints.toArray(new String[0])).permitAll()
+                        .requestMatchers(unauthenticatedEndpoints.toArray(EMPTY_STRING_ARRAY)).permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(basic -> basic

--- a/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
+++ b/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
@@ -32,7 +32,6 @@ public class BookRuleEvaluatorService {
     private static final Set<RuleField> COMPOSITE_FIELDS = Set.of(
             RuleField.SERIES_STATUS, RuleField.SERIES_GAPS, RuleField.SERIES_POSITION
     );
-    private static final Predicate[] EMPTY_PREDICATE_ARRAY = new Predicate[0];
 
     public Specification<BookEntity> toSpecification(GroupRule groupRule, Long userId) {
         return (root, query, cb) -> {
@@ -89,8 +88,8 @@ public class BookRuleEvaluatorService {
         }
 
         return group.getJoin() == org.booklore.model.dto.JoinType.AND
-                ? cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY))
-                : cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+                ? cb.and(predicates.toArray(Predicate[]::new))
+                : cb.or(predicates.toArray(Predicate[]::new));
     }
 
     private Predicate buildRulePredicate(Rule rule, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin, Long userId) {
@@ -871,7 +870,7 @@ public class BookRuleEvaluatorService {
                     })
                     .toList();
 
-            return cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY));
+            return cb.and(predicates.toArray(Predicate[]::new));
         } else {
             Subquery<Long> subquery = query.subquery(Long.class);
             Root<BookEntity> subRoot = subquery.from(BookEntity.class);

--- a/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
+++ b/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
@@ -32,6 +32,7 @@ public class BookRuleEvaluatorService {
     private static final Set<RuleField> COMPOSITE_FIELDS = Set.of(
             RuleField.SERIES_STATUS, RuleField.SERIES_GAPS, RuleField.SERIES_POSITION
     );
+    private static final Predicate[] EMPTY_PREDICATE_ARRAY = new Predicate[0];
 
     public Specification<BookEntity> toSpecification(GroupRule groupRule, Long userId) {
         return (root, query, cb) -> {
@@ -88,8 +89,8 @@ public class BookRuleEvaluatorService {
         }
 
         return group.getJoin() == org.booklore.model.dto.JoinType.AND
-                ? cb.and(predicates.toArray(new Predicate[0]))
-                : cb.or(predicates.toArray(new Predicate[0]));
+                ? cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY))
+                : cb.or(predicates.toArray(EMPTY_PREDICATE_ARRAY));
     }
 
     private Predicate buildRulePredicate(Rule rule, CriteriaQuery<?> query, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin, Long userId) {
@@ -870,7 +871,7 @@ public class BookRuleEvaluatorService {
                     })
                     .toList();
 
-            return cb.and(predicates.toArray(new Predicate[0]));
+            return cb.and(predicates.toArray(EMPTY_PREDICATE_ARRAY));
         } else {
             Subquery<Long> subquery = query.subquery(Long.class);
             Root<BookEntity> subRoot = subquery.from(BookEntity.class);


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request introduces a codebase-wide refactor to optimize array allocations when converting collections to arrays, especially for frequently used types like `Specification`, `Predicate`, and `String`. The main change is the introduction and use of static, pre-allocated empty arrays instead of creating new empty arrays each time, which improves performance and reduces unnecessary object creation. No logic or behavior is changed.

The most important changes are:

**Performance improvements (array allocation):**

* Introduced static empty arrays (`EMPTY_SPECIFICATION_ARRAY`, `EMPTY_PREDICATE_ARRAY`, `EMPTY_STRING_ARRAY`) for `Specification`, `Predicate`, and `String` types in their respective classes to avoid repeated allocations of empty arrays. 
* Replaced all instances of `toArray(new Type[0])` with `toArray(EMPTY_TYPE_ARRAY)` in methods that build specifications or predicates, across service and specification classes.

These changes are purely internal optimizations and do not affect application behavior or external interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal refactor across backend services to optimize small array handling and predicate construction. Improves efficiency and maintainability with no changes to functionality, APIs, or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->