### PR TITLE
refactor(metadata): avoid regex for AmazonBookParser

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -884,18 +884,12 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     }
 
     private boolean isWhitespaceNode(Node node) {
-        if (node instanceof TextNode) {
-            if (((TextNode) node).isBlank()) {
-                return true;
-            }
+        if (node instanceof TextNode textNode) {
+            return textNode.isBlank();
         }
 
-        if (node instanceof Element) {
-            Element element = (Element) node;
-
-            if ("br".equals(element.tagName())) {
-                return true;
-            }
+        if (node instanceof Element element) {
+            return "br".equals(element.tagName());
         }
 
         return false;

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -14,6 +14,8 @@ import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
@@ -34,10 +36,6 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     private static final Pattern ASIN_PATTERN = Pattern.compile("([A-Z0-9]{10})");
-    private static final Pattern TRAILING_BR_TAGS_PATTERN = Pattern.compile("(\\s*<br\\s*/?>\\s*)+$");
-    private static final Pattern LEADING_BR_TAGS_PATTERN = Pattern.compile("^(\\s*<br\\s*/?>\\s*)+");
-    private static final Pattern MULTIPLE_BR_TAGS_PATTERN = Pattern.compile("(<br\\s*/?>\\s*){3,}");
-    private static final Pattern MULTIPLE_BR_CLOSING_TAGS_PATTERN = Pattern.compile("(<br>\\s*){3,}");
 
     private static class AmazonAntiScrapingException extends RuntimeException {
         public AmazonAntiScrapingException(String message) {
@@ -885,6 +883,24 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         return parseDate(dateString, getLocaleInfoForDomain(domain));
     }
 
+    private boolean isWhitespaceNode(Node node) {
+        if (node instanceof TextNode) {
+            if (((TextNode) node).isBlank()) {
+                return true;
+            }
+        }
+
+        if (node instanceof Element) {
+            Element element = (Element) node;
+
+            if ("br".equals(element.tagName())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private String cleanDescriptionHtml(String html) {
         try {
             Document document = Jsoup.parse(html);
@@ -914,8 +930,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
             // Remove excessive line breaks (more than 2 consecutive <br> tags)
             Elements brTags = document.select("br");
-            for (int i = 0; i < brTags.size(); i++) {
-                Element br = brTags.get(i);
+            for (Element br : brTags) {
                 int consecutiveBrCount = 1;
                 Element next = br.nextElementSibling();
 
@@ -932,18 +947,17 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                 }
             }
 
+            // "trim" the start and end of the document of whitespace & <br>
+            Node node;
+            while ((node = document.body().firstChild()) != null && isWhitespaceNode(node)) {
+                node.remove();
+            }
+            while ((node = document.body().lastChild()) != null && isWhitespaceNode(node)) {
+                node.remove();
+            }
+
             // Clean up any remaining whitespace issues
-            String cleanedHtml = document.body().html();
-
-            // Replace multiple consecutive <br> patterns that might still exist
-            cleanedHtml = MULTIPLE_BR_CLOSING_TAGS_PATTERN.matcher(cleanedHtml).replaceAll("<br><br>");
-            cleanedHtml = MULTIPLE_BR_TAGS_PATTERN.matcher(cleanedHtml).replaceAll("<br><br>");
-
-            // Remove leading/trailing <br> tags
-            cleanedHtml = LEADING_BR_TAGS_PATTERN.matcher(cleanedHtml).replaceAll("");
-            cleanedHtml = TRAILING_BR_TAGS_PATTERN.matcher(cleanedHtml).replaceAll("");
-
-            return cleanedHtml;
+            return document.body().html().trim();
         } catch (Exception e) {
             log.warn("Error cleaning html description, Error: {}", e.getMessage());
         }

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -191,5 +192,30 @@ public class AmazonBookParserTest {
         amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
 
         mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/SEARCHASIN"));
+    }
+
+    @Test
+    public void fetchTopMetadata_cleansLineBreaks() throws Exception {
+        String fakePageHtml = """
+        <html><body>
+        <div class="product-description">
+        <br /><br   ><br><div>Hello</div><br /><br /><br><div>World</div><br /><br   ><br>
+        </div>
+        </body></html>
+        """;
+
+        mockAmazonIDSearch("Example");
+        mockJsoupConnect(
+                "https://www.amazon.com/dp/SEARCHASIN", fakePageHtml);
+
+        Book book = getBook(null);
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().title("Example").build();
+
+        mockJsoup.when(() -> Jsoup.parse(anyString())).thenCallRealMethod();
+
+        BookMetadata metadata = amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        String actual = metadata.getDescription().replace("\n", "");
+        assertEquals("<div>Hello</div><br><br><div>World</div>", actual);
     }
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
this resolves the CodeQL warning that an inefficient regular expression is in place for AmazonBookParser and also avoids trying to parse HTML with a regular expression.  This defines whitespace as only blank text nodes & `br` elements.  In the future we could include other values or improve these in other ways, but this is close enough to match the existing behavior.

**Linked Issue:** Fixes #924

## Changes

* use jsoup rather than regex for cleaning up line breaks
* add test to confirm behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved book description formatting for titles imported from Amazon, normalizing line breaks and trimming extraneous whitespace so content blocks render with consistent spacing.
* **Tests**
  * Added a unit test to verify normalized description output after HTML cleaning to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->