### PR TITLE
style(api): replace ignored exceptions with Java's unnamed pattern (_)

### DIFF
--- a/backend/src/main/java/org/booklore/app/controller/AppUserController.java
+++ b/backend/src/main/java/org/booklore/app/controller/AppUserController.java
@@ -37,7 +37,7 @@ public class AppUserController {
             if (configured != null) {
                 maxUploadSizeMb = configured;
             }
-        } catch (Exception ignored) {
+        } catch (Exception _) {
             // fall back to default
         }
 

--- a/backend/src/main/java/org/booklore/nativelib/NativeLibraries.java
+++ b/backend/src/main/java/org/booklore/nativelib/NativeLibraries.java
@@ -127,7 +127,7 @@ public final class NativeLibraries {
     }
 
     public static void ensureInitialized() {
-        NativeLibraries ignored = Holder.INSTANCE;
+        NativeLibraries _ = Holder.INSTANCE;
     }
 
     public boolean isAvailable(Library library) {

--- a/backend/src/main/java/org/booklore/service/ArchiveService.java
+++ b/backend/src/main/java/org/booklore/service/ArchiveService.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 public class ArchiveService {
     private static final int LOCK_STRIPE_COUNT = 256;
     private final ReentrantLock[] lockStripes = IntStream.range(0, LOCK_STRIPE_COUNT)
-            .mapToObj(ignored -> new ReentrantLock())
+            .mapToObj(_ -> new ReentrantLock())
             .toArray(ReentrantLock[]::new);
 
     // Route through the JVM-wide serialized native loader.

--- a/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
+++ b/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
@@ -920,7 +920,7 @@ public class BookRuleEvaluatorService {
         if (isNumericField(field)) {
             try {
                 return Double.parseDouble(value.toString());
-            } catch (NumberFormatException ignored) {
+            } catch (NumberFormatException _) {
             }
         }
 

--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -174,7 +174,7 @@ public class AppSettingService {
         if (sessionDurationStr != null && !sessionDurationStr.isBlank()) {
             try {
                 builder.oidcSessionDurationHours(Integer.parseInt(sessionDurationStr));
-            } catch (NumberFormatException ignored) {
+            } catch (NumberFormatException _) {
             }
         }
 

--- a/backend/src/main/java/org/booklore/service/audit/AuditService.java
+++ b/backend/src/main/java/org/booklore/service/audit/AuditService.java
@@ -45,7 +45,7 @@ public class AuditService {
             String ipAddress = null;
             try {
                 ipAddress = RequestUtils.getCurrentRequest().getRemoteAddr();
-            } catch (Exception ignored) {
+            } catch (Exception _) {
                 // Non-HTTP context (scheduled tasks, etc.)
             }
 

--- a/backend/src/main/java/org/booklore/service/book/PhysicalBookService.java
+++ b/backend/src/main/java/org/booklore/service/book/PhysicalBookService.java
@@ -106,12 +106,12 @@ public class PhysicalBookService {
         // Try full date format first (YYYY-MM-DD)
         try {
             return LocalDate.parse(trimmed, DateTimeFormatter.ISO_LOCAL_DATE);
-        } catch (DateTimeParseException ignored) {}
+        } catch (DateTimeParseException _) {}
         // Try year only format (YYYY)
         try {
             int year = Integer.parseInt(trimmed);
             return LocalDate.of(year, 1, 1);
-        } catch (NumberFormatException ignored) {}
+        } catch (NumberFormatException _) {}
         return null;
     }
 

--- a/backend/src/main/java/org/booklore/service/bookdrop/FilenamePatternExtractor.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/FilenamePatternExtractor.java
@@ -428,7 +428,7 @@ public class FilenamePatternExtractor {
     private void setSeriesNumber(BookMetadata metadata, String value) {
         try {
             metadata.setSeriesNumber(Float.parseFloat(value));
-        } catch (NumberFormatException ignored) {
+        } catch (NumberFormatException _) {
         }
     }
 
@@ -590,7 +590,7 @@ public class FilenamePatternExtractor {
     private void setSeriesTotal(BookMetadata metadata, String value) {
         try {
             metadata.setSeriesTotal(Integer.parseInt(value));
-        } catch (NumberFormatException ignored) {
+        } catch (NumberFormatException _) {
         }
     }
 

--- a/backend/src/main/java/org/booklore/service/customfont/CustomFontService.java
+++ b/backend/src/main/java/org/booklore/service/customfont/CustomFontService.java
@@ -264,7 +264,7 @@ public class CustomFontService {
         FontFormat detectedFormat = null;
         try {
             detectedFormat = FontFormat.fromMimeType(detectedMime);
-        } catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException _) {
             // Tika may return a generic MIME treated as unknown format below
         }
 

--- a/backend/src/main/java/org/booklore/service/kobo/KoboReadingStateService.java
+++ b/backend/src/main/java/org/booklore/service/kobo/KoboReadingStateService.java
@@ -391,17 +391,17 @@ public class KoboReadingStateService {
         try {
             Instant instant = Instant.parse(trimmed).truncatedTo(ChronoUnit.SECONDS);
             return KOBO_TIMESTAMP_FORMAT.format(instant);
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
         try {
             OffsetDateTime offsetDateTime = OffsetDateTime.parse(trimmed);
             return KOBO_TIMESTAMP_FORMAT.format(offsetDateTime.toInstant().truncatedTo(ChronoUnit.SECONDS));
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
         try {
             LocalDateTime localDateTime = LocalDateTime.parse(trimmed, LOCAL_TIMESTAMP_FORMAT);
             return KOBO_TIMESTAMP_FORMAT.format(localDateTime.toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS));
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
         return value;
     }
@@ -506,16 +506,16 @@ public class KoboReadingStateService {
         String trimmed = value.trim();
         try {
             return Instant.parse(trimmed);
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
         try {
             return OffsetDateTime.parse(trimmed).toInstant();
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
         try {
             LocalDateTime localDateTime = LocalDateTime.parse(trimmed, LOCAL_TIMESTAMP_FORMAT);
             return localDateTime.toInstant(ZoneOffset.UTC);
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
         return null;
     }

--- a/backend/src/main/java/org/booklore/service/metadata/CoverImageGenerator.java
+++ b/backend/src/main/java/org/booklore/service/metadata/CoverImageGenerator.java
@@ -864,13 +864,13 @@ public class CoverImageGenerator {
             throw new RuntimeException("JPEG encoding failed", e);
         } finally {
             if (writer != null) writer.dispose();
-            if (ios != null) try { ios.close(); } catch (IOException ignored) {}
+            if (ios != null) try { ios.close(); } catch (IOException _) {}
         }
     }
 
     private void cleanup(Graphics2D g, BufferedImage... images) {
-        if (g != null) try { g.dispose(); } catch (Exception ignored) {}
+        if (g != null) try { g.dispose(); } catch (Exception _) {}
         for (BufferedImage img : images)
-            if (img != null) try { img.flush(); } catch (Exception ignored) {}
+            if (img != null) try { img.flush(); } catch (Exception _) {}
     }
 }

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/AudiobookMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/AudiobookMetadataExtractor.java
@@ -115,7 +115,7 @@ public class AudiobookMetadataExtractor implements FileMetadataExtractor {
                     if (yearInt >= 1 && yearInt <= 9999) {
                         builder.publishedDate(LocalDate.of(yearInt, 1, 1));
                     }
-                } catch (NumberFormatException ignored) {
+                } catch (NumberFormatException _) {
                 }
             }
 
@@ -141,7 +141,7 @@ public class AudiobookMetadataExtractor implements FileMetadataExtractor {
                 try {
                     String trackNum = trackNo.contains("/") ? trackNo.split("/")[0] : trackNo;
                     builder.seriesNumber((float) Integer.parseInt(trackNum.trim()));
-                } catch (NumberFormatException ignored) {
+                } catch (NumberFormatException _) {
                 }
             }
 
@@ -149,7 +149,7 @@ public class AudiobookMetadataExtractor implements FileMetadataExtractor {
             if (StringUtils.isNotBlank(trackTotal)) {
                 try {
                     builder.seriesTotal(Integer.parseInt(trackTotal.trim()));
-                } catch (NumberFormatException ignored) {
+                } catch (NumberFormatException _) {
                 }
             }
 
@@ -328,7 +328,7 @@ public class AudiobookMetadataExtractor implements FileMetadataExtractor {
                     return str;
                 }
             }
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
 
         return "Chapter " + (index + 1);

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -232,7 +232,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                             try {
                                 builderMeta.seriesNumber(Float.parseFloat(content));
                                 seriesIndexFound = true;
-                            } catch (NumberFormatException ignored) {
+                            } catch (NumberFormatException _) {
                             }
                         }
 
@@ -243,7 +243,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                                 JSONObject jsonroot = new JSONObject(content);
                                 Object value = jsonroot.opt("#value#");
                                 safeParseInt(String.valueOf(value), builderMeta::pageCount);
-                            } catch (JSONException ignored) {
+                            } catch (JSONException _) {
                             }
                         } else if ("calibre:user_metadata".equals(prop)) {
                             try {
@@ -428,14 +428,14 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
     private static void safeParseInt(String value, java.util.function.IntConsumer setter) {
         try {
             setter.accept(Integer.parseInt(value));
-        } catch (NumberFormatException ignored) {
+        } catch (NumberFormatException _) {
         }
     }
 
     private static void safeParseDouble(String value, java.util.function.DoubleConsumer setter) {
         try {
             setter.accept(Double.parseDouble(value));
-        } catch (NumberFormatException ignored) {
+        } catch (NumberFormatException _) {
         }
     }
     
@@ -531,19 +531,19 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
         try {
             return LocalDate.parse(value);
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
 
         try {
             return OffsetDateTime.parse(value).toLocalDate();
-        } catch (Exception ignored) {
+        } catch (Exception _) {
         }
 
         // Try parsing first 10 characters for ISO date format with extra content
         if (value.length() >= 10) {
             try {
                 return LocalDate.parse(value.substring(0, 10));
-            } catch (Exception ignored) {
+            } catch (Exception _) {
             }
         }
 

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/PdfMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/PdfMetadataExtractor.java
@@ -259,7 +259,7 @@ public class PdfMetadataExtractor implements FileMetadataExtractor {
                 if (StringUtils.isNotBlank(tags)) {
                     Arrays.stream(tags.split(";")).map(String::trim).forEach(knownNonCategories::add);
                 }
-            } catch (Exception ignored) {}
+            } catch (Exception _) {}
             
             subjects.removeAll(knownNonCategories);
             

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -861,7 +861,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         for (String pattern : DATE_PATTERNS) {
             try {
                 return LocalDate.parse(trimmedDate, DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH));
-            } catch (DateTimeParseException ignored) {
+            } catch (DateTimeParseException _) {
             }
         }
 
@@ -869,7 +869,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
             for (String pattern : DATE_PATTERNS) {
                 try {
                     return LocalDate.parse(trimmedDate, DateTimeFormatter.ofPattern(pattern, localeInfo.locale()));
-                } catch (DateTimeParseException ignored) {
+                } catch (DateTimeParseException _) {
                 }
             }
         }

--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -275,7 +275,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
             if (volume.getCountOfIssues() != null && volume.getCountOfIssues() >= requestedIssue) {
                 score += 20;
             }
-        } catch (NumberFormatException ignored) {}
+        } catch (NumberFormatException _) {}
 
         Set<String> majorPublishers = Set.of("Marvel", "DC Comics", "Image Comics", "Dark Horse Comics", "IDW Publishing", "Dynamite Entertainment", "BOOM! Studios", "Valiant Entertainment");
         if (volume.getPublisher() != null && volume.getPublisher().getName() != null) {
@@ -290,7 +290,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
                 if (year >= 2000) score += 5;
                 if (year >= 2010) score += 5;
                 if (year >= 2020) score += 5;
-            } catch (NumberFormatException ignored) {}
+            } catch (NumberFormatException _) {}
         }
 
         return score;
