### PR TITLE
build(backend): inject app version in jar manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN --mount=type=cache,target=/workspace/.yarn/cache \
 FROM --platform=$BUILDPLATFORM gradle:9.4.1-jdk25-alpine AS backend-build
 
 ARG TARGETARCH
+ARG APP_VERSION=development
+ARG APP_REVISION=unknown
 
 WORKDIR /workspace/backend
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "org.booklore"
-version = "0.0.1-SNAPSHOT"
+version = System.getenv("APP_VERSION") ?: "0.0.1-SNAPSHOT"
 
 val defaultFrontendDistDir = file("${rootDir}/../frontend/dist/grimmory/browser")
 val configuredFrontendDistDir = providers.gradleProperty("frontendDistDir")


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
updates the build so the gradle `version` for the project is set to the current `APP_VERSION`

**Linked Issue:** Fixes #890

## Changes

* update gradle config to include `version` from env vars
* ensure `APP_VERSION` is passed in the java build stage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container images now include OCI-compliant version and revision metadata labels, improving image identification and tracking across deployments.
  * Version configuration is now dynamic, reading from environment variables at build time for flexible versioning without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->