### PR TITLE
fix(ui): allow self frame-src for pdf doc mode

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,7 +6,7 @@
   <title>Grimmory</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
-  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; worker-src 'self' blob:; frame-src blob: data:; object-src 'none'; form-action 'none';">
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; worker-src 'self' blob:; frame-src 'self' blob: data:; object-src 'none'; form-action 'none';">
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg"/>
   <link rel="manifest" href="manifest.webmanifest">
 </head>


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
The content security policy inadvertently prevents the PDF doc mode from operating.  This loosens the `frame-src` to allow this feature to operate.

**Linked Issue:** Fixes #897

## Changes

* Adds `self` to CSP `frame-src`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configuration to permit same-origin embedded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->