### PR TITLE
refactor(api): replace Stream.collect(Collectors.toList()) with Stream.toList()

### DIFF
--- a/backend/src/main/java/org/booklore/app/controller/AppLibraryController.java
+++ b/backend/src/main/java/org/booklore/app/controller/AppLibraryController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @RestController
@@ -44,7 +43,7 @@ public class AppLibraryController {
             libraries = libraryRepository.findAll();
         } else {
             List<Long> libraryIds = user.getAssignedLibraries() != null
-                    ? user.getAssignedLibraries().stream().map(Library::getId).collect(Collectors.toList())
+                    ? user.getAssignedLibraries().stream().map(Library::getId).toList()
                     : List.of();
             libraries = libraryRepository.findByIdIn(libraryIds);
         }
@@ -54,7 +53,7 @@ public class AppLibraryController {
                     long bookCount = bookRepository.countByLibraryId(library.getId());
                     return mobileBookMapper.toLibrarySummary(library, bookCount);
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         return ResponseEntity.ok(summaries);
     }

--- a/backend/src/main/java/org/booklore/app/controller/AppShelfController.java
+++ b/backend/src/main/java/org/booklore/app/controller/AppShelfController.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @RestController
@@ -50,7 +49,7 @@ public class AppShelfController {
 
         List<AppShelfSummary> summaries = shelves.stream()
                 .map(mobileBookMapper::toShelfSummaryFromEntity)
-                .collect(Collectors.toList());
+                .toList();
 
         return ResponseEntity.ok(summaries);
     }
@@ -88,7 +87,7 @@ public class AppShelfController {
 
         List<AppMagicShelfSummary> summaries = allShelves.stream()
                 .map(mobileBookMapper::toMagicShelfSummary)
-                .collect(Collectors.toList());
+                .toList();
 
         return ResponseEntity.ok(summaries);
     }

