### PR TITLE
refactor(api): use package imports in tests where possible

### DIFF
--- a/backend/src/test/java/org/booklore/service/book/BookFileDetachmentServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookFileDetachmentServiceTest.java
@@ -7,6 +7,7 @@ import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.response.DetachBookFileResponse;
 import org.booklore.model.entity.*;
+import org.booklore.model.enums.AuditAction;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserBookProgressRepository;
@@ -122,7 +123,7 @@ class BookFileDetachmentServiceTest {
         assertThat(response).isNotNull();
         assertThat(book.getBookFiles()).hasSize(1);
         assertThat(book.getBookFiles().getFirst().getId()).isEqualTo(10L);
-        verify(auditService).log(eq(org.booklore.model.enums.AuditAction.BOOK_FILE_DETACHED), anyString(), eq(1L), anyString());
+        verify(auditService).log(eq(AuditAction.BOOK_FILE_DETACHED), anyString(), eq(1L), anyString());
         verify(bookRepository).saveAndFlush(argThat(newBook -> {
             assertThat(newBook.getMetadata().getTitle()).isEqualTo("Test Book 1");
             return true;

--- a/backend/src/test/java/org/booklore/service/fileprocessor/AbstractFileProcessorTest.java
+++ b/backend/src/test/java/org/booklore/service/fileprocessor/AbstractFileProcessorTest.java
@@ -25,6 +25,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -214,8 +215,8 @@ class AbstractFileProcessorTest {
         }
 
         @Override
-        public java.util.List<org.booklore.model.enums.BookFileType> getSupportedTypes() {
-            return java.util.List.of();
+        public List<BookFileType> getSupportedTypes() {
+            return List.of();
         }
 
         Path exposedGetBookFolderForCoverFallback(LibraryFile libraryFile) {

--- a/backend/src/test/java/org/booklore/service/metadata/BookMetadataServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookMetadataServiceTest.java
@@ -24,6 +24,7 @@ import org.booklore.repository.BookMetadataRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.NotificationService;
 import org.booklore.service.appsettings.AppSettingService;
+import org.booklore.service.audit.AuditService;
 import org.booklore.service.book.BookQueryService;
 import org.booklore.service.metadata.extractor.CbxMetadataExtractor;
 import org.booklore.service.metadata.extractor.MetadataExtractorFactory;
@@ -59,7 +60,7 @@ class BookMetadataServiceTest {
     @Mock private NotificationService notificationService;
     @Mock private BookMetadataRepository bookMetadataRepository;
     @Mock private BookQueryService bookQueryService;
-    @Mock private org.booklore.service.audit.AuditService auditService;
+    @Mock private AuditService auditService;
     @Mock private CbxMetadataExtractor cbxMetadataExtractor;
     @Mock private MetadataExtractorFactory metadataExtractorFactory;
     @Mock private MetadataClearFlagsMapper metadataClearFlagsMapper;

--- a/backend/src/test/java/org/booklore/service/opds/OpdsFeedServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/opds/OpdsFeedServiceTest.java
@@ -3,6 +3,7 @@ package org.booklore.service.opds;
 import jakarta.servlet.http.HttpServletRequest;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.config.security.userdetails.OpdsUserDetails;
+import org.booklore.exception.APIException;
 import org.booklore.model.dto.*;
 import org.booklore.model.entity.ShelfEntity;
 import org.booklore.model.enums.BookFileType;
@@ -119,7 +120,7 @@ class OpdsFeedServiceTest {
     void generateShelvesNavigation_shouldThrowWhenNotAuthenticated() {
         when(authenticationService.getOpdsUser()).thenReturn(null);
         assertThatThrownBy(() -> opdsFeedService.generateShelvesNavigation(request))
-                .isInstanceOf(org.booklore.exception.APIException.class)
+                .isInstanceOf(APIException.class)
                 .hasMessageContaining("OPDS authentication required");
         verify(opdsBookService, never()).getUserShelves(any());
     }
@@ -308,7 +309,7 @@ class OpdsFeedServiceTest {
         var method = OpdsFeedService.class.getDeclaredMethod("getUserId");
         method.setAccessible(true);
         assertThatThrownBy(() -> method.invoke(opdsFeedService))
-                .hasCauseInstanceOf(org.booklore.exception.APIException.class)
+                .hasCauseInstanceOf(APIException.class)
                 .hasRootCauseMessage("OPDS authentication required");
     }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
a few more tests were using the fully qualified package names for classes when they can be using imports

this is to reduce churn needed for #853

**Linked Issue:** Related to #853

## Changes

* updates `BookFileDetachmentServiceTest`, `AbstractFileProcessorTest`, `BookMetadataServiceTest`, and `OpdsFeedServiceTest` to use imports where possible for `org.booklore` packages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cleaned up and organized test file imports for improved code consistency across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->