### PR TITLE
fix(cbx): drain NightCompress InputStream before closing

### DIFF
--- a/backend/src/main/java/org/booklore/service/ArchiveService.java
+++ b/backend/src/main/java/org/booklore/service/ArchiveService.java
@@ -97,7 +97,16 @@ public class ArchiveService {
         lock.lock();
         try (InputStream inputStream = Archive.getInputStream(path, entryName)) {
             if (inputStream != null) {
-                return inputStream.transferTo(outputStream);
+                try {
+                    return inputStream.transferTo(outputStream);
+                } finally {
+                    // For some reason, NightCompress fails with a SIGSEGV if you
+                    // do not read the entirety of the input stream from the zip.
+                    //
+                    // To keep NightCompress happy, we need to exhaust the stream
+                    // before we continue.
+                    inputStream.transferTo(OutputStream.nullOutputStream());
+                }
             }
         } catch (Exception e) {
             throw new IOException("Failed to extract from archive: " + e.getMessage(), e);

--- a/backend/src/main/java/org/booklore/service/ArchiveService.java
+++ b/backend/src/main/java/org/booklore/service/ArchiveService.java
@@ -100,11 +100,8 @@ public class ArchiveService {
                 try {
                     return inputStream.transferTo(outputStream);
                 } finally {
-                    // For some reason, NightCompress fails with a SIGSEGV if you
-                    // do not read the entirety of the input stream from the zip.
-                    //
-                    // To keep NightCompress happy, we need to exhaust the stream
-                    // before we continue.
+                    // NightCompress fails with a SIGSEGV if you do not read the
+                    // entirety of the input stream from the zip.
                     inputStream.transferTo(OutputStream.nullOutputStream());
                 }
             }

--- a/backend/src/main/java/org/booklore/service/ArchiveService.java
+++ b/backend/src/main/java/org/booklore/service/ArchiveService.java
@@ -14,6 +14,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
@@ -191,16 +192,24 @@ public class ArchiveService {
         requireAvailable();
         ReentrantLock lock = getFileLock(path);
         lock.lock();
-        try (InputStream inputStream = Archive.getInputStream(path, entryName)) {
-            if (inputStream != null) {
-                return Files.copy(inputStream, outputPath);
-            }
+
+        boolean hasCreatedFile = false;
+        try (OutputStream outputStream = Files.newOutputStream(outputPath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+            hasCreatedFile = true;
+
+            return transferEntryTo(path, entryName, outputStream);
         } catch (Exception e) {
+            if (hasCreatedFile) {
+                try {
+                    Files.deleteIfExists(outputPath);
+                } catch (Exception ce) {
+                    e.addSuppressed(ce);
+                }
+            }
+
             throw new IOException("Failed to extract from archive: " + e.getMessage(), e);
         } finally {
             lock.unlock();
         }
-
-        throw new IOException("Entry not found in archive");
     }
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
When `getEntryBytesPrefix` is called, the `BoundedOutputStream` raises an `LimitReachedException` when it reaches a limit of bytes is used.  This caused the `InputStream` to not fully exhaust (required for cleanup) which triggers a segfault.  This is caused by an internal behavior of `NightCompress` where an input stream for an archive entry gets grumpy when it is not fully read and tucked into bed.  This only seems to become a problem after a number of entries have been each individually read.

[This is avoided in Komga by always reading all bytes from the archive.](https://github.com/gotson/komga/blob/3d7615e7b436ec530984d6a8752e1edc024bd2ff/komga/src/main/kotlin/org/gotson/komga/infrastructure/mediacontainer/divina/Rar5Extractor.kt#L75)

To do something similar, we can wrap the call to `transferTo` with a `try..finally` and exhaust the input stream - leading to no crash.

In the future, we may want to investigate approaches for non-RAR archives and reverting to pre-nightcompress code in those cases.

**Linked Issue:** Fixes #939

## Testing

After finding a file which reliably replicates the failing behavior, I was able to confirm that without this change the file will cause a segfault and with this change the file will complete successfully.

### Testing Steps

1. Start Grimmory (`develop`)
2. Clear all caches (this could be made easier somehow..)
3. Open a large CBR (eg, 100-200 page)
4. Observe a segfault with the API call to get image sizes occurs
5. Switch to this branch
6. Clear all caches
7. Open a large CBR (eg, 100-200 pages)
8. Observe no segfault
9. Swap back to `develop`, do the same and observe the segfault

## Changes

* clean up NightCompress `InputStream` by exhausting it when transfer to an outputstream is interrupted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive extraction reliability so transfers consistently complete and no longer exit early.
  * Ensures remaining compressed data is fully drained after transfer, always creates a new output file, and deletes partially written files on failure.
  * Reduces spurious "entry not found" errors, resource leaks, and incomplete output files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->