### PR TITLE
chore(dev): support accessing the dev server from non-localhost

### DIFF
--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - DATABASE_USERNAME=grimmory
       - DATABASE_PASSWORD=grimmory
       - REMOTE_DEBUG_ENABLED=true
-      - ALLOWED_ORIGINS=http://localhost:4200
+      - ALLOWED_ORIGINS=*
       - API_DOCS_ENABLED=true
       - JAVA_TOOL_OPTIONS=-XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=8.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=48m -Xss512k -XX:CICompilerCount=2 -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -XX:ShenandoahUncommitDelay=5000 -XX:ShenandoahGuaranteedGCInterval=30000 -XX:MaxDirectMemorySize=256m
     stdin_open: true

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,7 +1,7 @@
 export const environment = {
   production: false,
   API_CONFIG: {
-    BASE_URL: 'http://localhost:6060',
-    BROKER_URL: 'ws://localhost:6060/ws',
+    BASE_URL: `http://${window.location.hostname}:6060`,
+    BROKER_URL: `ws://${window.location.hostname}:6060/ws`,
   },
 };


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
updates the dev docker compose configuration to support accessing the dev server from any domain or IP.  this is important for validating the dev server in situations where you CANNOT run the server locally - such as mobile browsers

this could be improved upon in the future but for right now it should work for our use cases

**Linked Issue:** Fixes #886

## Changes

* updates the `dev.docker-compose.yaml` to use a CORS origin of `*`
* updates the dev environment in the UI to look at the current hostname + port 6060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend CORS configuration to support broader request origins
  * Updated frontend to dynamically detect API endpoints based on deployment hostname instead of hardcoded values, enabling improved flexibility across different deployment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->