@@ -523,7 +523,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
             log.debug("Rate limiting: sleeping {}ms before next request", sleepTime);
             try {
                 Thread.sleep(sleepTime);
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
             }
         }
@@ -554,7 +554,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
                          response.statusCode(), retriesLeft);
                 try {
                     Thread.sleep(2000);
-                } catch (InterruptedException ignored) {}
+                } catch (InterruptedException _) {}
                 return sendRequestWithRetry(uri, responseType, retriesLeft - 1);
             } else {
                 log.error("Comicvine API returned status code {}. Body: {}", response.statusCode(), response.body());
@@ -564,7 +564,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
                 log.warn("IOException during ComicVine request. Retrying... ({} retries left)", retriesLeft, e);
                 try {
                     Thread.sleep(1000);
-                } catch (InterruptedException ignored) {}
+                } catch (InterruptedException _) {}
                 return sendRequestWithRetry(uri, responseType, retriesLeft - 1);
             } else {
                 log.error("Error fetching data from Comicvine API after retries", e);
@@ -888,7 +888,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
                     year = y;
                     yearString = yearMatcher.group(0);
                 }
-            } catch (NumberFormatException ignored) {}
+            } catch (NumberFormatException _) {}
         }
 
         String cleaned = term;

--- a/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
@@ -296,7 +296,6 @@ public class GoogleParser implements BookParser {
                     seriesNumber = Float.parseFloat(seriesInfo.getBookDisplayNumber());
                 } catch (NumberFormatException _) {
                     // Not a valid number, ignore
-                    return null;
                 }
             }
             

