### PR TITLE
fix(metadata): bypass service worker for cross-origin cover thumbnails

### DIFF
--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.html
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.html
@@ -70,7 +70,7 @@
           <div class="result-card">
             <div class="result-image">
               @if (result.imageUrl) {
-                <img [src]="result.imageUrl" [alt]="result.name" loading="lazy"/>
+                <img [src]="(result.imageUrl | ngswBypass)" [alt]="result.name" loading="lazy"/>
               } @else {
                 <div class="result-placeholder">
                   <i class="pi pi-user"></i>

--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.ts
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.ts
@@ -8,6 +8,7 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {MessageService} from 'primeng/api';
 import {AuthorService} from '../../service/author.service';
 import {AuthorDetails, AuthorMatchRequest, AuthorSearchResult} from '../../model/author.model';
+import {NgswBypassPipe} from '../../../../shared/pipes/ngsw-bypass.pipe';
 
 interface RegionOption {
   label: string;
@@ -25,7 +26,8 @@ interface RegionOption {
     InputText,
     Select,
     ProgressSpinner,
-    TranslocoDirective
+    TranslocoDirective,
+    NgswBypassPipe
   ]
 })
 export class AuthorMatchComponent implements OnInit {

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
@@ -161,7 +161,7 @@
               (keydown.enter)="onBookClick(metadata)">
               <div class="card-image">
                 <img
-                  [src]="metadata.thumbnailUrl || 'assets/images/missing-cover.jpg'"
+                  [src]="(metadata.thumbnailUrl | ngswBypass) || 'assets/images/missing-cover.jpg'"
                   [alt]="metadata.title"
                   loading="lazy"/>
                 <div class="card-overlay">

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
@@ -14,6 +14,7 @@ import {MetadataPickerComponent} from '../metadata-picker/metadata-picker.compon
 import {BookMetadataService} from '../../../../book/service/book-metadata.service';
 import {Tooltip} from 'primeng/tooltip';
 import {TranslocoDirective} from '@jsverse/transloco';
+import {NgswBypassPipe} from '../../../../../shared/pipes/ngsw-bypass.pipe';
 
 @Component({
   selector: 'app-metadata-searcher',
@@ -27,7 +28,8 @@ import {TranslocoDirective} from '@jsverse/transloco';
     MetadataPickerComponent,
     MultiSelect,
     Tooltip,
-    TranslocoDirective
+    TranslocoDirective,
+    NgswBypassPipe
   ],
   standalone: true
 })

--- a/frontend/src/app/shared/pipes/ngsw-bypass.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/ngsw-bypass.pipe.spec.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from 'vitest';
+import {NgswBypassPipe} from './ngsw-bypass.pipe';
+
+describe('NgswBypassPipe', () => {
+  const pipe = new NgswBypassPipe();
+
+  it('returns null for null input', () => {
+    expect(pipe.transform(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(pipe.transform(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(pipe.transform('')).toBeNull();
+  });
+
+  it('appends with ? when URL has no query string', () => {
+    expect(pipe.transform('https://cdn.example.com/cover.jpg'))
+      .toBe('https://cdn.example.com/cover.jpg?ngsw-bypass=true');
+  });
+
+  it('appends with & when URL already has a query string', () => {
+    expect(pipe.transform('https://cdn.example.com/cover.jpg?w=200'))
+      .toBe('https://cdn.example.com/cover.jpg?w=200&ngsw-bypass=true');
+  });
+});

--- a/frontend/src/app/shared/pipes/ngsw-bypass.pipe.ts
+++ b/frontend/src/app/shared/pipes/ngsw-bypass.pipe.ts
@@ -1,0 +1,14 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+/**
+ * Appends the `ngsw-bypass=true` query parameter so the Angular service worker
+ * does not intercept the request. Useful for cross-origin image URLs whose
+ * default SW passthrough produces responses that browsers refuse to render.
+ */
+@Pipe({name: 'ngswBypass', standalone: true, pure: true})
+export class NgswBypassPipe implements PipeTransform {
+  transform(url: string | null | undefined): string | null {
+    if (!url) return null;
+    return url + (url.includes('?') ? '&' : '?') + 'ngsw-bypass=true';
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #919.

Cover thumbnails on the **Metadata Search** and **Author Match** screens fail to render in Chromium browsers (Chrome, Brave). JPEG bytes arrive with HTTP 200 in the Network tab but the `<img>` element shows the broken-image placeholder; the same URL loads correctly in a standalone tab.

Root cause is that the Angular service worker added in v3.0.0 intercepts cross-origin image fetches and on first load returns a response that Chromium's image decoder rejects, even though the bytes are valid JPEG.

## Changes

* New `NgswBypassPipe` (standalone, pure) at `frontend/src/app/shared/pipes/ngsw-bypass.pipe.ts` plus Vitest spec.
* Applied the pipe to `metadata-searcher.component.html` and `author-match.component.html`. These are the two surfaces that load cross-origin metadata thumbnails dynamically via SSE/signal updates.
* Same-origin Grimmory cover URLs (book/series browsers, `cover-search`) are unchanged.
* `loading="lazy"` is preserved.

The `?ngsw-bypass=true` escape hatch is Angular's documented way to opt a request out of SW handling and is already used in this codebase by `audiobook.service.ts:33,42,47`.

## Verification

Empirically validated by building three custom `v3.0.2` images and testing in fresh browser sessions in Chrome and Brave:

| Variant | Covers render? |
|---|---|
| Removed `loading="lazy"` | No |
| Disabled the service worker entirely | Yes |
| Applied `?ngsw-bypass=true` (this PR) | Yes |

Local instance has been running the patched build for several hours across multiple sessions and provider searches with no regressions.

## Test plan

- [x] `corepack yarn typecheck` (clean)
- [x] `corepack yarn lint` (clean)
- [x] `corepack yarn test`: new pipe spec passes (5/5). 5 pre-existing failures in `magic-shelf-utils.spec.ts` (timezone date assertions) are unrelated to this change and reproduce on unmodified `develop`.
- [x] Manual: Brave fresh session, Search Metadata returns covers across multiple providers and books.
- [x] Manual: Chrome fresh session, same.
- [x] Manual: Author Match cover thumbnails render.

## Notes for reviewers

* The pipe uses simple string concatenation rather than the `URL` API, matching the existing `audiobook.service.ts` pattern. URL fragments would technically place the query in the wrong position but no metadata provider CDN returns URLs with fragments in practice.
* The pipe is not idempotent (calling it twice on the same URL produces `&ngsw-bypass=true&ngsw-bypass=true`). Harmless but worth noting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated image loading mechanisms in author profiles and book metadata to improve how images are cached and displayed, ensuring more reliable and consistent presentation across the application.

* **Tests**
  * Implemented comprehensive test coverage for image caching functionality to verify proper behavior and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->