### PR TITLE
test: add tests for ComicvineBookParser

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -59,7 +59,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
 
     private final ObjectMapper objectMapper;
     private final AppSettingService appSettingService;
-    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final HttpClient httpClient;
 
     private final AtomicBoolean rateLimited = new AtomicBoolean(false);
     private final AtomicLong rateLimitResetTime = new AtomicLong(0);

--- a/backend/src/test/java/org/booklore/service/metadata/parser/ComicvineBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/ComicvineBookParserTest.java
@@ -1,0 +1,157 @@
+package org.booklore.service.metadata.parser;
+
+
+import org.booklore.model.dto.Book;
+import org.booklore.model.dto.BookMetadata;
+import org.booklore.model.dto.request.FetchMetadataRequest;
+import org.booklore.model.dto.settings.AppSettings;
+import org.booklore.model.dto.settings.MetadataProviderSettings;
+import org.booklore.service.appsettings.AppSettingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ComicvineBookParserTest {
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private AppSettingService mockAppSettingService;
+
+    @InjectMocks
+    private ComicvineBookParser comicvineBookParser;
+
+    @SuppressWarnings("unchecked")
+    private HttpResponse<String> getResponse(int statusCode, String payload) {
+        HttpResponse<String> mockResponse = mock(HttpResponse.class);
+
+        when(mockResponse.statusCode()).thenReturn(statusCode);
+        when(mockResponse.body()).thenReturn(payload);
+
+        return mockResponse;
+    }
+
+    private void mockResponse(String uri, int statusCode, String payload) throws IOException, InterruptedException {
+        HttpResponse<String> response = getResponse(statusCode, payload);
+        when(
+            httpClient.<String>send(
+                argThat(arg -> arg != null && arg.uri().toString().startsWith(("https://comicvine.gamespot.com/api" + uri))),
+                any()
+            )
+        ).thenReturn(response);
+    }
+
+    private String readFixture(String fixtureName) throws IOException {
+        String filename = Paths.get("comicvinebookparser", fixtureName + ".fixture").toString();
+
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(filename)) {
+            assert is != null;
+
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private Book getBook(String comicvineId) {
+        BookMetadata bookMetadata = BookMetadata.builder()
+                .comicvineId(comicvineId)
+                .build();
+
+        return Book.builder()
+                .title("Example")
+                .metadata(bookMetadata)
+                .build();
+    }
+
+    private AppSettings getAppSettings() {
+        MetadataProviderSettings.Comicvine comicvineSettings = new MetadataProviderSettings.Comicvine();
+        comicvineSettings.setEnabled(true);
+        comicvineSettings.setApiKey("example");
+
+        MetadataProviderSettings metadataProviderSettings = new MetadataProviderSettings();
+        metadataProviderSettings.setComicvine(comicvineSettings);
+
+        return AppSettings.builder()
+                .metadataProviderSettings(metadataProviderSettings)
+                .build();
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings());
+    }
+
+    @Test
+    public void fetchTopMetadata_getsTitle() throws IOException, InterruptedException {
+        mockResponse(
+                "/search/?api_key=example&format=json&resources=volume,issue&query=Example&",
+                200,
+                readFixture("search.json")
+        );
+
+        mockResponse(
+                "/issue/4000-60593/",
+                200,
+                readFixture("issue.json")
+        );
+
+        Book book = getBook("EXAMPLE");
+        FetchMetadataRequest request = FetchMetadataRequest.builder()
+                .title("Example")
+                .build();
+
+        BookMetadata metadata = comicvineBookParser.fetchTopMetadata(book, request);
+
+        assertNotNull(metadata);
+        assertEquals("The Example", metadata.getTitle());
+    }
+
+    @Test
+    public void fetchTopMetadata_parsesSeriesInfoFromTitle() throws IOException, InterruptedException {
+        mockResponse(
+                "/volumes/?api_key=example&format=json&filter=name:The%20Example&",
+                200,
+                readFixture("search.json")
+        );
+
+        mockResponse(
+                "/issues/?api_key=example&format=json&filter=volume:60593,issue_number:1&",
+                200,
+                readFixture("issues.json")
+        );
+
+        Book book = getBook("EXAMPLE");
+        FetchMetadataRequest request = FetchMetadataRequest.builder()
+                .title("The Example #1")
+                .build();
+
+        BookMetadata metadata = comicvineBookParser.fetchTopMetadata(book, request);
+
+        assertNotNull(metadata);
+        assertEquals("The Example", metadata.getSeriesName());
+        assertEquals(1.0f, metadata.getSeriesNumber());
+    }
+}

