### PR TITLE
fix(books): add missing book metadata fields

### DIFF
--- a/backend/src/main/java/org/booklore/app/dto/AppBookSummary.java
+++ b/backend/src/main/java/org/booklore/app/dto/AppBookSummary.java
@@ -28,16 +28,37 @@ public class AppBookSummary {
     private Instant addedOn;
     private Instant lastReadTime;
     private Float readProgress;
+    private Long primaryFileId;
     private String primaryFileType;
+    private String primaryFileName;
     private Instant coverUpdatedOn;
     private Instant audiobookCoverUpdatedOn;
     private Boolean isPhysical;
 
     // Metadata for filtering
+    private String publisher;
+    private List<String> categories;
+    private List<String> tags;
+    private List<String> moods;
+    private String language;
+    private String narrator;
+    private String isbn13;
+    private String isbn10;
     private LocalDate publishedDate;
     private Integer pageCount;
     private Integer ageRating;
     private String contentRating;
     private Float metadataMatchScore;
     private Long fileSizeKb;
+    private Double amazonRating;
+    private Integer amazonReviewCount;
+    private Double goodreadsRating;
+    private Integer goodreadsReviewCount;
+    private Double hardcoverRating;
+    private Integer hardcoverReviewCount;
+    private Double ranobedbRating;
+    private Double lubimyczytacRating;
+    private Double audibleRating;
+    private Integer audibleReviewCount;
+    private Boolean allMetadataLocked;
 }

