### PR TITLE
test: disable flakey BookRuleEval test

### DIFF
--- a/backend/src/test/java/org/booklore/service/BookRuleEvaluatorServiceIntegrationTest.java
+++ b/backend/src/test/java/org/booklore/service/BookRuleEvaluatorServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -624,6 +625,7 @@ class BookRuleEvaluatorServiceIntegrationTest {
         }
 
         @Test
+        @Disabled("This test fails at the end of the month because of a timezone bug")
         void thisPeriod_month_matchesThisMonthBook() {
             BookEntity thisMonth = createBook("This Month Book");
             thisMonth.setAddedOn(Instant.now().minus(1, ChronoUnit.HOURS));


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

the `BookRuleEvalulatorServiceIntegrationTest` uses `Instant.now()` and `LocalDate.now()`.  The test is flakey during some date ranges (eg, end of month) so this disables the test for now

failure seen in https://github.com/grimmory-tools/grimmory/actions/runs/25195531780/job/73875148169

## Changes

* Disable `BookRuleEvalulatorServiceIntegrationTest.thisPeriod_month_matchesThisMonthBook`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled a test related to monthly book matching to address an identified issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->