### PR TITLE
refactor(metadata): add support for refetching metadata with manual input and improve title cleaning logic

### DIFF
--- a/backend/src/main/java/org/booklore/controller/BookdropFileController.java
+++ b/backend/src/main/java/org/booklore/controller/BookdropFileController.java
@@ -1,5 +1,6 @@
 package org.booklore.controller;
 
+import org.booklore.model.dto.BookMetadata;
 import org.booklore.model.dto.BookdropFile;
 import org.booklore.model.dto.BookdropFileNotification;
 import org.booklore.model.dto.request.BookdropBulkEditRequest;
@@ -100,6 +101,17 @@ public class BookdropFileController {
     public ResponseEntity<BookdropBulkEditResult> bulkEditMetadata(
             @Parameter(description = "Bulk edit request") @Valid @RequestBody BookdropBulkEditRequest request) {
         BookdropBulkEditResult result = bookdropBulkEditService.bulkEdit(request);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "Refetch metadata for a bookdrop file", description = "Trigger a metadata refetch for a specific file, optionally with provided ISBN or search data.")
+    @ApiResponse(responseCode = "200", description = "Metadata refetched successfully")
+    @PostMapping("/files/{id}/refetch")
+    @PreAuthorize("@securityUtil.canAccessBookdrop() or @securityUtil.isAdmin()")
+    public ResponseEntity<BookdropFile> refetchMetadata(
+            @Parameter(description = "ID of the bookdrop file") @PathVariable Long id,
+            @Parameter(description = "Optional manual metadata to use for refetching") @RequestBody(required = false) BookMetadata request) {
+        BookdropFile result = bookDropService.refetchMetadata(id, request);
         return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/org/booklore/model/entity/BookdropFileEntity.java
+++ b/backend/src/main/java/org/booklore/model/entity/BookdropFileEntity.java
@@ -36,14 +36,12 @@ public class BookdropFileEntity {
     private Status status = Status.PENDING_REVIEW;
 
     @Lob
-    @Basic(fetch = FetchType.LAZY)
-    @LazyGroup("metadata")
+    @Basic(fetch = FetchType.EAGER)
     @Column(name = "original_metadata", columnDefinition = "JSON")
     private String originalMetadata;
 
     @Lob
-    @Basic(fetch = FetchType.LAZY)
-    @LazyGroup("metadata")
+    @Basic(fetch = FetchType.EAGER)
     @Column(name = "fetched_metadata", columnDefinition = "JSON")
     private String fetchedMetadata;
 

--- a/backend/src/main/java/org/booklore/service/bookdrop/BookDropService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookDropService.java
@@ -40,6 +40,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.ObjectMapper;
 
@@ -62,6 +63,7 @@ import java.util.stream.Stream;
 @Transactional
 public class BookDropService {
 
+    private final BookdropMetadataService bookdropMetadataService;
     private final BookdropFileRepository bookdropFileRepository;
     private final LibraryRepository libraryRepository;
     private final BookRepository bookRepository;
@@ -76,6 +78,11 @@ public class BookDropService {
     private final FileMovingHelper fileMovingHelper;
     private final MonitoringRegistrationService monitoringRegistrationService;
     private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public BookdropFile refetchMetadata(Long id, BookMetadata manualMetadata) {
+        return mapper.toDto(bookdropMetadataService.refetchMetadata(id, manualMetadata));
+    }
 
     private static final int CHUNK_SIZE = 100;
 

--- a/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataPersistenceService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataPersistenceService.java
@@ -1,0 +1,26 @@
+package org.booklore.service.bookdrop;
+
+import lombok.RequiredArgsConstructor;
+import org.booklore.model.entity.BookdropFileEntity;
+import org.booklore.repository.BookdropFileRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class BookdropMetadataPersistenceService {
+
+    private final BookdropFileRepository bookdropFileRepository;
+
+    @Transactional
+    public BookdropFileEntity saveRefetchedMetadata(BookdropFileEntity entity, String fetchedJson, BookdropFileEntity.Status status) {
+        entity.setFetchedMetadata(fetchedJson);
+        if (status != null) {
+            entity.setStatus(status);
+        }
+        entity.setUpdatedAt(Instant.now());
+        return bookdropFileRepository.save(entity);
+    }
+}

--- a/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookdropMetadataService.java
@@ -14,6 +14,7 @@ import org.booklore.repository.BookdropFileRepository;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.service.metadata.MetadataRefreshService;
 import org.booklore.service.metadata.extractor.MetadataExtractorFactory;
+import org.booklore.util.BookUtils;
 import org.booklore.util.FileService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +45,7 @@ public class BookdropMetadataService {
     private final MetadataExtractorFactory metadataExtractorFactory;
     private final MetadataRefreshService metadataRefreshService;
     private final FileService fileService;
+    private final BookdropMetadataPersistenceService persistenceService;
 
     @Transactional
     public BookdropFileEntity attachInitialMetadata(Long bookdropFileId) throws JacksonException {
@@ -64,45 +66,55 @@ public class BookdropMetadataService {
         return bookdropFileRepository.save(entity);
     }
 
-    @Transactional
-    public BookdropFileEntity attachFetchedMetadata(Long bookdropFileId) throws JacksonException {
+
+    public BookdropFileEntity attachFetchedMetadata(Long bookdropFileId) {
         BookdropFileEntity entity = getOrThrow(bookdropFileId);
+        try {
+            BookMetadata initial = objectMapper.readValue(entity.getOriginalMetadata(), BookMetadata.class);
 
-        AppSettings appSettings = appSettingService.getAppSettings();
+            if (!hasSearchableMetadata(initial, entity)) {
+                log.info("Skipping online metadata fetch for '{}' — no reliable search data (title derived from filename, no ISBN or ASIN).", entity.getFileName());
+                return persistenceService.saveRefetchedMetadata(entity, null, PENDING_REVIEW);
+            }
 
-        MetadataRefreshOptions refreshOptions = appSettings.getDefaultMetadataRefreshOptions();
-
-        BookMetadata initial = objectMapper.readValue(entity.getOriginalMetadata(), BookMetadata.class);
-
-        if (!hasSearchableMetadata(initial, entity)) {
-            log.info("Skipping online metadata fetch for '{}' — no reliable search data (title derived from filename, no ISBN or ASIN).", entity.getFileName());
-            entity.setStatus(PENDING_REVIEW);
-            entity.setUpdatedAt(Instant.now());
-            return bookdropFileRepository.save(entity);
+            String fetchedJson = fetchOnlineMetadata(bookdropFileId, initial);
+            return persistenceService.saveRefetchedMetadata(entity, fetchedJson, PENDING_REVIEW);
+        } catch (JacksonException e) {
+            throw new IllegalStateException("Failed to parse/serialize metadata for file " + bookdropFileId, e);
         }
+    }
+
+    public BookdropFileEntity refetchMetadata(Long bookdropFileId, BookMetadata manualMetadata) {
+        BookdropFileEntity entity = getOrThrow(bookdropFileId);
+        try {
+            String fetchedJson = fetchOnlineMetadata(bookdropFileId, manualMetadata);
+            return persistenceService.saveRefetchedMetadata(entity, fetchedJson, null);
+        } catch (JacksonException e) {
+            throw new IllegalStateException("Failed to parse/serialize metadata for file " + bookdropFileId, e);
+        }
+    }
+
+    private String fetchOnlineMetadata(Long bookdropFileId, BookMetadata searchMetadata) throws JacksonException {
+        AppSettings appSettings = appSettingService.getAppSettings();
+        MetadataRefreshOptions refreshOptions = appSettings.getDefaultMetadataRefreshOptions();
 
         List<MetadataProvider> providers = metadataRefreshService.prepareProviders(refreshOptions);
         Book book = Book.builder()
-                .metadata(initial)
+                .metadata(searchMetadata)
                 .build();
 
         if (providers.contains(MetadataProvider.GoodReads)) {
             try {
                 Thread.sleep(ThreadLocalRandom.current().nextLong(250, 1250));
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
         }
 
         Map<MetadataProvider, BookMetadata> metadataMap = metadataRefreshService.fetchMetadataForBook(providers, book);
-        BookMetadata fetchedMetadata = metadataRefreshService.buildFetchMetadata(initial, book.getId(), refreshOptions, metadataMap);
-        String fetchedJson = objectMapper.writeValueAsString(fetchedMetadata);
-
-        entity.setFetchedMetadata(fetchedJson);
-        entity.setStatus(PENDING_REVIEW);
-        entity.setUpdatedAt(Instant.now());
-
-        return bookdropFileRepository.save(entity);
+        BookMetadata fetchedMetadata = metadataRefreshService.buildFetchMetadata(searchMetadata, book.getId(), refreshOptions, metadataMap);
+        return objectMapper.writeValueAsString(fetchedMetadata);
     }
 
     private boolean hasSearchableMetadata(BookMetadata metadata, BookdropFileEntity entity) {
@@ -110,9 +122,20 @@ public class BookdropMetadataService {
             return true;
         }
         String title = metadata.getTitle();
+        if (title == null || title.isBlank()) {
+            return false;
+        }
+
         String filenameFallback = FilenameUtils.getBaseName(entity.getFileName());
-        return title != null && !title.isBlank()
-                && !title.strip().equalsIgnoreCase(filenameFallback.strip());
+        
+        // If title is NOT the same as filename, it's definitely searchable (likely from internal metadata)
+        if (!title.strip().equalsIgnoreCase(filenameFallback.strip())) {
+            return true;
+        }
+
+        // If title matches filename, we only skip if it's "junk" (too short or just generic)
+        String cleanedTitle = BookUtils.cleanFileName(entity.getFileName());
+        return cleanedTitle != null && cleanedTitle.length() >= 3;
     }
 
     private boolean hasAnyKnownIdentifier(BookMetadata m) {

--- a/backend/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
@@ -38,9 +38,11 @@ import tools.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.booklore.model.enums.MetadataProvider.*;
 
@@ -228,15 +230,7 @@ public class MetadataRefreshService {
     }
 
     public Map<MetadataProvider, BookMetadata> fetchMetadataForBook(List<MetadataProvider> providers, BookEntity bookEntity) {
-        Book book = bookMapper.toBook(bookEntity);
-        return providers.stream()
-                .map(provider -> fetchTopMetadataFromAProvider(provider, book))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toMap(
-                        BookMetadata::getProvider,
-                        metadata -> metadata,
-                        (existing, replacement) -> existing
-                ));
+        return fetchMetadataForBook(providers, bookMapper.toBook(bookEntity));
     }
 
     private void reportProgressIfNeeded(MetadataFetchJobEntity task, String taskId, int completedCount, int total, BookEntity book, boolean isReviewMode) {
@@ -335,38 +329,20 @@ public class MetadataRefreshService {
         Set<MetadataProvider> uniqueProviders = EnumSet.noneOf(MetadataProvider.class);
 
         if (fieldOptions != null) {
-            addProviderToSet(fieldOptions.getTitle(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getSubtitle(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getDescription(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getAuthors(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getPublisher(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getPublishedDate(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getSeriesName(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getSeriesNumber(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getSeriesTotal(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getIsbn13(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getIsbn10(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getLanguage(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getCategories(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getCover(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getPageCount(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getAsin(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getGoodreadsId(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getComicvineId(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getHardcoverId(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getGoogleId(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getLubimyczytacId(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getAmazonRating(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getAmazonReviewCount(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getGoodreadsRating(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getGoodreadsReviewCount(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getHardcoverRating(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getHardcoverReviewCount(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getLubimyczytacRating(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getRanobedbId(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getRanobedbRating(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getMoods(), uniqueProviders, appSettings);
-            addProviderToSet(fieldOptions.getTags(), uniqueProviders, appSettings);
+            Stream.of(
+                    fieldOptions.getTitle(), fieldOptions.getSubtitle(), fieldOptions.getDescription(),
+                    fieldOptions.getAuthors(), fieldOptions.getPublisher(), fieldOptions.getPublishedDate(),
+                    fieldOptions.getSeriesName(), fieldOptions.getSeriesNumber(), fieldOptions.getSeriesTotal(),
+                    fieldOptions.getIsbn13(), fieldOptions.getIsbn10(), fieldOptions.getLanguage(),
+                    fieldOptions.getCategories(), fieldOptions.getCover(), fieldOptions.getPageCount(),
+                    fieldOptions.getAsin(), fieldOptions.getGoodreadsId(), fieldOptions.getComicvineId(),
+                    fieldOptions.getHardcoverId(), fieldOptions.getGoogleId(), fieldOptions.getLubimyczytacId(),
+                    fieldOptions.getAmazonRating(), fieldOptions.getAmazonReviewCount(),
+                    fieldOptions.getGoodreadsRating(), fieldOptions.getGoodreadsReviewCount(),
+                    fieldOptions.getHardcoverRating(), fieldOptions.getHardcoverReviewCount(),
+                    fieldOptions.getLubimyczytacRating(), fieldOptions.getRanobedbId(),
+                    fieldOptions.getRanobedbRating(), fieldOptions.getMoods(), fieldOptions.getTags()
+            ).filter(Objects::nonNull).forEach(p -> addProviderToSet(p, uniqueProviders, appSettings));
         }
 
         return uniqueProviders;
@@ -374,10 +350,9 @@ public class MetadataRefreshService {
 
     protected void addProviderToSet(MetadataRefreshOptions.FieldProvider fieldProvider, Set<MetadataProvider> providerSet, AppSettings appSettings) {
         if (fieldProvider != null) {
-            if (fieldProvider.getP1() != null && isProviderEnabled(fieldProvider.getP1(), appSettings)) providerSet.add(fieldProvider.getP1());
-            if (fieldProvider.getP2() != null && isProviderEnabled(fieldProvider.getP2(), appSettings)) providerSet.add(fieldProvider.getP2());
-            if (fieldProvider.getP3() != null && isProviderEnabled(fieldProvider.getP3(), appSettings)) providerSet.add(fieldProvider.getP3());
-            if (fieldProvider.getP4() != null && isProviderEnabled(fieldProvider.getP4(), appSettings)) providerSet.add(fieldProvider.getP4());
+            Stream.of(fieldProvider.getP1(), fieldProvider.getP2(), fieldProvider.getP3(), fieldProvider.getP4())
+                    .filter(p -> p != null && isProviderEnabled(p, appSettings))
+                    .forEach(providerSet::add);
         }
     }
 
@@ -427,7 +402,7 @@ public class MetadataRefreshService {
                 .isbn(isbn)
                 .asin(metadata.getAsin())
                 .author(metadata.getAuthors() != null ? BookUtils.cleanSearchTerm(String.join(", ", metadata.getAuthors())) : null)
-                .title(BookUtils.cleanSearchTerm(metadata.getTitle()))
+                .title(metadata.getTitle() != null ? BookUtils.cleanSearchTerm(metadata.getTitle()) : null)
                 .bookId(book.getId())
                 .build();
     }
@@ -448,151 +423,29 @@ public class MetadataRefreshService {
         MetadataReplaceMode replaceMode = refreshOptions.getReplaceMode();
         boolean isReplaceAll = replaceMode == MetadataReplaceMode.REPLACE_ALL;
 
-        if (enabledFields.isTitle()) {
-            metadata.setTitle(resolveFieldAsString(metadataMap, fieldOptions.getTitle(), BookMetadata::getTitle));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setTitle(existingMetadata.getTitle());
-        }
-        
-        if (enabledFields.isSubtitle()) {
-            metadata.setSubtitle(resolveFieldAsString(metadataMap, fieldOptions.getSubtitle(), BookMetadata::getSubtitle));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setSubtitle(existingMetadata.getSubtitle());
-        }
-        
-        if (enabledFields.isDescription()) {
-            metadata.setDescription(resolveFieldAsString(metadataMap, fieldOptions.getDescription(), BookMetadata::getDescription));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setDescription(existingMetadata.getDescription());
-        }
-        
-        if (enabledFields.isAuthors()) {
-            metadata.setAuthors(resolveFieldAsList(metadataMap, fieldOptions.getAuthors(), BookMetadata::getAuthors));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setAuthors(existingMetadata.getAuthors());
-        }
-        
-        if (enabledFields.isPublisher()) {
-            metadata.setPublisher(resolveFieldAsString(metadataMap, fieldOptions.getPublisher(), BookMetadata::getPublisher));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setPublisher(existingMetadata.getPublisher());
-        }
-        
-        if (enabledFields.isPublishedDate()) {
-            metadata.setPublishedDate(resolveField(metadataMap, fieldOptions.getPublishedDate(), BookMetadata::getPublishedDate));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setPublishedDate(existingMetadata.getPublishedDate());
-        }
-        
-        if (enabledFields.isSeriesName()) {
-            metadata.setSeriesName(resolveFieldAsString(metadataMap, fieldOptions.getSeriesName(), BookMetadata::getSeriesName));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setSeriesName(existingMetadata.getSeriesName());
-        }
-        
-        if (enabledFields.isSeriesNumber()) {
-            metadata.setSeriesNumber(resolveField(metadataMap, fieldOptions.getSeriesNumber(), BookMetadata::getSeriesNumber));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setSeriesNumber(existingMetadata.getSeriesNumber());
-        }
-        
-        if (enabledFields.isSeriesTotal()) {
-            metadata.setSeriesTotal(resolveFieldAsInteger(metadataMap, fieldOptions.getSeriesTotal(), BookMetadata::getSeriesTotal));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setSeriesTotal(existingMetadata.getSeriesTotal());
-        }
-        
-        if (enabledFields.isIsbn13()) {
-            metadata.setIsbn13(resolveFieldAsString(metadataMap, fieldOptions.getIsbn13(), BookMetadata::getIsbn13));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setIsbn13(existingMetadata.getIsbn13());
-        }
-        
-        if (enabledFields.isIsbn10()) {
-            metadata.setIsbn10(resolveFieldAsString(metadataMap, fieldOptions.getIsbn10(), BookMetadata::getIsbn10));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setIsbn10(existingMetadata.getIsbn10());
-        }
-        
-        if (enabledFields.isLanguage()) {
-            metadata.setLanguage(resolveFieldAsString(metadataMap, fieldOptions.getLanguage(), BookMetadata::getLanguage));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setLanguage(existingMetadata.getLanguage());
-        }
-        
-        if (enabledFields.isPageCount()) {
-            metadata.setPageCount(resolveFieldAsInteger(metadataMap, fieldOptions.getPageCount(), BookMetadata::getPageCount));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setPageCount(existingMetadata.getPageCount());
-        }
-        
-        if (enabledFields.isCover()) {
-            metadata.setThumbnailUrl(resolveFieldAsString(metadataMap, fieldOptions.getCover(), BookMetadata::getThumbnailUrl));
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setThumbnailUrl(existingMetadata.getThumbnailUrl());
-        }
-        if (enabledFields.isAmazonRating()) {
-            if (metadataMap.containsKey(Amazon)) {
-                metadata.setAmazonRating(metadataMap.get(Amazon).getAmazonRating());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setAmazonRating(existingMetadata.getAmazonRating());
-        }
+        applyField(enabledFields.isTitle(), resolveFieldAsString(metadataMap, fieldOptions.getTitle(), BookMetadata::getTitle), metadata::setTitle, isReplaceAll, existingMetadata != null ? existingMetadata.getTitle() : null);
+        applyField(enabledFields.isSubtitle(), resolveFieldAsString(metadataMap, fieldOptions.getSubtitle(), BookMetadata::getSubtitle), metadata::setSubtitle, isReplaceAll, existingMetadata != null ? existingMetadata.getSubtitle() : null);
+        applyField(enabledFields.isDescription(), resolveFieldAsString(metadataMap, fieldOptions.getDescription(), BookMetadata::getDescription), metadata::setDescription, isReplaceAll, existingMetadata != null ? existingMetadata.getDescription() : null);
+        applyField(enabledFields.isAuthors(), resolveFieldAsList(metadataMap, fieldOptions.getAuthors(), BookMetadata::getAuthors), metadata::setAuthors, isReplaceAll, existingMetadata != null ? existingMetadata.getAuthors() : null);
+        applyField(enabledFields.isPublisher(), resolveFieldAsString(metadataMap, fieldOptions.getPublisher(), BookMetadata::getPublisher), metadata::setPublisher, isReplaceAll, existingMetadata != null ? existingMetadata.getPublisher() : null);
+        applyField(enabledFields.isPublishedDate(), resolveField(metadataMap, fieldOptions.getPublishedDate(), BookMetadata::getPublishedDate), metadata::setPublishedDate, isReplaceAll, existingMetadata != null ? existingMetadata.getPublishedDate() : null);
+        applyField(enabledFields.isSeriesName(), resolveFieldAsString(metadataMap, fieldOptions.getSeriesName(), BookMetadata::getSeriesName), metadata::setSeriesName, isReplaceAll, existingMetadata != null ? existingMetadata.getSeriesName() : null);
+        applyField(enabledFields.isSeriesNumber(), resolveField(metadataMap, fieldOptions.getSeriesNumber(), BookMetadata::getSeriesNumber), metadata::setSeriesNumber, isReplaceAll, existingMetadata != null ? existingMetadata.getSeriesNumber() : null);
+        applyField(enabledFields.isSeriesTotal(), resolveFieldAsInteger(metadataMap, fieldOptions.getSeriesTotal(), BookMetadata::getSeriesTotal), metadata::setSeriesTotal, isReplaceAll, existingMetadata != null ? existingMetadata.getSeriesTotal() : null);
+        applyField(enabledFields.isIsbn13(), resolveFieldAsString(metadataMap, fieldOptions.getIsbn13(), BookMetadata::getIsbn13), metadata::setIsbn13, isReplaceAll, existingMetadata != null ? existingMetadata.getIsbn13() : null);
+        applyField(enabledFields.isIsbn10(), resolveFieldAsString(metadataMap, fieldOptions.getIsbn10(), BookMetadata::getIsbn10), metadata::setIsbn10, isReplaceAll, existingMetadata != null ? existingMetadata.getIsbn10() : null);
+        applyField(enabledFields.isLanguage(), resolveFieldAsString(metadataMap, fieldOptions.getLanguage(), BookMetadata::getLanguage), metadata::setLanguage, isReplaceAll, existingMetadata != null ? existingMetadata.getLanguage() : null);
+        applyField(enabledFields.isPageCount(), resolveFieldAsInteger(metadataMap, fieldOptions.getPageCount(), BookMetadata::getPageCount), metadata::setPageCount, isReplaceAll, existingMetadata != null ? existingMetadata.getPageCount() : null);
+        applyField(enabledFields.isCover(), resolveFieldAsString(metadataMap, fieldOptions.getCover(), BookMetadata::getThumbnailUrl), metadata::setThumbnailUrl, isReplaceAll, existingMetadata != null ? existingMetadata.getThumbnailUrl() : null);
 
-        if (enabledFields.isAmazonReviewCount()) {
-            if (metadataMap.containsKey(Amazon)) {
-                metadata.setAmazonReviewCount(metadataMap.get(Amazon).getAmazonReviewCount());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setAmazonReviewCount(existingMetadata.getAmazonReviewCount());
-        }
-
-        if (enabledFields.isGoodreadsRating()) {
-            if (metadataMap.containsKey(GoodReads)) {
-                metadata.setGoodreadsRating(metadataMap.get(GoodReads).getGoodreadsRating());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setGoodreadsRating(existingMetadata.getGoodreadsRating());
-        }
-
-        if (enabledFields.isGoodreadsReviewCount()) {
-            if (metadataMap.containsKey(GoodReads)) {
-                metadata.setGoodreadsReviewCount(metadataMap.get(GoodReads).getGoodreadsReviewCount());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setGoodreadsReviewCount(existingMetadata.getGoodreadsReviewCount());
-        }
-
-        if (enabledFields.isHardcoverRating()) {
-            if (metadataMap.containsKey(Hardcover)) {
-                metadata.setHardcoverRating(metadataMap.get(Hardcover).getHardcoverRating());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setHardcoverRating(existingMetadata.getHardcoverRating());
-        }
-
-        if (enabledFields.isHardcoverReviewCount()) {
-            if (metadataMap.containsKey(Hardcover)) {
-                metadata.setHardcoverReviewCount(metadataMap.get(Hardcover).getHardcoverReviewCount());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setHardcoverReviewCount(existingMetadata.getHardcoverReviewCount());
-        }
-
-        if (enabledFields.isAsin()) {
-            if (metadataMap.containsKey(Amazon)) {
-                metadata.setAsin(metadataMap.get(Amazon).getAsin());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setAsin(existingMetadata.getAsin());
-        }
-        if (enabledFields.isGoodreadsId()) {
-            if (metadataMap.containsKey(GoodReads)) {
-                metadata.setGoodreadsId(metadataMap.get(GoodReads).getGoodreadsId());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setGoodreadsId(existingMetadata.getGoodreadsId());
-        }
+        applyField(enabledFields.isAmazonRating(), metadataMap.containsKey(Amazon) ? metadataMap.get(Amazon).getAmazonRating() : null, metadata::setAmazonRating, isReplaceAll, existingMetadata != null ? existingMetadata.getAmazonRating() : null);
+        applyField(enabledFields.isAmazonReviewCount(), metadataMap.containsKey(Amazon) ? metadataMap.get(Amazon).getAmazonReviewCount() : null, metadata::setAmazonReviewCount, isReplaceAll, existingMetadata != null ? existingMetadata.getAmazonReviewCount() : null);
+        applyField(enabledFields.isGoodreadsRating(), metadataMap.containsKey(GoodReads) ? metadataMap.get(GoodReads).getGoodreadsRating() : null, metadata::setGoodreadsRating, isReplaceAll, existingMetadata != null ? existingMetadata.getGoodreadsRating() : null);
+        applyField(enabledFields.isGoodreadsReviewCount(), metadataMap.containsKey(GoodReads) ? metadataMap.get(GoodReads).getGoodreadsReviewCount() : null, metadata::setGoodreadsReviewCount, isReplaceAll, existingMetadata != null ? existingMetadata.getGoodreadsReviewCount() : null);
+        applyField(enabledFields.isHardcoverRating(), metadataMap.containsKey(Hardcover) ? metadataMap.get(Hardcover).getHardcoverRating() : null, metadata::setHardcoverRating, isReplaceAll, existingMetadata != null ? existingMetadata.getHardcoverRating() : null);
+        applyField(enabledFields.isHardcoverReviewCount(), metadataMap.containsKey(Hardcover) ? metadataMap.get(Hardcover).getHardcoverReviewCount() : null, metadata::setHardcoverReviewCount, isReplaceAll, existingMetadata != null ? existingMetadata.getHardcoverReviewCount() : null);
+        applyField(enabledFields.isAsin(), metadataMap.containsKey(Amazon) ? metadataMap.get(Amazon).getAsin() : null, metadata::setAsin, isReplaceAll, existingMetadata != null ? existingMetadata.getAsin() : null);
+        applyField(enabledFields.isGoodreadsId(), metadataMap.containsKey(GoodReads) ? metadataMap.get(GoodReads).getGoodreadsId() : null, metadata::setGoodreadsId, isReplaceAll, existingMetadata != null ? existingMetadata.getGoodreadsId() : null);
 
         if (enabledFields.isHardcoverId()) {
             if (metadataMap.containsKey(Hardcover)) {
@@ -604,73 +457,19 @@ public class MetadataRefreshService {
             metadata.setHardcoverBookId(existingMetadata.getHardcoverBookId());
         }
 
-        if (enabledFields.isGoogleId()) {
-            if (metadataMap.containsKey(Google)) {
-                metadata.setGoogleId(metadataMap.get(Google).getGoogleId());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setGoogleId(existingMetadata.getGoogleId());
-        }
-
-        if (enabledFields.isComicvineId()) {
-            if (metadataMap.containsKey(Comicvine)) {
-                metadata.setComicvineId(metadataMap.get(Comicvine).getComicvineId());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setComicvineId(existingMetadata.getComicvineId());
-        }
+        applyField(enabledFields.isGoogleId(), metadataMap.containsKey(Google) ? metadataMap.get(Google).getGoogleId() : null, metadata::setGoogleId, isReplaceAll, existingMetadata != null ? existingMetadata.getGoogleId() : null);
+        applyField(enabledFields.isComicvineId(), metadataMap.containsKey(Comicvine) ? metadataMap.get(Comicvine).getComicvineId() : null, metadata::setComicvineId, isReplaceAll, existingMetadata != null ? existingMetadata.getComicvineId() : null);
 
         if (metadataMap.containsKey(Comicvine) && metadataMap.get(Comicvine).getComicMetadata() != null) {
             metadata.setComicMetadata(metadataMap.get(Comicvine).getComicMetadata());
         }
 
-        if (enabledFields.isLubimyczytacId()) {
-            if (metadataMap.containsKey(Lubimyczytac)) {
-                metadata.setLubimyczytacId(metadataMap.get(Lubimyczytac).getLubimyczytacId());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setLubimyczytacId(existingMetadata.getLubimyczytacId());
-        }
-
-        if (enabledFields.isLubimyczytacRating()) {
-            if (metadataMap.containsKey(Lubimyczytac)) {
-                metadata.setLubimyczytacRating(metadataMap.get(Lubimyczytac).getLubimyczytacRating());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setLubimyczytacRating(existingMetadata.getLubimyczytacRating());
-        }
-
-        if (enabledFields.isRanobedbId()) {
-            if (metadataMap.containsKey(Ranobedb)) {
-                metadata.setRanobedbId(metadataMap.get(Ranobedb).getRanobedbId());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setRanobedbId(existingMetadata.getRanobedbId());
-        }
-
-        if (enabledFields.isRanobedbRating()) {
-            if (metadataMap.containsKey(Ranobedb)) {
-                metadata.setRanobedbRating(metadataMap.get(Ranobedb).getRanobedbRating());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setRanobedbRating(existingMetadata.getRanobedbRating());
-        }
-
-        if (enabledFields.isMoods()) {
-            if (metadataMap.containsKey(Hardcover)) {
-                metadata.setMoods(metadataMap.get(Hardcover).getMoods());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setMoods(existingMetadata.getMoods());
-        }
-
-        if (enabledFields.isTags()) {
-            if (metadataMap.containsKey(Hardcover)) {
-                metadata.setTags(metadataMap.get(Hardcover).getTags());
-            }
-        } else if (isReplaceAll && existingMetadata != null) {
-            metadata.setTags(existingMetadata.getTags());
-        }
+        applyField(enabledFields.isLubimyczytacId(), metadataMap.containsKey(Lubimyczytac) ? metadataMap.get(Lubimyczytac).getLubimyczytacId() : null, metadata::setLubimyczytacId, isReplaceAll, existingMetadata != null ? existingMetadata.getLubimyczytacId() : null);
+        applyField(enabledFields.isLubimyczytacRating(), metadataMap.containsKey(Lubimyczytac) ? metadataMap.get(Lubimyczytac).getLubimyczytacRating() : null, metadata::setLubimyczytacRating, isReplaceAll, existingMetadata != null ? existingMetadata.getLubimyczytacRating() : null);
+        applyField(enabledFields.isRanobedbId(), metadataMap.containsKey(Ranobedb) ? metadataMap.get(Ranobedb).getRanobedbId() : null, metadata::setRanobedbId, isReplaceAll, existingMetadata != null ? existingMetadata.getRanobedbId() : null);
+        applyField(enabledFields.isRanobedbRating(), metadataMap.containsKey(Ranobedb) ? metadataMap.get(Ranobedb).getRanobedbRating() : null, metadata::setRanobedbRating, isReplaceAll, existingMetadata != null ? existingMetadata.getRanobedbRating() : null);
+        applyField(enabledFields.isMoods(), metadataMap.containsKey(Hardcover) ? metadataMap.get(Hardcover).getMoods() : null, metadata::setMoods, isReplaceAll, existingMetadata != null ? existingMetadata.getMoods() : null);
+        applyField(enabledFields.isTags(), metadataMap.containsKey(Hardcover) ? metadataMap.get(Hardcover).getTags() : null, metadata::setTags, isReplaceAll, existingMetadata != null ? existingMetadata.getTags() : null);
 
         if (enabledFields.isCategories()) {
             if (refreshOptions.isMergeCategories()) {
@@ -761,6 +560,14 @@ public class MetadataRefreshService {
         }
 
         return metadata;
+    }
+
+    private <T> void applyField(boolean isEnabled, T fetchedValue, Consumer<T> setter, boolean isReplaceAll, T existingValue) {
+        if (isEnabled) {
+            setter.accept(fetchedValue);
+        } else if (isReplaceAll) {
+            setter.accept(existingValue);
+        }
     }
 
     protected <T > T resolveField(Map < MetadataProvider, BookMetadata > metadataMap, MetadataRefreshOptions.FieldProvider fieldProvider, Function < BookMetadata, T > extractor) {

--- a/backend/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
@@ -426,8 +426,8 @@ public class MetadataRefreshService {
         return FetchMetadataRequest.builder()
                 .isbn(isbn)
                 .asin(metadata.getAsin())
-                .author(metadata.getAuthors() != null ? String.join(", ", metadata.getAuthors()) : null)
-                .title(metadata.getTitle())
+                .author(metadata.getAuthors() != null ? BookUtils.cleanSearchTerm(String.join(", ", metadata.getAuthors())) : null)
+                .title(BookUtils.cleanSearchTerm(metadata.getTitle()))
                 .bookId(book.getId())
                 .build();
     }

--- a/backend/src/main/java/org/booklore/util/BookUtils.java
+++ b/backend/src/main/java/org/booklore/util/BookUtils.java
@@ -24,6 +24,7 @@ public class BookUtils {
     private static final Pattern SPECIAL_CHARACTERS_PATTERN = Pattern.compile("[!@$%^&*_=|~`<>?/\"]");
     private static final Pattern DIACRITICAL_MARKS_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
     private static final Pattern PARENTHESIS_PATTERN = Pattern.compile("\\s?\\([^()]*\\)");
+    private static final Pattern BRACKET_PATTERN = Pattern.compile("\\s?\\[[^\\]]*\\]");
 
     public static String buildSearchText(BookMetadataEntity e) {
         if (e == null) return null;
@@ -93,6 +94,15 @@ public class BookUtils {
             return "";
         }
         String s = term;
+        
+        // Remove content in parentheses and brackets first
+        String previous;
+        do {
+            previous = s;
+            s = PARENTHESIS_PATTERN.matcher(s).replaceAll("").trim();
+            s = BRACKET_PATTERN.matcher(s).replaceAll("").trim();
+        } while (!s.equals(previous));
+
         s = SPECIAL_CHARACTERS_PATTERN.matcher(s).replaceAll("").trim();
         s = WHITESPACE_PATTERN.matcher(s).replaceAll(" ");
         return s;

--- a/backend/src/main/java/org/booklore/util/BookUtils.java
+++ b/backend/src/main/java/org/booklore/util/BookUtils.java
@@ -23,8 +23,6 @@ public class BookUtils {
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
     private static final Pattern SPECIAL_CHARACTERS_PATTERN = Pattern.compile("[!@$%^&*_=|~`<>?/\"]");
     private static final Pattern DIACRITICAL_MARKS_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
-    private static final Pattern PARENTHESIS_PATTERN = Pattern.compile("\\s?\\([^()]*\\)");
-    private static final Pattern BRACKET_PATTERN = Pattern.compile("\\s?\\[[^\\]]*\\]");
 
     public static String buildSearchText(BookMetadataEntity e) {
         if (e == null) return null;
@@ -67,45 +65,46 @@ public class BookUtils {
     }
 
     public static String cleanFileName(String fileName) {
-        String name = fileName;
-        if (name == null) {
+        if (fileName == null) {
             return null;
         }
-        name = name.replace("(Z-Library)", "").trim();
-        
-        String previous;
-        do {
-            previous = name;
-            name = PARENTHESIS_PATTERN.matcher(name).replaceAll("").trim();
-        } while (!name.equals(previous));
-        
-        int dotIndex = name.lastIndexOf('.'); // Remove the file extension (e.g., .pdf, .docx)
+        String name = fileName.replace("(Z-Library)", "").trim();
+        name = stripNestedPairs(name, '(', ')');
+        name = stripNestedPairs(name, '[', ']');
+
+        int dotIndex = name.lastIndexOf('.');
         if (dotIndex > 0) {
             name = name.substring(0, dotIndex).trim();
         }
-        
-        name = WHITESPACE_PATTERN.matcher(name).replaceAll(" ").trim();
-        
-        return name;
+
+        return WHITESPACE_PATTERN.matcher(name).replaceAll(" ").trim();
     }
 
     public static String cleanSearchTerm(String term) {
         if (term == null) {
             return "";
         }
-        String s = term;
-        
-        // Remove content in parentheses and brackets first
-        String previous;
-        do {
-            previous = s;
-            s = PARENTHESIS_PATTERN.matcher(s).replaceAll("").trim();
-            s = BRACKET_PATTERN.matcher(s).replaceAll("").trim();
-        } while (!s.equals(previous));
-
-        s = SPECIAL_CHARACTERS_PATTERN.matcher(s).replaceAll("").trim();
+        String s = SPECIAL_CHARACTERS_PATTERN.matcher(term).replaceAll("").trim();
         s = WHITESPACE_PATTERN.matcher(s).replaceAll(" ");
         return s;
+    }
+
+    private static String stripNestedPairs(String input, char open, char close) {
+        StringBuilder result = new StringBuilder();
+        int depth = 0;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == open) {
+                depth++;
+            } else if (c == close) {
+                if (depth > 0) {
+                    depth--;
+                }
+            } else if (depth == 0) {
+                result.append(c);
+            }
+        }
+        return result.toString().trim();
     }
 
     public static String cleanAndTruncateSearchTerm(String term) {

--- a/backend/src/main/java/org/booklore/util/BookUtils.java
+++ b/backend/src/main/java/org/booklore/util/BookUtils.java
@@ -90,7 +90,23 @@ public class BookUtils {
     }
 
     private static String stripNestedPairs(String input, char open, char close) {
-        StringBuilder result = new StringBuilder();
+        int balance = 0;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == open) {
+                balance++;
+            } else if (c == close) {
+                if (balance == 0) {
+                    return input.trim();
+                }
+                balance--;
+            }
+        }
+        if (balance != 0) {
+            return input.trim();
+        }
+
+        StringBuilder result = new StringBuilder(input.length());
         int depth = 0;
         for (int i = 0; i < input.length(); i++) {
             char c = input.charAt(i);

--- a/backend/src/test/java/org/booklore/service/BookdropMetadataServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/BookdropMetadataServiceTest.java
@@ -10,6 +10,7 @@ import org.booklore.model.enums.MetadataProvider;
 import org.booklore.repository.BookdropFileRepository;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.service.bookdrop.BookdropMetadataService;
+import org.booklore.service.bookdrop.BookdropMetadataPersistenceService;
 import org.booklore.service.metadata.MetadataRefreshService;
 import org.booklore.service.metadata.extractor.CbxMetadataExtractor;
 import org.booklore.service.metadata.extractor.EpubMetadataExtractor;
@@ -58,6 +59,8 @@ class BookdropMetadataServiceTest {
     private FileService fileService;
     @Mock
     private MetadataExtractorFactory metadataExtractorFactory;
+    @Mock
+    private BookdropMetadataPersistenceService persistenceService;
 
     @InjectMocks
     private BookdropMetadataService bookdropMetadataService;
@@ -102,7 +105,6 @@ class BookdropMetadataServiceTest {
         AppSettings settings = new AppSettings();
         BookMetadata fetched = BookMetadata.builder().title("New Title").build();
 
-        when(bookdropFileRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(bookdropFileRepository.findById(1L)).thenReturn(Optional.of(sampleFile));
         when(appSettingService.getAppSettings()).thenReturn(settings);
         when(metadataRefreshService.prepareProviders(any())).thenReturn(List.of());
@@ -110,12 +112,16 @@ class BookdropMetadataServiceTest {
         when(metadataRefreshService.fetchMetadataForBook(any(), any(Book.class))).thenReturn(Map.of());
         when(metadataRefreshService.buildFetchMetadata(any(), any(), any(), any())).thenReturn(fetched);
         when(objectMapper.writeValueAsString(fetched)).thenReturn("{\"title\":\"New Title\"}");
+        when(persistenceService.saveRefetchedMetadata(any(), any(), any())).thenAnswer(invocation -> {
+            BookdropFileEntity e = invocation.getArgument(0);
+            e.setFetchedMetadata(invocation.getArgument(1));
+            return e;
+        });
 
         BookdropFileEntity result = bookdropMetadataService.attachFetchedMetadata(1L);
 
         assertThat(result.getFetchedMetadata()).contains("New Title");
         assertThat(result.getStatus()).isEqualTo(PENDING_REVIEW);
-        verify(bookdropFileRepository).save(result);
     }
 
     @Test
@@ -200,13 +206,16 @@ class BookdropMetadataServiceTest {
         when(metadataRefreshService.fetchMetadataForBook(any(), any(Book.class))).thenReturn(Map.of());
         when(metadataRefreshService.buildFetchMetadata(any(), any(), any(), any())).thenReturn(fetched);
         when(objectMapper.writeValueAsString(fetched)).thenReturn("{\"title\":\"Fetched Book\"}");
-        when(bookdropFileRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(persistenceService.saveRefetchedMetadata(any(), any(), any())).thenAnswer(invocation -> {
+            BookdropFileEntity e = invocation.getArgument(0);
+            e.setFetchedMetadata(invocation.getArgument(1));
+            return e;
+        });
 
         BookdropFileEntity result = bookdropMetadataService.attachFetchedMetadata(1L);
 
         assertThat(result.getFetchedMetadata()).contains("Fetched Book");
         assertThat(result.getStatus()).isEqualTo(PENDING_REVIEW);
-        verify(bookdropFileRepository).save(result);
     }
 
     @Test
@@ -214,12 +223,12 @@ class BookdropMetadataServiceTest {
         sampleFile.setOriginalMetadata("{invalidJson}");
 
         when(bookdropFileRepository.findById(1L)).thenReturn(Optional.of(sampleFile));
-        when(appSettingService.getAppSettings()).thenReturn(new AppSettings());
         when(objectMapper.readValue(anyString(), eq(BookMetadata.class)))
                 .thenThrow(new JacksonException("Invalid JSON") {
                 });
 
         assertThatThrownBy(() -> bookdropMetadataService.attachFetchedMetadata(1L))
-                .isInstanceOf(JacksonException.class);
+                .isInstanceOf(IllegalStateException.class)
+                .hasCauseInstanceOf(JacksonException.class);
     }
 }

--- a/backend/src/test/java/org/booklore/util/BookUtilsTest.java
+++ b/backend/src/test/java/org/booklore/util/BookUtilsTest.java
@@ -460,4 +460,18 @@ class BookUtilsTest {
         assertEquals("francois", BookUtils.normalizeForSearch("François"));
         assertEquals("francois", BookUtils.normalizeForSearch("FRANÇOIS"));
     }
+    @Test
+    void testCleanFileName_withUnbalancedDelimiters() {
+        // Unclosed parenthesis - should return the trimmed input minus extension
+        assertEquals("Book (Author", BookUtils.cleanFileName("Book (Author.pdf"));
+
+        // Unopened parenthesis - should return the trimmed input minus extension
+        assertEquals("Book Author)", BookUtils.cleanFileName("Book Author).pdf"));
+
+        // Unclosed bracket - should return the trimmed input minus extension
+        assertEquals("Book [Series", BookUtils.cleanFileName("Book [Series.epub"));
+
+        // Unopened bracket - should return the trimmed input minus extension
+        assertEquals("Book Series]", BookUtils.cleanFileName("Book Series].epub"));
+    }
 }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
@@ -173,9 +173,9 @@
   @if (isComparison) {
     <p-button
       size="small"
-      [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || fetchedMetadata[field.fetchedKey] == null ? 'pi pi-refresh' : 'pi pi-angle-left')"
+      [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || fetchedMetadata[field.fetchedKey] === null || fetchedMetadata[field.fetchedKey] === undefined ? 'pi pi-refresh' : 'pi pi-angle-left')"
       [outlined]="true"
-      [ngClass]="{ 'nosrc' : fetchedMetadata[field.fetchedKey] == null }"
+      [ngClass]="{ 'nosrc' : fetchedMetadata[field.fetchedKey] === null || fetchedMetadata[field.fetchedKey] === undefined }"
       class="arrow-button"
       [severity]="isValueChanged(field.controlName) ? 'warn' : null"
       [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
@@ -203,7 +203,7 @@
       
       <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
 
-      @if (isComparison && fetchedMetadata[field.fetchedKey] != null) {
+      @if (isComparison && fetchedMetadata[field.fetchedKey] !== null && fetchedMetadata[field.fetchedKey] !== undefined) {
         <input pSize="small" pInputText [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
                [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"/>
       }
@@ -223,7 +223,7 @@
 
       <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
 
-      @if (isComparison && fetchedMetadata[field.fetchedKey] != null) {
+      @if (isComparison && fetchedMetadata[field.fetchedKey] !== null && fetchedMetadata[field.fetchedKey] !== undefined) {
         <input pSize="small" pInputText [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
                [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"/>
       }
@@ -268,7 +268,7 @@
 
       <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
 
-      @if (isComparison && fetchedMetadata[field.fetchedKey] != null) {
+      @if (isComparison && fetchedMetadata[field.fetchedKey] !== null && fetchedMetadata[field.fetchedKey] !== undefined) {
         <p-autoComplete
           size="small" [ngModel]="fetchedMetadata[field.fetchedKey] ?? []" [ngModelOptions]="{standalone:true}"
           [disabled]="true" [multiple]="true" [typeahead]="false" [dropdown]="false" [forceSelection]="false"
@@ -287,7 +287,7 @@
       
       <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
 
-      @if (isComparison && fetchedMetadata[field.fetchedKey] != null) {
+      @if (isComparison && fetchedMetadata[field.fetchedKey] !== null && fetchedMetadata[field.fetchedKey] !== undefined) {
         <textarea pTextarea rows="4" pSize="small" [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
                   [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"></textarea>
       }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
@@ -27,6 +27,16 @@
           </button>
           <button
             type="button"
+            class="p-button p-button-outlined p-button-sm p-button-icon-only"
+            [pTooltip]="t('refetchOnlineTooltip')"
+            tooltipPosition="bottom"
+            (click)="refetchOnline()"
+            [disabled]="refetching"
+          >
+            <span class="p-button-icon pi" [ngClass]="refetching ? 'pi-spin pi-spinner' : 'pi-cloud-download'"></span>
+          </button>
+          <button
+            type="button"
             class="p-button p-button-outlined p-button-sm p-button-icon-only p-button-warn"
             [pTooltip]="t('resetAllTooltip')"
             tooltipPosition="bottom"
@@ -351,15 +361,27 @@
         <p class="missingmd">
           {{ t('unableToFetchMetadata') }}
         </p>
-        <p-button
-          size="small"
-          severity="warn"
-          icon="pi pi-refresh"
-          [outlined]="true"
-          [pTooltip]="t('resetAllTooltip')"
-          tooltipPosition="left"
-          (onClick)="confirmReset()"
-        ></p-button>
+        <div class="header-actions">
+          <p-button
+            size="small"
+            severity="warn"
+            icon="pi pi-refresh"
+            [outlined]="true"
+            [pTooltip]="t('resetAllTooltip')"
+            tooltipPosition="left"
+            (onClick)="confirmReset()"
+          ></p-button>
+          <p-button
+            size="small"
+            severity="info"
+            [icon]="refetching ? 'pi pi-spin pi-spinner' : 'pi pi-cloud-download'"
+            [outlined]="true"
+            [pTooltip]="t('refetchOnlineTooltip')"
+            tooltipPosition="left"
+            (onClick)="refetchOnline()"
+            [disabled]="refetching"
+          ></p-button>
+        </div>
       </div>
       <div class="metabody">
         <div class="editor-thumbnail-wrapper">

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
@@ -99,258 +99,7 @@
             </div>
           </div>
         </div>
-        @for (field of metadataFieldsTop; track field) {
-          <div class="meta-row field-{{field.controlName}}">
-            <label for="{{field.controlName}}" class="field-label">{{ field.label }}</label>
-            <div class="meta-fields">
-              <input
-                pSize="small"
-                fluid
-                pInputText
-                id="{{field.controlName}}"
-                formControlName="{{field.controlName}}"
-                class="dest"
-                [ngClass]="{
-                  'changed': isValueChanged(field.controlName),
-                }"
-              />
-              <p-button
-                size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
-                [outlined]="true"
-                [ngClass]="{
-                  'nosrc' : !fetchedMetadata[field.fetchedKey]
-                }"
-                class="arrow-button"
-                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
-                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-              />
-              @if (fetchedMetadata[field.fetchedKey]) {
-                <input
-                  pSize="small"
-                  pInputText
-                  [value]="fetchedMetadata[field.fetchedKey] ?? null"
-                  class="src"
-                  disabled
-                  [ngClass]="{
-                    'diff': isFetchedDifferent(field.controlName),
-                  }"
-                />
-              }
-            </div>
-          </div>
-        }
-        @for (field of metadataPublishDate; track field) {
-          <div class="meta-row field-{{field.controlName}}">
-            <label for="{{field.controlName}}" class="field-label">{{ field.label }}</label>
-            <div class="meta-fields">
-              <p-datepicker
-                size="small"
-                fluid
-                inputId="{{field.controlName}}"
-                formControlName="{{field.controlName}}"
-                dataType="string"
-                dateFormat="yy-mm-dd"
-                [keepInvalid]="true"
-                [showIcon]="true"
-                [iconDisplay]="'input'"
-                appendTo="body"
-                class="dest"
-                [ngClass]="{
-                  'changed': isValueChanged(field.controlName),
-                }">
-              </p-datepicker>
-              <p-button
-                size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
-                [outlined]="true"
-                [ngClass]="{
-                  'nosrc' : !fetchedMetadata[field.fetchedKey]
-                }"
-                class="arrow-button"
-                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
-                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-              />
-              @if (fetchedMetadata[field.fetchedKey]) {
-                <input
-                  pSize="small"
-                  pInputText
-                  [value]="fetchedMetadata[field.fetchedKey] ?? null"
-                  class="src"
-                  disabled
-                  [ngClass]="{
-                    'diff': isFetchedDifferent(field.controlName),
-                  }"
-                />
-              }
-            </div>
-          </div>
-        }
-        @for (field of metadataChips; track field) {
-          <div class="meta-row field-{{field.controlName}}">
-            <label for="{{field.controlName}}" class="field-label">{{ field.label }}</label>
-            <div class="meta-fields">
-              @if (field.controlName === 'authors') {
-                <div class="author-chips-container dest full-width"
-                     cdkDropList cdkDropListOrientation="mixed"
-                     (cdkDropListDropped)="dropAuthor($event)"
-                     [ngClass]="{ 'changed': isValueChanged('authors') }">
-                  @for (author of metadataForm.get('authors')!.value; track $index) {
-                    <span class="author-chip" [class.main-author]="$index === 0" cdkDrag>
-                      @if ($index === 0) { <span class="main-author-badge">m</span> }
-                      {{ author }}
-                      <i
-                        class="pi pi-times author-chip-remove"
-                        role="button"
-                        tabindex="0"
-                        (click)="removeAuthor($index)"
-                        (keydown.enter)="removeAuthor($index)"></i>
-                    </span>
-                  }
-                  <p-autoComplete
-                    class="author-add-input"
-                    [(ngModel)]="authorInputValue"
-                    [ngModelOptions]="{ standalone: true }"
-                    size="small"
-                    [forceSelection]="false"
-                    [dropdown]="false"
-                    (onKeyUp)="onAuthorInputKeyUp($event)"
-                    (onSelect)="onAuthorInputSelect($event)"
-                    placeholder="Add author..."
-                  />
-                </div>
-              } @else {
-                <p-autoComplete
-                  size="small"
-                  formControlName="{{field.controlName}}"
-                  [multiple]="true"
-                  [typeahead]="false"
-                  [dropdown]="false"
-                  [forceSelection]="false"
-                  class="dest full-width"
-                  [ngClass]="{
-                    'changed': isValueChanged(field.controlName),
-                  }"
-                  (onBlur)="onAutoCompleteBlur(field.controlName, $event)"
-                />
-              }
-              <p-button
-                size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
-                [outlined]="true"
-                [ngClass]="{
-                  'nosrc' : !fetchedMetadata[field.fetchedKey]
-                }"
-                class="arrow-button"
-                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
-                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-              />
-              @if (fetchedMetadata[field.fetchedKey]) {
-                <p-autoComplete
-                  size="small"
-                  [ngModel]="fetchedMetadata[field.fetchedKey] ?? []"
-                  [ngModelOptions]="{standalone:true}"
-                  [disabled]="true"
-                  [multiple]="true"
-                  [typeahead]="false"
-                  [dropdown]="false"
-                  [forceSelection]="false"
-                  class="src full-width"
-                  [ngClass]="{
-                    'diff': isFetchedDifferent(field.controlName),
-                  }"
-                />
-              }
-            </div>
-          </div>
-        }
-        @for (field of metadataDescription; track field) {
-          <div class="meta-row field-{{field.controlName}}">
-            <label for="{{field.controlName}}" class="field-label">{{ field.label }}</label>
-            <div class="meta-fields">
-              <textarea
-                pTextarea
-                rows="4"
-                pSize="small"
-                id="{{field.controlName}}"
-                formControlName="{{field.controlName}}"
-                class="dest"
-                [ngClass]="{
-                  'changed': isValueChanged(field.controlName),
-                }"
-              ></textarea>
-              <p-button
-                size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
-                [outlined]="true"
-                [ngClass]="{
-                  'nosrc' : !fetchedMetadata[field.fetchedKey]
-                }"
-                class="arrow-button"
-                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
-                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-              />
-              @if (fetchedMetadata[field.fetchedKey]) {
-                <textarea
-                  pTextarea
-                  rows="4"
-                  pSize="small"
-                  [value]="fetchedMetadata[field.fetchedKey] ?? null"
-                  class="src"
-                  disabled
-                  [ngClass]="{
-                    'diff': isFetchedDifferent(field.controlName),
-                  }"
-                ></textarea>
-              }
-            </div>
-          </div>
-        }
-        @for (field of metadataFieldsBottom; track field) {
-          <div class="meta-row field-{{field.controlName}}">
-            <label for="{{field.controlName}}" class="field-label">{{ field.label }}</label>
-            <div class="meta-fields">
-              <input
-                pInputText
-                pSize="small"
-                id="{{field.controlName}}"
-                formControlName="{{field.controlName}}"
-                class="dest"
-                [ngClass]="{
-                  'changed': isValueChanged(field.controlName),
-                }"
-              />
-              <p-button
-                size="small"
-                [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
-                [outlined]="true"
-                [ngClass]="{
-                  'nosrc' : !fetchedMetadata[field.fetchedKey]
-                }"
-                class="arrow-button"
-                [severity]="isValueChanged(field.controlName) ? 'warn' : null"
-                [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
-              />
-              @if (fetchedMetadata[field.fetchedKey]) {
-                <input
-                  pInputText
-                  pSize="small"
-                  [value]="fetchedMetadata[field.fetchedKey] ?? null"
-                  class="src"
-                  disabled
-                  [ngClass]="{
-                    'diff': isFetchedDifferent(field.controlName),
-                  }"
-                />
-              }
-            </div>
-          </div>
-        }
+        <ng-container *ngTemplateOutlet="fieldLoops; context: { isComparison: true }"></ng-container>
       </div>
     </div>
   </form>
@@ -395,184 +144,146 @@
           </div>
         </div>
         <div class="metacontent editor-metacontent">
-          @for (field of metadataFieldsTop; track field) {
-            <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'">
-              <label for="{{field.controlName}}" class="field-label field-label-fixed">{{ field.label }}</label>
-              <div class="field-input-row">
-                <input
-                  pSize="small"
-                  fluid
-                  pInputText
-                  id="{{field.controlName}}"
-                  formControlName="{{field.controlName}}"
-                  [ngClass]="{
-                    'changed': isValueChanged(field.controlName),
-                  }"
-                />
-                <p-button
-                  size="small"
-                  icon="pi pi-refresh"
-                  [outlined]="true"
-                  class="arrow-button"
-                  severity="warn"
-                  [disabled]="!isValueChanged(field.controlName)"
-                  (onClick)="resetField(field.controlName)"
-                />
-              </div>
-            </div>
-          }
-
-          @for (field of metadataPublishDate; track field) {
-            <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'">
-              <label for="{{field.controlName}}" class="field-label field-label-fixed">{{ field.label }}</label>
-              <div class="field-input-row">
-                <p-datepicker
-                  size="small"
-                  fluid
-                  inputId="{{field.controlName}}"
-                  formControlName="{{field.controlName}}"
-                  dataType="string"
-                  dateFormat="yy-mm-dd"
-                  [keepInvalid]="true"
-                  [showIcon]="true"
-                  [iconDisplay]="'input'"
-                  appendTo="body"
-                  class="full-width"
-                  [ngClass]="{
-                    'changed': isValueChanged(field.controlName),
-                  }">
-                </p-datepicker>
-                <p-button
-                  size="small"
-                  icon="pi pi-refresh"
-                  [outlined]="true"
-                  class="arrow-button"
-                  severity="warn"
-                  [disabled]="!isValueChanged(field.controlName)"
-                  (onClick)="resetField(field.controlName)"
-                />
-              </div>
-            </div>
-          }
-
-          @for (field of metadataChips; track field) {
-            <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'">
-              <label for="{{field.controlName}}" class="field-label field-label-fixed">{{ field.label }}</label>
-              <div class="field-input-row">
-                @if (field.controlName === 'authors') {
-                  <div class="author-chips-container full-width"
-                       cdkDropList cdkDropListOrientation="mixed"
-                       (cdkDropListDropped)="dropAuthor($event)"
-                       [ngClass]="{ 'changed': isValueChanged('authors') }">
-                    @for (author of metadataForm.get('authors')!.value; track $index) {
-                      <span class="author-chip" [class.main-author]="$index === 0" cdkDrag>
-                        @if ($index === 0) { <span class="main-author-badge">m</span> }
-                        {{ author }}
-                        <i
-                          class="pi pi-times author-chip-remove"
-                          role="button"
-                          tabindex="0"
-                          (click)="removeAuthor($index)"
-                          (keydown.enter)="removeAuthor($index)"></i>
-                      </span>
-                    }
-                    <p-autoComplete
-                      class="author-add-input"
-                      [(ngModel)]="authorInputValue"
-                      [ngModelOptions]="{ standalone: true }"
-                      size="small"
-                      [forceSelection]="false"
-                      [dropdown]="false"
-                      (onKeyUp)="onAuthorInputKeyUp($event)"
-                      (onSelect)="onAuthorInputSelect($event)"
-                      placeholder="Add author..."
-                    />
-                  </div>
-                } @else {
-                  <p-autoComplete
-                    size="small"
-                    formControlName="{{field.controlName}}"
-                    [multiple]="true"
-                    [typeahead]="false"
-                    [dropdown]="false"
-                    [forceSelection]="false"
-                    class="full-width"
-                    [ngClass]="{
-                      'changed': isValueChanged(field.controlName),
-                    }"
-                    (onBlur)="onAutoCompleteBlur(field.controlName, $event)"
-                  />
-                }
-                <p-button
-                  size="small"
-                  icon="pi pi-refresh"
-                  [outlined]="true"
-                  class="arrow-button"
-                  severity="warn"
-                  [disabled]="!isValueChanged(field.controlName)"
-                  (onClick)="resetField(field.controlName)"
-                />
-              </div>
-            </div>
-          }
-
-          @for (field of metadataDescription; track field) {
-            <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'">
-              <label for="{{field.controlName}}" class="field-label field-label-fixed">{{ field.label }}</label>
-              <div class="field-input-row">
-                <textarea
-                  pTextarea
-                  fluid
-                  rows="4"
-                  pSize="small"
-                  id="{{field.controlName}}"
-                  formControlName="{{field.controlName}}"
-                  [ngClass]="{
-                    'changed': isValueChanged(field.controlName),
-                  }"
-                ></textarea>
-                <p-button
-                  size="small"
-                  icon="pi pi-refresh"
-                  [outlined]="true"
-                  class="arrow-button"
-                  severity="warn"
-                  [disabled]="!isValueChanged(field.controlName)"
-                  (onClick)="resetField(field.controlName)"
-                />
-              </div>
-            </div>
-          }
-
-          @for (field of metadataFieldsBottom; track field) {
-            <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'">
-              <label for="{{field.controlName}}" class="field-label field-label-fixed">{{ field.label }}</label>
-              <div class="field-input-row">
-                <input
-                  pSize="small"
-                  fluid
-                  pInputText
-                  id="{{field.controlName}}"
-                  formControlName="{{field.controlName}}"
-                  [ngClass]="{
-                    'changed': isValueChanged(field.controlName),
-                  }"
-                />
-                <p-button
-                  size="small"
-                  icon="pi pi-refresh"
-                  [outlined]="true"
-                  class="arrow-button"
-                  severity="warn"
-                  [disabled]="!isValueChanged(field.controlName)"
-                  (onClick)="resetField(field.controlName)"
-                />
-              </div>
-            </div>
-          }
+          <ng-container *ngTemplateOutlet="fieldLoops; context: { isComparison: false }"></ng-container>
         </div>
       </div>
     </div>
   </form>
 }
+
+<ng-template #fieldLoops let-isComparison="isComparison">
+  @for (field of metadataFieldsTop; track field) {
+    <ng-container *ngTemplateOutlet="stringField; context: { field, isComparison }"></ng-container>
+  }
+  @for (field of metadataPublishDate; track field) {
+    <ng-container *ngTemplateOutlet="dateField; context: { field, isComparison }"></ng-container>
+  }
+  @for (field of metadataChips; track field) {
+    <ng-container *ngTemplateOutlet="chipsField; context: { field, isComparison }"></ng-container>
+  }
+  @for (field of metadataDescription; track field) {
+    <ng-container *ngTemplateOutlet="textareaField; context: { field, isComparison }"></ng-container>
+  }
+  @for (field of metadataFieldsBottom; track field) {
+    <ng-container *ngTemplateOutlet="stringField; context: { field, isComparison }"></ng-container>
+  }
+</ng-template>
+
+<ng-template #fieldAction let-field="field" let-isComparison="isComparison">
+  @if (isComparison) {
+    <p-button
+      size="small"
+      [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
+      [outlined]="true"
+      [ngClass]="{ 'nosrc' : !fetchedMetadata[field.fetchedKey] }"
+      class="arrow-button"
+      [severity]="isValueChanged(field.controlName) ? 'warn' : null"
+      [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
+      (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+    />
+  } @else {
+    <p-button
+      size="small"
+      icon="pi pi-refresh"
+      [outlined]="true"
+      class="arrow-button"
+      severity="warn"
+      [disabled]="!isValueChanged(field.controlName)"
+      (onClick)="resetField(field.controlName)"
+    />
+  }
+</ng-template>
+
+<ng-template #stringField let-field="field" let-isComparison="isComparison">
+  <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'" [formGroup]="metadataForm">
+    <label for="{{field.controlName}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
+    <div [class.meta-fields]="isComparison" [class.field-input-row]="!isComparison">
+      <input pInputText pSize="small" [fluid]="true" id="{{field.controlName}}" [formControlName]="field.controlName"
+             class="dest" [ngClass]="{ 'changed': isValueChanged(field.controlName) }"/>
+      
+      <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
+
+      @if (isComparison && fetchedMetadata[field.fetchedKey]) {
+        <input pSize="small" pInputText [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
+               [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"/>
+      }
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #dateField let-field="field" let-isComparison="isComparison">
+  <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'" [formGroup]="metadataForm">
+    <label for="{{field.controlName}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
+    <div [class.meta-fields]="isComparison" [class.field-input-row]="!isComparison">
+      <p-datepicker
+        size="small" [fluid]="true" inputId="{{field.controlName}}" [formControlName]="field.controlName"
+        dataType="string" dateFormat="yy-mm-dd" [keepInvalid]="true" [showIcon]="true" [iconDisplay]="'input'"
+        appendTo="body" class="dest" [class.full-width]="!isComparison" [ngClass]="{ 'changed': isValueChanged(field.controlName) }">
+      </p-datepicker>
+
+      <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
+
+      @if (isComparison && fetchedMetadata[field.fetchedKey]) {
+        <input pSize="small" pInputText [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
+               [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"/>
+      }
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #chipsField let-field="field" let-isComparison="isComparison">
+  <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'" [formGroup]="metadataForm">
+    <label for="{{field.controlName}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
+    <div [class.meta-fields]="isComparison" [class.field-input-row]="!isComparison">
+      @if (field.controlName === 'authors') {
+        <div class="author-chips-container dest full-width"
+             cdkDropList cdkDropListOrientation="mixed"
+             (cdkDropListDropped)="dropAuthor($event)"
+             [ngClass]="{ 'changed': isValueChanged('authors') }">
+          @for (author of metadataForm.get('authors')!.value; track $index) {
+            <span class="author-chip" [class.main-author]="$index === 0" cdkDrag>
+              @if ($index === 0) { <span class="main-author-badge">m</span> }
+              {{ author }}
+              <i class="pi pi-times author-chip-remove" role="button" tabindex="0" (click)="removeAuthor($index)" (keydown.enter)="removeAuthor($index)"></i>
+            </span>
+          }
+          <p-autoComplete class="author-add-input" [(ngModel)]="authorInputValue" [ngModelOptions]="{ standalone: true }"
+                          size="small" [forceSelection]="false" [dropdown]="false" (onKeyUp)="onAuthorInputKeyUp($event)"
+                          (onSelect)="onAuthorInputSelect($event)" placeholder="Add author..."/>
+        </div>
+      } @else {
+        <p-autoComplete
+          size="small" [formControlName]="field.controlName" [multiple]="true" [typeahead]="false" [dropdown]="false"
+          [forceSelection]="false" class="dest full-width" [ngClass]="{ 'changed': isValueChanged(field.controlName) }"
+          (onBlur)="onAutoCompleteBlur(field.controlName, $event)"/>
+      }
+
+      <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
+
+      @if (isComparison && fetchedMetadata[field.fetchedKey]) {
+        <p-autoComplete
+          size="small" [ngModel]="fetchedMetadata[field.fetchedKey] ?? []" [ngModelOptions]="{standalone:true}"
+          [disabled]="true" [multiple]="true" [typeahead]="false" [dropdown]="false" [forceSelection]="false"
+          class="src full-width" [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"/>
+      }
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #textareaField let-field="field" let-isComparison="isComparison">
+  <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'" [formGroup]="metadataForm">
+    <label for="{{field.controlName}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
+    <div [class.meta-fields]="isComparison" [class.field-input-row]="!isComparison">
+      <textarea pTextarea rows="4" pSize="small" [fluid]="!isComparison" id="{{field.controlName}}" [formControlName]="field.controlName"
+                class="dest" [ngClass]="{ 'changed': isValueChanged(field.controlName) }"></textarea>
+      
+      <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
+
+      @if (isComparison && fetchedMetadata[field.fetchedKey]) {
+        <textarea pTextarea rows="4" pSize="small" [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
+                  [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"></textarea>
+      }
+    </div>
+  </div>
+</ng-template>
 </ng-container>

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
@@ -70,7 +70,7 @@
               @else {
                 <div class="thumbnail no-cover-text">{{ t('noCoverImage') }}</div>
               }
-              <input type="hidden" id="thumbnailUrl" formControlName="thumbnailUrl"/>
+              <input type="hidden" id="thumbnailUrl-{{bookdropFileId}}" formControlName="thumbnailUrl"/>
             </div>
             <p-button
               size="small"
@@ -140,7 +140,7 @@
               alt="Book Thumbnail"
               class="thumbnail editor-thumbnail-img"
             />
-            <input type="hidden" id="thumbnailUrl" formControlName="thumbnailUrl"/>
+            <input type="hidden" id="thumbnailUrl-{{bookdropFileId}}" formControlName="thumbnailUrl"/>
           </div>
         </div>
         <div class="metacontent editor-metacontent">
@@ -173,9 +173,9 @@
   @if (isComparison) {
     <p-button
       size="small"
-      [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || !fetchedMetadata[field.fetchedKey] ? 'pi pi-refresh' : 'pi pi-angle-left')"
+      [icon]="isValueSaved(field.controlName) ? 'pi pi-check' : (isValueChanged(field.controlName) || fetchedMetadata[field.fetchedKey] == null ? 'pi pi-refresh' : 'pi pi-angle-left')"
       [outlined]="true"
-      [ngClass]="{ 'nosrc' : !fetchedMetadata[field.fetchedKey] }"
+      [ngClass]="{ 'nosrc' : fetchedMetadata[field.fetchedKey] == null }"
       class="arrow-button"
       [severity]="isValueChanged(field.controlName) ? 'warn' : null"
       [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
@@ -196,14 +196,14 @@
 
 <ng-template #stringField let-field="field" let-isComparison="isComparison">
   <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'" [formGroup]="metadataForm">
-    <label for="{{field.controlName}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
+    <label for="{{field.controlName}}-{{bookdropFileId}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
     <div [class.meta-fields]="isComparison" [class.field-input-row]="!isComparison">
-      <input pInputText pSize="small" [fluid]="true" id="{{field.controlName}}" [formControlName]="field.controlName"
+      <input pInputText pSize="small" [fluid]="true" id="{{field.controlName}}-{{bookdropFileId}}" [formControlName]="field.controlName"
              class="dest" [ngClass]="{ 'changed': isValueChanged(field.controlName) }"/>
       
       <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
 
-      @if (isComparison && fetchedMetadata[field.fetchedKey]) {
+      @if (isComparison && fetchedMetadata[field.fetchedKey] != null) {
         <input pSize="small" pInputText [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
                [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"/>
       }
@@ -213,17 +213,17 @@
 
 <ng-template #dateField let-field="field" let-isComparison="isComparison">
   <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'" [formGroup]="metadataForm">
-    <label for="{{field.controlName}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
+    <label for="{{field.controlName}}-{{bookdropFileId}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
     <div [class.meta-fields]="isComparison" [class.field-input-row]="!isComparison">
       <p-datepicker
-        size="small" [fluid]="true" inputId="{{field.controlName}}" [formControlName]="field.controlName"
+        size="small" [fluid]="true" inputId="{{field.controlName}}-{{bookdropFileId}}" [formControlName]="field.controlName"
         dataType="string" dateFormat="yy-mm-dd" [keepInvalid]="true" [showIcon]="true" [iconDisplay]="'input'"
         appendTo="body" class="dest" [class.full-width]="!isComparison" [ngClass]="{ 'changed': isValueChanged(field.controlName) }">
       </p-datepicker>
 
       <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
 
-      @if (isComparison && fetchedMetadata[field.fetchedKey]) {
+      @if (isComparison && fetchedMetadata[field.fetchedKey] != null) {
         <input pSize="small" pInputText [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
                [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"/>
       }
@@ -233,7 +233,7 @@
 
 <ng-template #chipsField let-field="field" let-isComparison="isComparison">
   <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'" [formGroup]="metadataForm">
-    <label for="{{field.controlName}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
+    <label for="{{field.controlName}}-{{bookdropFileId}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
     <div [class.meta-fields]="isComparison" [class.field-input-row]="!isComparison">
       @if (field.controlName === 'authors') {
         <div class="author-chips-container dest full-width"
@@ -249,7 +249,7 @@
           }
           <p-autoComplete class="author-add-input" [(ngModel)]="authorInputValue" [ngModelOptions]="{ standalone: true }"
                           size="small" [forceSelection]="false" [dropdown]="false" (onKeyUp)="onAuthorInputKeyUp($event)"
-                          (onSelect)="onAuthorInputSelect($event)" placeholder="Add author..."/>
+                          (onSelect)="onAuthorInputSelect($event)" [placeholder]="t('addAuthorPlaceholder')"/>
         </div>
       } @else {
         <p-autoComplete
@@ -260,7 +260,7 @@
 
       <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
 
-      @if (isComparison && fetchedMetadata[field.fetchedKey]) {
+      @if (isComparison && fetchedMetadata[field.fetchedKey] != null) {
         <p-autoComplete
           size="small" [ngModel]="fetchedMetadata[field.fetchedKey] ?? []" [ngModelOptions]="{standalone:true}"
           [disabled]="true" [multiple]="true" [typeahead]="false" [dropdown]="false" [forceSelection]="false"
@@ -272,14 +272,14 @@
 
 <ng-template #textareaField let-field="field" let-isComparison="isComparison">
   <div class="meta-row field-{{field.controlName}}" [class.field-series-name]="field.controlName === 'seriesName'" [formGroup]="metadataForm">
-    <label for="{{field.controlName}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
+    <label for="{{field.controlName}}-{{bookdropFileId}}" class="field-label" [class.field-label-fixed]="!isComparison">{{ field.label }}</label>
     <div [class.meta-fields]="isComparison" [class.field-input-row]="!isComparison">
-      <textarea pTextarea rows="4" pSize="small" [fluid]="!isComparison" id="{{field.controlName}}" [formControlName]="field.controlName"
+      <textarea pTextarea rows="4" pSize="small" [fluid]="!isComparison" id="{{field.controlName}}-{{bookdropFileId}}" [formControlName]="field.controlName"
                 class="dest" [ngClass]="{ 'changed': isValueChanged(field.controlName) }"></textarea>
       
       <ng-container *ngTemplateOutlet="fieldAction; context: { field, isComparison }"></ng-container>
 
-      @if (isComparison && fetchedMetadata[field.fetchedKey]) {
+      @if (isComparison && fetchedMetadata[field.fetchedKey] != null) {
         <textarea pTextarea rows="4" pSize="small" [value]="fetchedMetadata[field.fetchedKey] ?? null" class="src" disabled
                   [ngClass]="{ 'diff': isFetchedDifferent(field.controlName) }"></textarea>
       }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
@@ -79,7 +79,7 @@
               class="arrow-button"
               [severity]="isValueCopied('thumbnailUrl') ? 'warn' : null"
               [disabled]="!isFetchedDifferent('thumbnailUrl') && !isValueCopied('thumbnailUrl')"
-              (click)="isValueCopied('thumbnailUrl') ? resetField('thumbnailUrl') : copyFetchedToCurrent('thumbnailUrl')"
+              (onClick)="isValueCopied('thumbnailUrl') ? resetField('thumbnailUrl') : copyFetchedToCurrent('thumbnailUrl')"
             />
             <div class="thumbnail-column">
               @if (fetchedMetadata.thumbnailUrl) {
@@ -124,7 +124,7 @@
                 class="arrow-button"
                 [severity]="isValueChanged(field.controlName) ? 'warn' : null"
                 [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
               />
               @if (fetchedMetadata[field.fetchedKey]) {
                 <input
@@ -171,7 +171,7 @@
                 class="arrow-button"
                 [severity]="isValueChanged(field.controlName) ? 'warn' : null"
                 [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
               />
               @if (fetchedMetadata[field.fetchedKey]) {
                 <input
@@ -246,7 +246,7 @@
                 class="arrow-button"
                 [severity]="isValueChanged(field.controlName) ? 'warn' : null"
                 [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
               />
               @if (fetchedMetadata[field.fetchedKey]) {
                 <p-autoComplete
@@ -292,7 +292,7 @@
                 class="arrow-button"
                 [severity]="isValueChanged(field.controlName) ? 'warn' : null"
                 [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
               />
               @if (fetchedMetadata[field.fetchedKey]) {
                 <textarea
@@ -334,7 +334,7 @@
                 class="arrow-button"
                 [severity]="isValueChanged(field.controlName) ? 'warn' : null"
                 [disabled]="!isFetchedDifferent(field.controlName) && !isValueChanged(field.controlName)"
-                (click)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
+                (onClick)="isValueChanged(field.controlName) ? resetField(field.controlName) : copyFetchedToCurrent(field.controlName)"
               />
               @if (fetchedMetadata[field.fetchedKey]) {
                 <input
@@ -416,7 +416,7 @@
                   class="arrow-button"
                   severity="warn"
                   [disabled]="!isValueChanged(field.controlName)"
-                  (click)="resetField(field.controlName)"
+                  (onClick)="resetField(field.controlName)"
                 />
               </div>
             </div>
@@ -449,7 +449,7 @@
                   class="arrow-button"
                   severity="warn"
                   [disabled]="!isValueChanged(field.controlName)"
-                  (click)="resetField(field.controlName)"
+                  (onClick)="resetField(field.controlName)"
                 />
               </div>
             </div>
@@ -510,7 +510,7 @@
                   class="arrow-button"
                   severity="warn"
                   [disabled]="!isValueChanged(field.controlName)"
-                  (click)="resetField(field.controlName)"
+                  (onClick)="resetField(field.controlName)"
                 />
               </div>
             </div>
@@ -538,7 +538,7 @@
                   class="arrow-button"
                   severity="warn"
                   [disabled]="!isValueChanged(field.controlName)"
-                  (click)="resetField(field.controlName)"
+                  (onClick)="resetField(field.controlName)"
                 />
               </div>
             </div>
@@ -565,7 +565,7 @@
                   class="arrow-button"
                   severity="warn"
                   [disabled]="!isValueChanged(field.controlName)"
-                  (click)="resetField(field.controlName)"
+                  (onClick)="resetField(field.controlName)"
                 />
               </div>
             </div>

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.html
@@ -70,7 +70,7 @@
               @else {
                 <div class="thumbnail no-cover-text">{{ t('noCoverImage') }}</div>
               }
-              <input type="hidden" id="thumbnailUrl-{{bookdropFileId}}" formControlName="thumbnailUrl"/>
+              <input type="hidden" formControlName="thumbnailUrl"/>
             </div>
             <p-button
               size="small"
@@ -140,7 +140,7 @@
               alt="Book Thumbnail"
               class="thumbnail editor-thumbnail-img"
             />
-            <input type="hidden" id="thumbnailUrl-{{bookdropFileId}}" formControlName="thumbnailUrl"/>
+            <input type="hidden" formControlName="thumbnailUrl"/>
           </div>
         </div>
         <div class="metacontent editor-metacontent">
@@ -244,7 +244,15 @@
             <span class="author-chip" [class.main-author]="$index === 0" cdkDrag>
               @if ($index === 0) { <span class="main-author-badge">m</span> }
               {{ author }}
-              <i class="pi pi-times author-chip-remove" role="button" tabindex="0" (click)="removeAuthor($index)" (keydown.enter)="removeAuthor($index)"></i>
+              <button
+                type="button"
+                class="author-chip-remove-btn"
+                (click)="removeAuthor($index)"
+                (keydown.enter)="removeAuthor($index)"
+                [attr.aria-label]="t('removeAuthor')"
+              >
+                <i class="pi pi-times author-chip-remove"></i>
+              </button>
             </span>
           }
           <p-autoComplete class="author-add-input" [(ngModel)]="authorInputValue" [ngModelOptions]="{ standalone: true }"

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
@@ -253,6 +253,11 @@ textarea.changed,
   justify-content: space-between;
 }
 
+.header-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .metacontent {
   padding: 1rem;
 }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.ts
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.ts
@@ -238,6 +238,8 @@ export class BookdropFileMetadataPickerComponent {
         next: (updatedFile) => {
           if (updatedFile.fetchedMetadata && updatedFile.fetchedMetadata.title) {
             this.fetchedMetadata = updatedFile.fetchedMetadata;
+            Object.keys(this.copiedFields).forEach(key => delete this.copiedFields[key]);
+            this.metadataCopied.emit(false);
             this.metadataRefetched.emit(updatedFile.fetchedMetadata);
             this.messageService.add({
               severity: 'success',

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.ts
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.ts
@@ -1,7 +1,7 @@
 import {Component, effect, EventEmitter, inject, Input, Output} from '@angular/core';
 import {FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Button} from 'primeng/button';
-import {NgClass} from '@angular/common';
+import {NgClass, NgTemplateOutlet} from '@angular/common';
 import {Tooltip} from 'primeng/tooltip';
 import {InputText} from 'primeng/inputtext';
 import {BookMetadata} from '../../../book/model/book.model';
@@ -30,6 +30,7 @@ import {finalize} from 'rxjs';
     Tooltip,
     InputText,
     NgClass,
+    NgTemplateOutlet,
     FormsModule,
     Textarea,
     AutoComplete,

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.ts
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.ts
@@ -10,7 +10,7 @@ import {Textarea} from 'primeng/textarea';
 import {AutoComplete} from 'primeng/autocomplete';
 import {Image} from 'primeng/image';
 import {LazyLoadImageModule} from 'ng-lazyload-image';
-import {ConfirmationService} from 'primeng/api';
+import {ConfirmationService, MessageService} from 'primeng/api';
 import {CdkDragDrop, CdkDropList, CdkDrag, moveItemInArray} from '@angular/cdk/drag-drop';
 import {AutoCompleteSelectEvent} from 'primeng/autocomplete';
 import {DatePicker} from 'primeng/datepicker';
@@ -19,6 +19,8 @@ import {MetadataUtilsService} from '../../../../shared/metadata';
 import {MetadataProviderSpecificFields} from '../../../../shared/model/app-settings.model';
 import {AppSettingsService} from '../../../../shared/service/app-settings.service';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
+import {BookdropService} from '../../service/bookdrop.service';
+import {finalize} from 'rxjs';
 
 @Component({
   selector: 'app-bookdrop-file-metadata-picker-component',
@@ -48,6 +50,8 @@ export class BookdropFileMetadataPickerComponent {
   protected readonly urlHelper = inject(UrlHelperService);
   private readonly appSettingsService = inject(AppSettingsService);
   private readonly t = inject(TranslocoService);
+  private readonly bookdropService = inject(BookdropService);
+  private readonly messageService = inject(MessageService);
 
   @Input() fetchedMetadata!: BookMetadata;
   @Input() originalMetadata?: BookMetadata;
@@ -57,6 +61,9 @@ export class BookdropFileMetadataPickerComponent {
   @Input() bookdropFileId!: number;
 
   @Output() metadataCopied = new EventEmitter<boolean>();
+  @Output() metadataRefetched = new EventEmitter<BookMetadata>();
+
+  refetching = false;
 
   authorInputValue = '';
 
@@ -218,5 +225,40 @@ export class BookdropFileMetadataPickerComponent {
     }
     this.copiedFields = {};
     this.metadataCopied.emit(false);
+  }
+
+  refetchOnline(): void {
+    this.refetching = true;
+    const manualMetadata: BookMetadata = this.metadataForm.value;
+    
+    this.bookdropService.refetchMetadata(this.bookdropFileId, manualMetadata)
+      .pipe(finalize(() => this.refetching = false))
+      .subscribe({
+        next: (updatedFile) => {
+          if (updatedFile.fetchedMetadata && updatedFile.fetchedMetadata.title) {
+            this.fetchedMetadata = updatedFile.fetchedMetadata;
+            this.metadataRefetched.emit(updatedFile.fetchedMetadata);
+            this.messageService.add({
+              severity: 'success',
+              summary: this.t.translate('bookdrop.metadataPicker.refetchSuccessSummary'),
+              detail: this.t.translate('bookdrop.metadataPicker.refetchSuccessDetail')
+            });
+          } else {
+            this.messageService.add({
+              severity: 'warn',
+              summary: this.t.translate('bookdrop.metadataPicker.refetchNoResultsSummary'),
+              detail: this.t.translate('bookdrop.metadataPicker.refetchNoResultsDetail')
+            });
+          }
+        },
+        error: (err) => {
+          console.error('Error refetching metadata:', err);
+          this.messageService.add({
+            severity: 'error',
+            summary: this.t.translate('bookdrop.metadataPicker.refetchFailedSummary'),
+            detail: this.t.translate('bookdrop.metadataPicker.refetchFailedDetail')
+          });
+        }
+      });
   }
 }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.ts
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.ts
@@ -236,7 +236,7 @@ export class BookdropFileMetadataPickerComponent {
       .pipe(finalize(() => this.refetching = false))
       .subscribe({
         next: (updatedFile) => {
-          if (updatedFile.fetchedMetadata && updatedFile.fetchedMetadata.title) {
+          if (updatedFile.fetchedMetadata?.title) {
             this.fetchedMetadata = updatedFile.fetchedMetadata;
             Object.keys(this.copiedFields).forEach(key => delete this.copiedFields[key]);
             this.metadataCopied.emit(false);

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.html
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.html
@@ -259,7 +259,8 @@
                 [copiedFields]="file.copiedFields"
                 [savedFields]="file.savedFields"
                 [bookdropFileId]="file.file.id"
-                (metadataCopied)="onMetadataCopied(file.file.id, $event)">
+                (metadataCopied)="onMetadataCopied(file.file.id, $event)"
+                (metadataRefetched)="onMetadataRefetched(file.file.id, $event)">
               </app-bookdrop-file-metadata-picker-component>
             }
           </div>

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
@@ -257,6 +257,13 @@ export class BookdropFileReviewComponent implements OnInit {
     this.copiedFlags[fileId] = copied;
   }
 
+  onMetadataRefetched(fileId: number, fetchedMetadata: BookMetadata): void {
+    const cached = this.fileUiCache[fileId];
+    if (cached) {
+      cached.file.fetchedMetadata = fetchedMetadata;
+    }
+  }
+
   applyLibraryDefaults(): void {
     if (!this.defaultLibraryId || !this.libraries) return;
 

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.ts
@@ -261,6 +261,7 @@ export class BookdropFileReviewComponent implements OnInit {
     const cached = this.fileUiCache[fileId];
     if (cached) {
       cached.file.fetchedMetadata = fetchedMetadata;
+      this.copiedFlags[fileId] = false;
     }
   }
 

--- a/frontend/src/app/features/bookdrop/service/bookdrop.service.ts
+++ b/frontend/src/app/features/bookdrop/service/bookdrop.service.ts
@@ -125,4 +125,8 @@ export class BookdropService {
   bulkEditMetadata(payload: BulkEditRequest): Observable<BulkEditResult> {
     return this.http.post<BulkEditResult>(`${this.url}/files/bulk-edit`, payload);
   }
+  
+  refetchMetadata(id: number, manualMetadata?: BookMetadata): Observable<BookdropFile> {
+    return this.http.post<BookdropFile>(`${this.url}/files/${id}/refetch`, manualMetadata);
+  }
 }

--- a/frontend/src/i18n/en/bookdrop.json
+++ b/frontend/src/i18n/en/bookdrop.json
@@ -29,7 +29,14 @@
     "coverImageNotFound": "Cover image not found",
     "unableToFetchMetadata": "Unable to fetch metadata for this file",
     "confirmResetMessage": "Are you sure you want to reset all metadata changes made to this file?",
-    "confirmResetHeader": "Reset Metadata Changes?"
+    "confirmResetHeader": "Reset Metadata Changes?",
+    "refetchOnlineTooltip": "Search online for metadata using current form values",
+    "refetchSuccessSummary": "Metadata Refetched",
+    "refetchSuccessDetail": "Successfully updated metadata from online providers.",
+    "refetchNoResultsSummary": "No Results Found",
+    "refetchNoResultsDetail": "Could not find any matching metadata for the provided information.",
+    "refetchFailedSummary": "Refetch Failed",
+    "refetchFailedDetail": "An error occurred while searching for metadata online."
   },
   "fileReview": {
     "title": "Review Bookdrop Files",

--- a/frontend/src/i18n/en/bookdrop.json
+++ b/frontend/src/i18n/en/bookdrop.json
@@ -36,7 +36,8 @@
     "refetchNoResultsSummary": "No Results Found",
     "refetchNoResultsDetail": "Could not find any matching metadata for the provided information.",
     "refetchFailedSummary": "Refetch Failed",
-    "refetchFailedDetail": "An error occurred while searching for metadata online."
+    "refetchFailedDetail": "An error occurred while searching for metadata online.",
+    "addAuthorPlaceholder": "Add author..."
   },
   "fileReview": {
     "title": "Review Bookdrop Files",

--- a/frontend/src/i18n/en/bookdrop.json
+++ b/frontend/src/i18n/en/bookdrop.json
@@ -37,7 +37,8 @@
     "refetchNoResultsDetail": "Could not find any matching metadata for the provided information.",
     "refetchFailedSummary": "Refetch Failed",
     "refetchFailedDetail": "An error occurred while searching for metadata online.",
-    "addAuthorPlaceholder": "Add author..."
+    "addAuthorPlaceholder": "Add author...",
+    "removeAuthor": "Remove author"
   },
   "fileReview": {
     "title": "Review Bookdrop Files",


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "refetch online" button to metadata picker, allowing users to refresh metadata for bookdrop files with optional manual metadata input.
  * Enhanced metadata validation with improved title handling and search term cleaning.

* **UI/UX Improvements**
  * Added loading spinner feedback during metadata refetch operations.
  * Added toast notifications for refetch success, warnings, and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->