--- a/backend/src/main/java/org/booklore/app/mapper/AppBookMapper.java
+++ b/backend/src/main/java/org/booklore/app/mapper/AppBookMapper.java
@@ -137,7 +137,11 @@ public interface AppBookMapper {
 
     @Named("mapCategoryNames")
     default List<String> mapCategoryNames(Set<CategoryEntity> categories) {
-        return mapCategories(categories).stream()
+        if (categories == null || categories.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return categories.stream()
+                .map(CategoryEntity::getName)
                 .sorted()
                 .toList();
     }

--- a/backend/src/main/java/org/booklore/app/mapper/AppBookMapper.java
+++ b/backend/src/main/java/org/booklore/app/mapper/AppBookMapper.java
@@ -31,16 +31,37 @@ public interface AppBookMapper {
     @Mapping(target = "addedOn", source = "book.addedOn")
     @Mapping(target = "lastReadTime", source = "progress.lastReadTime")
     @Mapping(target = "readProgress", source = "progress", qualifiedByName = "mapReadProgress")
+    @Mapping(target = "primaryFileId", source = "book", qualifiedByName = "mapPrimaryFileId")
     @Mapping(target = "primaryFileType", source = "book", qualifiedByName = "mapPrimaryFileType")
+    @Mapping(target = "primaryFileName", source = "book", qualifiedByName = "mapPrimaryFileName")
     @Mapping(target = "coverUpdatedOn", source = "book.metadata.coverUpdatedOn")
     @Mapping(target = "audiobookCoverUpdatedOn", source = "book.metadata.audiobookCoverUpdatedOn")
     @Mapping(target = "isPhysical", source = "book.isPhysical")
+    @Mapping(target = "publisher", source = "book.metadata.publisher")
+    @Mapping(target = "categories", source = "book.metadata.categories", qualifiedByName = "mapCategoryNames")
+    @Mapping(target = "tags", source = "book.metadata.tags", qualifiedByName = "mapTagNames")
+    @Mapping(target = "moods", source = "book.metadata.moods", qualifiedByName = "mapMoodNames")
+    @Mapping(target = "language", source = "book.metadata.language")
+    @Mapping(target = "narrator", source = "book.metadata.narrator")
+    @Mapping(target = "isbn13", source = "book.metadata.isbn13")
+    @Mapping(target = "isbn10", source = "book.metadata.isbn10")
     @Mapping(target = "publishedDate", source = "book.metadata.publishedDate")
     @Mapping(target = "pageCount", source = "book.metadata.pageCount")
     @Mapping(target = "ageRating", source = "book.metadata.ageRating")
     @Mapping(target = "contentRating", source = "book.metadata.contentRating")
     @Mapping(target = "metadataMatchScore", source = "book.metadataMatchScore")
     @Mapping(target = "fileSizeKb", source = "book", qualifiedByName = "mapFileSizeKb")
+    @Mapping(target = "amazonRating", source = "book.metadata.amazonRating")
+    @Mapping(target = "amazonReviewCount", source = "book.metadata.amazonReviewCount")
+    @Mapping(target = "goodreadsRating", source = "book.metadata.goodreadsRating")
+    @Mapping(target = "goodreadsReviewCount", source = "book.metadata.goodreadsReviewCount")
+    @Mapping(target = "hardcoverRating", source = "book.metadata.hardcoverRating")
+    @Mapping(target = "hardcoverReviewCount", source = "book.metadata.hardcoverReviewCount")
+    @Mapping(target = "ranobedbRating", source = "book.metadata.ranobedbRating")
+    @Mapping(target = "lubimyczytacRating", source = "book.metadata.lubimyczytacRating")
+    @Mapping(target = "audibleRating", source = "book.metadata.audibleRating")
+    @Mapping(target = "audibleReviewCount", source = "book.metadata.audibleReviewCount")
+    @Mapping(target = "allMetadataLocked", source = "book.metadata", qualifiedByName = "mapAllMetadataLocked")
     AppBookSummary toSummary(BookEntity book, UserBookProgressEntity progress);
 
     @Mapping(target = "id", source = "book.id")
@@ -114,6 +135,35 @@ public interface AppBookMapper {
                 .collect(Collectors.toSet());
     }
 
+    @Named("mapCategoryNames")
+    default List<String> mapCategoryNames(Set<CategoryEntity> categories) {
+        return mapCategories(categories).stream()
+                .sorted()
+                .toList();
+    }
+
+    @Named("mapTagNames")
+    default List<String> mapTagNames(Set<TagEntity> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return tags.stream()
+                .map(TagEntity::getName)
+                .sorted()
+                .toList();
+    }
+
+    @Named("mapMoodNames")
+    default List<String> mapMoodNames(Set<MoodEntity> moods) {
+        if (moods == null || moods.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return moods.stream()
+                .map(MoodEntity::getName)
+                .sorted()
+                .toList();
+    }
+
     @Named("mapThumbnailUrl")
     default String mapThumbnailUrl(BookEntity book) {
         if (book == null || book.getId() == null) {
@@ -127,6 +177,11 @@ public interface AppBookMapper {
         if (book == null) return null;
         BookFileEntity primaryFile = book.getPrimaryBookFile();
         return primaryFile != null ? primaryFile.getFileSizeKb() : null;
+    }
+
+    @Named("mapAllMetadataLocked")
+    default Boolean mapAllMetadataLocked(BookMetadataEntity metadata) {
+        return metadata != null && metadata.areAllFieldsLocked();
     }
 
     @Named("mapShelves")
@@ -269,6 +324,24 @@ public interface AppBookMapper {
             return primaryFile.getBookType().name();
         }
         return null;
+    }
+
+    @Named("mapPrimaryFileId")
+    default Long mapPrimaryFileId(BookEntity book) {
+        if (book == null) {
+            return null;
+        }
+        BookFileEntity primaryFile = book.getPrimaryBookFile();
+        return primaryFile != null ? primaryFile.getId() : null;
+    }
+
+    @Named("mapPrimaryFileName")
+    default String mapPrimaryFileName(BookEntity book) {
+        if (book == null) {
+            return null;
+        }
+        BookFileEntity primaryFile = book.getPrimaryBookFile();
+        return primaryFile != null ? primaryFile.getFileName() : null;
     }
 
     @Named("mapFileTypes")

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -246,6 +246,9 @@ export class BookBrowserComponent implements AfterViewInit {
           case 'amazonRating': scopeFilters.amazonRating = strValues; break;
           case 'goodreadsRating': scopeFilters.goodreadsRating = strValues; break;
           case 'hardcoverRating': scopeFilters.hardcoverRating = strValues; break;
+          case 'lubimyczytacRating': scopeFilters.lubimyczytacRating = strValues; break;
+          case 'ranobedbRating': scopeFilters.ranobedbRating = strValues; break;
+          case 'audibleRating': scopeFilters.audibleRating = strValues; break;
           case 'pageCount': scopeFilters.pageCount = strValues; break;
           case 'shelfStatus':
             scopeFilters.shelfStatus = strValues;

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -246,9 +246,6 @@ export class BookBrowserComponent implements AfterViewInit {
           case 'amazonRating': scopeFilters.amazonRating = strValues; break;
           case 'goodreadsRating': scopeFilters.goodreadsRating = strValues; break;
           case 'hardcoverRating': scopeFilters.hardcoverRating = strValues; break;
-          case 'lubimyczytacRating': scopeFilters.lubimyczytacRating = strValues; break;
-          case 'ranobedbRating': scopeFilters.ranobedbRating = strValues; break;
-          case 'audibleRating': scopeFilters.audibleRating = strValues; break;
           case 'pageCount': scopeFilters.pageCount = strValues; break;
           case 'shelfStatus':
             scopeFilters.shelfStatus = strValues;

--- a/frontend/src/app/features/book/model/app-book.model.ts
+++ b/frontend/src/app/features/book/model/app-book.model.ts
@@ -21,16 +21,37 @@ export interface AppBookSummary {
   addedOn: string | null;
   lastReadTime: string | null;
   readProgress: number | null;
+  primaryFileId: number | null;
   primaryFileType: string | null;
+  primaryFileName: string | null;
   coverUpdatedOn: string | null;
   audiobookCoverUpdatedOn: string | null;
   isPhysical: boolean | null;
+  publisher: string | null;
+  categories: string[] | null;
+  tags: string[] | null;
+  moods: string[] | null;
+  language: string | null;
+  narrator: string | null;
+  isbn13: string | null;
+  isbn10: string | null;
   publishedDate: string | null;
   pageCount: number | null;
   ageRating: number | null;
   contentRating: string | null;
   metadataMatchScore: number | null;
   fileSizeKb: number | null;
+  amazonRating: number | null;
+  amazonReviewCount: number | null;
+  goodreadsRating: number | null;
+  goodreadsReviewCount: number | null;
+  hardcoverRating: number | null;
+  hardcoverReviewCount: number | null;
+  ranobedbRating: number | null;
+  lubimyczytacRating: number | null;
+  audibleRating: number | null;
+  audibleReviewCount: number | null;
+  allMetadataLocked: boolean | null;
 }
 
 export interface AppFilterOptions {

--- a/frontend/src/app/features/book/model/app-book.model.ts
+++ b/frontend/src/app/features/book/model/app-book.model.ts
@@ -1,3 +1,5 @@
+import {BookType} from './book.model';
+
 export interface AppPageResponse<T> {
   content: T[];
   page: number;
@@ -22,7 +24,7 @@ export interface AppBookSummary {
   lastReadTime: string | null;
   readProgress: number | null;
   primaryFileId: number | null;
-  primaryFileType: string | null;
+  primaryFileType: BookType | null;
   primaryFileName: string | null;
   coverUpdatedOn: string | null;
   audiobookCoverUpdatedOn: string | null;

--- a/frontend/src/app/features/book/service/app-books-api.service.ts
+++ b/frontend/src/app/features/book/service/app-books-api.service.ts
@@ -282,8 +282,8 @@ function summaryToPrimaryFile(summary: AppBookSummary): Partial<BookFile> | null
 
   const primaryFile: Partial<BookFile> = {
     bookId: summary.id,
-    bookType: summary.primaryFileType as BookType,
-    extension: summaryToPrimaryFileExtension(summary),
+    bookType: summary.primaryFileType,
+    extension: summaryToPrimaryFileExtension(summary, summary.primaryFileType),
     fileSizeKb: summary.fileSizeKb ?? undefined,
     fileName: summary.primaryFileName ?? undefined,
   };
@@ -295,7 +295,7 @@ function summaryToPrimaryFile(summary: AppBookSummary): Partial<BookFile> | null
   return primaryFile;
 }
 
-function summaryToPrimaryFileExtension(summary: AppBookSummary): string | undefined {
+function summaryToPrimaryFileExtension(summary: AppBookSummary, bookType: BookType): string | undefined {
   const fileName = summary.primaryFileName;
   if (fileName) {
     const dotIndex = fileName.lastIndexOf('.');
@@ -304,5 +304,5 @@ function summaryToPrimaryFileExtension(summary: AppBookSummary): string | undefi
     }
   }
 
-  return summary.primaryFileType?.toLowerCase() || undefined;
+  return bookType.toLowerCase();
 }

--- a/frontend/src/app/features/book/service/app-books-api.service.ts
+++ b/frontend/src/app/features/book/service/app-books-api.service.ts
@@ -11,7 +11,7 @@ import {
   AppFilterOptions,
   AppPageResponse,
 } from '../model/app-book.model';
-import {Book, BookType, ReadStatus} from '../model/book.model';
+import {Book, BookFile, BookType, ReadStatus} from '../model/book.model';
 
 const PAGE_SIZE = 50;
 
@@ -62,16 +62,6 @@ export class AppBooksApiService {
     const data = this.booksQuery.data();
     if (!data) return [];
     return data.pages.flatMap(page => page.content.map(summaryToBook));
-  }, {
-    equal: (a, b) => {
-      if (a.length !== b.length) return false;
-      for (let i = 0; i < a.length; i++) {
-        if (a[i].id !== b[i].id) return false;
-        if (a[i].metadata?.coverUpdatedOn !== b[i].metadata?.coverUpdatedOn) return false;
-        if (a[i].metadata?.audiobookCoverUpdatedOn !== b[i].metadata?.audiobookCoverUpdatedOn) return false;
-      }
-      return true;
-    }
   });
 
   readonly totalElements = computed(() => {
@@ -249,18 +239,35 @@ function summaryToBook(summary: AppBookSummary): Book {
       bookId: summary.id,
       title: summary.title,
       authors: summary.authors ?? [],
+      publisher: summary.publisher ?? undefined,
       seriesName: summary.seriesName,
       seriesNumber: summary.seriesNumber,
+      categories: summary.categories ?? [],
+      tags: summary.tags ?? [],
+      moods: summary.moods ?? [],
+      language: summary.language ?? undefined,
+      narrator: summary.narrator ?? undefined,
+      isbn13: summary.isbn13 ?? undefined,
+      isbn10: summary.isbn10 ?? undefined,
       coverUpdatedOn: summary.coverUpdatedOn,
       audiobookCoverUpdatedOn: summary.audiobookCoverUpdatedOn,
       publishedDate: summary.publishedDate ?? undefined,
       pageCount: summary.pageCount,
       ageRating: summary.ageRating,
       contentRating: summary.contentRating,
+      amazonRating: summary.amazonRating,
+      amazonReviewCount: summary.amazonReviewCount,
+      goodreadsRating: summary.goodreadsRating,
+      goodreadsReviewCount: summary.goodreadsReviewCount,
+      hardcoverRating: summary.hardcoverRating,
+      hardcoverReviewCount: summary.hardcoverReviewCount,
+      ranobedbRating: summary.ranobedbRating,
+      lubimyczytacRating: summary.lubimyczytacRating,
+      audibleRating: summary.audibleRating,
+      audibleReviewCount: summary.audibleReviewCount,
+      allMetadataLocked: summary.allMetadataLocked ?? false,
     },
-    primaryFile: summary.primaryFileType
-      ? {bookType: summary.primaryFileType as BookType, extension: summary.primaryFileType.toLowerCase()}
-      : null,
+    primaryFile: summaryToPrimaryFile(summary),
     pdfProgress: summary.readProgress != null
       ? {page: 0, percentage: summary.readProgress}
       : null,
@@ -268,4 +275,34 @@ function summaryToBook(summary: AppBookSummary): Book {
     cbxProgress: null,
     shelves: [],
   } as unknown as Book;
+}
+
+function summaryToPrimaryFile(summary: AppBookSummary): Partial<BookFile> | null {
+  if (!summary.primaryFileType) return null;
+
+  const primaryFile: Partial<BookFile> = {
+    bookId: summary.id,
+    bookType: summary.primaryFileType as BookType,
+    extension: summaryToPrimaryFileExtension(summary),
+    fileSizeKb: summary.fileSizeKb ?? undefined,
+    fileName: summary.primaryFileName ?? undefined,
+  };
+
+  if (summary.primaryFileId != null) {
+    primaryFile.id = summary.primaryFileId;
+  }
+
+  return primaryFile;
+}
+
+function summaryToPrimaryFileExtension(summary: AppBookSummary): string | undefined {
+  const fileName = summary.primaryFileName;
+  if (fileName) {
+    const dotIndex = fileName.lastIndexOf('.');
+    if (dotIndex >= 0 && dotIndex < fileName.length - 1) {
+      return fileName.slice(dotIndex + 1).toLowerCase();
+    }
+  }
+
+  return summary.primaryFileType?.toLowerCase() || undefined;
 }


### PR DESCRIPTION
## Description

**Linked Issue:** Fixes #965

Adds the missing metadata types to the paginated endpoint, restoring the empty columns in table view. 

<img width="1507" height="792" alt="Screenshot 2026-05-01 at 10 29 34" src="https://github.com/user-attachments/assets/5e8361eb-90b1-4db8-ba54-d79d2510f33b" />

## Changes
- Adds missing fields to `AppBookSummary`, maps through `AppBookMapper` and the frontend model.
- Made category/tag/mood summary lists deterministic by sorting them before returning
- Removed the equality comparator for id/cover. Makes sense to refresh using the main books signal instead of creating a crazy big comparator for every new metadata field. This ensures book data is isn't left stale after an update occurs. 
- Improved primary file parsing to replace the slightly messy object construction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Book summaries show richer metadata: publisher, language, narrator, categories, tags, moods, ISBN-10/13.
  * Display of multiple external ratings and review counts (Amazon, Goodreads, Hardcover, Ranobedb, Lubimyczytac, Audible).
  * Better primary book file identification (id, filename, inferred extension).
  * Metadata lock status is now exposed on summaries.
  * Sidebar filters now include RanobeDB, Lubimyczytac and Audible rating filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->