### PR TITLE
fix(ui): use signals to unfreeze library loading component

### DIFF
--- a/frontend/src/app/features/library-creator/library-loading/library-loading.component.html
+++ b/frontend/src/app/features/library-creator/library-loading/library-loading.component.html
@@ -8,12 +8,12 @@
 
       <div class="library-loader-body">
         <div class="book-title">
-          @if (!isComplete) {
+          @if (!isComplete()) {
             <ng-container>
-              {{ t('processing') }} <strong>{{ truncatedTitle }}</strong>
+              {{ t('processing') }} <strong>{{ bookTitle() }}</strong>
             </ng-container>
           }
-          @if (isComplete) {
+          @if (isComplete()) {
             <strong class="complete-message">
               <i class="pi pi-check-circle"></i>
               {{ t('complete') }}
@@ -22,15 +22,15 @@
         </div>
 
         <div class="progress-info">
-          <span>{{ current }} / {{ total }}</span>
-          <span>{{ percentage }}%</span>
+          <span>{{ current() }} / {{ total() }}</span>
+          <span>{{ percentage() }}%</span>
         </div>
 
         <div class="progress-bar-container">
-          <div class="progress-bar-fill" [style.width.%]="percentage"></div>
+          <div class="progress-bar-fill" [style.width.%]="percentage()"></div>
         </div>
 
-        @if (!isComplete) {
+        @if (!isComplete()) {
           <div class="loader-animation">
             <div class="dot"></div>
             <div class="dot"></div>
@@ -39,7 +39,7 @@
         }
       </div>
 
-      @if (isComplete) {
+      @if (isComplete()) {
         <div class="library-loader-footer">
           <button class="reload-button" (click)="onReload()">
             <i class="pi pi-bookmark"></i>

--- a/frontend/src/app/features/library-creator/library-loading/library-loading.component.spec.ts
+++ b/frontend/src/app/features/library-creator/library-loading/library-loading.component.spec.ts
@@ -8,11 +8,11 @@ describe('LibraryLoadingComponent', () => {
 
     component.updateProgress('Dune', 2, 3);
 
-    expect(component.bookTitle).toBe('Dune');
-    expect(component.current).toBe(2);
-    expect(component.total).toBe(3);
-    expect(component.percentage).toBe(67);
-    expect(component.isComplete).toBe(false);
+    expect(component.bookTitle()).toBe('Dune');
+    expect(component.current()).toBe(2);
+    expect(component.total()).toBe(3);
+    expect(component.percentage()).toBe(67);
+    expect(component.isComplete()).toBe(false);
   });
 
   it('marks the flow complete when current reaches the total', () => {
@@ -20,20 +20,21 @@ describe('LibraryLoadingComponent', () => {
 
     component.updateProgress('Children of Dune', 5, 5);
 
-    expect(component.isComplete).toBe(true);
-    expect(component.percentage).toBe(100);
+    expect(component.isComplete()).toBe(true);
+    expect(component.percentage()).toBe(100);
   });
 
   it('truncates very long titles for display', () => {
     const component = new LibraryLoadingComponent();
-    component.bookTitle = 'A'.repeat(60);
 
-    expect(component.truncatedTitle).toBe(`${'A'.repeat(50)}...`);
+    component.updateProgress('A'.repeat(200), 2, 3)
+
+    expect(component.bookTitle()).toBe(`${'A'.repeat(50)}...`);
   });
 
   it('returns zero percent when there is no total yet', () => {
     const component = new LibraryLoadingComponent();
 
-    expect(component.percentage).toBe(0);
+    expect(component.percentage()).toBe(0);
   });
 });

--- a/frontend/src/app/features/library-creator/library-loading/library-loading.component.ts
+++ b/frontend/src/app/features/library-creator/library-loading/library-loading.component.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { computed, signal, Component } from '@angular/core';
 import {TranslocoDirective} from '@jsverse/transloco';
+
+const MAX_TITLE_LENGTH = 50;
 
 @Component({
   selector: 'app-library-loading',
@@ -9,27 +11,26 @@ import {TranslocoDirective} from '@jsverse/transloco';
   styleUrl: './library-loading.component.scss'
 })
 export class LibraryLoadingComponent {
-  bookTitle = '';
-  current = 0;
-  total = 0;
-  isComplete = false;
+  bookTitle = signal('');
+  current = signal(0);
+  total = signal(0);
+  isComplete = signal(false);
 
-  get percentage(): number {
-    return this.total > 0 ? Math.round((this.current / this.total) * 100) : 0;
-  }
+  readonly percentage = computed(() => this.total() > 0 ? Math.round((this.current() / this.total()) * 100) : 0);
 
-  get truncatedTitle(): string {
-    const maxLength = 50;
-    return this.bookTitle.length <= maxLength
-      ? this.bookTitle
-      : this.bookTitle.substring(0, maxLength) + '...';
+  truncateTitle(title: string): string {
+    if (title.length > MAX_TITLE_LENGTH) {
+      return title.substring(0, MAX_TITLE_LENGTH) + "...";
+    }
+
+    return title;
   }
 
   updateProgress(bookTitle: string, current: number, total: number): void {
-    this.bookTitle = bookTitle;
-    this.current = current;
-    this.total = total;
-    this.isComplete = current >= total;
+    this.bookTitle.set(this.truncateTitle(bookTitle));
+    this.current.set(current);
+    this.total.set(total);
+    this.isComplete.set(current >= total);
   }
 
   onReload(): void {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
the library loading component does not update after opening because it's not using signals

**Linked Issue:** Fixes #955

## Changes

* use signals for library loading component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized internal state handling for the library loading view for more reliable UI updates.
* **Bug Fixes**
  * Long book titles are consistently truncated in the loading UI.
  * Progress values and completion status display and update more reliably during imports.
* **Tests**
  * Updated tests to reflect the new truncation and progress behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->