### PR TITLE
refactor(api): avoid polynomial regex issue in CustomFontService

### DIFF
--- a/backend/src/main/java/org/booklore/service/customfont/CustomFontService.java
+++ b/backend/src/main/java/org/booklore/service/customfont/CustomFontService.java
@@ -37,7 +37,7 @@ public class CustomFontService {
 
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
     private static final Pattern SPECIAL_CHARS_PATTERN = Pattern.compile("[<>\"'`]");
-    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^>]*>");
+    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^<>]*>");
     private static final Pattern CONTROL_CHARS_PATTERN = Pattern.compile("[\\p{Cntrl}\\p{Cc}\\p{Cf}\\p{Co}\\p{Cn}]");
     private final CustomFontRepository customFontRepository;
     private final UserRepository userRepository;


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Updates the regex in `CustomFontService` to avoid a polynomial issue by preventing the ambiguity for the start of the expression.  This is done by adding `<` to the characters to NOT match between the HTML tag start and stop.

This was done to avoid a possible Denial of Service identified by the CodeQL scanner.

**Linked Issue:** Fixes #932<!-- issue number leave empty if none -->

## Changes

* updates the `CustomFontService` regex to avoid a potential DoS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom font name sanitization to prevent incorrect handling of certain font names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->