--- a/backend/src/test/java/org/booklore/service/metadata/parser/ComicvineBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/ComicvineBookParserTest.java
@@ -66,7 +66,7 @@ public class ComicvineBookParserTest {
     }
 
     private String readFixture(String fixtureName) throws IOException {
-        String filename = Paths.get("comicvinebookparser", fixtureName + ".fixture").toString();
+        String filename = "comicvinebookparser/" + fixtureName + ".fixture";
 
         try (InputStream is = getClass().getClassLoader().getResourceAsStream(filename)) {
             assert is != null;

--- a/backend/src/test/resources/comicvinebookparser/issue.json.fixture
+++ b/backend/src/test/resources/comicvinebookparser/issue.json.fixture
@@ -1,0 +1,80 @@
+{
+  "error": "OK",
+  "limit": 1,
+  "offset": 0,
+  "number_of_page_results": 1,
+  "number_of_total_results": 1,
+  "status_code": 1,
+  "results": {
+    "aliases": null,
+    "api_detail_url": "https://comicvine.gamespot.com/api/issue/4000-400275/",
+    "associated_images": [],
+    "character_credits": [],
+    "character_died_in": [],
+    "concept_credits": [],
+    "cover_date": "2009-03-01",
+    "date_added": "2013-04-30 06:58:54",
+    "date_last_updated": "2013-09-18 11:45:32",
+    "deck": null,
+    "description": "<p><em>Two people. A train station. An unattended Briefcase.</em></p><p><em>Prejudice versus Preservation.</em></p><p><em>In the war on terror, will suspicion and fear win out?</em></p>",
+    "first_appearance_characters": null,
+    "first_appearance_concepts": null,
+    "first_appearance_locations": null,
+    "first_appearance_objects": null,
+    "first_appearance_storyarcs": null,
+    "first_appearance_teams": null,
+    "has_staff_review": false,
+    "id": 400275,
+    "image": {
+      "icon_url": "https://comicvine.gamespot.com/a/uploads/square_avatar/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "medium_url": "https://comicvine.gamespot.com/a/uploads/scale_medium/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "screen_url": "https://comicvine.gamespot.com/a/uploads/screen_medium/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "screen_large_url": "https://comicvine.gamespot.com/a/uploads/screen_kubrick/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "small_url": "https://comicvine.gamespot.com/a/uploads/scale_small/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "super_url": "https://comicvine.gamespot.com/a/uploads/scale_large/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "thumb_url": "https://comicvine.gamespot.com/a/uploads/scale_avatar/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "tiny_url": "https://comicvine.gamespot.com/a/uploads/square_mini/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "original_url": "https://comicvine.gamespot.com/a/uploads/original/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+      "image_tags": "All Images"
+    },
+    "issue_number": "1",
+    "location_credits": [],
+    "name": null,
+    "object_credits": [],
+    "person_credits": [
+      {
+        "api_detail_url": "https://comicvine.gamespot.com/api/person/4040-44855/",
+        "id": 44855,
+        "name": "Colin Wilson",
+        "site_detail_url": "https://comicvine.gamespot.com/colin-wilson/4040-44855/",
+        "role": "artist, cover"
+      },
+      {
+        "api_detail_url": "https://comicvine.gamespot.com/api/person/4040-58661/",
+        "id": 58661,
+        "name": "Justin Randall",
+        "site_detail_url": "https://comicvine.gamespot.com/justin-randall/4040-58661/",
+        "role": "cover"
+      },
+      {
+        "api_detail_url": "https://comicvine.gamespot.com/api/person/4040-57043/",
+        "id": 57043,
+        "name": "Tom Taylor",
+        "site_detail_url": "https://comicvine.gamespot.com/tom-taylor/4040-57043/",
+        "role": "writer"
+      }
+    ],
+    "site_detail_url": "https://comicvine.gamespot.com/the-example-1/4000-400275/",
+    "store_date": null,
+    "story_arc_credits": [],
+    "team_credits": [],
+    "team_disbanded_in": [],
+    "volume": {
+      "api_detail_url": "https://comicvine.gamespot.com/api/volume/4050-60593/",
+      "id": 60593,
+      "name": "The Example",
+      "site_detail_url": "https://comicvine.gamespot.com/the-example/4050-60593/"
+    }
+  },
+  "version": "1.0"
+}

--- a/backend/src/test/resources/comicvinebookparser/issues.json.fixture
+++ b/backend/src/test/resources/comicvinebookparser/issues.json.fixture
@@ -1,0 +1,82 @@
+{
+  "error": "OK",
+  "limit": 1,
+  "offset": 0,
+  "number_of_page_results": 1,
+  "number_of_total_results": 1,
+  "status_code": 1,
+  "results": [
+    {
+      "aliases": null,
+      "api_detail_url": "https://comicvine.gamespot.com/api/issue/4000-400275/",
+      "associated_images": [],
+      "character_credits": [],
+      "character_died_in": [],
+      "concept_credits": [],
+      "cover_date": "2009-03-01",
+      "date_added": "2013-04-30 06:58:54",
+      "date_last_updated": "2013-09-18 11:45:32",
+      "deck": null,
+      "description": "<p><em>Two people. A train station. An unattended Briefcase.</em></p><p><em>Prejudice versus Preservation.</em></p><p><em>In the war on terror, will suspicion and fear win out?</em></p>",
+      "first_appearance_characters": null,
+      "first_appearance_concepts": null,
+      "first_appearance_locations": null,
+      "first_appearance_objects": null,
+      "first_appearance_storyarcs": null,
+      "first_appearance_teams": null,
+      "has_staff_review": false,
+      "id": 400275,
+      "image": {
+        "icon_url": "https://comicvine.gamespot.com/a/uploads/square_avatar/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "medium_url": "https://comicvine.gamespot.com/a/uploads/scale_medium/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "screen_url": "https://comicvine.gamespot.com/a/uploads/screen_medium/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "screen_large_url": "https://comicvine.gamespot.com/a/uploads/screen_kubrick/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "small_url": "https://comicvine.gamespot.com/a/uploads/scale_small/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "super_url": "https://comicvine.gamespot.com/a/uploads/scale_large/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "thumb_url": "https://comicvine.gamespot.com/a/uploads/scale_avatar/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "tiny_url": "https://comicvine.gamespot.com/a/uploads/square_mini/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "original_url": "https://comicvine.gamespot.com/a/uploads/original/14/149950/3016257-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "image_tags": "All Images"
+      },
+      "issue_number": "1",
+      "location_credits": [],
+      "name": null,
+      "object_credits": [],
+      "person_credits": [
+        {
+          "api_detail_url": "https://comicvine.gamespot.com/api/person/4040-44855/",
+          "id": 44855,
+          "name": "Colin Wilson",
+          "site_detail_url": "https://comicvine.gamespot.com/colin-wilson/4040-44855/",
+          "role": "artist, cover"
+        },
+        {
+          "api_detail_url": "https://comicvine.gamespot.com/api/person/4040-58661/",
+          "id": 58661,
+          "name": "Justin Randall",
+          "site_detail_url": "https://comicvine.gamespot.com/justin-randall/4040-58661/",
+          "role": "cover"
+        },
+        {
+          "api_detail_url": "https://comicvine.gamespot.com/api/person/4040-57043/",
+          "id": 57043,
+          "name": "Tom Taylor",
+          "site_detail_url": "https://comicvine.gamespot.com/tom-taylor/4040-57043/",
+          "role": "writer"
+        }
+      ],
+      "site_detail_url": "https://comicvine.gamespot.com/the-example-1/4000-400275/",
+      "store_date": null,
+      "story_arc_credits": [],
+      "team_credits": [],
+      "team_disbanded_in": [],
+      "volume": {
+        "api_detail_url": "https://comicvine.gamespot.com/api/volume/4050-60593/",
+        "id": 60593,
+        "name": "The Example",
+        "site_detail_url": "https://comicvine.gamespot.com/the-example/4050-60593/"
+      }
+    }
+  ],
+  "version": "1.0"
+}

--- a/backend/src/test/resources/comicvinebookparser/search.json.fixture
+++ b/backend/src/test/resources/comicvinebookparser/search.json.fixture
@@ -1,0 +1,54 @@
+{
+  "error": "OK",
+  "limit": 10,
+  "offset": 0,
+  "number_of_page_results": 7,
+  "number_of_total_results": 7,
+  "status_code": 1,
+  "results": [
+    {
+      "aliases": null,
+      "api_detail_url": "https://comicvine.gamespot.com/api/volume/4050-60593/",
+      "count_of_issues": 1,
+      "date_added": "2013-04-30 06:57:41",
+      "date_last_updated": "2013-07-29 01:39:39",
+      "deck": null,
+      "description": "<p>Australian graphic novel.</p>",
+      "first_issue": {
+        "api_detail_url": "https://comicvine.gamespot.com/api/issue/4000-400275/",
+        "id": 400275,
+        "name": null,
+        "issue_number": "1"
+      },
+      "id": 60593,
+      "image": {
+        "icon_url": "https://comicvine.gamespot.com/a/uploads/square_avatar/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "medium_url": "https://comicvine.gamespot.com/a/uploads/scale_medium/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "screen_url": "https://comicvine.gamespot.com/a/uploads/screen_medium/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "screen_large_url": "https://comicvine.gamespot.com/a/uploads/screen_kubrick/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "small_url": "https://comicvine.gamespot.com/a/uploads/scale_small/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "super_url": "https://comicvine.gamespot.com/a/uploads/scale_large/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "thumb_url": "https://comicvine.gamespot.com/a/uploads/scale_avatar/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "tiny_url": "https://comicvine.gamespot.com/a/uploads/square_mini/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "original_url": "https://comicvine.gamespot.com/a/uploads/original/14/149950/3016256-the%20example%20%233%20%282009%29%20-%20page%201.jpg",
+        "image_tags": "All Images"
+      },
+      "last_issue": {
+        "api_detail_url": "https://comicvine.gamespot.com/api/issue/4000-400275/",
+        "id": 400275,
+        "name": null,
+        "issue_number": "1"
+      },
+      "name": "The Example",
+      "publisher": {
+        "api_detail_url": "https://comicvine.gamespot.com/api/publisher/4010-3027/",
+        "id": 3027,
+        "name": "Gestalt Comics"
+      },
+      "site_detail_url": "https://comicvine.gamespot.com/the-example/4050-60593/",
+      "start_year": "2009",
+      "resource_type": "volume"
+    }
+  ],
+  "version": "1.0"
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
add tests to ComicvineBookParser to help identify regressions

**Linked Issue:** Related to #925

## Changes

* adds a comicvine book parser test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating ComicVine book metadata parsing (title, series name/number).
  * Added JSON fixtures representing ComicVine search and issue responses to support parsing tests.
* **Refactor**
  * Updated the metadata parser to support configurable networking for easier testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->