### PR TITLE
refactor(metadata): avoid polynomial regexes in ComicvineBookParser

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -55,7 +55,6 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
     private static final String SEARCH_FIELDS = "api_detail_url,cover_date,store_date,description,deck,id,image,issue_number,name,publisher,volume,site_detail_url,resource_type,start_year,count_of_issues,aliases,person_credits";
     private static final Pattern ISSUE_NUMBER_PATTERN = Pattern.compile("issue\\s*#?\\d+");
     private static final Pattern ID_FORMAT_PATTERN = Pattern.compile("\\d+(-\\d+)?");
-    private static final Pattern TRAILING_SLASHES_PATTERN = Pattern.compile("(?<!/)/+$");
     private static final Pattern VOLUME_SUFFIX_PATTERN = Pattern.compile("\\s+Vol\\.?\\s*\\d+$");
 
     private static final String RESOURCE_TYPE_ISSUE = "4000";
@@ -609,7 +608,14 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
         String path = uri.getPath();
         if (path == null || path.isEmpty()) return "unknown";
 
-        path = TRAILING_SLASHES_PATTERN.matcher(path).replaceAll("");
+        // Avoid a regular expression to avoid the "polynomial regex" vuln
+        // that keeps getting reported by CodeQL.
+        int end = path.length();
+        while (end != 0  && path.charAt(end - 1) == '/') {
+            end--;
+        }
+        path = path.substring(0, end);
+
         int lastSlash = path.lastIndexOf('/');
         if (lastSlash >= 0 && lastSlash < path.length() - 1) {
             String segment = path.substring(lastSlash + 1);

--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -43,7 +43,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
     private static final Pattern SERIES_ISSUE_PATTERN = Pattern.compile("^(.+?)\\s+#?(\\d+(?:\\.\\d+)?)(?:\\s|$)", Pattern.CASE_INSENSITIVE);
     private static final Pattern DIGITAL_PATTERN = Pattern.compile("\\(digital\\)", Pattern.CASE_INSENSITIVE);
     private static final Pattern PARENTHETICAL_PATTERN = Pattern.compile("\\([^()]*\\)");
-    private static final Pattern BRACKETED_PATTERN = Pattern.compile("\\[[^\\]]*\\]");
+    private static final Pattern BRACKETED_PATTERN = Pattern.compile("\\[[^\\[\\]]*\\]");
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
     private static final Pattern SPECIAL_ISSUE_PATTERN = Pattern.compile("(annual|special|one-?shot)\\s+(\\d+)", Pattern.CASE_INSENSITIVE);
     private static final Pattern YEAR_PATTERN = Pattern.compile("\\(?(\\d{4})\\)?");

--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -40,7 +40,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
     private static final String COMICVINE_URL = "https://comicvine.gamespot.com/api/";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final Pattern DIGIT_PATTERN = Pattern.compile("\\d+");
-    private static final Pattern SERIES_ISSUE_PATTERN = Pattern.compile("^(.+?)\\s+#?(\\d+(?:\\.\\d+)?)(?:\\s|$)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SERIES_ISSUE_PATTERN = Pattern.compile("^([^\\s]+?)\\s+#?(\\d+(?:\\.\\d+)?)(?:\\s|$)", Pattern.CASE_INSENSITIVE);
     private static final Pattern DIGITAL_PATTERN = Pattern.compile("\\(digital\\)", Pattern.CASE_INSENSITIVE);
     private static final Pattern PARENTHETICAL_PATTERN = Pattern.compile("\\([^()]*\\)");
     private static final Pattern BRACKETED_PATTERN = Pattern.compile("\\[[^\\[\\]]*\\]");

--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -42,7 +42,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
     private static final Pattern DIGIT_PATTERN = Pattern.compile("\\d+");
     private static final Pattern SERIES_ISSUE_PATTERN = Pattern.compile("^(.+?)\\s+#?(\\d+(?:\\.\\d+)?)(?:\\s|$)", Pattern.CASE_INSENSITIVE);
     private static final Pattern DIGITAL_PATTERN = Pattern.compile("\\(digital\\)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern PARENTHETICAL_PATTERN = Pattern.compile("\\([^)]*\\)");
+    private static final Pattern PARENTHETICAL_PATTERN = Pattern.compile("\\([^()]*\\)");
     private static final Pattern BRACKETED_PATTERN = Pattern.compile("\\[[^\\]]*\\]");
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
     private static final Pattern SPECIAL_ISSUE_PATTERN = Pattern.compile("(annual|special|one-?shot)\\s+(\\d+)", Pattern.CASE_INSENSITIVE);

--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -54,7 +54,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
     private static final String ISSUE_DETAIL_FIELDS = "api_detail_url,cover_date,store_date,description,deck,id,image,issue_number,name,person_credits,volume,site_detail_url,aliases,character_credits,team_credits,story_arc_credits,location_credits";
     private static final String SEARCH_FIELDS = "api_detail_url,cover_date,store_date,description,deck,id,image,issue_number,name,publisher,volume,site_detail_url,resource_type,start_year,count_of_issues,aliases,person_credits";
     private static final Pattern ISSUE_NUMBER_PATTERN = Pattern.compile("issue\\s*#?\\d+");
-    private static final Pattern ID_FORMAT_PATTERN = Pattern.compile("\\d+-?\\d*");
+    private static final Pattern ID_FORMAT_PATTERN = Pattern.compile("\\d+(-\\d+)?");
     private static final Pattern TRAILING_SLASHES_PATTERN = Pattern.compile("(?<!/)/+$");
     private static final Pattern VOLUME_SUFFIX_PATTERN = Pattern.compile("\\s+Vol\\.?\\s*\\d+$");
 

--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -40,7 +40,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
     private static final String COMICVINE_URL = "https://comicvine.gamespot.com/api/";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final Pattern DIGIT_PATTERN = Pattern.compile("\\d+");
-    private static final Pattern SERIES_ISSUE_PATTERN = Pattern.compile("^([^\\s]+?)\\s+#?(\\d+(?:\\.\\d+)?)(?:\\s|$)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SERIES_ISSUE_NUMBER_PATTERN = Pattern.compile("\\s#?(\\d+(?:\\.\\d+)?)");
     private static final Pattern DIGITAL_PATTERN = Pattern.compile("\\(digital\\)", Pattern.CASE_INSENSITIVE);
     private static final Pattern PARENTHETICAL_PATTERN = Pattern.compile("\\([^()]*\\)");
     private static final Pattern BRACKETED_PATTERN = Pattern.compile("\\[[^\\[\\]]*\\]");
@@ -920,19 +920,17 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
             }
         }
 
-        Matcher matcher = SERIES_ISSUE_PATTERN.matcher(cleaned);
+        Matcher matcher = SERIES_ISSUE_NUMBER_PATTERN.matcher(cleaned);
         if (matcher.find()) {
-            String series = matcher.group(1).trim();
-            String issueNum = matcher.group(2);
-            
-            if (series.endsWith("#")) {
-                series = series.substring(0, series.length() - 1).trim();
-            }
+            String series = cleaned.substring(0, matcher.start()).trim();
+            String issueNum = matcher.group(1).trim();
 
             String remainder = cleaned.substring(matcher.end()).trim();
 
-            log.debug("Extracted - Series: '{}', Issue: '{}', Remainder: '{}'", series, issueNum, remainder);
-            return new SeriesAndIssue(series, issueNum, year, null, remainder);
+            if (!series.isBlank()) {
+                log.debug("Extracted - Series: '{}', Issue: '{}', Remainder: '{}'", series, issueNum, remainder);
+                return new SeriesAndIssue(series, issueNum, year, null, remainder);
+            }
         }
         
         log.debug("No issue number found in: '{}'", cleaned);

--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -55,7 +55,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
     private static final String SEARCH_FIELDS = "api_detail_url,cover_date,store_date,description,deck,id,image,issue_number,name,publisher,volume,site_detail_url,resource_type,start_year,count_of_issues,aliases,person_credits";
     private static final Pattern ISSUE_NUMBER_PATTERN = Pattern.compile("issue\\s*#?\\d+");
     private static final Pattern ID_FORMAT_PATTERN = Pattern.compile("\\d+-?\\d*");
-    private static final Pattern TRAILING_SLASHES_PATTERN = Pattern.compile("/+$");
+    private static final Pattern TRAILING_SLASHES_PATTERN = Pattern.compile("(?<!/)/+$");
     private static final Pattern VOLUME_SUFFIX_PATTERN = Pattern.compile("\\s+Vol\\.?\\s*\\d+$");
 
     private static final String RESOURCE_TYPE_ISSUE = "4000";
@@ -608,7 +608,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
     private String extractEndpointFromUri(URI uri) {
         String path = uri.getPath();
         if (path == null || path.isEmpty()) return "unknown";
-        
+
         path = TRAILING_SLASHES_PATTERN.matcher(path).replaceAll("");
         int lastSlash = path.lastIndexOf('/');
         if (lastSlash >= 0 && lastSlash < path.length() - 1) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
avoid regular expressions that could inadvertently cause CWE-1333 and trigger the CodeQL

**Linked Issue:** Fixes #925

## Changes

* update `BRACKETED_PATTERN` to include `[` in the check
* update `PARENTHETICAL_PATTERN` to include `(` in the check
* update the ID_FORMAT detection to avoid an inefficient regex
* replace the trailing slashes removal with a while loop
* handle the polynomial issue in SERIES_ISSUE_PATTERN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata parsing accuracy for comic book series and issue number extraction, ensuring more reliable data representation.
  * Enhanced handling of titles with special characters, parentheses, and brackets for better data integrity.
  * Refined API identifier normalization for more stable and consistent system behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->