### PR TITLE
chore(docker): drop mariadb container_name property

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ services:
 
   mariadb:
     image: lscr.io/linuxserver/mariadb:11.4.5
-    container_name: mariadb
+    container_name: grimmory_mariadb
     environment:
       - PUID=${DB_USER_ID}
       - PGID=${DB_GROUP_ID}

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ services:
 
   mariadb:
     image: lscr.io/linuxserver/mariadb:11.4.5
-    container_name: grimmory_mariadb
     environment:
       - PUID=${DB_USER_ID}
       - PGID=${DB_GROUP_ID}

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -43,7 +43,7 @@ services:
 
   mariadb:
     image: lscr.io/linuxserver/mariadb:11.4.8
-    container_name: mariadb
+    container_name: grimmory_mariadb
     environment:
       - PUID=1000
       - PGID=1000

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -43,7 +43,6 @@ services:
 
   mariadb:
     image: lscr.io/linuxserver/mariadb:11.4.8
-    container_name: grimmory_mariadb
     environment:
       - PUID=1000
       - PGID=1000

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -51,7 +51,6 @@ services:
       - "${FRONTEND_PORT:-4200}:4200"
   backend_db:
     image: mariadb:11.4
-    container_name: grimmory_backend_db
     volumes:
       - backend_db:/var/lib/mysql
     restart: unless-stopped

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - "${FRONTEND_PORT:-4200}:4200"
   backend_db:
     image: mariadb:11.4
-    container_name: backend_db
+    container_name: grimmory_backend_db
     volumes:
       - backend_db:/var/lib/mysql
     restart: unless-stopped


### PR DESCRIPTION
## Description

Renamed `mariadb` instances to `grimmory_mariadb`

**Linked Issue:** Fixes #155

## Changes
Updated docker-compose as suggested by @obviouslyallie also included an update to the Readme.md as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit Docker container names from Compose configs so services use default Compose naming. This improves portability and reduces naming conflicts across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->