### PR TITLE
ci: skip discord notification on release when no token

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -185,13 +185,28 @@ jobs:
       release_type: ${{ steps.notes.outputs.release_type }}
       released: ${{ steps.notes.outputs.released }}
       to_sha: ${{ steps.notes.outputs.to_sha }}
+      available: ${{ steps.webhook_secrets_check.outputs.available }}
     steps:
+      - name: Check Discord Webhook secrets
+        id: webhook_secrets_check
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK != '' && secrets.DISCORD_NIGHTLY_WEBHOOK || secrets.DISCORD_RELEASE_WEBHOOK }}
+        run: |
+          # Check here rather than in the `if`.
+          # Github actions does not support the `secrets` context in `if` blocks.
+          if [[ -n "${DISCORD_WEBHOOK}" ]]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout Workflow Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Build Full Changelog
+        if: ${{ steps.webhook_secrets_available.outputs.available == 'true' }}
         id: notes
         uses: ./.github/actions/compute-release-notes
         with:
@@ -202,7 +217,7 @@ jobs:
 
   notify-discord:
     name: Notify Discord (Nightly)
-    if: ${{ always() && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' && needs.export-openapi.result == 'success' && needs.generate-notes.outputs.predicted_version != '' }}
+    if: ${{ always() && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' && needs.export-openapi.result == 'success' && needs.generate-notes.outputs.available == 'true' && needs.generate-notes.outputs.predicted_version != '' }}
     needs: [resolve_ref, build-and-push, export-openapi, generate-notes]
     permissions: {}
     uses: ./.github/workflows/notify-discord-release-notes.yml

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -206,7 +206,7 @@ jobs:
           fetch-depth: 1
 
       - name: Build Full Changelog
-        if: ${{ steps.webhook_secrets_available.outputs.available == 'true' }}
+        if: ${{ steps.webhook_secrets_check.outputs.available == 'true' }}
         id: notes
         uses: ./.github/actions/compute-release-notes
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -82,11 +82,25 @@ jobs:
     outputs:
       base_tag: ${{ steps.metadata.outputs.base_tag }}
       compare_url: ${{ steps.metadata.outputs.compare_url }}
+      available: ${{ steps.webhook_secrets_check.outputs.available }}
 
     permissions:
       contents: read
 
     steps:
+      - name: Check Discord Webhook secrets
+        id: webhook_secrets_check
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_STABLE_WEBHOOK }}
+        run: |
+          # Check here rather than in the `if`.
+          # Github actions does not support the `secrets` context in `if` blocks.
+          if [[ -n "${DISCORD_WEBHOOK}" ]]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -95,6 +109,7 @@ jobs:
 
       - name: Extract Stable Release Metadata
         id: metadata
+        if: ${{ steps.webhook_secrets_available.outputs.available == 'true' }}
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
@@ -117,6 +132,7 @@ jobs:
     name: Notify Discord Release
     needs:
       - prepare-release-notification
+    if: ${{ needs.prepare-release-notification.outputs.available == 'true' }}
     permissions: {}
     uses: ./.github/workflows/notify-discord-release-notes.yml
     secrets:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Extract Stable Release Metadata
         id: metadata
-        if: ${{ steps.webhook_secrets_available.outputs.available == 'true' }}
+        if: ${{ steps.webhook_secrets_check.outputs.available == 'true' }}
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
update the discord notification so that the attempt to send to the discord webhook is skipped when the discord webhook is not in secrets.  this should only be the case on forks that are not doing discord notifications

**Linked Issue:** Fixes #1009

## Testing

Ran at https://github.com/imnotjames/grimmory/actions/runs/25198851263

## Changes

* add check for discord webhook env var
* add `if` block to prevent notification send when unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal build notification reliability by adding conditional checks for deployment notification availability across publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->