--- a/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
@@ -294,8 +294,9 @@ public class GoogleParser implements BookParser {
             if (seriesNumber == null && seriesInfo.getBookDisplayNumber() != null) {
                 try {
                     seriesNumber = Float.parseFloat(seriesInfo.getBookDisplayNumber());
-                } catch (NumberFormatException ignored) {
+                } catch (NumberFormatException _) {
                     // Not a valid number, ignore
+                    return null;
                 }
             }
             

--- a/backend/src/main/java/org/booklore/service/metadata/parser/HardcoverParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/HardcoverParser.java
@@ -236,7 +236,7 @@ public class HardcoverParser implements BookParser {
             if (book.getFeaturedBookSeries().getPosition() != null) {
                 try {
                     metadata.setSeriesNumber(Float.parseFloat(String.valueOf(book.getFeaturedBookSeries().getPosition())));
-                } catch (NumberFormatException ignored) {
+                } catch (NumberFormatException _) {
                 }
             }
         }
@@ -321,7 +321,7 @@ public class HardcoverParser implements BookParser {
         if (doc.getFeaturedSeries().getPosition() != null) {
             try {
                 metadata.setSeriesNumber(Float.parseFloat(String.valueOf(doc.getFeaturedSeries().getPosition())));
-            } catch (NumberFormatException ignored) {
+            } catch (NumberFormatException _) {
             }
         }
     }

--- a/backend/src/main/java/org/booklore/service/metadata/writer/CbxMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/CbxMetadataWriter.java
@@ -449,7 +449,7 @@ public class CbxMetadataWriter implements MetadataWriter {
         // Ensure 2-space indentation if possible
         try {
             marshaller.setProperty("com.sun.xml.bind.indentString", "  ");
-        } catch (Exception ignored) {
+        } catch (Exception _) {
             log.debug("Custom indentation property not supported via 'com.sun.xml.bind.indentString'");
         }
         

--- a/backend/src/main/java/org/booklore/service/reader/ChapterCacheService.java
+++ b/backend/src/main/java/org/booklore/service/reader/ChapterCacheService.java
@@ -37,7 +37,7 @@ public class ChapterCacheService {
      * which can cause SIGSEGV / out-of-memory crashes in the native heap.
      */
     public void prepareCbxCache(String cacheKey, Path cbxPath, List<String> entries) throws IOException {
-        ReentrantLock lock = cacheLocks.computeIfAbsent(cacheKey, ignored -> new ReentrantLock());
+        ReentrantLock lock = cacheLocks.computeIfAbsent(cacheKey, _ -> new ReentrantLock());
         lock.lock();
         try {
             Path cacheDir = getCacheDir(cacheKey);

--- a/backend/src/main/java/org/booklore/util/kobo/BookloreSyncTokenGenerator.java
+++ b/backend/src/main/java/org/booklore/util/kobo/BookloreSyncTokenGenerator.java
@@ -33,7 +33,7 @@ public class BookloreSyncTokenGenerator {
                         .rawKoboSyncToken(base64Token)
                         .build();
             }
-        } catch (Exception ignored) {
+        } catch (Exception _) {
 
         }
         return new BookloreSyncToken();

--- a/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
@@ -412,7 +412,7 @@ class BookCoverServiceTest {
             try {
                 when(file.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0})); // JPEG
                 when(file.getBytes()).thenReturn(new byte[]{1, 2, 3});
-            } catch (Exception ignored) {}
+            } catch (Exception _) {}
 
             service.updateCoverFromFileForBooks(Set.of(1L, 2L), file);
 
@@ -473,7 +473,7 @@ class BookCoverServiceTest {
             try {
                 when(file.getInputStream()).thenReturn(new java.io.ByteArrayInputStream(new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0}));
                 when(file.getBytes()).thenReturn(new byte[]{1, 2, 3});
-            } catch (Exception ignored) {}
+            } catch (Exception _) {}
 
             when(bookQueryService.findAllWithMetadataByIds(any())).thenReturn(List.of());
 
@@ -491,7 +491,7 @@ class BookCoverServiceTest {
             try {
                 when(file.getInputStream()).thenReturn(new java.io.ByteArrayInputStream(new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}));
                 when(file.getBytes()).thenReturn(new byte[]{1, 2, 3});
-            } catch (Exception ignored) {}
+            } catch (Exception _) {}
 
             when(bookQueryService.findAllWithMetadataByIds(any())).thenReturn(List.of());
 

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/PdfMetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/PdfMetadataExtractorTest.java
@@ -101,7 +101,7 @@ class PdfMetadataExtractorTest {
 
     @Test
     void extractMetadata_minimalPdf_usesFilenameAsTitle() throws Exception {
-        File pdf = createPdf(ignored -> {});
+        File pdf = createPdf(_ -> {});
         BookMetadata meta = extractor.extractMetadata(pdf);
         assertThat(meta.getTitle()).isEqualTo("test");
         assertThat(meta.getPageCount()).isEqualTo(1);

--- a/backend/src/test/java/org/booklore/service/metadata/writer/CbxComicInfoComplianceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/CbxComicInfoComplianceTest.java
@@ -62,7 +62,7 @@ class CbxComicInfoComplianceTest {
                     .forEach(p -> {
                         try {
                             Files.deleteIfExists(p);
-                        } catch (Exception ignore) {
+                        } catch (Exception _) {
                         }
                     });
         }

--- a/backend/src/test/java/org/booklore/service/metadata/writer/CbxMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/CbxMetadataWriterTest.java
@@ -68,7 +68,7 @@ class CbxMetadataWriterTest {
                     .forEach(p -> {
                         try {
                             Files.deleteIfExists(p);
-                        } catch (Exception ignore) {
+                        } catch (Exception _) {
                         }
                     });
         }

--- a/backend/src/test/java/org/booklore/service/metadata/writer/PdfMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/PdfMetadataWriterTest.java
@@ -66,7 +66,7 @@ class PdfMetadataWriterTest {
                     .forEach(p -> {
                         try {
                             Files.deleteIfExists(p);
-                        } catch (Exception ignore) {
+                        } catch (Exception _) {
                         }
                     });
         }

--- a/backend/src/test/java/org/booklore/service/monitoring/LibraryWatchServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/monitoring/LibraryWatchServiceTest.java
@@ -37,7 +37,7 @@ class LibraryWatchServiceTest {
     void teardown() {
         try {
             service.stop();
-        } catch (Exception ignored) {}
+        } catch (Exception _) {}
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/task/TaskHistoryServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/task/TaskHistoryServiceTest.java
@@ -281,7 +281,7 @@ class TaskHistoryServiceTest {
                 java.lang.reflect.Field field = TaskType.class.getDeclaredField("hiddenFromUI");
                 field.setAccessible(true);
                 field.set(type, true);
-            } catch (Exception ignored) {
+            } catch (Exception _) {
             }
         });
 

--- a/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
@@ -250,7 +250,7 @@ class LibraryFileEventProcessorTest {
             } finally {
                 try (var stream = Files.walk(outsideFolder)) {
                     stream.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
-                        try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+                        try { Files.deleteIfExists(p); } catch (IOException _) {}
                     });
                 }
             }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

This pull request performs a consistent code style update across the backend codebase. All instances of catch blocks using the variable name `ignored` for unused exceptions have been replaced with the underscore `_` to better indicate that the exception variable is intentionally unused. No functional changes are introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized unused exception variable naming across backend and tests to use the underscore (_) placeholder, improving code clarity and consistency without changing behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->