### PR TITLE
fix(kobo): add endpoints for devices to run with proxy off

### DIFF
--- a/backend/src/main/java/org/booklore/controller/KoboController.java
+++ b/backend/src/main/java/org/booklore/controller/KoboController.java
@@ -227,6 +227,31 @@ public class KoboController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "Get user profile", description = "Get Kobo user configuration.")
+    @ApiResponse(responseCode = "200", description = "Retrieved Kobo User configuration")
+    @GetMapping("/v1/user/profile")
+    public ResponseEntity<?> getUserProfile() {
+        if (isForwardingToKoboStore()) {
+            return koboServerProxy.proxyCurrentRequest(null, false);
+        }
+
+        return ResponseEntity.ok()
+                .body(KoboUserProfile.builder().build());
+
+    }
+
+    @Operation(summary = "Get Kobo Deals", description = "Get promotional deals on Kobo entitlements.")
+    @ApiResponse(responseCode = "200", description = "Deals Retrieved successfully")
+    @GetMapping("/v1/deals")
+    public ResponseEntity<?> getDeals() {
+        if (isForwardingToKoboStore()) {
+            return koboServerProxy.proxyCurrentRequest(null, false);
+        }
+
+        return ResponseEntity.ok()
+                .body(KoboDeals.builder().build());
+
+    }
 
     @Operation(summary = "Catch-all for Kobo API", description = "Catch-all endpoint for unhandled Kobo API requests.")
     @ApiResponse(responseCode = "200", description = "Request proxied successfully")

--- a/backend/src/main/java/org/booklore/model/dto/kobo/KoboDeals.java
+++ b/backend/src/main/java/org/booklore/model/dto/kobo/KoboDeals.java
@@ -1,0 +1,34 @@
+package org.booklore.model.dto.kobo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KoboDeals {
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class KoboDealEntry {
+        private String id;
+    }
+
+
+    @Builder.Default
+    private List<KoboDealEntry> deals = List.of();
+}

--- a/backend/src/main/java/org/booklore/model/dto/kobo/KoboUserProfile.java
+++ b/backend/src/main/java/org/booklore/model/dto/kobo/KoboUserProfile.java
@@ -1,0 +1,70 @@
+package org.booklore.model.dto.kobo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KoboUserProfile {
+    @Builder.Default
+    private String affiliateName = "Grimmory";
+
+    @Builder.Default
+    private boolean isOneStore = false;
+
+    @Builder.Default
+    private boolean isChildAccount = false;
+
+    @Builder.Default
+    private boolean isLibraryMigrated = true;
+
+    @Builder.Default
+    private boolean vipMembershipPurchased = true;
+
+    @Builder.Default
+    private boolean hasPurchased = true;
+
+    @Builder.Default
+    private boolean hasPurchasedBook = true;
+
+    @Builder.Default
+    private boolean hasPurchasedAudiobook = false;
+
+    @Builder.Default
+    private boolean safeSearch = false;
+
+    @Builder.Default
+    private boolean audiobooksEnabled = false;
+
+    @Builder.Default
+    private boolean isOrangeAffiliated = false;
+
+    @Builder.Default
+    private boolean isEligibleForOrangeDeal = false;
+
+    @Builder.Default
+    private String platformId = "00000000-0000-0000-0000-000000000001";
+
+    @Builder.Default
+    private String partnerId = "00000000-0000-0000-0000-000000000001";
+
+    @Builder.Default
+    private String koboCrmOptInSettings = "ExplicitlyConsentedNo";
+
+    @Builder.Default
+    private List<String> privatePermissions = List.of();
+
+    @Builder.Default
+    private List<String> linkedAccounts = List.of();
+}

--- a/backend/src/main/java/org/booklore/service/kobo/KoboInitializationService.java
+++ b/backend/src/main/java/org/booklore/service/kobo/KoboInitializationService.java
@@ -32,7 +32,9 @@ public class KoboInitializationService {
             Map.entry("library_search", new String[]{"v1", "library", "search"}),
             Map.entry("library_sync", new String[]{"v1", "library", "sync"}),
             Map.entry("post_analytics_event", new String[]{"v1", "analytics", "event"}),
-            Map.entry("reading_state", new String[]{"v1", "library", "{Ids}", "state"})
+            Map.entry("reading_state", new String[]{"v1", "library", "{Ids}", "state"}),
+            Map.entry("user_profile", new String[]{"v1", "user", "profile"}),
+            Map.entry("deals", new String[]{"v1", "deals"})
     );
 
     private boolean isForwardingToKoboStore() {


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Depending on how your device has been configured the forward to rakuten setting may be required today.
This is because Kobo devices look for a user profile and deals endpoint - and if they need the data off
of them the sync process will stall when the response is completely empty.

This change adds the deals and user profile endpoints with "safe" stubbed values that can be parsed by
kobo devices.

Note: this is somewhere between a fix and a feature - I opted for fix as there is functionality that is currently not operating in the Kobo devices.

**Linked Issue:** Related to #1053

## Testing

Configured new Kobo device with Rakuten
Pointed new Kobo device to grimmory instance via `Kobo eReader.conf`
Turned forward to proxy off
Confirm device can sync and get new books

## Changes

* add `/v1/deals` kobo endpoint with an empty stubbed deals endpoint
* add a `/v1/user/profile` kobo endpoint with reasonable defaults
* update the `/v1/initialization` kobo endpoint to point kobo devices at these endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/v1/user/profile` endpoint to retrieve user profile information
  * Added `/v1/deals` endpoint to retrieve available deals
  * Both endpoints dynamically proxy requests when Kobo forwarding is enabled, or return default responses otherwise

<!-- end of auto-generated comment: release notes by coderabbit.ai -->