### PR TITLE
fix(ui): disable critical-inlining to prevent CSP failure

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -95,7 +95,15 @@
                 }
               ],
               "outputHashing": "all",
-              "serviceWorker": "ngsw-config.json"
+              "serviceWorker": "ngsw-config.json",
+              "optimization": {
+                "scripts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": false
+                },
+                "fonts": true
+              }
             },
             "development": {
               "optimization": false,


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

this critical inlining option is meant to improve the first contentful paint metric but does so in a way that is not compatible with a safe content-security-policy

this only affected production builds which is why we never saw it in development

## Changes

disalble angular option `projects.grimmory.architect.build.configurations.production.optimization.styles.inlineCritical`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production build configuration for improved app performance and reduced bundle sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->