### PR TITLE
refactor(metadata): simplify category and tag handling in CbxMetadata Extractor

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/extractor/CbxMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/CbxMetadataExtractor.java
@@ -132,12 +132,12 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
             builder.authors(authors);
         }
 
-        Set<String> categories = new HashSet<>(splitValues(getTextContent(document, "Genre")));
+        Set<String> categories = splitValues(getTextContent(document, "Genre"));
         if (!categories.isEmpty()) {
             builder.categories(categories);
         }
 
-        Set<String> tags = new HashSet<>(splitValues(getTextContent(document, "Tags")));
+        Set<String> tags = splitValues(getTextContent(document, "Tags"));
         if (!tags.isEmpty()) {
             builder.tags(tags);
         }

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/CbxMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/CbxMetadataExtractor.java
@@ -132,14 +132,12 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
             builder.authors(authors);
         }
 
-        Set<String> categories = new HashSet<>();
-        categories.addAll(splitValues(getTextContent(document, "Genre")));
+        Set<String> categories = new HashSet<>(splitValues(getTextContent(document, "Genre")));
         if (!categories.isEmpty()) {
             builder.categories(categories);
         }
 
-        Set<String> tags = new HashSet<>();
-        tags.addAll(splitValues(getTextContent(document, "Tags")));
+        Set<String> tags = new HashSet<>(splitValues(getTextContent(document, "Tags")));
         if (!tags.isEmpty()) {
             builder.tags(tags);
         }


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


Reports Collection.addAll() and Map.putAll() calls immediately after an instantiation of a collection using a no-arg constructor.

Such constructs can be replaced with a single call to a parametrized constructor, which simplifies the code. Also, for some collections the replacement might be more performant.

Example:
```java
Set<String> set = new HashSet<>();
set.addAll(Arrays.asList("alpha", "beta", "gamma"));
```
After the quick-fix is applied:

```java
Set<String> set = new HashSet<>(Arrays.asList("alpha", "beta", "gamma"));
```
 
The JDK collection classes are supported by default. Additionally, you can specify other classes using the Classes to check panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined metadata extraction for comic book files by simplifying how category and tag information is processed, improving internal efficiency and maintainability. No changes to visible behavior; users should see the same metadata while benefiting from slightly faster and more reliable processing behind the scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->