### PR TITLE
ci(release): Use repo variables instead of hardcoding names

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -121,17 +121,17 @@ jobs:
           tags: |
             ${{ vars.DOCKER_HUB_REPOSITORY || github.repository }}:${{ env.nightly_tag }}
             ${{ vars.DOCKER_HUB_REPOSITORY || github.repository }}:nightly
-            ghcr.io/${{ github.repository_owner }}/grimmory:${{ env.nightly_tag }}
-            ghcr.io/${{ github.repository_owner }}/grimmory:nightly
+            ghcr.io/${{ github.repository }}:${{ env.nightly_tag }}
+            ghcr.io/${{ github.repository }}:nightly
           build-args: |
             APP_VERSION=${{ env.nightly_tag }}
             APP_REVISION=${{ env.commit_sha }}
           cache-from: |
             type=gha,scope=image-shared
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/grimmory:buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: |
             type=gha,scope=image-shared,mode=max
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/grimmory:buildcache,mode=max
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
   generate-notes:
     name: Nightly Changelog

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -119,19 +119,19 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            grimmory/grimmory:${{ env.nightly_tag }}
-            grimmory/grimmory:nightly
-            ghcr.io/grimmory-tools/grimmory:${{ env.nightly_tag }}
-            ghcr.io/grimmory-tools/grimmory:nightly
+            ${{ vars.DOCKER_HUB_REPOSITORY || github.repository }}:${{ env.nightly_tag }}
+            ${{ vars.DOCKER_HUB_REPOSITORY || github.repository }}:nightly
+            ghcr.io/${{ github.repository_owner }}/grimmory:${{ env.nightly_tag }}
+            ghcr.io/${{ github.repository_owner }}/grimmory:nightly
           build-args: |
             APP_VERSION=${{ env.nightly_tag }}
             APP_REVISION=${{ env.commit_sha }}
           cache-from: |
             type=gha,scope=image-shared
-            type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/grimmory:buildcache
           cache-to: |
             type=gha,scope=image-shared,mode=max
-            type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache,mode=max
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/grimmory:buildcache,mode=max
 
   generate-notes:
     name: Nightly Changelog

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,19 +50,19 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            grimmory/grimmory:${{ github.event.release.tag_name }}
-            grimmory/grimmory:latest
-            ghcr.io/grimmory-tools/grimmory:${{ github.event.release.tag_name }}
-            ghcr.io/grimmory-tools/grimmory:latest
+            ${{ vars.DOCKER_HUB_REPOSITORY || github.repository }}:${{ github.event.release.tag_name }}
+            ${{ vars.DOCKER_HUB_REPOSITORY || github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+            ghcr.io/${{ github.repository }}:latest
           build-args: |
             APP_VERSION=${{ github.event.release.tag_name }}
             APP_REVISION=${{ github.sha }}
           cache-from: |
             type=gha,scope=image-shared
-            type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: |
             type=gha,scope=image-shared,mode=max
-            type=registry,ref=ghcr.io/grimmory-tools/grimmory:buildcache,mode=max
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
   prepare-release-notification:
     name: Prepare Stable Release Notification


### PR DESCRIPTION
## Description

The CI used to hardcode `grimmory` in several places when publishing release and nightly images.

This PR uses GitHub's CI variables to make it easier to work on the publishing process in forks.

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

- Updates the `public-release.yaml` workflow so it doesn't use hardcoded `grimmory`
- Updates the `public-nightly.yaml` workflow so it doesn't use hardcoded `grimmory`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing workflows to use dynamic repository configuration for Docker Hub and GitHub Container Registry, improving flexibility for build caches and image tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->