### PR TITLE
fix(cbx-reader): fix two-page layout + navigation

### DIFF
--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
@@ -67,13 +67,14 @@
     <div class="pages-wrapper" role="button" tabindex="0" (click)="onImageClick()" (keydown.enter)="onImageClick()"
       (dblclick)="onImageDoubleClick()">
       @if (isPageTransitioning() && previousImageUrls().length > 0) {
-      <div class="previous-page-layer">
+      <div class="previous-page-layer" [class.single-page-layer]="previousImageUrls().length === 1">
         @for (url of previousImageUrls(); track url) {
         <img [src]="url" alt="Previous Page" class="page-image previous-image" />
         }
       </div>
       }
-      <div class="current-page-layer" [class.fade-in]="isPageTransitioning() && imagesLoaded()">
+      <div class="current-page-layer" [class.fade-in]="isPageTransitioning() && imagesLoaded()"
+        [class.single-page-layer]="isSinglePageLayer()">
         @if (shouldUseCanvasRenderer()) {
         <app-canvas-renderer [imageUrl]="currentImageUrls()[0]" [splitState]="canvasSplitState()"
           [splitOption]="pageSplitOption()">

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
@@ -67,7 +67,7 @@
     <div class="pages-wrapper" role="button" tabindex="0" (click)="onImageClick()" (keydown.enter)="onImageClick()"
       (dblclick)="onImageDoubleClick()">
       @if (isPageTransitioning() && previousImageUrls().length > 0) {
-      <div class="previous-page-layer" [class.single-page-layer]="previousImageUrls().length === 1">
+      <div class="previous-page-layer" [class.single-page-layer]="isPreviousSinglePageLayer()">
         @for (url of previousImageUrls(); track url) {
         <img [src]="url" alt="Previous Page" class="page-image previous-image" />
         }

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -325,28 +325,32 @@
       }
 
       &.fit-height {
-        .pages-wrapper,
-        .previous-page-layer,
+        overflow: auto;
+        align-items: stretch;
+        touch-action: pan-x pan-y;
+
+        .pages-wrapper {
+          width: max-content;
+          min-width: 100%;
+          min-height: 100%;
+          height: auto;
+        }
+
         .current-page-layer {
-          width: auto;
-          max-width: 100%;
+          width: max-content;
+          height: auto;
+          margin-inline: auto;
         }
 
         .page-image {
           width: auto;
-          height: 100%;
+          height: calc(100dvh - 1rem);
+          max-width: none;
         }
 
         &.two-page-view {
-          overflow: auto;
-          align-items: stretch;
-          touch-action: pan-x pan-y;
-
           .pages-wrapper {
-            width: max-content;
-            min-width: 100%;
-            min-height: 100%;
-            height: auto;
+            display: block;
           }
 
           .previous-page-layer,
@@ -368,7 +372,7 @@
             grid-template-columns: max-content;
 
             .page-image {
-              max-width: 100%;
+              max-width: none;
             }
           }
         }

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -281,7 +281,7 @@
 
       &.fit-width {
         overflow-y: auto;
-        align-items: stretch;
+        align-items: flex-start;
         touch-action: pan-y;
 
         .pages-wrapper,
@@ -291,23 +291,26 @@
           max-height: none;
         }
 
+        .pages-wrapper {
+          min-height: 100%;
+        }
+
+        .current-page-layer {
+          margin-block: auto;
+        }
+
         .page-image {
           width: 100%;
           height: auto;
         }
 
         &.two-page-view {
-          .pages-wrapper {
-            display: grid;
-            align-content: center;
-            min-height: 100%;
-          }
-
           .previous-page-layer,
           .current-page-layer {
             display: grid;
             grid-template-columns: repeat(2, minmax(0, 1fr));
             gap: 1rem;
+            width: 100%;
           }
 
           .single-page-layer {
@@ -340,8 +343,6 @@
           touch-action: pan-x pan-y;
 
           .pages-wrapper {
-            display: grid;
-            place-items: center;
             width: max-content;
             min-width: 100%;
             min-height: 100%;
@@ -354,7 +355,7 @@
             grid-template-columns: repeat(2, max-content);
             width: max-content;
             height: auto;
-            justify-content: center;
+            margin-inline: auto;
           }
 
           .page-image {

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -281,7 +281,7 @@
 
       &.fit-width {
         overflow-y: auto;
-        align-items: flex-start;
+        align-items: stretch;
         touch-action: pan-y;
 
         .pages-wrapper,
@@ -298,7 +298,9 @@
 
         &.two-page-view {
           .pages-wrapper {
-            display: block;
+            display: grid;
+            align-content: center;
+            min-height: 100%;
           }
 
           .previous-page-layer,
@@ -333,13 +335,37 @@
         }
 
         &.two-page-view {
+          overflow: auto;
+          align-items: stretch;
+          touch-action: pan-x pan-y;
+
+          .pages-wrapper {
+            display: grid;
+            place-items: center;
+            width: max-content;
+            min-width: 100%;
+            min-height: 100%;
+            height: auto;
+          }
+
+          .previous-page-layer,
+          .current-page-layer {
+            display: grid;
+            grid-template-columns: repeat(2, max-content);
+            width: max-content;
+            height: auto;
+            justify-content: center;
+          }
+
           .page-image {
             width: auto;
-            height: 100%;
-            max-width: calc(50% - 0.5rem);
+            height: calc(100dvh - 1rem);
+            max-width: none;
           }
 
           .single-page-layer {
+            grid-template-columns: max-content;
+
             .page-image {
               max-width: 100%;
             }
@@ -366,6 +392,28 @@
           height: auto;
           max-width: none;
           max-height: none;
+        }
+
+        &.two-page-view {
+          .pages-wrapper {
+            display: block;
+            width: max-content;
+            min-width: 100%;
+            height: max-content;
+          }
+
+          .previous-page-layer,
+          .current-page-layer {
+            display: grid;
+            grid-template-columns: repeat(2, max-content);
+            width: max-content;
+            height: max-content;
+            justify-content: start;
+          }
+
+          .single-page-layer {
+            grid-template-columns: max-content;
+          }
         }
       }
 

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -274,16 +274,8 @@
         object-fit: contain;
         box-shadow: 0 8px 32px rgb(0 0 0 / 60%);
         border-radius: 4px;
-        transition: transform 0.2s ease;
-
-        &:hover {
-          transform: scale(1.02);
-        }
 
         &.previous-image {
-          &:hover {
-            transform: none;
-          }
         }
       }
 
@@ -302,19 +294,22 @@
         .page-image {
           width: 100%;
           height: auto;
-
-          &:hover {
-            transform: scale(1.02);
-          }
         }
 
         &.two-page-view {
-          .pages-wrapper,
+          .pages-wrapper {
+            display: block;
+          }
+
           .previous-page-layer,
           .current-page-layer {
             display: grid;
-            grid-template-columns: 1fr 1fr;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
             gap: 1rem;
+          }
+
+          .single-page-layer {
+            grid-template-columns: 1fr;
           }
 
           .page-image {
@@ -335,10 +330,6 @@
         .page-image {
           width: auto;
           height: 100%;
-
-          &:hover {
-            transform: scale(1.02);
-          }
         }
 
         &.two-page-view {
@@ -346,6 +337,12 @@
             width: auto;
             height: 100%;
             max-width: calc(50% - 0.5rem);
+          }
+
+          .single-page-layer {
+            .page-image {
+              max-width: 100%;
+            }
           }
         }
       }
@@ -369,10 +366,6 @@
           height: auto;
           max-width: none;
           max-height: none;
-
-          &:hover {
-            transform: none;
-          }
         }
       }
 
@@ -382,10 +375,6 @@
           max-height: 100%;
           width: auto;
           height: auto;
-
-          &:hover {
-            transform: scale(1.02);
-          }
         }
 
         &.two-page-view {
@@ -394,6 +383,12 @@
             max-height: 100%;
             width: auto;
             height: auto;
+          }
+
+          .single-page-layer {
+            .page-image {
+              max-width: 100%;
+            }
           }
         }
       }
