### PR TITLE
fix(fileattachment-service): enforce base directory boundary to block path traversal

### DIFF
--- a/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
@@ -125,7 +125,12 @@ public class BookFileAttachmentService {
                 } else {
                     Path sourceLibraryRoot = Paths.get(sourceBook.getLibraryPath().getPath()).toAbsolutePath().normalize();
                     for (BookFileEntity file : bookFormatFiles) {
-                        Path fileDir = sourceLibraryRoot.resolve(file.getFileSubPath()).normalize();
+                        Path subPath = Paths.get(file.getFileSubPath());
+                        if (subPath.isAbsolute()) {
+                            throw ApiError.GENERIC_BAD_REQUEST.createException(
+                                    "Absolute sub-path not allowed for file id " + file.getId());
+                        }
+                        Path fileDir = sourceLibraryRoot.resolve(subPath).normalize();
                         // Derive the relative subpath from the source root, then apply it to the target root.
                         final Path relativeSubPath;
                         try {
@@ -134,11 +139,17 @@ public class BookFileAttachmentService {
                             throw ApiError.GENERIC_BAD_REQUEST.createException(
                                     "Invalid source file sub-path for file id " + file.getId() + ": " + file.getFileSubPath());
                         }
-                        if (relativeSubPath.toString().startsWith("..") || relativeSubPath.isAbsolute()) {
+                        if (relativeSubPath.startsWith("..") || relativeSubPath.isAbsolute()) {
                             throw ApiError.GENERIC_BAD_REQUEST.createException(
-                                    "Disallowed source file sub-path traversal for file id " + file.getId() + ": " + file.getFileSubPath());
+                                    "Disallowed source file sub-path traversal for file id " + file.getId());
                         }
-                        String newSubPath = relativeSubPath.toString();
+                        // Verify resolved path stays within target root
+                        String newSubPath = relativeSubPath.toString().replace('\\', '/');
+                        Path targetFileDir = targetLibraryRoot.resolve(newSubPath).normalize();
+                        if (!targetFileDir.startsWith(targetLibraryRoot)) {
+                            throw ApiError.GENERIC_BAD_REQUEST.createException(
+                                    "Resolved path escapes target library root for file id " + file.getId());
+                        }
                         bookFileRepository.reassignFileToBookWithPath(targetBook.getId(), newSubPath, file.getId());
                     }
                 }

--- a/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
@@ -143,10 +143,22 @@ public class BookFileAttachmentService {
                             throw ApiError.GENERIC_BAD_REQUEST.createException(
                                     "Disallowed source file sub-path traversal for file id " + file.getId());
                         }
-                        // Verify resolved path stays within target root
+                        // Verify the full target file path stays within target root
+                        final Path fileNamePath;
+                        try {
+                            fileNamePath = Paths.get(file.getFileName());
+                        } catch (IllegalArgumentException e) {
+                            throw ApiError.GENERIC_BAD_REQUEST.createException(
+                                    "Invalid source file name for file id " + file.getId());
+                        }
+                        if (fileNamePath.isAbsolute() || fileNamePath.getNameCount() != 1) {
+                            throw ApiError.GENERIC_BAD_REQUEST.createException(
+                                    "Invalid source file name for file id " + file.getId());
+                        }
+
                         String newSubPath = relativeSubPath.toString().replace('\\', '/');
-                        Path targetFileDir = targetLibraryRoot.resolve(newSubPath).normalize();
-                        if (!targetFileDir.startsWith(targetLibraryRoot)) {
+                        Path targetFilePath = targetLibraryRoot.resolve(relativeSubPath).resolve(fileNamePath).normalize();
+                        if (!targetFilePath.startsWith(targetLibraryRoot)) {
                             throw ApiError.GENERIC_BAD_REQUEST.createException(
                                     "Resolved path escapes target library root for file id " + file.getId());
                         }

--- a/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
@@ -126,9 +126,19 @@ public class BookFileAttachmentService {
                     Path sourceLibraryRoot = Paths.get(sourceBook.getLibraryPath().getPath()).toAbsolutePath().normalize();
                     for (BookFileEntity file : bookFormatFiles) {
                         Path fileDir = sourceLibraryRoot.resolve(file.getFileSubPath()).normalize();
-                        String newSubPath = fileDir.equals(targetLibraryRoot)
-                                ? ""
-                                : targetLibraryRoot.relativize(fileDir).toString();
+                        // Derive the relative subpath from the source root, then apply it to the target root.
+                        final Path relativeSubPath;
+                        try {
+                            relativeSubPath = sourceLibraryRoot.relativize(fileDir);
+                        } catch (IllegalArgumentException e) {
+                            throw ApiError.GENERIC_BAD_REQUEST.createException(
+                                    "Invalid source file sub-path for file id " + file.getId() + ": " + file.getFileSubPath());
+                        }
+                        if (relativeSubPath.toString().startsWith("..") || relativeSubPath.isAbsolute()) {
+                            throw ApiError.GENERIC_BAD_REQUEST.createException(
+                                    "Disallowed source file sub-path traversal for file id " + file.getId() + ": " + file.getFileSubPath());
+                        }
+                        String newSubPath = relativeSubPath.toString();
                         bookFileRepository.reassignFileToBookWithPath(targetBook.getId(), newSubPath, file.getId());
                     }
                 }

--- a/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
@@ -156,7 +156,7 @@ public class BookFileAttachmentService {
                                     "Invalid source file name for file id " + file.getId());
                         }
 
-                        String newSubPath = relativeSubPath.toString().replace('\\', '/');
+                        String newSubPath = relativeSubPath.toString();
                         Path targetFilePath = targetLibraryRoot.resolve(relativeSubPath).resolve(fileNamePath).normalize();
                         if (!targetFilePath.startsWith(targetLibraryRoot)) {
                             throw ApiError.GENERIC_BAD_REQUEST.createException(


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

This pull request adds improved validation and error handling for file path operations in the `attachWithoutFileMove` method of `BookFileAttachmentService`. The main focus is to prevent invalid or unsafe file path manipulations when reassigning files between books.

**File path validation and error handling:**

* Improved the derivation of the relative file subpath by explicitly catching `IllegalArgumentException` and throwing an API error with a descriptive message if the source file subpath is invalid.
* Added checks to prevent directory traversal or absolute path issues by ensuring the computed subpath does not start with `..` or is not absolute, throwing an appropriate API error if such a case is detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened file attachment validation: rejects absolute paths and traversal-style targets, enforces single-segment file names, validates relative-path resolution, and ensures the final resolved destination remains inside the chosen library—preventing directory traversal and incorrect placement during cross-library attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->