### PR TITLE
chore(ci): publish an openapi json artifact with nightly releases

### DIFF
--- a/.github/actions/export-openapi/action.yml
+++ b/.github/actions/export-openapi/action.yml
@@ -1,0 +1,36 @@
+name: Export OpenAPI
+description: Check out a ref, set up the backend toolchain, and export grimmory-openapi.json.
+
+inputs:
+  app_version:
+    description: Application version string to embed into the exported OpenAPI document.
+    required: true
+  checkout_ref:
+    description: Git ref or SHA to export from.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        fetch-depth: 1
+        ref: ${{ inputs.checkout_ref }}
+
+    - name: Install just
+      uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+      with:
+        tool: just
+
+    - name: Set Up JDK 25
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+
+    - name: Export OpenAPI JSON
+      shell: bash
+      env:
+        APP_VERSION: ${{ inputs.app_version }}
+      run: just api openapi-export

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -133,6 +133,28 @@ jobs:
             type=gha,scope=image-shared,mode=max
             type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache,mode=max
 
+  export-openapi:
+    name: Export Nightly OpenAPI Artifact
+    needs: [resolve_ref, test-suite, build-and-push]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Export OpenAPI JSON
+        uses: ./.github/actions/export-openapi
+        with:
+          checkout_ref: ${{ needs.resolve_ref.outputs.commit_sha }}
+          app_version: ${{ needs.resolve_ref.outputs.nightly_tag }}
+
+      - name: Upload Nightly OpenAPI Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-openapi-${{ needs.resolve_ref.outputs.nightly_tag }}
+          path: backend/build/openapi/grimmory-openapi.json
+          retention-days: 30
+
   generate-notes:
     name: Nightly Changelog
     if: ${{ always() && needs.test-suite.result == 'success' }}
@@ -165,8 +187,8 @@ jobs:
 
   notify-discord:
     name: Notify Discord (Nightly)
