### PR TITLE
fix(books): include physical books in app book list query

### DIFF
--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -800,7 +800,7 @@ public class AppBookService {
 
         List<Specification<BookEntity>> specs = new ArrayList<>();
         specs.add(AppBookSpecification.notDeleted());
-        specs.add(AppBookSpecification.hasDigitalFile());
+        specs.add(AppBookSpecification.hasDigitalFileOrIsPhysical());
 
         if (accessibleLibraryIds != null) {
             if (req.libraryId() != null && accessibleLibraryIds.contains(req.libraryId())) {
@@ -1105,7 +1105,7 @@ public class AppBookService {
     private Specification<BookEntity> buildBaseSpecification(Set<Long> accessibleLibraryIds, Long libraryId) {
         List<Specification<BookEntity>> specs = new ArrayList<>();
         specs.add(AppBookSpecification.notDeleted());
-        specs.add(AppBookSpecification.hasDigitalFile());
+        specs.add(AppBookSpecification.hasDigitalFileOrIsPhysical());
 
         if (accessibleLibraryIds != null) {
             if (libraryId != null && !accessibleLibraryIds.contains(libraryId)) {

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -247,7 +247,7 @@ public class AppBookService {
 
         Specification<BookEntity> spec = AppBookSpecification.combine(
                 AppBookSpecification.notDeleted(),
-                AppBookSpecification.hasDigitalFile(),
+                AppBookSpecification.hasDigitalFileOrIsPhysical(),
                 AppBookSpecification.inLibraries(accessibleLibraryIds),
                 AppBookSpecification.searchText(query)
         );
@@ -311,7 +311,7 @@ public class AppBookService {
 
         Specification<BookEntity> spec = AppBookSpecification.combine(
                 AppBookSpecification.notDeleted(),
-                AppBookSpecification.hasDigitalFile(),
+                AppBookSpecification.hasDigitalFileOrIsPhysical(),
                 AppBookSpecification.inLibraries(accessibleLibraryIds),
                 AppBookSpecification.addedWithinDays(30)
         );
@@ -404,7 +404,7 @@ public class AppBookService {
         List<AppBookSummary> summaries = orderedBookIds.stream()
                 .map(bookEntitiesById::get)
                 .filter(Objects::nonNull)
-                .filter(BookEntity::hasFiles)
+                .filter(b -> b.hasFiles() || Boolean.TRUE.equals(b.getIsPhysical()))
                 .map(bookEntity -> mobileBookMapper.toSummary(bookEntity, progressMap.get(bookEntity.getId())))
                 .collect(Collectors.toList());
 
@@ -573,7 +573,7 @@ public class AppBookService {
                 "FROM UserBookProgressEntity ubp " +
                 "WHERE ubp.user.id = :userId AND ubp.personalRating IS NOT NULL " +
                 "AND ubp.book.id IN (SELECT b.id FROM BookEntity b WHERE (b.deleted IS NULL OR b.deleted = false) " +
-                "AND b.bookFiles IS NOT EMPTY " +
+                "AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true) " +
                 scopeClause + ") " +
                 "GROUP BY 1 ORDER BY 1 DESC";
         var prQ = entityManager.createQuery(personalRatingQuery, Tuple.class);
@@ -624,7 +624,7 @@ public class AppBookService {
         String creatorJpql = "SELECT cr.name, mapping.role, COUNT(DISTINCT b.id) FROM BookEntity b"
                 + " JOIN b.metadata m JOIN m.comicMetadata cm JOIN cm.creatorMappings mapping JOIN mapping.creator cr"
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND b.bookFiles IS NOT EMPTY"
+                + " AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                 + " " + scopeClause
                 + " GROUP BY cr.name, mapping.role ORDER BY COUNT(DISTINCT b.id) DESC";
         var creatorQ = entityManager.createQuery(creatorJpql, Tuple.class);
@@ -1155,7 +1155,7 @@ public class AppBookService {
         String jpql = "SELECT " + selectExpr + ", COUNT(DISTINCT b.id) FROM BookEntity b"
                 + " " + joins
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND b.bookFiles IS NOT EMPTY"
+                + " AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                 + (extraWhere.isEmpty() ? "" : " " + extraWhere)
                 + " " + scopeClause
                 + " GROUP BY " + selectExpr + " ORDER BY COUNT(DISTINCT b.id) DESC";
@@ -1208,7 +1208,7 @@ public class AppBookService {
                 + " AND ubp.book.id IN ("
                 + "   SELECT b.id FROM BookEntity b"
                 + "   WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + "   AND b.bookFiles IS NOT EMPTY"
+                + "   AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                 + " " + scopeClause
                 + " )"
                 + " GROUP BY ubp.readStatus ORDER BY COUNT(DISTINCT ubp.book.id) DESC";
@@ -1223,7 +1223,7 @@ public class AppBookService {
 
         String baseQuery = "SELECT COUNT(DISTINCT b.id) FROM BookEntity b"
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND b.bookFiles IS NOT EMPTY"
+                + " AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                 + " AND b.id NOT IN ("
                 + "   SELECT ubp.book.id FROM UserBookProgressEntity ubp WHERE ubp.user.id = :userId"
                 + " )"
@@ -1262,7 +1262,7 @@ public class AppBookService {
             String scopeClause, Set<Long> accessibleLibraryIds,
             Long libraryId, Long shelfId, Set<Long> magicBookIds) {
         String jpql = "SELECT " + caseExpr + ", COUNT(DISTINCT b.id) FROM BookEntity b " + joins +
-                " WHERE (b.deleted IS NULL OR b.deleted = false) AND b.bookFiles IS NOT EMPTY "
+                " WHERE (b.deleted IS NULL OR b.deleted = false) AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true) "
                 + extraWhere + " " + scopeClause +
                 " GROUP BY 1";
         var q = entityManager.createQuery(jpql, Tuple.class);

--- a/backend/src/main/java/org/booklore/app/service/AppSeriesService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppSeriesService.java
@@ -362,7 +362,7 @@ public class AppSeriesService {
     private Specification<BookEntity> buildSeriesBooksSpec(Set<Long> accessibleLibraryIds, Long libraryId, String seriesName) {
         List<Specification<BookEntity>> specs = new ArrayList<>();
         specs.add(AppBookSpecification.notDeleted());
-        specs.add(AppBookSpecification.hasDigitalFile());
+        specs.add(AppBookSpecification.hasDigitalFileOrIsPhysical());
         specs.add(AppBookSpecification.inSeries(seriesName));
 
         if (accessibleLibraryIds != null) {

--- a/backend/src/main/java/org/booklore/app/service/AppSeriesService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppSeriesService.java
@@ -80,7 +80,7 @@ public class AppSeriesService {
                 + " FROM BookEntity b JOIN b.metadata m"
                 + " LEFT JOIN b.userBookProgress p ON p.user.id = :userId"
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND b.bookFiles IS NOT EMPTY"
+                + " AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                 + " AND m.seriesName IS NOT NULL"
                 + libraryClause
                 + searchClause
@@ -103,7 +103,7 @@ public class AppSeriesService {
         String countQuery = "SELECT COUNT(DISTINCT m.seriesName) FROM BookEntity b JOIN b.metadata m"
                 + (inProgressOnly ? " LEFT JOIN b.userBookProgress p ON p.user.id = :userId" : "")
                 + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                + " AND b.bookFiles IS NOT EMPTY"
+                + " AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                 + " AND m.seriesName IS NOT NULL"
                 + libraryClause
                 + searchClause;
@@ -114,7 +114,7 @@ public class AppSeriesService {
                     + "SELECT m.seriesName FROM BookEntity b JOIN b.metadata m"
                     + " LEFT JOIN b.userBookProgress p ON p.user.id = :userId"
                     + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                    + " AND b.bookFiles IS NOT EMPTY"
+                    + " AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                     + " AND m.seriesName IS NOT NULL"
                     + libraryClause
                     + searchClause
@@ -125,7 +125,7 @@ public class AppSeriesService {
             String countAlt = "SELECT m.seriesName FROM BookEntity b JOIN b.metadata m"
                     + " LEFT JOIN b.userBookProgress p ON p.user.id = :userId"
                     + " WHERE (b.deleted IS NULL OR b.deleted = false)"
-                    + " AND b.bookFiles IS NOT EMPTY"
+                    + " AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                     + " AND m.seriesName IS NOT NULL"
                     + libraryClause
                     + searchClause
@@ -178,7 +178,7 @@ public class AppSeriesService {
                 + " JOIN FETCH b.metadata m"
                 + " WHERE m.seriesName IN :seriesNames"
                 + " AND (b.deleted IS NULL OR b.deleted = false)"
-                + " AND b.bookFiles IS NOT EMPTY"
+                + " AND (b.bookFiles IS NOT EMPTY OR b.isPhysical = true)"
                 + libraryClause;
 
         var booksQ = entityManager.createQuery(booksQuery, BookEntity.class);

--- a/backend/src/main/java/org/booklore/app/specification/AppBookSpecification.java
+++ b/backend/src/main/java/org/booklore/app/specification/AppBookSpecification.java
@@ -202,6 +202,13 @@ public class AppBookSpecification {
         return (root, query, cb) -> cb.isNotEmpty(root.get("bookFiles"));
     }
 
+    public static Specification<BookEntity> hasDigitalFileOrIsPhysical() {
+        return (root, query, cb) -> cb.or(
+                cb.isNotEmpty(root.get("bookFiles")),
+                cb.equal(root.get("isPhysical"), true)
+        );
+    }
+
     public static Specification<BookEntity> hasAudiobookFile() {
         return (root, query, cb) -> {
             Subquery<Long> subquery = query.subquery(Long.class);


### PR DESCRIPTION
## Description

Physical books were excluded from the app book list (`GET /api/v1/app/books`) because the `hasDigitalFile()` specification predicate filters on `cb.isNotEmpty(root.get("bookFiles"))`, which is always false for physical books.

Added a new `hasDigitalFileOrIsPhysical()` predicate that passes books which either have at least one file or are marked `isPhysical = true`, and swapped it in at both call sites in `AppBookService`: `buildSpecification` and `buildBaseSpecification`

**Linked Issue:** Fixes #780

<img width="1280"  alt="physical_books" src="https://github.com/user-attachments/assets/700bbc78-27a9-43e5-84ae-874aaa71c8a3" />

## Changes
- `AppBookSpecification`: added `hasDigitalFileOrIsPhysical()` specification method
- `AppBookService.buildSpecification`: replaced `hasDigitalFile()` with `hasDigitalFileOrIsPhysical()`
- `AppBookService.buildBaseSpecification`: replaced `hasDigitalFile()` with `hasDigitalFileOrIsPhysical()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Book listings, series pages, and search results now include books that are either digital or marked physical.
  * Filter option counts and groupings (ratings, creators, read-status, etc.) updated to reflect inclusion of physical items.
  * Shelf/result post-filtering now preserves physical books alongside digital ones for more complete results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->