@@ -404,10 +399,6 @@
           max-height: 100%;
           width: auto;
           height: auto;
-
-          &:hover {
-            transform: scale(1.02);
-          }
         }
 
         &.two-page-view {
@@ -416,6 +407,12 @@
             max-height: 100%;
             width: auto;
             height: auto;
+          }
+
+          .single-page-layer {
+            .page-image {
+              max-width: 100%;
+            }
           }
         }
       }

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -392,6 +392,16 @@
           min-height: 0;
         }
 
+        .pages-wrapper {
+          display: block;
+        }
+
+        .previous-page-layer,
+        .current-page-layer {
+          justify-content: flex-start;
+          align-items: flex-start;
+        }
+
         .page-image {
           width: auto;
           height: auto;
@@ -400,13 +410,6 @@
         }
 
         &.two-page-view {
-          .pages-wrapper {
-            display: block;
-            width: max-content;
-            min-width: 100%;
-            height: max-content;
-          }
-
           .previous-page-layer,
           .current-page-layer {
             display: grid;

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -7,7 +7,7 @@ import { PageTitleService } from "../../../shared/service/page-title.service";
 import { CbxReaderService } from '../../book/service/cbx-reader.service';
 import { BookService } from '../../book/service/book.service';
 import { CbxBackgroundColor, CbxFitMode, CbxMagnifierLensSize, CbxMagnifierZoom, CbxPageSpread, CbxPageSplitOption, CbxPageViewMode, CbxScrollMode, CbxReadingDirection, CbxSlideshowInterval, UserService } from '../../settings/user-management/user.service';
-import { CbxPageDimensionService, DoublePairs } from './core/cbx-page-dimension.service';
+import { CbxPageDimensionService } from './core/cbx-page-dimension.service';
 import { CbxPageDimension } from './models/cbx-page-dimension.model';
 import { MessageService } from 'primeng/api';
 import { TranslocoService, TranslocoPipe } from '@jsverse/transloco';
@@ -39,6 +39,7 @@ import {
   shouldOfferWebtoonHint,
   writeStripWidthPercentPerBook
 } from './core/cbx-reader-storage';
+import {computeCbxSpreads, findCbxSpreadForPage} from './core/cbx-spread.util';
 
 
 @Component({
@@ -91,7 +92,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   currentPage = signal(0);
   isLoading = signal(true);
 
-  pageSpread = signal<CbxPageSpread>(CbxPageSpread.ODD);
+  pageSpread = signal<CbxPageSpread>(CbxPageSpread.EVEN);
   pageViewMode = signal<CbxPageViewMode>(CbxPageViewMode.SINGLE_PAGE);
   backgroundColor = signal<CbxBackgroundColor>(CbxBackgroundColor.GRAY);
   fitMode = signal<CbxFitMode>(CbxFitMode.FIT_PAGE);
@@ -198,8 +199,6 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
   // Page dimensions from backend
   pageDimensions = signal<CbxPageDimension[]>([]);
-  doublePairs = signal<DoublePairs>({});
-
   // Double page detection (fallback cache for pages without backend dims)
   private pageDimensionsCache = new Map<number, { width: number, height: number }>();
 
@@ -390,8 +389,6 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
         this.pages.set(pages);
         this.pageDimensions.set(dimensions);
-        this.doublePairs.set(this.pageDimensionService.computeDoublePairs(dimensions));
-
         if (this.bookType() === CbxReaderComponent.TYPE_CBX) {
           const global = userSettings.perBookSetting.cbx === CbxReaderComponent.SETTING_GLOBAL;
           this.cbxSettingsUsesGlobal.set(global);
@@ -406,8 +403,8 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
             : this.CbxPageViewMode[bookSettings.cbxSettings?.pageViewMode as keyof typeof CbxPageViewMode] || this.CbxPageViewMode[userSettings.cbxReaderSetting.pageViewMode as keyof typeof CbxPageViewMode] || this.CbxPageViewMode.SINGLE_PAGE);
 
           this.pageSpread.set(global
-            ? this.CbxPageSpread[userSettings.cbxReaderSetting.pageSpread as keyof typeof CbxPageSpread] || this.CbxPageSpread.ODD
-            : this.CbxPageSpread[bookSettings.cbxSettings?.pageSpread as keyof typeof CbxPageSpread] || this.CbxPageSpread[userSettings.cbxReaderSetting.pageSpread as keyof typeof CbxPageSpread] || this.CbxPageSpread.ODD);
+            ? this.CbxPageSpread[userSettings.cbxReaderSetting.pageSpread as keyof typeof CbxPageSpread] || this.CbxPageSpread.EVEN
+            : this.CbxPageSpread[bookSettings.cbxSettings?.pageSpread as keyof typeof CbxPageSpread] || this.CbxPageSpread[userSettings.cbxReaderSetting.pageSpread as keyof typeof CbxPageSpread] || this.CbxPageSpread.EVEN);
 
           this.fitMode.set(global
             ? this.CbxFitMode[userSettings.cbxReaderSetting.fitMode as keyof typeof CbxFitMode] || this.CbxFitMode.FIT_PAGE
@@ -653,7 +650,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     this.footerService.updateState({
       currentPage: this.currentPage(),
       totalPages: this.pages().length,
-      isTwoPageView: this.isTwoPageView(),
+      isTwoPageView: this.isTwoPageView() && this.getCurrentSpreadPages().length > 1,
       previousBookInSeries: this.previousBookInSeries(),
       nextBookInSeries: this.nextBookInSeries(),
       hasSeries: this.hasSeries()
@@ -758,41 +755,38 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   private updateFooterPage(): void {
     this.resetSwipeBoundaryHits();
     this.footerService.setCurrentPage(this.currentPage());
+    this.footerService.setTwoPageView(this.isTwoPageView() && this.getCurrentSpreadPages().length > 1);
     this.sidebarService.setCurrentPage(this.currentPage() + 1);
     this.updateBookmarkState();
     this.updateNotesState();
   }
 
-  private getRightPageForLeftPage(leftPage: number): number | undefined {
-    const pair = Object.entries(this.doublePairs()).find(([, pairedLeft]) => pairedLeft === leftPage);
-    if (!pair) return undefined;
+  private getCbxSpreads(): number[][] {
+    return computeCbxSpreads(this.pages(), this.pageDimensions(), this.pageSpread())
+      .map(spread => spread.pages);
+  }
 
-    const rightPage = Number(pair[0]);
-    return Number.isFinite(rightPage) ? rightPage : undefined;
+  private getCurrentSpreadPages(): number[] {
+    if (!this.isTwoPageView()) {
+      return [this.currentPage()];
+    }
+    return findCbxSpreadForPage(
+      computeCbxSpreads(this.pages(), this.pageDimensions(), this.pageSpread()),
+      this.currentPage()
+    )?.pages ?? [this.currentPage()];
+  }
+
+  isSinglePageLayer(): boolean {
+    return this.scrollMode() === CbxScrollMode.PAGINATED && this.isTwoPageView() && this.getCurrentSpreadPages().length === 1;
+  }
+
+  private getImageUrlsForCurrentPage(): string[] {
+    if (!this.pages().length) return [];
+    return this.getCurrentSpreadPages().map(pageIndex => this.getPageImageUrl(pageIndex));
   }
 
   private updateCurrentImageUrls(): void {
-    if (!this.pages().length) {
-      this.currentImageUrls.set([]);
-      return;
-    }
-
-    const urls: string[] = [];
-    urls.push(this.getPageImageUrl(this.currentPage()));
-
-    if (this.isTwoPageView()) {
-      // Use doublePairs for dimension-aware pairing
-      if (Object.keys(this.doublePairs()).length > 0) {
-        const pairedWith = this.getRightPageForLeftPage(this.currentPage());
-        if (pairedWith !== undefined && pairedWith < this.pages().length) {
-          urls.push(this.getPageImageUrl(pairedWith));
-        }
-      } else if (this.currentPage() + 1 < this.pages().length) {
-        urls.push(this.getPageImageUrl(this.currentPage() + 1));
-      }
-    }
-
-    this.currentImageUrls.set(urls);
+    this.currentImageUrls.set(this.getImageUrlsForCurrentPage());
   }
 
   private preloadAdjacentPages(): void {
@@ -854,7 +848,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
     this.resetPaginatedScroll();
 
-    const newUrls = this.getNewImageUrls();
+    const newUrls = this.getImageUrlsForCurrentPage();
 
     const allPreloaded = newUrls.every(url => {
       const img = this.preloadedImages.get(url);
@@ -880,26 +874,6 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     }
 
     this.preloadAdjacentPages();
-  }
-
-  private getNewImageUrls(): string[] {
-    if (!this.pages().length) return [];
-
-    const urls: string[] = [];
-    urls.push(this.getPageImageUrl(this.currentPage()));
-
-    if (this.isTwoPageView()) {
-      if (Object.keys(this.doublePairs()).length > 0) {
-        const pairedWith = this.getRightPageForLeftPage(this.currentPage());
-        if (pairedWith !== undefined && pairedWith < this.pages().length) {
-          urls.push(this.getPageImageUrl(pairedWith));
-        }
-      } else if (this.currentPage() + 1 < this.pages().length) {
-        urls.push(this.getPageImageUrl(this.currentPage() + 1));
-      }
-    }
-
-    return urls;
   }
 
   private preloadImagesAndTransition(urls: string[]): void {
@@ -951,8 +925,6 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
 
   private advancePage(direction: 1 | -1): void {
     const previousPage = this.currentPage();
-    const step = this.getPageStep();
-
     if (this.scrollMode() === CbxScrollMode.LONG_STRIP) {
       const newPage = this.currentPage() + direction;
       if (newPage >= 0 && newPage < this.pages().length) {
@@ -980,29 +952,11 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     if (direction > 0) {
       // Forward navigation
       if (this.isTwoPageView()) {
-        // Use doublePairs for dimension-aware stepping
-        if (Object.keys(this.doublePairs()).length > 0) {
-          const pairedWith = this.getRightPageForLeftPage(this.currentPage());
-          if (pairedWith !== undefined) {
-            // Current page is paired — skip past its partner
-            const nextPage = Math.max(this.currentPage(), pairedWith) + 1;
-            if (nextPage < this.pages().length) {
-              this.currentPage.set(nextPage);
-            }
-          } else {
-            // Current page is solo (wide or cover) — advance by 1
-            if (this.currentPage() + 1 < this.pages().length) {
-              this.currentPage.set(this.currentPage() + 1);
-            }
-          }
-        } else {
-          // Fallback: use old heuristic
-          const effectiveStep = this.shouldShowSinglePage(this.currentPage()) ? 1 : step;
-          if (this.currentPage() + effectiveStep < this.pages().length) {
-            this.currentPage.set(this.currentPage() + effectiveStep);
-          } else if (this.currentPage() + 1 < this.pages().length) {
-            this.currentPage.set(this.currentPage() + 1);
-          }
+        const spreads = this.getCbxSpreads();
+        const spreadIndex = spreads.findIndex(spread => spread.includes(this.currentPage()));
+        const nextSpread = spreadIndex >= 0 ? spreads[spreadIndex + 1] : undefined;
+        if (nextSpread) {
+          this.currentPage.set(nextSpread[0]);
         }
       } else if (this.currentPage() < this.pages().length - 1) {
         // Single-page mode: handle canvas split state for wide pages
@@ -1022,21 +976,11 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     } else {
       // Backward navigation
       if (this.isTwoPageView()) {
-        if (Object.keys(this.doublePairs()).length > 0) {
-          // Find the page that starts the previous spread
-          const targetPage = this.currentPage() - 1;
-          if (targetPage >= 0) {
-            const pairedWith = this.doublePairs()[targetPage];
-            if (pairedWith !== undefined) {
-              // Land on the lower-indexed page of the pair
-              this.currentPage.set(Math.min(targetPage, pairedWith));
-            } else {
-              // Previous page is solo — just go there
-              this.currentPage.set(targetPage);
-            }
-          }
-        } else {
-          this.currentPage.set(Math.max(0, this.currentPage() - step));
+        const spreads = this.getCbxSpreads();
+        const spreadIndex = spreads.findIndex(spread => spread.includes(this.currentPage()));
+        const previousSpread = spreadIndex > 0 ? spreads[spreadIndex - 1] : undefined;
+        if (previousSpread) {
+          this.currentPage.set(previousSpread[0]);
         }
       } else {
         // Single-page backward: handle canvas split for wide pages
@@ -1072,27 +1016,13 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     }
   }
 
-  private getPageStep(): number {
-    return this.isTwoPageView() ? 2 : 1;
-  }
-
   private alignCurrentPageToParity() {
     if (!this.pages().length || !this.isTwoPageView()) return;
 
-    const desiredOdd = this.pageSpread() === CbxPageSpread.ODD;
-    for (let i = this.currentPage(); i >= 0; i--) {
-      if ((this.pages()[i] % 2 === 1) === desiredOdd) {
-        this.currentPage.set(i);
-        this.updateProgress();
-        return;
-      }
-    }
-    for (let i = 0; i < this.pages().length; i++) {
-      if ((this.pages()[i] % 2 === 1) === desiredOdd) {
-        this.currentPage.set(i);
-        this.updateProgress();
-        return;
-      }
+    const spread = this.getCurrentSpreadPages();
+    if (spread.length && this.currentPage() !== spread[0]) {
+      this.currentPage.set(spread[0]);
+      this.updateProgress();
     }
   }
 
@@ -1142,7 +1072,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     this.alignCurrentPageToParity();
     this.updateCurrentImageUrls();
     this.preloadAdjacentPages();
-    this.footerService.setTwoPageView(this.isTwoPageView());
+    this.footerService.setTwoPageView(this.isTwoPageView() && this.getCurrentSpreadPages().length > 1);
     this.updateViewerSetting();
   }
 
@@ -1152,6 +1082,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     this.alignCurrentPageToParity();
     this.updateCurrentImageUrls();
     this.preloadAdjacentPages();
+    this.footerService.setTwoPageView(this.isTwoPageView() && this.getCurrentSpreadPages().length > 1);
     this.updateViewerSetting();
   }
 

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -650,7 +650,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     this.footerService.updateState({
       currentPage: this.currentPage(),
       totalPages: this.pages().length,
-      isTwoPageView: this.isTwoPageView() && this.getCurrentSpreadPages().length > 1,
+      isTwoPageView: this.hasVisibleTwoPageSpread(),
       previousBookInSeries: this.previousBookInSeries(),
       nextBookInSeries: this.nextBookInSeries(),
       hasSeries: this.hasSeries()
@@ -755,7 +755,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   private updateFooterPage(): void {
     this.resetSwipeBoundaryHits();
     this.footerService.setCurrentPage(this.currentPage());
-    this.footerService.setTwoPageView(this.isTwoPageView() && this.getCurrentSpreadPages().length > 1);
+    this.footerService.setTwoPageView(this.hasVisibleTwoPageSpread());
     this.sidebarService.setCurrentPage(this.currentPage() + 1);
     this.updateBookmarkState();
     this.updateNotesState();
@@ -776,8 +776,20 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     )?.pages ?? [this.currentPage()];
   }
 
+  private isPaginatedTwoPageView(): boolean {
+    return this.scrollMode() === CbxScrollMode.PAGINATED && this.isTwoPageView();
+  }
+
+  private hasVisibleTwoPageSpread(): boolean {
+    return this.isPaginatedTwoPageView() && this.getCurrentSpreadPages().length > 1;
+  }
+
+  isPreviousSinglePageLayer(): boolean {
+    return this.isPaginatedTwoPageView() && this.previousImageUrls().length === 1;
+  }
+
   isSinglePageLayer(): boolean {
-    return this.scrollMode() === CbxScrollMode.PAGINATED && this.isTwoPageView() && this.getCurrentSpreadPages().length === 1;
+    return this.isPaginatedTwoPageView() && !this.hasVisibleTwoPageSpread();
   }
 
   private getImageUrlsForCurrentPage(): string[] {
@@ -1072,7 +1084,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     this.alignCurrentPageToParity();
     this.updateCurrentImageUrls();
     this.preloadAdjacentPages();
-    this.footerService.setTwoPageView(this.isTwoPageView() && this.getCurrentSpreadPages().length > 1);
+    this.footerService.setTwoPageView(this.hasVisibleTwoPageSpread());
     this.updateViewerSetting();
   }
 
@@ -1082,7 +1094,7 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     this.alignCurrentPageToParity();
     this.updateCurrentImageUrls();
     this.preloadAdjacentPages();
-    this.footerService.setTwoPageView(this.isTwoPageView() && this.getCurrentSpreadPages().length > 1);
+    this.footerService.setTwoPageView(this.hasVisibleTwoPageSpread());
     this.updateViewerSetting();
   }
 

--- a/frontend/src/app/features/readers/cbx-reader/core/cbx-spread.util.spec.ts
+++ b/frontend/src/app/features/readers/cbx-reader/core/cbx-spread.util.spec.ts
@@ -15,6 +15,13 @@ function dimensions(widePages: number[] = []): CbxPageDimension[] {
 describe('cbx spread utilities', () => {
   const pages = [1, 2, 3, 4, 5, 6];
 
+  it('returns no spreads for an empty page list', () => {
+    const spreads = computeCbxSpreads([], [], CbxPageSpread.EVEN);
+
+    expect(spreads).toEqual([]);
+    expect(findCbxSpreadForPage(spreads, 0)).toBeUndefined();
+  });
+
   it('keeps the cover solo and pairs even-starting spreads for LTR comics', () => {
     const spreads = computeCbxSpreads(pages, dimensions(), CbxPageSpread.EVEN);
 

--- a/frontend/src/app/features/readers/cbx-reader/core/cbx-spread.util.spec.ts
+++ b/frontend/src/app/features/readers/cbx-reader/core/cbx-spread.util.spec.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from 'vitest';
+import {CbxPageSpread} from '../../../settings/user-management/user.service';
+import {computeCbxSpreads, findCbxSpreadForPage} from './cbx-spread.util';
+import {CbxPageDimension} from '../models/cbx-page-dimension.model';
+
+function dimensions(widePages: number[] = []): CbxPageDimension[] {
+  return Array.from({length: 6}, (_, index) => ({
+    pageNumber: index + 1,
+    width: widePages.includes(index) ? 1800 : 900,
+    height: 1200,
+    wide: widePages.includes(index)
+  }));
+}
+
+describe('cbx spread utilities', () => {
+  const pages = [1, 2, 3, 4, 5, 6];
+
+  it('keeps the cover solo and pairs even-starting spreads for LTR comics', () => {
+    const spreads = computeCbxSpreads(pages, dimensions(), CbxPageSpread.EVEN);
+
+    expect(spreads.map(spread => spread.pages)).toEqual([
+      [0],
+      [1, 2],
+      [3, 4],
+      [5],
+    ]);
+  });
+
+  it('keeps alignment pages solo until the configured spread parity starts', () => {
+    const spreads = computeCbxSpreads(pages, dimensions(), CbxPageSpread.ODD);
+
+    expect(spreads.map(spread => spread.pages)).toEqual([
+      [0],
+      [1],
+      [2, 3],
+      [4, 5],
+    ]);
+  });
+
+  it('keeps wide pages solo and resumes pairing after them', () => {
+    const spreads = computeCbxSpreads(pages, dimensions([3]), CbxPageSpread.EVEN);
+
+    expect(spreads.map(spread => spread.pages)).toEqual([
+      [0],
+      [1, 2],
+      [3],
+      [4],
+      [5],
+    ]);
+  });
+
+  it('finds the spread for either page in a pair', () => {
+    const spreads = computeCbxSpreads(pages, dimensions(), CbxPageSpread.EVEN);
+
+    expect(findCbxSpreadForPage(spreads, 1)?.pages).toEqual([1, 2]);
+    expect(findCbxSpreadForPage(spreads, 2)?.pages).toEqual([1, 2]);
+  });
+});

--- a/frontend/src/app/features/readers/cbx-reader/core/cbx-spread.util.ts
+++ b/frontend/src/app/features/readers/cbx-reader/core/cbx-spread.util.ts
@@ -1,0 +1,52 @@
+import {CbxPageSpread} from '../../../settings/user-management/user.service';
+import {CbxPageDimension} from '../models/cbx-page-dimension.model';
+
+export interface CbxSpread {
+  readonly pages: number[];
+}
+
+function isWidePage(dimensions: CbxPageDimension[], pageIndex: number): boolean {
+  return dimensions[pageIndex]?.wide === true;
+}
+
+function pageMatchesSpreadStart(pageNumber: number, pageSpread: CbxPageSpread): boolean {
+  const startsOdd = pageSpread === CbxPageSpread.ODD;
+  return (pageNumber % 2 === 1) === startsOdd;
+}
+
+export function computeCbxSpreads(
+  pages: number[],
+  dimensions: CbxPageDimension[],
+  pageSpread: CbxPageSpread
+): CbxSpread[] {
+  if (!pages.length) {
+    return [];
+  }
+
+  const spreads: CbxSpread[] = [{pages: [0]}];
+  let pageIndex = 1;
+
+  while (pageIndex < pages.length) {
+    const nextIndex = pageIndex + 1;
+
+    if (
+      isWidePage(dimensions, pageIndex) ||
+      !pageMatchesSpreadStart(pages[pageIndex], pageSpread) ||
+      nextIndex >= pages.length ||
+      isWidePage(dimensions, nextIndex)
+    ) {
+      spreads.push({pages: [pageIndex]});
+      pageIndex++;
+      continue;
+    }
+
+    spreads.push({pages: [pageIndex, nextIndex]});
+    pageIndex += 2;
+  }
+
+  return spreads;
+}
+
+export function findCbxSpreadForPage(spreads: CbxSpread[], pageIndex: number): CbxSpread | undefined {
+  return spreads.find(spread => spread.pages.includes(pageIndex));
+}

--- a/frontend/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.service.spec.ts
+++ b/frontend/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.service.spec.ts
@@ -60,7 +60,7 @@ describe('CbxQuickSettingsService', () => {
       fitMode: CbxFitMode.FIT_PAGE,
       scrollMode: CbxScrollMode.PAGINATED,
       pageViewMode: CbxPageViewMode.SINGLE_PAGE,
-      pageSpread: CbxPageSpread.ODD,
+      pageSpread: CbxPageSpread.EVEN,
       backgroundColor: CbxBackgroundColor.GRAY,
       readingDirection: CbxReadingDirection.LTR,
       slideshowInterval: CbxSlideshowInterval.FIVE_SECONDS,

--- a/frontend/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.service.ts
+++ b/frontend/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.service.ts
@@ -26,7 +26,7 @@ export class CbxQuickSettingsService {
     fitMode: CbxFitMode.FIT_PAGE,
     scrollMode: CbxScrollMode.PAGINATED,
     pageViewMode: CbxPageViewMode.SINGLE_PAGE,
-    pageSpread: CbxPageSpread.ODD,
+    pageSpread: CbxPageSpread.EVEN,
     backgroundColor: CbxBackgroundColor.GRAY,
     readingDirection: CbxReadingDirection.LTR,
     slideshowInterval: CbxSlideshowInterval.FIVE_SECONDS,


### PR DESCRIPTION
## Description

Fixes CBX reader regressions in paginated two-page mode by unifying spread calculation for rendering, navigation, and alignment, and by tightening the paginated fit-mode layout rules.

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/1029

## Changes

- unify CBX two-page spread handling across rendering, navigation, and alignment
- fix paginated `fit-width`, `fit-height`, and `actual-size` behavior in two-page view
- remove the CBX page hover zoom effect
- add focused spread utility tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Two-page mode now computes and navigates spreads reliably, snapping to the correct spread and correctly handling single- vs two-page spreads during transitions.

* **Style**
  * Removed hover-zoom on page images.
  * Improved centering and sizing across fit modes (width/height/page/auto) and refined two-page layout behavior.

* **Refactor**
  * Default page-spread parity changed from odd to even.

* **Tests**
  * Added tests for spread computation and lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->