### PR TITLE
refactor(dependencies): change certain implementations to compileOnly and exclude unnecessary modules for better build

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -154,7 +154,7 @@ dependencies {
     implementation("org.jsoup:jsoup:1.22.2")
 
     // --- Mapping (DTOs & Entities) ---
-    compileOnly("org.mapstruct:mapstruct:1.6.3")
+    testImplementation("org.mapstruct:mapstruct:1.6.3")
     annotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")
 
     // --- API Documentation ---

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -154,8 +154,9 @@ dependencies {
     implementation("org.jsoup:jsoup:1.22.2")
 
     // --- Mapping (DTOs & Entities) ---
-    testImplementation("org.mapstruct:mapstruct:1.6.3")
+    implementation("org.mapstruct:mapstruct:1.6.3")
     annotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")
+
 
     // --- API Documentation ---
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:3.0.3")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -96,11 +96,16 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("org.springframework.boot:spring-boot-configuration-processor")
+    implementation("org.springframework.boot:spring-boot-starter-actuator") {
+        exclude(group = "org.springframework.boot", module = "spring-boot-starter-jmx")
+        exclude(group = "io.micrometer", module = "micrometer-core") // PROD: No metrics objects/overhead
+    }
+    compileOnly("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-mail")
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
+    // --- Context Indexer for faster/leaner startup ---
+    annotationProcessor("org.springframework:spring-context-indexer")
 
     // --- Reactive Streams ---
     implementation("io.projectreactor:reactor-core")
@@ -148,7 +153,7 @@ dependencies {
     implementation("org.jsoup:jsoup:1.22.2")
 
     // --- Mapping (DTOs & Entities) ---
-    implementation("org.mapstruct:mapstruct:1.6.3")
+    compileOnly("org.mapstruct:mapstruct:1.6.3")
     annotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")
 
     // --- API Documentation ---
@@ -161,7 +166,7 @@ dependencies {
     implementation("org.apache.tika:tika-core:3.3.0")
 
     // --- XML Support (JAXB) ---
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.5")
+    compileOnly("jakarta.xml.bind:jakarta.xml.bind-api:4.0.5")
     runtimeOnly("org.glassfish.jaxb:jaxb-runtime:4.0.7")
 
     // --- Template Engine ---

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     // --- Context Indexer for faster/leaner startup ---
     annotationProcessor("org.springframework:spring-context-indexer")


### PR DESCRIPTION


## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

This pull request updates the dependency management in `backend/build.gradle.kts` to optimize production performance, reduce unnecessary runtime dependencies, and improve build efficiency. The main changes involve refining how certain libraries are included (e.g., switching some to `compileOnly`), excluding unneeded modules, and removing redundant dependencies.

**Dependency management and optimization:**

* Changed `spring-boot-starter-actuator` to exclude both the JMX and Micrometer metrics modules, reducing production overhead.
* Moved `spring-boot-configuration-processor`, `mapstruct`, and `jakarta.xml.bind-api` dependencies to `compileOnly`, ensuring they are not included in the final runtime artifact. 
* Added `spring-context-indexer` as an annotation processor to enable faster application startup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend dependencies and build configuration
  * Removed OAuth2 client starter dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->