### PR TITLE
ci: get OpenAPI json export operating on nightly

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Upload Nightly OpenAPI Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: nightly-openapi-${{ needs.resolve_ref.outputs.nightly_tag }}
+          name: openapi-${{ needs.resolve_ref.outputs.nightly_tag }}
           path: backend/build/openapi/grimmory-openapi.json
           retention-days: 30
 

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -155,6 +155,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          ref: ${{ needs.resolve_ref.outputs.commit_sha }}
 
       - name: Export OpenAPI JSON
         uses: ./.github/actions/export-openapi

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -144,7 +144,7 @@ jobs:
 
   export-openapi:
     name: Export Nightly OpenAPI Artifact
-    needs: [resolve_ref, test-suite, build-and-push]
+    needs: [resolve_ref]
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -151,6 +151,11 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout Workflow Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
       - name: Export OpenAPI JSON
         uses: ./.github/actions/export-openapi
         with:


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
ensures that the action yaml for the openapi export task is available before trying to execute it

to make testing / building easier - does not wait for tests to finish as this is an artifact related to the build rather than part of any release & makes the exposed artifact name clearer

**Linked Issue:** Fixes #1021<!-- issue number leave empty if none -->

## Testing

Ran in https://github.com/imnotjames/grimmory/actions/runs/25195541750

## Changes

* checks out the repo before running an action so the action is found
* drops the unnecessary `needs` from the job
* makes artifact name less redundant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the nightly workflow to eliminate unnecessary waits and run more efficiently.
  * Ensured the repository is checked out at the resolved commit before export steps for more reliable artifact generation.
  * Standardized artifact naming for clearer, consistent OpenAPI artifact names and simpler downstream handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->