### PR TITLE
fix(ui): virtual grid scroll restore

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -307,7 +307,6 @@ export class BookBrowserComponent implements AfterViewInit {
   );
   private readonly virtualGridGap = computed(() => this.isMobile() ? this.MOBILE_GAP : this.GRID_GAP);
   private readonly virtualGridColumns = computed(() => this.isMobile() ? this.mobileColumnCount() : undefined);
-  private readonly isGridView = computed(() => this.currentViewMode() === VIEW_MODES.GRID);
   private readonly virtualBookCount = computed(() => {
     const renderedBookCount = this.gridBooks().length;
     return this.appBooksApi.hasNextPage()
@@ -321,7 +320,6 @@ export class BookBrowserComponent implements AfterViewInit {
     gap: this.virtualGridGap,
     columns: this.virtualGridColumns,
     count: this.virtualBookCount,
-    enabled: this.isGridView,
     initialOffset: this.initialScrollOffset,
     fillItemWidth: true,
     estimateItemHeight: itemWidth => this.isMobile()

--- a/frontend/src/app/shared/util/virtual-grid.util.ts
+++ b/frontend/src/app/shared/util/virtual-grid.util.ts
@@ -16,7 +16,6 @@ export interface VirtualGridOptions {
   columns?: Signal<number | undefined>;
   initialOffset?: () => number;
   fillItemWidth?: boolean;
-  enabled?: Signal<boolean>;
 }
 
 function getScrollContentWidth(element: HTMLElement | null): number {
@@ -94,7 +93,6 @@ export function createVirtualGrid(options: VirtualGridOptions) {
     return Math.max(options.minItemWidth(), (availableWidth - totalGap) / columns);
   });
   const itemHeight = computed(() => options.estimateItemHeight(itemWidth()));
-  const enabled = computed(() => !!options.scrollElement() && (options.enabled?.() ?? true));
   const columnGap = computed(() => {
     if (options.fillItemWidth) {
       return gap();
@@ -116,7 +114,6 @@ export function createVirtualGrid(options: VirtualGridOptions) {
     overscan: toSafeInteger(options.overscan ?? gridColumns() * DEFAULT_OVERSCAN_ROWS, DEFAULT_OVERSCAN_ROWS),
     gap: toSafeSize(columnGap(), DEFAULT_ITEM_SIZE),
     lanes: toSafeInteger(gridColumns(), 1),
-    enabled: enabled(),
     initialOffset: () => options.initialOffset?.() ?? 0,
     observeElementRect: (instance, callback) => observeElementRect(instance, rect => {
       callback(rect);
@@ -129,9 +126,7 @@ export function createVirtualGrid(options: VirtualGridOptions) {
     itemHeight();
     gridColumns();
     columnGap();
-    if (enabled()) {
-      queueMicrotask(() => virtualizer.measure());
-    }
+    queueMicrotask(() => virtualizer.measure());
   });
 
   const updatePreservingScrollPosition = (update: () => void): void => {


### PR DESCRIPTION
## Description

This fixes a regression with #941 surfaced after a review change that would lose your scroll position after returning to the book grid. 

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes
- Remove `enabled` gate on the virtual grid - allowing the grid to always restore scroll position and grid location. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified virtual grid initialization logic in the book browser. The grid now consistently measures layout changes without conditional mode switching, improving overall responsiveness and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->