### PR TITLE
fix(ui): prevent console error when leaving reader

### DIFF
--- a/frontend/src/assets/foliate/paginator.js
+++ b/frontend/src/assets/foliate/paginator.js
@@ -360,7 +360,9 @@ class View {
         }
     }
     expand() {
-        const { documentElement } = this.document
+        const documentElement = this.document?.documentElement
+        // If the document element isn't set we probably have disconnected the paginator
+        if (!documentElement) return;
         if (this.#column) {
             const side = this.#vertical ? 'height' : 'width'
             const otherSide = this.#vertical ? 'width' : 'height'
@@ -415,8 +417,8 @@ class View {
     get overlayer() {
         return this.#overlayer
     }
-    destroy() {
-        if (this.document) this.#observer.unobserve(this.document.body)
+    disconnectedCallback() {
+      this.#observer.disconnect()
     }
 }
 
@@ -665,7 +667,7 @@ export class Paginator extends HTMLElement {
     }
     #createView() {
         if (this.#view) {
-            this.#view.destroy()
+            this.#view.disconnectedCallback()
             this.#container.removeChild(this.#view.element)
         }
         this.#view = new View({
@@ -1118,9 +1120,9 @@ export class Paginator extends HTMLElement {
     focusView() {
         this.#view.document.defaultView.focus()
     }
-    destroy() {
-        this.#observer.unobserve(this)
-        this.#view.destroy()
+    disconnectedCallback() {
+        this.#observer.disconnect();
+        this.#view?.disconnectedCallback()
         this.#view = null
         this.sections[this.#index]?.unload?.()
         this.#mediaQuery.removeEventListener('change', this.#mediaQueryListener)


### PR DESCRIPTION
the reader was not properly cleaning up after itself after being closed. instead of using the `destroy` helper, we use the custom element callback `disconnectedCallback()` to ensure clean up happens

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #954

## Changes

* actually destroy the foliate `Paginator` when disconnected from the document

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved component lifecycle handling to ensure observers and resources are cleanly disconnected when views change or are removed.
  * Safer view handling to avoid errors if embedded content is unavailable, resulting in more stable navigation and smoother view replacements.
  * Reduces potential resource leaks and improves overall UI reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->