--- a/backend/src/main/java/org/booklore/app/mapper/AppBookMapper.java
+++ b/backend/src/main/java/org/booklore/app/mapper/AppBookMapper.java
@@ -136,7 +136,7 @@ public interface AppBookMapper {
         }
         return shelves.stream()
                 .map(this::toShelfSummary)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     default AppShelfSummary toShelfSummary(ShelfEntity shelf) {
@@ -280,7 +280,7 @@ public interface AppBookMapper {
                 .filter(bf -> bf.getBookType() != null)
                 .map(bf -> bf.getBookType().name())
                 .distinct()
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Named("mapFiles")
@@ -319,7 +319,7 @@ public interface AppBookMapper {
                             .isPrimary(bf.getId().equals(primaryId))
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     default AppLibrarySummary toLibrarySummary(LibraryEntity library, long bookCount) {
@@ -333,7 +333,7 @@ public interface AppBookMapper {
                             .id(lp.getId())
                             .path(lp.getPath())
                             .build())
-                    .collect(Collectors.toList());
+                    .toList();
         }
         return AppLibrarySummary.builder()
                 .id(library.getId())

--- a/backend/src/main/java/org/booklore/app/service/AppAuthorService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppAuthorService.java
@@ -91,13 +91,13 @@ public class AppAuthorService {
                             .hasPhoto(authorHasPhoto)
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         // Post-filter by hasPhoto if requested
         if (hasPhoto != null) {
             summaries = summaries.stream()
                     .filter(s -> s.isHasPhoto() == hasPhoto)
-                    .collect(Collectors.toList());
+                    .toList();
             // Adjust total count for hasPhoto filter — requires a separate count
             long filteredTotal = countAuthorsWithPhotoFilter(accessibleLibraryIds, libraryId, search, hasPhoto);
             return AppPageResponse.of(summaries, pageNum, pageSize, filteredTotal);

--- a/backend/src/main/java/org/booklore/app/service/AppBookService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppBookService.java
@@ -276,7 +276,7 @@ public class AppBookService {
         return topIds.stream()
                 .filter(enrichedMap::containsKey)
                 .map(id -> mobileBookMapper.toSummary(enrichedMap.get(id), progressMap.get(id)))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<AppBookSummary> getContinueListening(Integer limit) {
@@ -299,7 +299,7 @@ public class AppBookService {
         return topIds.stream()
                 .filter(enrichedMap::containsKey)
                 .map(id -> mobileBookMapper.toSummary(enrichedMap.get(id), progressMap.get(id)))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<AppBookSummary> getRecentlyAdded(Integer limit) {
@@ -322,7 +322,7 @@ public class AppBookService {
 
         return bookPage.getContent().stream()
                 .map(book -> mobileBookMapper.toSummary(book, progressMap.get(book.getId())))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<AppBookSummary> getRecentlyScanned(Integer limit) {
@@ -344,7 +344,7 @@ public class AppBookService {
 
         return bookPage.getContent().stream()
                 .map(book -> mobileBookMapper.toSummary(book, progressMap.get(book.getId())))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public AppPageResponse<AppBookSummary> getRandomBooks(
@@ -406,7 +406,7 @@ public class AppBookService {
                 .filter(Objects::nonNull)
                 .filter(BookEntity::hasFiles)
                 .map(bookEntity -> mobileBookMapper.toSummary(bookEntity, progressMap.get(bookEntity.getId())))
-                .collect(Collectors.toList());
+                .toList();
 
         return AppPageResponse.of(summaries, pageNum, pageSize, booksPage.getTotalElements());
     }
@@ -1132,7 +1132,7 @@ public class AppBookService {
 
         List<AppBookSummary> summaries = books.stream()
                 .map(book -> mobileBookMapper.toSummary(book, progressMap.get(book.getId())))
-                .collect(Collectors.toList());
+                .toList();
 
         return AppPageResponse.of(summaries, pageNum, pageSize, bookPage.getTotalElements());
     }

--- a/backend/src/main/java/org/booklore/config/JacksonConfig.java
+++ b/backend/src/main/java/org/booklore/config/JacksonConfig.java
@@ -8,7 +8,6 @@ import tools.jackson.databind.ser.BeanPropertyWriter;
 import tools.jackson.databind.ser.ValueSerializerModifier;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Jackson configuration for Komga API clean mode.
@@ -32,8 +31,8 @@ public class JacksonConfig {
                                     List<BeanPropertyWriter> beanProperties) {
 
                                 return beanProperties.stream()
-                                    .map(KomgaCleanBeanPropertyWriter::new)
-                                    .collect(Collectors.toList());
+                                    .<BeanPropertyWriter>map(KomgaCleanBeanPropertyWriter::new)
+                                    .toList();
                             }
                         })
                 )

--- a/backend/src/main/java/org/booklore/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/booklore/exception/GlobalExceptionHandler.java
@@ -15,7 +15,6 @@ import org.springframework.web.context.request.async.AsyncRequestNotUsableExcept
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
@@ -40,7 +39,7 @@ public class GlobalExceptionHandler {
                 .getFieldErrors()
                 .stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
-                .collect(Collectors.toList());
+                .toList();
 
         ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Validation error", errors);
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
@@ -51,7 +50,7 @@ public class GlobalExceptionHandler {
         List<String> errors = ex.getConstraintViolations()
                 .stream()
                 .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
-                .collect(Collectors.toList());
+                .toList();
 
         ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Validation error", errors);
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/org/booklore/mapper/custom/BookLoreUserTransformer.java
+++ b/backend/src/main/java/org/booklore/mapper/custom/BookLoreUserTransformer.java
@@ -14,7 +14,6 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -85,7 +84,7 @@ public class BookLoreUserTransformer {
             bookLoreUser.setAssignedLibraries(
                     userEntity.getLibraries().stream()
                             .map(libraryMapper::toLibrary)
-                            .collect(Collectors.toList())
+                            .toList()
             );
         } else {
             bookLoreUser.setAssignedLibraries(Collections.emptyList());

--- a/backend/src/main/java/org/booklore/mapper/komga/KomgaMapper.java
+++ b/backend/src/main/java/org/booklore/mapper/komga/KomgaMapper.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -122,14 +121,14 @@ public class KomgaMapper {
                             .name(author.getName())
                             .role("writer")
                             .build())
-                    .collect(Collectors.toList());
+                    .toList();
         }
         
         List<String> tags = new ArrayList<>();
         if (metadata.getTags() != null) {
             tags = metadata.getTags().stream()
                     .map(TagEntity::getName)
-                    .collect(Collectors.toList());
+                    .toList();
         }
         
         return KomgaBookMetadataDto.builder()
@@ -165,12 +164,12 @@ public class KomgaMapper {
             if (firstMetadata.getCategories() != null) {
                 genres = firstMetadata.getCategories().stream()
                         .map(CategoryEntity::getName)
-                        .collect(Collectors.toList());
+                        .toList();
             }
             if (firstMetadata.getTags() != null) {
                 tags = firstMetadata.getTags().stream()
                         .map(TagEntity::getName)
-                        .collect(Collectors.toList());
+                        .toList();
             }
         }
         String language = firstMetadata != null ? firstMetadata.getLanguage() : null;
@@ -233,7 +232,7 @@ public class KomgaMapper {
         
         List<KomgaAuthorDto> authors = authorNames.stream()
                 .map(name -> KomgaAuthorDto.builder().name(name).role("writer").build())
-                .collect(Collectors.toList());
+                .toList();
         
         return KomgaBookMetadataAggregationDto.builder()
                 .authors(authors)

--- a/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
+++ b/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
@@ -20,7 +20,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -336,7 +335,7 @@ public class BookRuleEvaluatorService {
 
         List<ReadStatus> readStatuses = statuses.stream()
                 .map(ReadStatus::valueOf)
-                .collect(Collectors.toList());
+                .toList();
 
         sub.select(cb.literal(1L)).where(
                 cb.equal(subRoot.get("metadata").get("seriesName"), root.get("metadata").get("seriesName")),
@@ -741,11 +740,11 @@ public class BookRuleEvaluatorService {
             boolean hasUnset = ruleList.stream().anyMatch("UNSET"::equals);
             List<String> nonUnsetValues = ruleList.stream()
                     .filter(v -> !"UNSET".equals(v))
-                    .collect(Collectors.toList());
+                    .toList();
 
             List<ReadStatus> statuses = nonUnsetValues.stream()
                     .map(ReadStatus::valueOf)
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (hasUnset && !statuses.isEmpty()) {
                 return cb.or(
@@ -759,7 +758,7 @@ public class BookRuleEvaluatorService {
             }
         }
 
-        List<String> lowerList = ruleList.stream().map(String::toLowerCase).collect(Collectors.toList());
+        List<String> lowerList = ruleList.stream().map(String::toLowerCase).toList();
         return cb.lower(field.as(String.class)).in(lowerList);
     }
 
@@ -879,7 +878,7 @@ public class BookRuleEvaluatorService {
 
             List<String> lowerValues = values.stream()
                     .map(String::toLowerCase)
-                    .collect(Collectors.toList());
+                    .toList();
 
             subquery.select(cb.literal(1L)).where(
                     cb.equal(subRoot.get("id"), root.get("id")),
@@ -947,7 +946,7 @@ public class BookRuleEvaluatorService {
         if (value instanceof List) {
             return ((Collection<?>) value).stream()
                     .map(Object::toString)
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         return Collections.singletonList(value.toString());

--- a/backend/src/main/java/org/booklore/service/MagicShelfService.java
+++ b/backend/src/main/java/org/booklore/service/MagicShelfService.java
@@ -10,8 +10,8 @@ import org.booklore.service.audit.AuditService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @Service
@@ -32,9 +32,9 @@ public class MagicShelfService {
     }
 
     private List<MagicShelf> getShelvesForUser(Long userId) {
-        List<MagicShelf> shelves = magicShelfRepository.findAllByUserId(userId).stream()
+        List<MagicShelf> shelves = new ArrayList<>(magicShelfRepository.findAllByUserId(userId).stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList());
 
         List<Long> userShelfIds = shelves.stream().map(MagicShelf::getId).toList();
 

--- a/backend/src/main/java/org/booklore/service/ReadingSessionService.java
+++ b/backend/src/main/java/org/booklore/service/ReadingSessionService.java
@@ -83,7 +83,7 @@ public class ReadingSessionService {
                         .count(e.getValue())
                         .build())
                 .sorted(Comparator.comparing(ReadingSessionHeatmapResponse::getDate))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static int toSundayFirstDow(DayOfWeek dow) {
@@ -158,7 +158,7 @@ public class ReadingSessionService {
                         .totalSessions(dto.getTotalSessions())
                         .totalDurationSeconds(dto.getTotalDurationSeconds())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<ReadingSpeedResponse> getReadingSpeedForYear(int year) {
@@ -175,7 +175,7 @@ public class ReadingSessionService {
                         .avgProgressPerMinute(dto.getAvgProgressPerMinute())
                         .totalSessions(dto.getTotalSessions())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<PeakHoursResponse> getPeakReadingHours(Integer year, Integer month) {
@@ -198,7 +198,7 @@ public class ReadingSessionService {
                         .sessionCount(e.getValue()[0])
                         .totalDurationSeconds(e.getValue()[1])
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<FavoriteReadingDaysResponse> getFavoriteReadingDays(Integer year, Integer month) {
@@ -226,7 +226,7 @@ public class ReadingSessionService {
                             .build();
                 })
                 .sorted(Comparator.comparingInt(FavoriteReadingDaysResponse::getDayOfWeek))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<GenreStatisticsResponse> getGenreStatistics() {
@@ -248,7 +248,7 @@ public class ReadingSessionService {
                             .averageSessionsPerBook(Math.round(avgSessionsPerBook * 100.0) / 100.0)
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<CompletionTimelineResponse> getCompletionTimeline(int year) {
@@ -286,7 +286,7 @@ public class ReadingSessionService {
                     int cmp = b.getYear().compareTo(a.getYear());
                     return cmp != 0 ? cmp : b.getMonth().compareTo(a.getMonth());
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public Page<ReadingSessionResponse> getReadingSessionsForBook(Long bookId, int page, int size) {
@@ -331,7 +331,7 @@ public class ReadingSessionService {
                         .month(dto.getMonth())
                         .count(dto.getCount())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<PageTurnerScoreResponse> getPageTurnerScores() {
@@ -351,7 +351,7 @@ public class ReadingSessionService {
                         ? book.getMetadata().getCategories().stream()
                         .map(CategoryEntity::getName)
                         .sorted()
-                        .collect(Collectors.toList())
+                        .toList()
                         : List.of();
                 bookCategories.put(book.getId(), categories);
             });
@@ -366,7 +366,7 @@ public class ReadingSessionService {
 
                     List<Double> durations = bookSessions.stream()
                             .map(s -> s.getDurationSeconds() != null ? s.getDurationSeconds().doubleValue() : 0.0)
-                            .collect(Collectors.toList());
+                            .toList();
 
                     List<Double> gaps = new ArrayList<>();
                     for (int i = 1; i < bookSessions.size(); i++) {
@@ -412,7 +412,7 @@ public class ReadingSessionService {
                             .build();
                 })
                 .sorted(Comparator.comparingInt(PageTurnerScoreResponse::getGripScore).reversed())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static final int COMPLETION_RACE_BOOK_LIMIT = 10;
@@ -445,7 +445,7 @@ public class ReadingSessionService {
                         .sessionDate(dto.getSessionDate())
                         .endProgress(dto.getEndProgress())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<ReadingSessionHeatmapResponse> getReadingDates() {
@@ -466,7 +466,7 @@ public class ReadingSessionService {
                         .rating(dto.getRating())
                         .count(dto.getCount())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
 
         // Status distribution
         List<BookDistributionsResponse.StatusBucket> statusBuckets = userBookProgressRepository.findStatusDistributionByUser(userId)
@@ -475,7 +475,7 @@ public class ReadingSessionService {
                         .status(dto.getStatus().name())
                         .count(dto.getCount())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
 
         // Progress distribution — coalesce to max across sources, then bucket
         List<ProgressPercentDto> progressRows = userBookProgressRepository.findAllProgressPercentsByUser(userId);
@@ -544,7 +544,7 @@ public class ReadingSessionService {
                             .dayOfWeek(toSundayFirstDow(zdt.getDayOfWeek()))
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public ReadingStreakResponse getReadingStreak() {
@@ -626,7 +626,7 @@ public class ReadingSessionService {
                         .maxProgress(dto.getMaxProgress())
                         .readStatus(dto.getReadStatus())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private double linearRegressionSlope(List<Double> values) {
@@ -671,7 +671,7 @@ public class ReadingSessionService {
                         .sessions(e.getValue()[0])
                         .durationMinutes(Math.round(e.getValue()[1] / 60.0))
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<WeeklyListeningTrendResponse> getWeeklyListeningTrend(int weeks) {
@@ -701,7 +701,7 @@ public class ReadingSessionService {
                             .sessions(entry.getValue()[1])
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public ListeningCompletionResponse getListeningCompletion() {
@@ -736,7 +736,7 @@ public class ReadingSessionService {
                 .totalAudiobooks(totalAudiobooks)
                 .completed(completed)
                 .inProgressCount(inProgressCount)
-                .inProgress(inProgress.stream().limit(10).collect(Collectors.toList()))
+                .inProgress(inProgress.stream().limit(10).toList())
                 .build();
     }
 
@@ -766,7 +766,7 @@ public class ReadingSessionService {
                             .totalListeningSeconds(listeningSeconds)
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public ListeningFinishFunnelResponse getListeningFinishFunnel() {
@@ -819,7 +819,7 @@ public class ReadingSessionService {
                         .sessionCount(e.getValue()[0])
                         .totalDurationSeconds(e.getValue()[1])
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<GenreStatisticsResponse> getListeningGenreStatistics() {
@@ -839,7 +839,7 @@ public class ReadingSessionService {
                             .averageSessionsPerBook(Math.round(avgSessionsPerBook * 100.0) / 100.0)
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<ListeningAuthorResponse> getListeningAuthorStats() {
@@ -852,7 +852,7 @@ public class ReadingSessionService {
                         .totalSessions(dto.getTotalSessions())
                         .totalDurationSeconds(dto.getTotalDurationSeconds())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<SessionScatterResponse> getListeningSessionScatter() {
@@ -869,7 +869,7 @@ public class ReadingSessionService {
                             .dayOfWeek(toSundayFirstDow(zdt.getDayOfWeek()))
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<LongestAudiobookResponse> getListeningLongestBooks() {
@@ -890,6 +890,6 @@ public class ReadingSessionService {
                             .progressPercent(Math.round(maxProg * 10.0) / 10.0)
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
@@ -76,7 +76,7 @@ public class BookFileAttachmentService {
 
             List<BookFileEntity> sourceBookFiles = sourceBook.getBookFiles().stream()
                     .filter(BookFileEntity::isBookFormat)
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (sourceBookFiles.isEmpty()) {
                 throw ApiError.GENERIC_BAD_REQUEST.createException("Source book " + sourceBook.getId() + " has no book format files to attach");

--- a/backend/src/main/java/org/booklore/service/book/BookNoteService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookNoteService.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -36,7 +35,7 @@ public class BookNoteService {
         return bookNoteRepository.findByBookIdAndUserIdOrderByUpdatedAtDesc(bookId, currentUser.getId())
                 .stream()
                 .map(mapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/org/booklore/service/book/BookQueryService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookQueryService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @Service
@@ -118,7 +119,7 @@ public class BookQueryService {
     private List<Book> mapBooksToDto(List<BookEntity> books, boolean includeDescription, Long userId, boolean stripForListView) {
         return books.stream()
                 .map(book -> mapBookToDto(book, includeDescription, userId, stripForListView))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Book mapBookToDto(BookEntity bookEntity, boolean includeDescription, Long userId, boolean stripForListView) {

--- a/backend/src/main/java/org/booklore/service/book/BookReviewService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookReviewService.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -43,7 +43,7 @@ public class BookReviewService {
 
         List<BookReview> existingReviews = bookReviewRepository.findByBookMetadataBookId(bookId).stream()
                 .map(mapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
 
         MetadataPublicReviewsSettings reviewSettings = appSettingService.getAppSettings().getMetadataPublicReviewsSettings();
 
@@ -67,7 +67,7 @@ public class BookReviewService {
                 bookRepository.save(bookEntity);
                 return bookReviewRepository.findByBookMetadataBookId(bookId).stream()
                         .map(mapper::toDto)
-                        .collect(Collectors.toList());
+                        .toList();
             }
         } catch (Exception e) {
             log.warn("Failed to auto-fetch reviews for book {}: {}", bookId, e.getMessage());
@@ -86,14 +86,14 @@ public class BookReviewService {
         List<MetadataProvider> providers = settings.getProviders().stream()
                 .filter(MetadataPublicReviewsSettings.ReviewProviderConfig::isEnabled)
                 .map(MetadataPublicReviewsSettings.ReviewProviderConfig::getProvider)
-                .collect(Collectors.toList());
+                .toList();
 
         Map<MetadataProvider, BookMetadata> metadataMap = metadataRefreshService.fetchMetadataForBook(providers, bookEntity);
 
         return metadataMap.values().stream()
                 .filter(meta -> meta.getBookReviews() != null)
                 .flatMap(meta -> meta.getBookReviews().stream())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional
@@ -120,7 +120,7 @@ public class BookReviewService {
 
         return bookReviewRepository.findByBookMetadataBookId(bookId).stream()
                 .map(mapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/org/booklore/service/book/BookService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookService.java
@@ -166,7 +166,7 @@ public class BookService {
                     fileProgressMap.get(bookEntity.getId())
             );
             return book;
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     public Book getBook(long bookId, boolean withDescription) {

--- a/backend/src/main/java/org/booklore/service/book/BookUpdateService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookUpdateService.java
@@ -233,7 +233,7 @@ public class BookUpdateService {
         BookLoreUserEntity userEntity = findUserOrThrow(userId);
         List<UserBookProgressEntity> newProgressEntities = newProgressBookIds.stream()
                 .map(bookId -> createProgressEntity(userEntity, bookId, status, now, dateFinished))
-                .collect(Collectors.toList());
+                .toList();
 
         userBookProgressRepository.saveAll(newProgressEntities);
     }
@@ -262,7 +262,7 @@ public class BookUpdateService {
         BookLoreUserEntity userEntity = findUserOrThrow(userId);
         List<UserBookProgressEntity> newProgressEntities = newProgressBookIds.stream()
                 .map(bookId -> createProgressEntityWithRating(userEntity, bookId, rating))
-                .collect(Collectors.toList());
+                .toList();
 
         userBookProgressRepository.saveAll(newProgressEntities);
     }
@@ -306,7 +306,7 @@ public class BookUpdateService {
 
         return bookEntities.stream()
                 .map(bookEntity -> buildBook(bookEntity, userId, progressMap, fileProgressMap))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Book buildBook(BookEntity bookEntity, Long userId,
@@ -350,7 +350,7 @@ public class BookUpdateService {
                         .readStatusModifiedTime(now)
                         .dateFinished(dateFinished)
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<PersonalRatingUpdateResponse> buildRatingUpdateResponses(List<Long> bookIds, Integer rating) {
@@ -359,7 +359,7 @@ public class BookUpdateService {
                         .bookId(bookId)
                         .personalRating(rating)
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Set<Shelf> filterShelvesByUserId(Set<Shelf> shelves, Long userId) {

--- a/backend/src/main/java/org/booklore/service/customfont/CustomFontService.java
+++ b/backend/src/main/java/org/booklore/service/customfont/CustomFontService.java
@@ -28,7 +28,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -117,7 +117,7 @@ public class CustomFontService {
         List<CustomFontEntity> fonts = customFontRepository.findByUserId(userId);
         return fonts.stream()
                 .map(customFontMapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/org/booklore/service/file/PathService.java
+++ b/backend/src/main/java/org/booklore/service/file/PathService.java
@@ -12,7 +12,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -54,7 +53,7 @@ public class PathService {
                     .filter(Files::isDirectory)
                     .map(p -> directory.resolve(p.getFileName()).toString())
                     .sorted()
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (IOException e) {
             log.error("Error accessing path {}: {}", path, e.getMessage(), e);
             return Collections.emptyList();

--- a/backend/src/main/java/org/booklore/service/fileprocessor/AudiobookProcessor.java
+++ b/backend/src/main/java/org/booklore/service/fileprocessor/AudiobookProcessor.java
@@ -279,6 +279,6 @@ public class AudiobookProcessor extends AbstractFileProcessor implements BookFil
                         .endTimeMs(ch.getEndTimeMs())
                         .durationMs(ch.getDurationMs())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/backend/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
+++ b/backend/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
@@ -67,7 +67,7 @@ public class KoboEntitlementService {
                                 .readingState(getReadingStateForBook(book))
                                 .build())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<? extends Entitlement> generateChangedEntitlements(Set<Long> bookIds, String token, boolean removed) {
@@ -95,7 +95,7 @@ public class KoboEntitlementService {
                                         .build())
                                 .build();
                     })
-                    .collect(Collectors.toList());
+                    .toList();
         }
         return books.stream()
                 .filter(bookEntity -> bookEntity.getPrimaryBookFile() != null && bookEntity.getPrimaryBookFile().getBookType() == BookFileType.EPUB)
@@ -105,7 +105,7 @@ public class KoboEntitlementService {
                                 .bookMetadata(mapToKoboMetadata(book, token))
                                 .build())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<ChangedReadingState> generateChangedReadingStates(List<UserBookProgressEntity> progressEntries) {

--- a/backend/src/main/java/org/booklore/service/kobo/KoboLibrarySnapshotService.java
+++ b/backend/src/main/java/org/booklore/service/kobo/KoboLibrarySnapshotService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @Service
@@ -143,7 +142,7 @@ public class KoboLibrarySnapshotService {
                     snapshotBook.setMetadataUpdatedAt(book.getMetadataUpdatedAt());
                     return snapshotBook;
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private boolean isBookOwnedByUser(BookEntity book, Long userId) {

--- a/backend/src/main/java/org/booklore/service/kobo/KoboReadingStateService.java
+++ b/backend/src/main/java/org/booklore/service/kobo/KoboReadingStateService.java
@@ -30,7 +30,6 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -70,7 +69,7 @@ public class KoboReadingStateService {
                         .statisticsResult(KoboReadingStateResponse.Result.success())
                         .statusInfoResult(KoboReadingStateResponse.Result.success())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
 
         return KoboReadingStateResponse.builder()
                 .requestResult("Success")
@@ -120,7 +119,7 @@ public class KoboReadingStateService {
 
                     return savedState;
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/org/booklore/service/komga/KomgaService.java
+++ b/backend/src/main/java/org/booklore/service/komga/KomgaService.java
@@ -30,7 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -50,7 +50,7 @@ public class KomgaService {
     public List<KomgaLibraryDto> getAllLibraries() {
         return libraryRepository.findAll().stream()
                 .map(komgaMapper::toKomgaLibraryDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public KomgaLibraryDto getLibraryById(Long libraryId) {
@@ -258,7 +258,7 @@ public class KomgaService {
             // Return all books without pagination
             content = seriesBooks.stream()
                     .map(book -> komgaMapper.toKomgaBookDto(book))
-                    .collect(Collectors.toList());
+                    .toList();
             actualPage = 0;
             actualSize = totalElements;
             totalPages = totalElements > 0 ? 1 : 0;
@@ -270,7 +270,7 @@ public class KomgaService {
             
             content = seriesBooks.subList(fromIndex, toIndex).stream()
                     .map(book -> komgaMapper.toKomgaBookDto(book))
-                    .collect(Collectors.toList());
+                    .toList();
             actualPage = page;
             actualSize = size;
         }
@@ -300,7 +300,7 @@ public class KomgaService {
         
         List<KomgaBookDto> content = bookPage.getContent().stream()
                 .map(book -> komgaMapper.toKomgaBookDto(book))
-                .collect(Collectors.toList());
+                .toList();
         
         return KomgaPageableDto.<KomgaBookDto>builder()
                 .content(content)
@@ -364,7 +364,7 @@ public class KomgaService {
         List<KomgaCollectionDto> allCollections = magicShelves.stream()
                 .map(shelf -> komgaMapper.toKomgaCollectionDto(shelf, 0))
                 .sorted(Comparator.comparing(KomgaCollectionDto::getName))
-                .collect(Collectors.toList());
+                .toList();
         
         log.debug("Mapped to {} collection DTOs", allCollections.size());
         

--- a/backend/src/main/java/org/booklore/service/library/BookRestorationService.java
+++ b/backend/src/main/java/org/booklore/service/library/BookRestorationService.java
@@ -42,7 +42,7 @@ public class BookRestorationService {
         List<BookEntity> toRestore = deletedBooks.stream()
                 .filter(book -> book.getBookFiles() != null && !book.getBookFiles().isEmpty())
                 .filter(book -> currentPaths.contains(book.getFullFilePath()))
-                .collect(Collectors.toList());
+                .toList();
 
         if (toRestore.isEmpty()) return;
 

--- a/backend/src/main/java/org/booklore/service/library/LibraryFileHelper.java
+++ b/backend/src/main/java/org/booklore/service/library/LibraryFileHelper.java
@@ -51,7 +51,7 @@ public class LibraryFileHelper {
                     return !currentFullPaths.contains(book.getFullFilePath());
                 })
                 .map(BookEntity::getId)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<Long> detectDeletedAdditionalFiles(List<LibraryFile> libraryFiles, List<BookFileEntity> allAdditionalFiles) {
@@ -63,7 +63,7 @@ public class LibraryFileHelper {
                 .filter(BookFileEntity::isBookFormat)
                 .filter(additionalFile -> !currentFileKeys.contains(generateUniqueKey(additionalFile)))
                 .map(BookFileEntity::getId)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<LibraryFile> detectNewBookPaths(List<LibraryFile> libraryFiles, List<BookEntity> books, List<BookFileEntity> allAdditionalFiles) {
@@ -80,7 +80,7 @@ public class LibraryFileHelper {
 
         return libraryFiles.stream()
                 .filter(file -> !existingKeys.contains(generateUniqueKey(file)))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private String generateUniqueKey(BookEntity book) {
@@ -227,7 +227,7 @@ public class LibraryFileHelper {
         Set<BookFileType> allowed = EnumSet.copyOf(allowedFormats);
         return files.stream()
                 .filter(file -> allowed.contains(file.getBookFileType()))
-                .collect(java.util.stream.Collectors.toList());
+                .toList();
     }
 
     private List<LibraryFile> findLibraryFiles(LibraryPathEntity pathEntity, LibraryEntity libraryEntity) throws IOException {

--- a/backend/src/main/java/org/booklore/service/library/LibraryService.java
+++ b/backend/src/main/java/org/booklore/service/library/LibraryService.java
@@ -72,7 +72,7 @@ public class LibraryService {
     @Transactional
     @EventListener(ApplicationReadyEvent.class)
     public void initializeMonitoring() {
-        List<Library> libraries = libraryRepository.findAll().stream().map(libraryMapper::toLibrary).collect(Collectors.toList());
+        List<Library> libraries = libraryRepository.findAll().stream().map(libraryMapper::toLibrary).toList();
         libraryWatchService.registerLibraries(libraries);
         log.info("Monitoring initialized with {} libraries", libraries.size());
     }
@@ -161,9 +161,9 @@ public class LibraryService {
                 .libraryPaths(
                         request.getPaths() == null || request.getPaths().isEmpty() ?
                                 Collections.emptyList() :
-                                request.getPaths().stream()
+                                new ArrayList<>(request.getPaths().stream()
                                         .map(path -> LibraryPathEntity.builder().path(path.getPath()).build())
-                                        .collect(Collectors.toList())
+                                        .toList())
                 )
                 .icon(request.getIcon())
                 .iconType(request.getIconType())

--- a/backend/src/main/java/org/booklore/service/library/LibraryService.java
+++ b/backend/src/main/java/org/booklore/service/library/LibraryService.java
@@ -156,6 +156,8 @@ public class LibraryService {
         BookLoreUserEntity userEntity = userRepository.findById(bookLoreUser.getId())
                 .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(bookLoreUser.getId()));
 
+        // Stream.toList() returns an unmodifiable list, while JPA/Hibernate requires a mutable collection for entity
+        // relationship fields
         LibraryEntity libraryEntity = LibraryEntity.builder()
                 .name(request.getName())
                 .libraryPaths(

--- a/backend/src/main/java/org/booklore/service/metadata/BookMetadataService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookMetadataService.java
@@ -44,7 +44,6 @@ import org.booklore.model.dto.request.IsbnLookupRequest;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -207,7 +206,7 @@ public class BookMetadataService {
                 .peek(book -> book.getMetadata().applyLockToAllFields(lock))
                 .toList();
         bookRepository.saveAll(books);
-        return books.stream().map(b -> bookMetadataMapper.toBookMetadata(b.getMetadata(), false)).collect(Collectors.toList());
+        return books.stream().map(b -> bookMetadataMapper.toBookMetadata(b.getMetadata(), false)).toList();
     }
 
     public BookMetadata getComicInfoMetadata(long bookId) {

--- a/backend/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
@@ -685,7 +685,7 @@ public class MetadataRefreshService {
         List<BookReview> allReviews = metadataMap.values().stream()
                 .filter(Objects::nonNull)
                 .flatMap(md -> Optional.ofNullable(md.getBookReviews()).stream().flatMap(Collection::stream))
-                .collect(Collectors.toList());
+                .toList();
         if (!allReviews.isEmpty()) {
             metadata.setBookReviews(allReviews);
         }

--- a/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -494,7 +494,7 @@ public class ComicvineBookParser implements BookParser, DetailedMetadataProvider
         if (response != null && response.getResults() != null) {
             return response.getResults().stream()
                     .map(comic -> convertToBookMetadata(comic, null))
-                    .collect(Collectors.toList());
+                    .toList();
         }
         return Collections.emptyList();
     }

--- a/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
@@ -200,7 +200,7 @@ public class GoogleParser implements BookParser {
         
         return results.stream()
                 .filter(this::isRelevantResult)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private boolean isRelevantResult(BookMetadata metadata) {
@@ -231,7 +231,7 @@ public class GoogleParser implements BookParser {
         if (googleBooksApiResponse != null && googleBooksApiResponse.getItems() != null) {
             return googleBooksApiResponse.getItems().stream()
                     .map(this::convertToFetchedBookMetadata)
-                    .collect(Collectors.toList());
+                    .toList();
         }
         return List.of();
     }
@@ -619,7 +619,7 @@ public class GoogleParser implements BookParser {
                 .sorted((a, b) -> Integer.compare(
                         countPopulatedFields(b),
                         countPopulatedFields(a)))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private int countPopulatedFields(BookMetadata metadata) {

--- a/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
@@ -171,7 +171,7 @@ public class RanobeDbParser implements BookParser {
         } else {
             return searchResponse.getBooks().stream()
                     .map(book -> searchResultToBookMetadata(book.getId()))
-                    .collect(Collectors.toList());
+                    .toList();
         }
     }
 

--- a/backend/src/main/java/org/booklore/service/opds/OpdsBookService.java
+++ b/backend/src/main/java/org/booklore/service/opds/OpdsBookService.java
@@ -464,7 +464,7 @@ public class OpdsBookService {
         List<BookEntity> orderedEntities = idPage.getContent().stream()
                 .map(bookMap::get)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
 
         if (userId != null) {
             orderedEntities = contentRestrictionService.applyRestrictions(orderedEntities, userId);
@@ -480,7 +480,7 @@ public class OpdsBookService {
     private Page<Book> applyBookFilters(Page<Book> books, Long userId) {
         List<Book> filtered = books.getContent().stream()
                 .map(book -> filterBook(book, userId))
-                .collect(Collectors.toList());
+                .toList();
         return new PageImpl<>(filtered, books.getPageable(), books.getTotalElements());
     }
 

--- a/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -499,7 +499,7 @@ public class ReadingProgressService {
                         .readStatusModifiedTime(existingBookIds.contains(bookId) ? now : null)
                         .dateFinished(null)
                         .build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private BookLoreUserEntity findUserOrThrow(Long userId) {

--- a/backend/src/main/java/org/booklore/service/recommender/BookRecommendationService.java
+++ b/backend/src/main/java/org/booklore/service/recommender/BookRecommendationService.java
@@ -78,7 +78,7 @@ public class BookRecommendationService {
                 })
                 .filter(Objects::nonNull)
                 .limit(limit)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     protected Set<BookRecommendationLite> findSimilarBookIds(Long bookId, int limit) {

--- a/backend/src/main/java/org/booklore/service/recommender/BookVectorService.java
+++ b/backend/src/main/java/org/booklore/service/recommender/BookVectorService.java
@@ -14,7 +14,7 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -143,7 +143,7 @@ public class BookVectorService {
         return candidates.stream()
                 .sorted(Comparator.comparingDouble(ScoredBook::getScore).reversed())
                 .limit(k)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Getter

--- a/backend/src/main/java/org/booklore/service/restriction/ContentRestrictionService.java
+++ b/backend/src/main/java/org/booklore/service/restriction/ContentRestrictionService.java
@@ -32,7 +32,7 @@ public class ContentRestrictionService {
     public List<ContentRestriction> getUserRestrictions(Long userId) {
         return restrictionRepository.findByUserId(userId).stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public ContentRestriction getRestriction(Long restrictionId) {
@@ -75,11 +75,11 @@ public class ContentRestrictionService {
                         .mode(r.getMode())
                         .value(r.getValue())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
 
         return restrictionRepository.saveAll(entities).stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional
@@ -118,7 +118,7 @@ public class ContentRestrictionService {
                 .filter(book -> !hasExcludedContent(book, excludedCategories, excludedTags, excludedMoods, excludedContentRatings))
                 .filter(book -> matchesAllowList(book, allowedCategories, allowedTags, allowedMoods, allowedContentRatings))
                 .filter(book -> isWithinAgeRating(book, maxAgeRating))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Set<String> getValuesForTypeAndMode(List<UserContentRestrictionEntity> restrictions,

--- a/backend/src/main/java/org/booklore/service/task/TaskService.java
+++ b/backend/src/main/java/org/booklore/service/task/TaskService.java
@@ -129,7 +129,7 @@ public class TaskService {
                     }
                     return metadata;
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public void executeCronTask(TaskType taskType) {

--- a/backend/src/main/java/org/booklore/service/user/UserService.java
+++ b/backend/src/main/java/org/booklore/service/user/UserService.java
@@ -26,7 +26,6 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -45,7 +44,7 @@ public class UserService {
         return userRepository.findAllWithDetails()
                 .stream()
                 .map(bookLoreUserTransformer::toDTO)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/org/booklore/task/tasks/BookRecommendationUpdaterTask.java
+++ b/backend/src/main/java/org/booklore/task/tasks/BookRecommendationUpdaterTask.java
@@ -132,7 +132,7 @@ public class BookRecommendationUpdaterTask implements Task {
                             return new BookVectorService.ScoredBook(candidateId, similarity);
                         })
                         .filter(scored -> scored.getScore() > 0.1)
-                        .collect(Collectors.toList());
+                        .toList();
 
                 List<BookVectorService.ScoredBook> topSimilar = vectorService.findTopKSimilar(
                         targetVector,

--- a/backend/src/test/java/org/booklore/service/HibernateRegressionTest.java
+++ b/backend/src/test/java/org/booklore/service/HibernateRegressionTest.java
@@ -585,7 +585,7 @@ class HibernateRegressionTest {
 
             List<String> pathStrings = loaded.getLibraryPaths().stream()
                     .map(LibraryPathEntity::getPath)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertThat(pathStrings).containsExactlyInAnyOrder("/books", "/audiobooks");
         }

--- a/backend/src/test/java/org/booklore/util/builder/LibraryTestBuilderAssert.java
+++ b/backend/src/test/java/org/booklore/util/builder/LibraryTestBuilderAssert.java
@@ -6,7 +6,6 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class LibraryTestBuilderAssert extends AbstractAssert<LibraryTestBuilderAssert, LibraryTestBuilder> {
 
@@ -46,7 +45,7 @@ public class LibraryTestBuilderAssert extends AbstractAssert<LibraryTestBuilderA
                 .filter(a -> !a.equals(book.getPrimaryBookFile()))
                 .map(BookFileEntity::getBookType)
                 .filter(a -> a != null)
-                .collect(Collectors.toList());
+                .toList();
 
         Assertions.assertThat(additionalFormatTypesActual)
                 .describedAs("Book '%s' should have additional formats: %s", bookTitle, additionalFormatTypes)
@@ -90,7 +89,7 @@ public class LibraryTestBuilderAssert extends AbstractAssert<LibraryTestBuilderA
                 .filter(a -> !a.equals(book.getPrimaryBookFile()))
                 .map(BookFileEntity::getBookType)
                 .filter(a -> a != null)
-                .collect(Collectors.toList());
+                .toList();
 
         Assertions.assertThat(additionalFormatTypesActual)
                 .describedAs("Book '%s' should have no additional formats", bookTitle)


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes


This pull request refactors the Java backend to modernize the usage of Java streams throughout the codebase. Specifically, it replaces the older `.collect(Collectors.toList())` pattern with the more concise `.toList()` method available since Java 16. This change simplifies the code, improves readability, and removes unnecessary imports of `Collectors`. No functional changes are introduced, only code cleanup and modernization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized internal list collection across backend components (use of modern stream collection), improving code consistency.
  * Removed numerous unused imports.
  * Changes span controllers, services, mappers, exception handlers, processors, and tests; no user-facing behavior or APIs were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->