### PR TITLE
fix(ui): prevent directory picker folder clicks selecting

### DIFF
--- a/frontend/src/app/shared/components/directory-picker/directory-picker.component.html
+++ b/frontend/src/app/shared/components/directory-picker/directory-picker.component.html
@@ -138,6 +138,12 @@
             <div
               class="directory-item"
               [class.selected]="isFolderSelected(folder)"
+              tabindex="0"
+              role="button"
+              [attr.aria-label]="getFolderName(folder)"
+              (click)="onRowClick(folder)"
+              (keydown.enter)="onRowClick(folder)"
+              (keydown.space)="onRowClick(folder)"
             >
               <div class="directory-checkbox">
                 <p-checkbox
@@ -146,14 +152,11 @@
                   [(ngModel)]="selectedFoldersMap[folder]"
                   (ngModelChange)="onCheckboxChange(folder, $event)"
                   (click)="$event.stopPropagation()"
+                  (keydown.enter)="$event.stopPropagation()"
+                  (keydown.space)="$event.stopPropagation()"
                 />
               </div>
-              <label
-                [for]="'folder-' + folder"
-                class="directory-label"
-                tabindex="0"
-                (click)="onRowClick(folder)"
-                (keydown.enter)="onRowClick(folder)">
+              <div class="directory-label">
                 <div class="directory-icon-wrapper">
                   <i class="pi pi-folder directory-icon"></i>
                 </div>
@@ -162,7 +165,7 @@
                   <span class="directory-path">{{ folder }}</span>
                 </div>
                 <i class="pi pi-chevron-right navigate-icon"></i>
-              </label>
+              </div>
             </div>
           }
         </div>

--- a/frontend/src/app/shared/components/directory-picker/directory-picker.component.scss
+++ b/frontend/src/app/shared/components/directory-picker/directory-picker.component.scss
@@ -370,6 +370,12 @@
     }
   }
 
+  &:focus-visible {
+    outline: none;
+    border-color: var(--primary-color);
+    outline-offset: 0;
+  }
+
   &:hover {
     border-color: var(--primary-color);
     transform: translateY(3px);


### PR DESCRIPTION


## Description

<!-- What does this PR do? -->

clicking the directory picker rows causes the picker to select those rows while entering them.  only clicks on the checkbox should select the folder, clicking the rest of the row should lead to the user entering the folder

this prevents the folder text from activating the checkbox and moves the row selector to the row element - now clicking the checkbox selects, and everything else enters


https://github.com/user-attachments/assets/93cf431a-693e-41a0-be6f-089652faf3ca



**Linked Issue:** Fixes #985 <!-- issue number leave empty if none -->

## Changes

* moves `onRowClick` call to the row itself
* swaps the `label` to a `div` + removes `for` so clicking it doesn't activate the checkbox
* prevents space / enter on checkbox from causing row activation
* adds styling for the row to handle the new selector location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory rows now activate with Enter/Space without duplicate triggers; checkbox keypresses no longer accidentally select the row. Aria labels improved for folder items.

* **Style**
  * Improved keyboard focus styling on folder items with a clear, theme-colored focus ring for better accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->