### PR TITLE
ci: support building images in forks

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -99,6 +99,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Authenticate to Docker Hub
+        if: ${{ vars.DOCKERHUB_REGISTRY != '' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -111,27 +112,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and push Docker image
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: |
+            ${{ vars.DOCKERHUB_REGISTRY }}
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=nightly
+            type=raw,value=${{ env.nightly_tag }}
+
+      - name: Build and push Stable image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            grimmory/grimmory:${{ env.nightly_tag }}
-            grimmory/grimmory:nightly
-            ghcr.io/grimmory-tools/grimmory:${{ env.nightly_tag }}
-            ghcr.io/grimmory-tools/grimmory:nightly
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             APP_VERSION=${{ env.nightly_tag }}
             APP_REVISION=${{ env.commit_sha }}
           cache-from: |
             type=gha,scope=image-shared
-            type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: |
             type=gha,scope=image-shared,mode=max
-            type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache,mode=max
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
   export-openapi:
     name: Export Nightly OpenAPI Artifact

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Authenticate to Docker Hub
+        if: ${{ vars.DOCKERHUB_REGISTRY != '' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -42,6 +43,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: |
+            ${{ vars.DOCKERHUB_REGISTRY }}
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern=v{{version}},value=${{ github.event.release.tag_name }},match=^v(.+)$
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ github.event.release.tag_name }},match=^v(.+)$
+
       - name: Build and push Stable image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -49,20 +61,17 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            grimmory/grimmory:${{ github.event.release.tag_name }}
-            grimmory/grimmory:latest
-            ghcr.io/grimmory-tools/grimmory:${{ github.event.release.tag_name }}
-            ghcr.io/grimmory-tools/grimmory:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             APP_VERSION=${{ github.event.release.tag_name }}
             APP_REVISION=${{ github.sha }}
           cache-from: |
             type=gha,scope=image-shared
-            type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: |
             type=gha,scope=image-shared,mode=max
-            type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache,mode=max
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
   prepare-release-notification:
     name: Prepare Stable Release Notification


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
currently, even in forks when CI is run to push docker images we attempt to push to dockerhub for `grimmory/grimmory` & the ghcr.io for grimmory.  this can be a problem when users are trying to test out changes to CI and want to do so in their own fork

this change allows for an optional dockerhub registry & dynamic ghcr registries based off the repository name - allowing for forks to run the image build & push CI 

to simplify this, the docker metadata action is being used to generate the tags

**Linked Issue:** Fixes #1001 & supports #993 

## Testing

Cut release `v0.0.2` on a fork.

[Action Run](https://github.com/imnotjames/grimmory/actions/runs/25147566131)

## Changes

* switches the dockerhub registry to be based off a repository variable
* adds `docker/metadata-action` to simplify an optional dockerhub registry
* switches the ghcr registry to be based off the current repository name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker image publishing to dynamically generate tags and annotations for both Docker Hub and GitHub Container Registry across nightly and release/semver flows.
  * Made Docker Hub authentication conditional based on registry configuration.
  * Updated publish steps to consume generated metadata instead of fixed tag lists (removed explicit latest tagging).
  * Generalized CI build cache references to the current repository namespace for portable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->