### PR TITLE
fix(ui): add back the dashboard scroller scrollbar

### DIFF
--- a/frontend/src/app/features/dashboard/components/dashboard-scroller/dashboard-scroller.component.scss
+++ b/frontend/src/app/features/dashboard/components/dashboard-scroller/dashboard-scroller.component.scss
@@ -79,11 +79,7 @@
   width: 100%;
   position: relative;
   z-index: 2;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
+  scrollbar-color: var(--primary-color) rgb(20 20 30 / 50%);
 }
 
 .dashboard-scroller-card {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
for some reason the scrollbar was dropped in #440 - which seems erroneous.

this change adds the scrollbar back so users can more easily scroll without a horizontal scrollwheel or the arrow keys

<img width="1464" height="369" alt="image" src="https://github.com/user-attachments/assets/4689b305-64dd-4e61-97dd-25b20ff0be58" />


Look at that pretty scrollbar.

**Linked Issue:** Fixes #982<!-- issue number leave empty if none -->

## Changes

* drop CSS that explicitly hides scrollbar from the dashboard scroller
* add CSS scroll bar color back to match primary color

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the dashboard scrollbar to be visible with themed colors, improving visibility and navigation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->