### PR TITLE
ci(release): publish Helm chart as OCI artifact on release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -172,6 +172,7 @@ jobs:
     needs:
       - prepare-release-notification
     if: ${{ needs.prepare-release-notification.outputs.available == 'true' }}
+      - publish-helm-chart
     permissions: {}
     uses: ./.github/workflows/notify-discord-release-notes.yml
     secrets:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -110,7 +110,7 @@ jobs:
           helm package deploy/helm/grimmory \
             --version "${VERSION}" \
             --app-version "${RELEASE_TAG}"
-          helm push "grimmory-${VERSION}.tgz" oci://ghcr.io/grimmory-tools/charts
+          helm push "grimmory-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
 
   prepare-release-notification:
     name: Prepare Stable Release Notification

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -110,7 +110,7 @@ jobs:
           helm package deploy/helm/grimmory \
             --version "${VERSION}" \
             --app-version "${RELEASE_TAG}"
-          helm push "grimmory-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+          helm push "grimmory-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/helm-charts"
 
   prepare-release-notification:
     name: Prepare Stable Release Notification
@@ -171,8 +171,8 @@ jobs:
     name: Notify Discord Release
     needs:
       - prepare-release-notification
-    if: ${{ needs.prepare-release-notification.outputs.available == 'true' }}
       - publish-helm-chart
+    if: ${{ needs.prepare-release-notification.outputs.available == 'true' }}
     permissions: {}
     uses: ./.github/workflows/notify-discord-release-notes.yml
     secrets:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -73,6 +73,45 @@ jobs:
             type=gha,scope=image-shared,mode=max
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
+  publish-helm-chart:
+    name: Publish Helm Chart to GHCR
+    needs:
+      - build-and-release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
+      - name: Set Up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Authenticate to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Package and Push Helm Chart
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -eu
+          VERSION="${RELEASE_TAG#v}"
+          helm dependency update deploy/helm/grimmory
+          helm package deploy/helm/grimmory \
+            --version "${VERSION}" \
+            --app-version "${RELEASE_TAG}"
+          helm push "grimmory-${VERSION}.tgz" oci://ghcr.io/grimmory-tools/charts
+
   prepare-release-notification:
     name: Prepare Stable Release Notification
     needs:


### PR DESCRIPTION
## Description

This PR automatically publishes an OCI Helm chart when a release is cut. I could test that the image and chart are built and published (see https://github.com/thibaultamartin?tab=packages&repo_name=grimmory).

I could do a `helm install temp oci://ghcr.io/thibaultamartin/charts/grimmory:3.0.3-test` on my cluster. The chart behaved well but failed to pull Grimmory's image because the upstream image doesn't have a `v3.0.3-test`.

Discussed in #868 and https://github.com/grimmory-tools/grimmory/pull/881#discussion_r3142417221

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

1. Not hardcode gimmory's name and repo in the CI, so it's easier to test publishing images and charts in forks
2. Publish OCI Helm chart when a release is cut

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Helm charts are now published automatically as part of the release process, enabling installation via the Helm package manager.
  * Release notifications are delayed until chart publishing completes, ensuring notifications reflect successful chart publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->