-    if: ${{ always() && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' && needs.generate-notes.outputs.predicted_version != '' }}
-    needs: [resolve_ref, build-and-push, generate-notes]
+    if: ${{ always() && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' && needs.export-openapi.result == 'success' && needs.generate-notes.outputs.predicted_version != '' }}
+    needs: [resolve_ref, build-and-push, export-openapi, generate-notes]
     permissions: {}
     uses: ./.github/workflows/notify-discord-release-notes.yml
     secrets:

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ When enabled via `API_DOCS_ENABLED`, API reference documentation is available as
 - API reference docs are available at `http://localhost:6060/api/docs`
 - OpenAPI JSON is available at `http://localhost:6060/api/openapi.json`
 
+Stable releases also publish a downloadable OpenAPI artifact at:
+- `https://github.com/grimmory-tools/grimmory/releases/latest/download/grimmory-openapi.json`
+
 ---
 
 ## BookDrop

--- a/README.md
+++ b/README.md
@@ -206,9 +206,6 @@ When enabled via `API_DOCS_ENABLED`, API reference documentation is available as
 - API reference docs are available at `http://localhost:6060/api/docs`
 - OpenAPI JSON is available at `http://localhost:6060/api/openapi.json`
 
-Stable releases also publish a downloadable OpenAPI artifact at:
-- `https://github.com/grimmory-tools/grimmory/releases/latest/download/grimmory-openapi.json`
-
 ---
 
 ## BookDrop

--- a/backend/DEVELOPMENT.md
+++ b/backend/DEVELOPMENT.md
@@ -47,7 +47,7 @@ just api check
 
 ## Running Locally
 
-The backend expects a MariaDB instance and a local `application-dev.yml` with your database and
+The backend expects a MariaDB instance plus environment or local configuration for your database and
 storage paths. The common backend loop is:
 
 ```bash
@@ -80,10 +80,14 @@ backend-only development and test runs, frontend resources are optional.
 
 - `application.yaml` binds `app.api-docs.enabled` to `API_DOCS_ENABLED` (default `false`).
 - `application.yaml` binds `springdoc.api-docs.enabled` to `app.api-docs.enabled`.
-- `application-dev.yml` enables docs for local dev profile runs by default.
 - For runtime or container profiles, set `API_DOCS_ENABLED=true` to expose:
   - `/api/openapi.json`
   - `/api/docs`
+- To export a release-ready spec without running the full container stack, use:
+
+```bash
+just openapi-export
+```
 
 ## Packaging Notes
 

--- a/backend/Justfile
+++ b/backend/Justfile
@@ -18,6 +18,10 @@ run profile='dev':
 build:
     {{ gradle }} build --no-daemon --parallel --build-cache
 
+# Build the backend jar and export build/openapi/grimmory-openapi.json.
+openapi-export:
+    {{ gradle }} buildOpenApiArtifacts --no-daemon --parallel --build-cache
+
 # Run the backend test suite.
 test:
     {{ gradle }} test --no-daemon --parallel --build-cache

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.springframework.boot.gradle.tasks.bundling.BootJar
@@ -31,6 +32,11 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 val useLocalLibs = providers.gradleProperty("useLocalLibs").isPresent
+val mainSourceSet = the<SourceSetContainer>()["main"]
+val openApiOutputDir = layout.buildDirectory.dir("openapi")
+val openApiOutputFile = openApiOutputDir.map { it.file("grimmory-openapi.json") }
+val openApiLogFile = openApiOutputDir.map { it.file("export-openapi.log") }
+val openApiExportScript = layout.projectDirectory.file("scripts/export-openapi.sh")
 
 repositories {
     if (useLocalLibs) mavenLocal()
@@ -89,6 +95,8 @@ configurations {
         extendsFrom(configurations.annotationProcessor.get())
     }
 }
+
+val openApiExportRuntimeOnly by configurations.creating
 
 dependencies {
     // --- Spring Boot ---
@@ -187,6 +195,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("org.mockito:mockito-inline:5.2.0")
     testRuntimeOnly("com.h2database:h2")
+    add(openApiExportRuntimeOnly.name, "com.h2database:h2")
 
     // PDFBox for test PDF creation only (production code uses PDFium4j)
     testImplementation("org.apache.pdfbox:pdfbox:3.0.7")
@@ -238,4 +247,44 @@ tasks.named<BootRun>("bootRun") {
 
 tasks.named<BootJar>("bootJar") {
     mainClass.set("org.booklore.BookloreApplication")
+}
+
+tasks.register("exportOpenApi") {
+    group = "documentation"
+    description = "Boot the backend with the openapi-export profile and write build/openapi/grimmory-openapi.json."
+    dependsOn(tasks.named("classes"))
+    inputs.files(mainSourceSet.runtimeClasspath, openApiExportRuntimeOnly, openApiExportScript)
+    outputs.file(openApiOutputFile)
+
+    doLast {
+        val outputFile = openApiOutputFile.get().asFile
+        val logFile = openApiLogFile.get().asFile
+        val classpath = files(mainSourceSet.runtimeClasspath, openApiExportRuntimeOnly).asPath
+        val javaExecutable = javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(25))
+        }.get().executablePath.asFile.absolutePath
+
+        val result = ProcessBuilder(
+            "bash",
+            openApiExportScript.asFile.absolutePath,
+            javaExecutable,
+            classpath,
+            outputFile.absolutePath
+        )
+            .directory(project.projectDir)
+            .inheritIO()
+            .apply {
+                environment()["OPENAPI_EXPORT_LOG_FILE"] = logFile.absolutePath
+            }
+            .start()
+
+        val exitCode = result.waitFor()
+        check(exitCode == 0) { "OpenAPI export script failed with exit code $exitCode. See ${logFile.absolutePath}." }
+    }
+}
+
+tasks.register("buildOpenApiArtifacts") {
+    group = "build"
+    description = "Build the backend jar and export build/openapi/grimmory-openapi.json from the openapi-export profile."
+    dependsOn(tasks.named("bootJar"), tasks.named("exportOpenApi"))
 }

--- a/backend/scripts/export-openapi.sh
+++ b/backend/scripts/export-openapi.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <java-executable> <classpath> <output-file>" >&2
+  exit 1
+fi
+
+java_executable="$1"
+classpath="$2"
+output_file="$3"
+output_dir="$(dirname "$output_file")"
+log_file="${OPENAPI_EXPORT_LOG_FILE:-$output_dir/export-openapi.log}"
+
+mkdir -p "$output_dir"
+: > "$log_file"
+
+port="$(
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+
+endpoint="http://127.0.0.1:${port}/api/openapi.json"
+
+"$java_executable" \
+  --enable-native-access=ALL-UNNAMED \
+  --enable-preview \
+  -Dspring.profiles.active=openapi-export \
+  -Dserver.port="$port" \
+  -cp "$classpath" \
+  org.booklore.BookloreApplication \
+  >>"$log_file" 2>&1 &
+app_pid=$!
+
+cleanup() {
+  if kill -0 "$app_pid" 2>/dev/null; then
+    kill "$app_pid" 2>/dev/null || true
+    wait "$app_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 60); do
+  if ! kill -0 "$app_pid" 2>/dev/null; then
+    echo "OpenAPI export application exited before serving ${endpoint}. See ${log_file}." >&2
+    exit 1
+  fi
+
+  if curl --silent --show-error --fail --max-time 5 "$endpoint" -o "$output_file"; then
+    if grep -q '"openapi"' "$output_file"; then
+      exit 0
+    fi
+  fi
+
+  sleep 1
+done
+
+echo "Timed out waiting for ${endpoint}. See ${log_file}." >&2
+exit 1

--- a/backend/src/main/resources/application-openapi-export.yaml
+++ b/backend/src/main/resources/application-openapi-export.yaml
@@ -1,0 +1,39 @@
+app:
+  api-docs:
+    enabled: true
+  path-config: ${OPENAPI_EXPORT_APP_PATH:${java.io.tmpdir}/grimmory-openapi-export/data}
+  bookdrop-folder: ${OPENAPI_EXPORT_BOOKDROP:${java.io.tmpdir}/grimmory-openapi-export/bookdrop}
+  cors:
+    allowed-origins: http://127.0.0.1
+
+server:
+  port: ${OPENAPI_EXPORT_PORT:9091}
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:openapi-export;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE;NON_KEYWORDS=VALUE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  flyway:
+    enabled: false
+  jpa:
+    properties:
+      hibernate:
+        connection:
+          provider_disables_autocommit: false
+  task:
+    scheduling:
+      enabled: false
+
+logging:
+  level:
+    root: WARN
+    org.booklore: WARN
+    org.hibernate.orm.deprecation: ERROR
+    com.github.gotson.nightcompress.Archive: ERROR
+    io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics: ERROR
+    org.booklore.config.WebSocketConfig: ERROR
+    org.booklore.config.security.SecurityConfig: ERROR
+    org.booklore.service.monitoring.LibraryWatchService: ERROR
+    org.booklore.service.watcher.LibraryFileEventProcessor: ERROR

--- a/docs/MAKING-A-RELEASE.md
+++ b/docs/MAKING-A-RELEASE.md
@@ -100,6 +100,7 @@ They come from `develop` through [`.github/workflows/publish-nightly.yml`](../.g
 
 - `nightly`
 - `nightly-YYYYMMDD-<sha>`
+- `grimmory-openapi.json`
 
 ## Preview Builds
 


### PR DESCRIPTION
## Description

Adds automated OpenAPI JSON exports to the nightly build pipeline

Once this is in, nightly will generate `backend/build/openapi/grimmory-openapi.json` from a dedicated `openapi-export` profile and upload it as a workflow artifact. This will give us a consistent source for the latest nightly API spec without depending on an external database or running it locally.

Once we've confirmed this behaves to our liking, we can merge in the next PR to introduce this flow to stable releases.

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/291

## Changes

- add a dedicated backend `openapi-export` profile for lightweight OpenAPI generation
- add `just api openapi-export` / `buildOpenApiArtifacts` support for exporting `grimmory-openapi.json`
- wire nightly CI to generate and upload the OpenAPI JSON artifact
- add a small shared GitHub action for OpenAPI export setup
- kills outdated refs to `application-dev.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated OpenAPI specification export to nightly builds, published as a versioned artifact
  * Updated development and release documentation to reflect workflow changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->