### PR TITLE
refactor(api): use package imports in more situations

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/oidc/OidcTokenValidator.java
+++ b/backend/src/main/java/org/booklore/config/security/oidc/OidcTokenValidator.java
@@ -16,6 +16,7 @@ import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.booklore.exception.APIException;
 import org.booklore.exception.ApiError;
 import org.booklore.util.FileUtils;
 import org.springframework.stereotype.Service;
@@ -60,7 +61,7 @@ public class OidcTokenValidator {
             validateAccessTokenHash(claims, accessToken, idTokenStr);
 
             return claims;
-        } catch (org.booklore.exception.APIException e) {
+        } catch (APIException e) {
             throw e;
         } catch (Exception e) {
             log.warn("OIDC ID token validation failed: {}", e.getMessage());
@@ -181,7 +182,7 @@ public class OidcTokenValidator {
             if (!computed.equals(atHash)) {
                 throw ApiError.OIDC_INVALID_TOKEN.createException("ID token at_hash mismatch");
             }
-        } catch (org.booklore.exception.APIException e) {
+        } catch (APIException e) {
             throw e;
         } catch (java.text.ParseException | NoSuchAlgorithmException e) {
             log.warn("Failed to validate at_hash: {}", e.getMessage());
@@ -219,7 +220,7 @@ public class OidcTokenValidator {
             }
 
             return claims;
-        } catch (org.booklore.exception.APIException e) {
+        } catch (APIException e) {
             throw e;
         } catch (Exception e) {
             log.warn("OIDC logout token validation failed: {}", e.getMessage());

--- a/backend/src/main/java/org/booklore/repository/BookRepository.java
+++ b/backend/src/main/java/org/booklore/repository/BookRepository.java
@@ -1,5 +1,6 @@
 package org.booklore.repository;
 
+import org.booklore.repository.projection.BookEmbeddingProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
@@ -516,6 +517,6 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
             AND b.id <> :excludeBookId
             AND m.embeddingVector IS NOT NULL
             """)
-    List<org.booklore.repository.projection.BookEmbeddingProjection> findAllEmbeddingsForRecommendation(@Param("excludeBookId") Long excludeBookId);
+    List<BookEmbeddingProjection> findAllEmbeddingsForRecommendation(@Param("excludeBookId") Long excludeBookId);
 
 }

--- a/backend/src/main/java/org/booklore/repository/UserBookProgressRepository.java
+++ b/backend/src/main/java/org/booklore/repository/UserBookProgressRepository.java
@@ -6,6 +6,7 @@ import org.booklore.model.dto.ProgressPercentDto;
 import org.booklore.model.dto.RatingDistributionDto;
 import org.booklore.model.dto.StatusDistributionDto;
 import org.booklore.model.entity.UserBookProgressEntity;
+import org.booklore.model.enums.ReadStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -100,9 +101,9 @@ public interface UserBookProgressRepository extends JpaRepository<UserBookProgre
     int bulkUpdateReadStatus(
             @Param("userId") Long userId,
             @Param("bookIds") List<Long> bookIds,
-            @Param("readStatus") org.booklore.model.enums.ReadStatus readStatus,
-            @Param("modifiedTime") java.time.Instant modifiedTime,
-            @Param("dateFinished") java.time.Instant dateFinished
+            @Param("readStatus") ReadStatus readStatus,
+            @Param("modifiedTime") Instant modifiedTime,
+            @Param("dateFinished") Instant dateFinished
     );
 
     @Query("""

--- a/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -1,7 +1,6 @@
 package org.booklore.service.progress;
 
-import
-        org.booklore.config.security.service.AuthenticationService;
+import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.exception.ApiError;
 import org.booklore.model.dto.*;
 import org.booklore.model.dto.progress.AudiobookProgress;

--- a/backend/src/main/java/org/booklore/service/reader/ChapterCacheService.java
+++ b/backend/src/main/java/org/booklore/service/reader/ChapterCacheService.java
@@ -3,6 +3,7 @@ package org.booklore.service.reader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.config.AppProperties;
+import org.booklore.exception.ApiError;
 import org.booklore.service.ArchiveService;
 import org.springframework.stereotype.Service;
 
@@ -102,7 +103,7 @@ public class ChapterCacheService {
 
     private Path getCacheDir(String cacheKey) {
         if (cacheKey == null || cacheKey.contains("..") || cacheKey.contains("/") || cacheKey.contains("\\")) {
-            throw org.booklore.exception.ApiError.INVALID_INPUT.createException("Invalid cache key: " + cacheKey);
+            throw ApiError.INVALID_INPUT.createException("Invalid cache key: " + cacheKey);
         }
         return Paths.get(appProperties.getPathConfig(), "cache", "chapters", cacheKey);
     }

--- a/backend/src/main/java/org/booklore/service/watcher/PendingDeletionPool.java
+++ b/backend/src/main/java/org/booklore/service/watcher/PendingDeletionPool.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.booklore.mapper.BookMapper;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookFileEntity;
+import org.booklore.model.entity.LibraryPathEntity;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.model.enums.PermissionType;
 import org.booklore.model.websocket.Topic;
@@ -241,7 +242,7 @@ public class PendingDeletionPool {
     }
 
     @Transactional
-    public void recoverBook(MatchResult match, org.booklore.model.entity.LibraryPathEntity newLibraryPath, String newFileSubPath, String newFileName, String hash) {
+    public void recoverBook(MatchResult match, LibraryPathEntity newLibraryPath, String newFileSubPath, String newFileName, String hash) {
         BookEntity book = bookRepository.findById(match.book().bookId())
                 .orElseThrow(() -> new IllegalStateException("Book not found: " + match.book().bookId()));
 

--- a/backend/src/test/java/org/booklore/service/Rar5IntegrationTest.java
+++ b/backend/src/test/java/org/booklore/service/Rar5IntegrationTest.java
@@ -1,6 +1,8 @@
 package org.booklore.service;
 
 import org.booklore.model.dto.BookMetadata;
+import org.booklore.model.dto.settings.AppSettings;
+import org.booklore.model.dto.settings.MetadataPersistenceSettings;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.service.kobo.CbxConversionService;
@@ -9,6 +11,8 @@ import org.booklore.service.metadata.writer.CbxMetadataWriter;
 import org.booklore.service.reader.CbxReaderService;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.appsettings.AppSettingService;
+import org.booklore.service.reader.ChapterCacheService;
+import org.booklore.util.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
@@ -61,10 +65,10 @@ class Rar5IntegrationTest {
         book.setId(99L);
         BookRepository mockRepo = org.mockito.Mockito.mock(BookRepository.class);
         org.mockito.Mockito.when(mockRepo.findByIdForStreaming(99L)).thenReturn(java.util.Optional.of(book));
-        org.booklore.service.reader.ChapterCacheService mockCache = org.mockito.Mockito.mock(org.booklore.service.reader.ChapterCacheService.class);
+        ChapterCacheService mockCache = org.mockito.Mockito.mock(ChapterCacheService.class);
 
-        try (var fileUtilsStatic = org.mockito.Mockito.mockStatic(org.booklore.util.FileUtils.class)) {
-            fileUtilsStatic.when(() -> org.booklore.util.FileUtils.getBookFullPath(book))
+        try (var fileUtilsStatic = org.mockito.Mockito.mockStatic(FileUtils.class)) {
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(book))
                     .thenReturn(cbrCopy);
 
             CbxReaderService readerService = new CbxReaderService(mockRepo, new ArchiveService(), mockCache);
@@ -84,12 +88,12 @@ class Rar5IntegrationTest {
         book.setId(99L);
         BookRepository mockRepo = org.mockito.Mockito.mock(BookRepository.class);
         org.mockito.Mockito.when(mockRepo.findByIdForStreaming(99L)).thenReturn(java.util.Optional.of(book));
-        org.booklore.service.reader.ChapterCacheService mockCache = org.mockito.Mockito.mock(org.booklore.service.reader.ChapterCacheService.class);
+        ChapterCacheService mockCache = org.mockito.Mockito.mock(ChapterCacheService.class);
 
         try (
-            var fileUtilsStatic = org.mockito.Mockito.mockStatic(org.booklore.util.FileUtils.class)
+            var fileUtilsStatic = org.mockito.Mockito.mockStatic(FileUtils.class)
         ) {
-            fileUtilsStatic.when(() -> org.booklore.util.FileUtils.getBookFullPath(book))
+            fileUtilsStatic.when(() -> FileUtils.getBookFullPath(book))
                     .thenReturn(cbrCopy);
 
             CbxReaderService readerService = new CbxReaderService(mockRepo, new ArchiveService(), mockCache);
@@ -142,10 +146,10 @@ class Rar5IntegrationTest {
         Files.copy(RAR5_CBR, cbrCopy);
 
         AppSettingService mockSettings = org.mockito.Mockito.mock(AppSettingService.class);
-        var appSettings = new org.booklore.model.dto.settings.AppSettings();
-        var persistenceSettings = new org.booklore.model.dto.settings.MetadataPersistenceSettings();
-        var saveToFile = new org.booklore.model.dto.settings.MetadataPersistenceSettings.SaveToOriginalFile();
-        var cbxSettings = new org.booklore.model.dto.settings.MetadataPersistenceSettings.FormatSettings();
+        var appSettings = new AppSettings();
+        var persistenceSettings = new MetadataPersistenceSettings();
+        var saveToFile = new MetadataPersistenceSettings.SaveToOriginalFile();
+        var cbxSettings = new MetadataPersistenceSettings.FormatSettings();
         cbxSettings.setEnabled(true);
         cbxSettings.setMaxFileSizeInMb(500);
         saveToFile.setCbx(cbxSettings);


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
For some reason, a number of references to packages are not using imports.  This makes it more difficult to do a clean rename to use `org.grimmory`, so fixing these imports is helpful.  this does not fix all cases of this - it seems some files do this more -- but it at least should get all cases of `org.booklore`

**Linked Issue:** Related to #853 

## Changes

* use `import` where possible for referencing packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code cleanup: simplified import statements and replaced fully-qualified type references with imported types across backend modules for improved code readability.

* **Tests**
  * Updated test imports and type references to maintain consistency with codebase changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->