### PR TITLE
ci: publish stable OpenAPI artifact on stable release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -73,10 +73,46 @@ jobs:
             type=gha,scope=image-shared,mode=max
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
+  export-openapi:
+    name: Export Stable OpenAPI Artifact
+    needs:
+      - build-and-release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Workflow Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Export OpenAPI JSON
+        uses: ./.github/actions/export-openapi
+        with:
+          checkout_ref: ${{ github.event.release.tag_name }}
+          app_version: ${{ github.event.release.tag_name }}
+
+      - name: Upload OpenAPI Workflow Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: stable-openapi-${{ github.event.release.tag_name }}
+          path: backend/build/openapi/grimmory-openapi.json
+          retention-days: 30
+
+      - name: Attach OpenAPI JSON to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" backend/build/openapi/grimmory-openapi.json --clobber
+
   prepare-release-notification:
     name: Prepare Stable Release Notification
     needs:
       - build-and-release
+      - export-openapi
     runs-on: ubuntu-latest
 
     outputs:

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ When enabled via `API_DOCS_ENABLED`, API reference documentation is available as
 - API reference docs are available at `http://localhost:6060/api/docs`
 - OpenAPI JSON is available at `http://localhost:6060/api/openapi.json`
 
+Stable releases also publish a downloadable OpenAPI artifact at:
+- `https://github.com/grimmory-tools/grimmory/releases/latest/download/grimmory-openapi.json`
+
 ---
 
 ## BookDrop

--- a/docs/MAKING-A-RELEASE.md
+++ b/docs/MAKING-A-RELEASE.md
@@ -86,6 +86,8 @@ When `semantic-release` creates a release, [`.github/workflows/release-main.yml`
 That workflow will:
 
 - build the multi-architecture container image,
+- export `backend/build/openapi/grimmory-openapi.json`,
+- attach `grimmory-openapi.json` to the published GitHub release,
 - publish `grimmory/grimmory:vX.Y.Z`,
 - publish `grimmory/grimmory:latest`,
 - publish `ghcr.io/grimmory-tools/grimmory:vX.Y.Z`,
@@ -112,3 +114,4 @@ Use the preview-image workflow if you want a one-off test image without creating
 
 - Stable releases are driven by commit history on `main`, not by labels or manual version bump inputs.
 - If you need to understand why a release did or did not happen, start with the `Release - Dry Run Preview` workflow and then inspect the `semantic-release` output.
+- The latest stable OpenAPI artifact is always available at `https://github.com/grimmory-tools/grimmory/releases/latest/download/grimmory-openapi.json`.


### PR DESCRIPTION
## Description

Upload an openapi.json artifact on stable build release

**Linked Issue:** Fixes https://github.com/grimmory-tools/grimmory/issues/291

## Changes

implement the same action as in nightly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenAPI specification file is now automatically attached to stable releases on GitHub for download.

* **Documentation**
  * Updated documentation to describe the OpenAPI artifact availability and download process for stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->