### PR TITLE
feat(offline): add PWA offline reading

### DIFF
--- a/frontend/ngsw-config.json
+++ b/frontend/ngsw-config.json
@@ -44,6 +44,26 @@
         "maxAge": "0u",
         "timeout": "0u"
       }
+    },
+    {
+      "name": "book-content",
+      "urls": ["/api/v1/books/*/content*"],
+      "cacheConfig": {
+        "strategy": "performance",
+        "maxSize": 100,
+        "maxAge": "7d",
+        "timeout": "10s"
+      }
+    },
+    {
+      "name": "book-covers",
+      "urls": ["/api/v1/books/*/cover*", "/api/v1/books/*/thumbnail*"],
+      "cacheConfig": {
+        "strategy": "performance",
+        "maxSize": 50,
+        "maxAge": "30d",
+        "timeout": "5s"
+      }
     }
   ]
 }

--- a/frontend/src/app/features/book/service/book-file.service.ts
+++ b/frontend/src/app/features/book/service/book-file.service.ts
@@ -1,5 +1,5 @@
 import {inject, Injectable} from '@angular/core';
-import {Observable, throwError, from} from 'rxjs';
+import {Observable, throwError, from, firstValueFrom} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
 import {catchError, tap} from 'rxjs/operators';
 import {AdditionalFile, AdditionalFileType, Book, DetachBookFileResponse, DuplicateDetectionRequest, DuplicateGroup} from '../model/book.model';
@@ -8,6 +8,8 @@ import {MessageService} from 'primeng/api';
 import {FileDownloadService} from '../../../shared/service/file-download.service';
 import {CacheStorageService} from '../../../shared/service/cache-storage.service';
 import {LocalSettingsService} from '../../../shared/service/local-settings.service';
+import {OfflineStorageService} from '../../../shared/service/offline-storage.service';
+import {RecentlyReadService} from '../../../shared/service/recently-read.service';
 import {TranslocoService} from '@jsverse/transloco';
 import {QueryClient} from '@tanstack/angular-query-experimental';
 import {patchBookInCacheWith, patchBooksInCache, removeBooksFromCache} from './book-query-cache';
@@ -25,6 +27,8 @@ export class BookFileService {
   private queryClient = inject(QueryClient);
   private cacheStorageService = inject(CacheStorageService);
   private localSettingsService = inject(LocalSettingsService);
+  private offlineStorage = inject(OfflineStorageService);
+  private recentlyRead = inject(RecentlyReadService);
   private readonly t = inject(TranslocoService);
 
   getFileContent(bookId: number, bookType?: string): Observable<Blob> {
@@ -32,7 +36,32 @@ export class BookFileService {
     if (bookType) {
       url += `?bookType=${bookType}`;
     }
-    if (this.localSettingsService.get().cacheStorageEnabled)
+    const localSettings = this.localSettingsService.get();
+
+    if (localSettings.offlineReadingEnabled) {
+      const fileType = bookType ?? 'EPUB';
+      return from(
+        this.offlineStorage.getBookContent(bookId, fileType).then(async (cached) => {
+          if (cached) {
+            this.recentlyRead.recordBookOpened(bookId);
+            return cached;
+          }
+          const httpResponse = await firstValueFrom(
+            this.http.get(url, {responseType: 'blob' as 'json'})
+          ) as Blob;
+          this.offlineStorage.cacheBook(bookId, httpResponse, fileType,
+            `${bookId}.${fileType.toLowerCase()}`, {
+              title: String(bookId), fileType,
+              fileName: `${bookId}.${fileType.toLowerCase()}`,
+              cachedAt: new Date().toISOString()
+            }).catch(() => undefined);
+          this.recentlyRead.recordBookOpened(bookId);
+          return httpResponse;
+        })
+      );
+    }
+
+    if (localSettings.cacheStorageEnabled)
       return from(this.cacheStorageService.getCache(url).then(response => response.blob()));
     return this.http.get<Blob>(url, {responseType: 'blob' as 'json'});
   }

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -16,6 +16,8 @@ import { ProgressSpinner } from 'primeng/progressspinner';
 import { FormsModule } from "@angular/forms";
 import { ReadingSessionService } from '../../../shared/service/reading-session.service';
 import { WakeLockService } from '../../../shared/service/wake-lock.service';
+import { OfflineProgressQueueService } from '../../../shared/service/offline-progress-queue.service';
+import { RecentlyReadService } from '../../../shared/service/recently-read.service';
 import { ReaderHeaderFooterVisibilityManager } from '../ebook-reader';
 
 import { CbxHeaderComponent } from './layout/header/cbx-header.component';
@@ -218,6 +220,8 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   private cbxReaderService = inject(CbxReaderService);
   private bookService = inject(BookService);
+  private offlineProgressQueue = inject(OfflineProgressQueueService);
+  private recentlyRead = inject(RecentlyReadService);
   private userService = inject(UserService);
   private messageService = inject(MessageService);
   private readonly t = inject(TranslocoService);
@@ -344,6 +348,11 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
             }
             this.bookType.set(resolvedBookType);
             this.currentBook.set(book);
+            this.recentlyRead.recordBookOpened(this.bookId()!, {
+              title: book.metadata?.title as string | undefined,
+              author: book.metadata?.['author'] as string | undefined,
+              fileType: resolvedBookType,
+            });
 
             // Determine which file ID to use for progress tracking
             if (this.altBookType()) {
@@ -1586,7 +1595,11 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
       ? Math.round(((this.currentPage() + 1) / this.pages().length) * 1000) / 10
       : 0;
 
-    this.bookService.saveCbxProgress(this.bookId()!, this.currentPage() + 1, percentage, this.bookFileId()!).subscribe();
+    if (navigator.onLine) {
+      this.bookService.saveCbxProgress(this.bookId()!, this.currentPage() + 1, percentage, this.bookFileId()!).subscribe();
+    } else {
+      this.offlineProgressQueue.queue(this.bookId()!, 'cbx', {page: this.currentPage() + 1, percentage, bookFileId: this.bookFileId()!});
+    }
   }
 
   private updateSessionProgress(): void {

--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
@@ -34,6 +34,7 @@ import {EbookShortcutsHelpComponent} from './dialogs/shortcuts-help.component';
 import {TranslocoPipe} from '@jsverse/transloco';
 import {RelocateProgressData} from './state/progress.service';
 import {WakeLockService} from '../../../shared/service/wake-lock.service';
+import {RecentlyReadService} from '../../../shared/service/recently-read.service';
 import {ViewEvent} from './core/view-manager.service';
 
 interface PendingInitialChapterRestore {
@@ -96,6 +97,7 @@ export class EbookReaderComponent implements OnInit {
   private noteService = inject(ReaderNoteService);
   private wakeLockService = inject(WakeLockService);
   private messageService = inject(MessageService);
+  private recentlyRead = inject(RecentlyReadService);
 
   public sidebarService = inject(ReaderSidebarService);
   public leftSidebarService = inject(ReaderLeftSidebarService);
@@ -214,6 +216,11 @@ export class EbookReaderComponent implements OnInit {
     ]).pipe(
       switchMap(([, book]) => {
         this.book.set(book);
+        this.recentlyRead.recordBookOpened(this.bookId, {
+          title: book.metadata?.title as string | undefined,
+          author: book.metadata?.['author'] as string | undefined,
+          fileType: book.primaryFile?.bookType,
+        });
         const bookType = (this.altBookType as BookType | undefined) ?? book.primaryFile?.bookType;
         if (!bookType) {
           return throwError(() => new Error('Book type not found'));

--- a/frontend/src/app/features/readers/ebook-reader/state/progress.service.ts
+++ b/frontend/src/app/features/readers/ebook-reader/state/progress.service.ts
@@ -3,6 +3,7 @@ import {Subject} from 'rxjs';
 import {TranslocoService} from '@jsverse/transloco';
 import {BookPatchService} from '../../../book/service/book-patch.service';
 import {ReadingSessionService} from '../../../../shared/service/reading-session.service';
+import {OfflineProgressQueueService} from '../../../../shared/service/offline-progress-queue.service';
 import {PageInfo, ThemeInfo} from '../core/view-manager.service';
 import {ReaderViewManagerService} from '../core/view-manager.service';
 import {ReaderStateService} from './reader-state.service';
@@ -48,6 +49,7 @@ export interface RelocateProgressData {
 export class ReaderProgressService {
   private bookPatchService = inject(BookPatchService);
   private readingSessionService = inject(ReadingSessionService);
+  private offlineProgressQueue = inject(OfflineProgressQueueService);
   private readonly t = inject(TranslocoService);
   private viewManager = inject(ReaderViewManagerService);
   private stateService = inject(ReaderStateService);
@@ -108,7 +110,11 @@ export class ReaderProgressService {
     }
 
     if (cfi && percentage !== null) {
-      this.bookPatchService.saveEpubProgress(this.bookId, cfi, href ?? '', percentage, this.bookFileId);
+      if (navigator.onLine) {
+        this.bookPatchService.saveEpubProgress(this.bookId, cfi, href ?? '', percentage, this.bookFileId);
+      } else {
+        this.offlineProgressQueue.queue(this.bookId, 'epub', {cfi, href: href ?? undefined, percentage, bookFileId: this.bookFileId});
+      }
       this.readingSessionService.updateProgress(cfi, percentage);
     }
 

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -23,6 +23,8 @@ import { MessageService } from 'primeng/api';
 import { TranslocoService, TranslocoPipe } from '@jsverse/transloco';
 import { CacheStorageService } from '../../../shared/service/cache-storage.service'
 import { LocalSettingsService } from '../../../shared/service/local-settings.service';
+import { OfflineProgressQueueService } from '../../../shared/service/offline-progress-queue.service';
+import { RecentlyReadService } from '../../../shared/service/recently-read.service';
 import { ReadingSessionService } from '../../../shared/service/reading-session.service';
 import { WakeLockService } from '../../../shared/service/wake-lock.service';
 import { Location } from '@angular/common';
@@ -184,6 +186,8 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   private localSettingsService = inject(LocalSettingsService);
   private readonly t = inject(TranslocoService);
   private wakeLockService = inject(WakeLockService);
+  private offlineProgressQueue = inject(OfflineProgressQueueService);
+  private recentlyRead = inject(RecentlyReadService);
   readonly embedPdfBook = inject(EmbedPdfBookService);
   readonly pdfBookmarkService = inject(PdfBookmarkService);
   private readonly ngZone = inject(NgZone);
@@ -374,6 +378,11 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
 
         this.pageTitle.setBookPageTitle(pdfMeta);
         this.bookTitle.set(pdfMeta.metadata?.title || '');
+        this.recentlyRead.recordBookOpened(this.bookId, {
+          title: pdfMeta.metadata?.title as string | undefined,
+          author: pdfMeta.metadata?.['author'] as string | undefined,
+          fileType: 'PDF',
+        });
 
         const globalOrIndividual = myself.userSettings.perBookSetting.pdf;
         let zoomVal: string;
@@ -1122,7 +1131,11 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
     const currentPage = this.page();
     const total = this.totalPages();
     const percentage = total > 0 ? Math.round((currentPage / total) * 1000) / 10 : 0;
-    this.bookService.savePdfProgress(this.bookId, currentPage, percentage, this.bookFileId).subscribe();
+    if (navigator.onLine) {
+      this.bookService.savePdfProgress(this.bookId, currentPage, percentage, this.bookFileId).subscribe();
+    } else {
+      this.offlineProgressQueue.queue(this.bookId, 'pdf', {page: currentPage, percentage, bookFileId: this.bookFileId});
+    }
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/features/settings/reader-preferences/offline-settings/offline-settings.component.html
+++ b/frontend/src/app/features/settings/reader-preferences/offline-settings/offline-settings.component.html
@@ -1,0 +1,82 @@
+<ng-container *transloco="let t; prefix: 'settingsReader.offline'">
+  <div class="offline-settings-container">
+    <div class="settings-card">
+      <div class="section-header">
+        <h3 class="section-title">
+          <i class="pi pi-cloud-download"></i>
+          {{ t('title') }}
+        </h3>
+        <p class="section-description">
+          {{ t('description') }}
+        </p>
+      </div>
+
+      @if (!opfsAvailable()) {
+        <div class="settings-info-notice">
+          {{ t('notAvailable') }}
+        </div>
+      }
+
+      <div class="settings-content">
+        <div class="setting-item">
+          <div class="setting-info">
+            <span class="setting-label">{{ t('enabled') }}</span>
+            <span class="setting-description">{{ t('enabledDesc') }}</span>
+          </div>
+          <div class="setting-control">
+            <p-toggleswitch [(ngModel)]="settings.offlineReadingEnabled" (onChange)="onToggleChange()"></p-toggleswitch>
+          </div>
+        </div>
+
+        <div class="setting-item">
+          <div class="setting-info">
+            <span class="setting-label">{{ t('maxBooks') }}</span>
+            <span class="setting-description">{{ t('maxBooksDesc') }}</span>
+          </div>
+          <div class="setting-control">
+            <p-inputNumber [(ngModel)]="settings.maxOfflineBooks" [min]="1" [max]="50" (onInput)="onMaxBooksChange()">
+            </p-inputNumber>
+            <span class="setting-unit">{{ t('unit') }}</span>
+          </div>
+        </div>
+
+        <div class="setting-item">
+          <div class="setting-info">
+            <span class="setting-label">{{ t('storageLabel') }}</span>
+            <span class="setting-description">{{ t('storageDesc') }}</span>
+          </div>
+          <div class="setting-control storage-info">
+            @if (isLoadingStorage()) {
+              <span>---</span>
+            } @else {
+              <div class="storage-bar-wrapper">
+                <div class="storage-bar">
+                  <div class="storage-bar-fill" [style.width.%]="storageQuotaBytes() > 0 ? (storageUsageBytes() / storageQuotaBytes() * 100) : 0"></div>
+                </div>
+                <span class="storage-text">
+                  {{ storageUsageBytes() / (1024 * 1024) | number:'1.1-1' }} MB / {{ storageQuotaBytes() / (1024 * 1024 * 1024) | number:'1.1-1' }} GB
+                </span>
+              </div>
+            }
+          </div>
+        </div>
+
+        <div class="settings-info-notice">
+          {{ t('storageNote') }}
+        </div>
+
+        <div class="setting-item action-item">
+          <div class="setting-info">
+            <span class="setting-label">{{ t('clearButton') }}</span>
+            <span class="setting-description">{{ t('clearButtonDesc') }}</span>
+          </div>
+          <div class="setting-control">
+            <p-button type="button" [label]="t('clearButton')" icon="pi pi-trash" severity="danger" [outlined]="true"
+              [disabled]="isClearing()" [loading]="isClearing()" (onClick)="clearAllBooks()">
+            </p-button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</ng-container>

--- a/frontend/src/app/features/settings/reader-preferences/offline-settings/offline-settings.component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/offline-settings/offline-settings.component.scss
@@ -1,0 +1,134 @@
+@use "../../../../shared/styles/settings-shared" as settings;
+
+.offline-settings-container {
+  @include settings.settings-page-container;
+}
+
+@include settings.settings-page-header;
+
+.settings-card {
+  @include settings.settings-card;
+}
+
+.section-header {
+  @include settings.settings-section-header;
+
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  @include settings.settings-section-title;
+
+  margin: 0;
+}
+
+.section-description {
+  @include settings.settings-section-description;
+}
+
+.settings-content {
+  @include settings.settings-section-body;
+}
+
+.setting-item {
+  @include settings.settings-item;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  &.action-item {
+    border-left-color: var(--p-orange-500);
+    background: color-mix(
+      in srgb,
+      var(--ground-background) 40%,
+      var(--p-surface-800) 60%
+    );
+
+    &:hover {
+      background: color-mix(
+        in srgb,
+        var(--ground-background) 20%,
+        var(--p-surface-800) 80%
+      );
+    }
+  }
+
+  @media (width <= 768px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+.setting-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.setting-label {
+  @include settings.settings-label;
+}
+
+.setting-description {
+  @include settings.settings-item-description;
+}
+
+.setting-control {
+  flex-shrink: 0;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+
+  &.storage-info {
+    min-width: 200px;
+  }
+
+  @media (width <= 768px) {
+    width: 100%;
+    justify-content: flex-start;
+    align-items: flex-start;
+  }
+}
+
+.setting-unit {
+  font-size: 0.875rem;
+  color: var(--text-color-secondary);
+  white-space: nowrap;
+}
+
+.storage-bar-wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.storage-bar {
+  width: 100%;
+  height: 8px;
+  background: var(--p-surface-700);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.storage-bar-fill {
+  height: 100%;
+  background: var(--p-primary-color);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.storage-text {
+  font-size: 0.8rem;
+  color: var(--text-color-secondary);
+}
+
+.settings-info-notice {
+  @include settings.settings-info-notice;
+
+  margin-bottom: 0.75rem;
+}

--- a/frontend/src/app/features/settings/reader-preferences/offline-settings/offline-settings.component.ts
+++ b/frontend/src/app/features/settings/reader-preferences/offline-settings/offline-settings.component.ts
@@ -1,0 +1,124 @@
+import {Component, inject, OnInit, signal} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {DecimalPipe} from '@angular/common';
+import {ToggleSwitch} from 'primeng/toggleswitch';
+import {InputNumber} from 'primeng/inputnumber';
+import {Button} from 'primeng/button';
+import {ConfirmationService, MessageService} from 'primeng/api';
+import {TranslocoDirective} from '@jsverse/transloco';
+import {LocalSettingsService} from '../../../../shared/service/local-settings.service';
+import {OfflineStorageService} from '../../../../shared/service/offline-storage.service';
+import {OfflineIndexedDBService} from '../../../../shared/service/offline-indexeddb.service';
+
+@Component({
+  selector: 'app-offline-settings',
+  standalone: true,
+  imports: [
+    FormsModule,
+    DecimalPipe,
+    ToggleSwitch,
+    InputNumber,
+    Button,
+    TranslocoDirective,
+  ],
+  templateUrl: './offline-settings.component.html',
+  styleUrl: './offline-settings.component.scss',
+})
+export class OfflineSettingsComponent implements OnInit {
+  private localSettingsService = inject(LocalSettingsService);
+  private offlineStorage = inject(OfflineStorageService);
+  private offlineIndexedDB = inject(OfflineIndexedDBService);
+  private messageService = inject(MessageService);
+  private confirmationService = inject(ConfirmationService);
+
+  protected settings = this.localSettingsService.get();
+
+  protected opfsAvailable = signal(false);
+  protected storageUsageBytes = signal(0);
+  protected storageQuotaBytes = signal(0);
+  protected storageBookCount = signal(0);
+  protected isLoadingStorage = signal(false);
+  protected isClearing = signal(false);
+
+  async ngOnInit(): Promise<void> {
+    this.opfsAvailable.set(await this.offlineStorage.isAvailable());
+    await this.loadStorageInfo();
+  }
+
+  onToggleChange(): void {
+    this.localSettingsService.commitSettings();
+    if (!this.settings.offlineReadingEnabled) {
+      this.clearAllBooksSilently();
+    }
+  }
+
+  onMaxBooksChange(): void {
+    this.localSettingsService.commitSettings();
+  }
+
+  async loadStorageInfo(): Promise<void> {
+    this.isLoadingStorage.set(true);
+    try {
+      const estimate = await navigator.storage.estimate();
+      this.storageQuotaBytes.set(estimate.quota ?? 0);
+      this.storageUsageBytes.set(estimate.usage ?? 0);
+
+      const info = await this.offlineStorage.getStorageInfo();
+      this.storageBookCount.set(info.bookCount);
+    } catch {
+      this.storageUsageBytes.set(0);
+      this.storageQuotaBytes.set(0);
+      this.storageBookCount.set(0);
+    } finally {
+      this.isLoadingStorage.set(false);
+    }
+  }
+
+  clearAllBooks(): void {
+    this.confirmationService.confirm({
+      message: 'Are you sure you want to clear all cached books? This action cannot be undone.',
+      header: 'Clear All Cached Books',
+      icon: 'pi pi-exclamation-triangle',
+      acceptLabel: 'Clear',
+      rejectLabel: 'Cancel',
+      acceptButtonProps: {
+        label: 'Clear',
+        severity: 'danger',
+      },
+      rejectButtonProps: {
+        label: 'Cancel',
+        severity: 'secondary',
+      },
+      accept: async () => {
+        this.isClearing.set(true);
+        try {
+          await this.offlineStorage.clearAllBooks();
+          await this.loadStorageInfo();
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Cached books cleared',
+            detail: 'All cached book files have been removed.',
+          });
+        } catch {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Clear failed',
+            detail: 'Unable to clear cached books. Please try again.',
+          });
+        } finally {
+          this.isClearing.set(false);
+        }
+      },
+    });
+  }
+
+  private async clearAllBooksSilently(): Promise<void> {
+    try {
+      await this.offlineStorage.clearAllBooks();
+      this.storageBookCount.set(0);
+      this.storageUsageBytes.set(0);
+    } catch {
+      // silent
+    }
+  }
+}

--- a/frontend/src/app/features/settings/reader-preferences/reader-preferences.component.html
+++ b/frontend/src/app/features/settings/reader-preferences/reader-preferences.component.html
@@ -13,6 +13,7 @@
     <div class="settings-content">
       <app-settings-application-mode [userSettings]="userSettings"></app-settings-application-mode>
       <app-local-settings/>
+      <app-offline-settings/>
 
       <div class="preferences-section">
         <div class="section-header">

--- a/frontend/src/app/features/settings/reader-preferences/reader-preferences.component.ts
+++ b/frontend/src/app/features/settings/reader-preferences/reader-preferences.component.ts
@@ -10,13 +10,14 @@ import {CbxReaderPreferencesComponent} from './cbx-reader-preferences/cbx-reader
 import {CustomFontsComponent} from '../custom-fonts/custom-fonts.component';
 import {SettingsApplicationModeComponent} from './settings-application-mode/settings-application-mode.component';
 import {LocalSettingsComponent} from "./local-settings/local-settings.component";
+import {OfflineSettingsComponent} from "./offline-settings/offline-settings.component";
 
 @Component({
   selector: 'app-reader-preferences',
   templateUrl: './reader-preferences.component.html',
   standalone: true,
   styleUrls: ['./reader-preferences.component.scss'],
-  imports: [FormsModule, TranslocoDirective, EpubReaderPreferencesComponent, PdfReaderPreferencesComponent, CbxReaderPreferencesComponent, CustomFontsComponent, SettingsApplicationModeComponent, LocalSettingsComponent]
+  imports: [FormsModule, TranslocoDirective, EpubReaderPreferencesComponent, PdfReaderPreferencesComponent, CbxReaderPreferencesComponent, CustomFontsComponent, SettingsApplicationModeComponent, LocalSettingsComponent, OfflineSettingsComponent]
 })
 export class ReaderPreferences {
   private readonly userService = inject(UserService);

--- a/frontend/src/app/shared/service/local-settings.service.ts
+++ b/frontend/src/app/shared/service/local-settings.service.ts
@@ -3,6 +3,8 @@ import { LocalStorageService } from "./local-storage.service";
 
 export interface LocalSettings {
   cacheStorageEnabled: boolean;
+  offlineReadingEnabled: boolean;
+  maxOfflineBooks: number;
 }
 
 @Injectable({
@@ -14,6 +16,8 @@ export class LocalSettingsService {
 
   public readonly defaultSettings: LocalSettings = {
     cacheStorageEnabled: true,
+    offlineReadingEnabled: false,
+    maxOfflineBooks: 5,
   };
 
   protected settings: LocalSettings;

--- a/frontend/src/app/shared/service/offline-indexeddb.service.ts
+++ b/frontend/src/app/shared/service/offline-indexeddb.service.ts
@@ -1,0 +1,208 @@
+import { Injectable } from '@angular/core';
+
+const DB_NAME = 'grimmory-offline';
+const DB_VERSION = 1;
+
+export interface RecentlyReadEntry {
+  bookId: number;
+  title: string;
+  author: string;
+  fileType: string;
+  lastReadAt: string;
+}
+
+export interface QueuedProgress {
+  id?: number;
+  bookId: number;
+  progressType: 'epub' | 'pdf' | 'cbx';
+  cfi?: string;
+  page?: number;
+  percentage: number;
+  href?: string;
+  bookFileId?: number;
+  queuedAt: string;
+  synced: 0 | 1;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OfflineIndexedDBService {
+  private db: IDBDatabase | null = null;
+  private readyPromise: Promise<void>;
+
+  constructor() {
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      if (typeof window === 'undefined' || !window.indexedDB) {
+        resolve();
+        return;
+      }
+      const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+
+      request.onupgradeneeded = () => {
+        const db = request.result;
+
+        if (!db.objectStoreNames.contains('recently_read')) {
+          db.createObjectStore('recently_read', { keyPath: 'bookId' });
+        }
+
+        if (!db.objectStoreNames.contains('progress_queue')) {
+          const store = db.createObjectStore('progress_queue', { autoIncrement: true });
+          store.createIndex('synced', 'synced', { unique: false });
+          store.createIndex('bookId_type', ['bookId', 'progressType'], { unique: false });
+        }
+
+        if (!db.objectStoreNames.contains('settings')) {
+          db.createObjectStore('settings', { keyPath: 'key' });
+        }
+      };
+
+      request.onsuccess = () => {
+        this.db = request.result;
+        resolve();
+      };
+
+      request.onerror = () => {
+        reject(request.error);
+      };
+    });
+  }
+
+  ready(): Promise<void> {
+    return this.readyPromise;
+  }
+
+  // -- recently_read store --
+
+  getRecentlyRead(): Promise<RecentlyReadEntry[]> {
+    return this.requestPromise('recently_read', 'readonly', (store) => store.getAll());
+  }
+
+  upsertRecentRead(entry: RecentlyReadEntry): Promise<void> {
+    return this.requestPromise('recently_read', 'readwrite', (store) => store.put(entry)).then(() => undefined);
+  }
+
+  deleteRecentRead(bookId: number): Promise<void> {
+    return this.requestPromise('recently_read', 'readwrite', (store) => store.delete(bookId)).then(() => undefined);
+  }
+
+  // -- progress_queue store --
+
+  async queueProgress(entry: Omit<QueuedProgress, 'id'>): Promise<void> {
+    await this.readyPromise;
+    return new Promise<void>((resolve, reject) => {
+      const tx = this.db!.transaction('progress_queue', 'readwrite');
+      const store = tx.objectStore('progress_queue');
+
+      const index = store.index('bookId_type');
+      const getRequest = index.getAllKeys(IDBKeyRange.only([entry.bookId, entry.progressType]));
+
+      getRequest.onsuccess = () => {
+        const keys = getRequest.result;
+        for (const key of keys) {
+          store.delete(key);
+        }
+        store.add(entry);
+      };
+
+      getRequest.onerror = () => {
+        store.add(entry);
+      };
+
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  getUnsyncedProgress(): Promise<QueuedProgress[]> {
+    return this.readyPromise.then(() => {
+      return new Promise<QueuedProgress[]>((resolve, reject) => {
+        const tx = this.db!.transaction('progress_queue', 'readonly');
+        const store = tx.objectStore('progress_queue');
+        const index = store.index('synced');
+        const range = IDBKeyRange.only(0);
+        const request = index.getAll(range);
+
+        request.onsuccess = () => resolve(request.result as QueuedProgress[]);
+        request.onerror = () => reject(request.error);
+      });
+    });
+  }
+
+  async markSynced(id: number): Promise<void> {
+    await this.readyPromise;
+    return new Promise<void>((resolve, reject) => {
+      const tx = this.db!.transaction('progress_queue', 'readwrite');
+      const store = tx.objectStore('progress_queue');
+      const request = store.get(id);
+
+      request.onsuccess = () => {
+        const entry = request.result as QueuedProgress | undefined;
+        if (entry) {
+          entry.synced = 1;
+          store.put(entry);
+        }
+      };
+
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async deleteSyncedOlderThan(days: number): Promise<void> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    const cutoffStr = cutoff.toISOString();
+
+    await this.readyPromise;
+    const all = await new Promise<QueuedProgress[]>((resolve, reject) => {
+      const tx = this.db!.transaction('progress_queue', 'readonly');
+      const store = tx.objectStore('progress_queue');
+      const request = store.getAll();
+
+      request.onsuccess = () => resolve(request.result as QueuedProgress[]);
+      request.onerror = () => reject(request.error);
+    });
+
+    const toDelete = all.filter((e) => e.synced === 1 && e.queuedAt < cutoffStr);
+    if (toDelete.length === 0) return;
+
+    return new Promise<void>((resolve, reject) => {
+      const tx = this.db!.transaction('progress_queue', 'readwrite');
+      const store = tx.objectStore('progress_queue');
+      for (const entry of toDelete) {
+        if (entry.id !== undefined) {
+          store.delete(entry.id);
+        }
+      }
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  // -- settings store --
+
+  getSetting(key: string): Promise<string | null> {
+    return this.requestPromise<{ key: string; value: string } | undefined>('settings', 'readonly', (store) => store.get(key))
+      .then((result) => result?.value ?? null);
+  }
+
+  setSetting(key: string, value: string): Promise<void> {
+    return this.requestPromise('settings', 'readwrite', (store) => store.put({ key, value })).then(() => undefined);
+  }
+
+  private async requestPromise<T>(storeName: string, mode: IDBTransactionMode, operation: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+    await this.readyPromise;
+    if (!this.db) {
+      return undefined as T;
+    }
+    return new Promise<T>((resolve, reject) => {
+      const tx = this.db!.transaction(storeName, mode);
+      const store = tx.objectStore(storeName);
+      const request = operation(store);
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+}

--- a/frontend/src/app/shared/service/offline-progress-queue.service.ts
+++ b/frontend/src/app/shared/service/offline-progress-queue.service.ts
@@ -1,0 +1,100 @@
+import { inject, Injectable } from '@angular/core';
+import { OfflineIndexedDBService } from './offline-indexeddb.service';
+import { BookPatchService } from '../../features/book/service/book-patch.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OfflineProgressQueueService {
+  private indexedDB = inject(OfflineIndexedDBService);
+  private bookPatchService = inject(BookPatchService);
+
+  private syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    window.addEventListener('online', () => this.scheduleSync());
+  }
+
+  queue(
+    bookId: number,
+    progressType: 'epub' | 'pdf' | 'cbx',
+    data: {
+      cfi?: string;
+      page?: number;
+      percentage: number;
+      href?: string;
+      bookFileId?: number;
+    }
+  ): void {
+    this.indexedDB
+      .queueProgress({
+        bookId,
+        progressType,
+        cfi: data.cfi,
+        page: data.page,
+        percentage: data.percentage,
+        href: data.href,
+        bookFileId: data.bookFileId,
+        queuedAt: new Date().toISOString(),
+        synced: 0,
+      })
+      .catch(() => undefined);
+  }
+
+  async syncAll(): Promise<{ synced: number; failed: number }> {
+    const entries = await this.indexedDB.getUnsyncedProgress();
+    let synced = 0;
+    let failed = 0;
+
+    for (const entry of entries) {
+      try {
+        if (entry.progressType === 'epub') {
+          this.bookPatchService.saveEpubProgress(
+            entry.bookId,
+            entry.cfi ?? '',
+            entry.href ?? '',
+            entry.percentage,
+            entry.bookFileId
+          );
+        } else if (entry.progressType === 'pdf') {
+          await this.bookPatchService
+            .savePdfProgress(entry.bookId, entry.page ?? 1, entry.percentage, entry.bookFileId)
+            .toPromise();
+        } else if (entry.progressType === 'cbx') {
+          await this.bookPatchService
+            .saveCbxProgress(entry.bookId, entry.page ?? 1, entry.percentage, entry.bookFileId)
+            .toPromise();
+        }
+
+        if (entry.id !== undefined) {
+          await this.indexedDB.markSynced(entry.id);
+        }
+        synced++;
+      } catch {
+        failed++;
+      }
+    }
+
+    // Cleanup old synced entries
+    try {
+      await this.indexedDB.deleteSyncedOlderThan(7);
+    } catch {
+      // ignore
+    }
+
+    return { synced, failed };
+  }
+
+  private scheduleSync(): void {
+    if (this.syncDebounceTimer) {
+      clearTimeout(this.syncDebounceTimer);
+    }
+    this.syncDebounceTimer = setTimeout(() => {
+      this.syncAll().catch(() => undefined);
+    }, 5000);
+  }
+
+  isOnline(): boolean {
+    return navigator.onLine;
+  }
+}

--- a/frontend/src/app/shared/service/offline-storage.service.ts
+++ b/frontend/src/app/shared/service/offline-storage.service.ts
@@ -1,0 +1,134 @@
+import { Injectable } from '@angular/core';
+
+export interface CacheBookMetadata {
+  title: string;
+  author?: string;
+  fileType: string;
+  fileName: string;
+  cachedAt: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OfflineStorageService {
+  private readonly OPFS_ROOT = 'books';
+
+  async isAvailable(): Promise<boolean> {
+    if (!navigator.storage?.getDirectory) return false;
+    try {
+      await navigator.storage.getDirectory();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getBookContent(bookId: number, fileType: string): Promise<File | null> {
+    try {
+      const root = await navigator.storage.getDirectory();
+      const dirHandle = await this.ensureDir(root, [this.OPFS_ROOT, String(bookId)]);
+      const fileHandle = await dirHandle.getFileHandle(`content.${fileType.toLowerCase()}`);
+      const file = await fileHandle.getFile();
+      return file;
+    } catch {
+      return null;
+    }
+  }
+
+  async cacheBook(
+    bookId: number,
+    content: Blob,
+    fileType: string,
+    fileName: string,
+    metadata: CacheBookMetadata
+  ): Promise<void> {
+    try {
+      const root = await navigator.storage.getDirectory();
+      const dirHandle = await this.ensureDir(root, [this.OPFS_ROOT, String(bookId)]);
+
+      const contentHandle = await dirHandle.getFileHandle(`content.${fileType.toLowerCase()}`, { create: true });
+      const contentWritable = await contentHandle.createWritable();
+      await contentWritable.write(content);
+      await contentWritable.close();
+
+      const metaHandle = await dirHandle.getFileHandle('metadata.json', { create: true });
+      const metaWritable = await metaHandle.createWritable();
+      await metaWritable.write(JSON.stringify(metadata));
+      await metaWritable.close();
+    } catch (err) {
+      console.warn('[OfflineStorage] cacheBook failed:', err);
+    }
+  }
+
+  async cacheCover(bookId: number, coverBlob: Blob, extension: string): Promise<void> {
+    try {
+      const root = await navigator.storage.getDirectory();
+      const dirHandle = await this.ensureDir(root, [this.OPFS_ROOT, String(bookId)]);
+      const coverHandle = await dirHandle.getFileHandle(`cover.${extension}`, { create: true });
+      const writable = await coverHandle.createWritable();
+      await writable.write(coverBlob);
+      await writable.close();
+    } catch (err) {
+      console.warn('[OfflineStorage] cacheCover failed:', err);
+    }
+  }
+
+  async deleteBookFiles(bookId: number): Promise<void> {
+    try {
+      const root = await navigator.storage.getDirectory();
+      const booksDir = await this.ensureDir(root, [this.OPFS_ROOT]);
+      await booksDir.removeEntry(String(bookId), { recursive: true });
+    } catch (err) {
+      console.warn('[OfflineStorage] deleteBookFiles failed:', err);
+    }
+  }
+
+  async clearAllBooks(): Promise<void> {
+    try {
+      const root = await navigator.storage.getDirectory();
+      const booksDir = await this.ensureDir(root, [this.OPFS_ROOT]);
+      const entries = booksDir.values();
+      for await (const entry of entries) {
+        await booksDir.removeEntry(entry.name, { recursive: true });
+      }
+    } catch (err) {
+      console.warn('[OfflineStorage] clearAllBooks failed:', err);
+    }
+  }
+
+  async getStorageInfo(): Promise<{ bookCount: number; opfsBytes: number }> {
+    try {
+      const root = await navigator.storage.getDirectory();
+      const booksDir = await this.ensureDir(root, [this.OPFS_ROOT]);
+      let bookCount = 0;
+      let opfsBytes = 0;
+      for await (const entry of booksDir.values()) {
+        if (entry.kind === 'directory') {
+          bookCount++;
+          const bookDir = await this.ensureDir(booksDir, [entry.name]);
+          for await (const fileEntry of bookDir.values()) {
+            if (fileEntry.kind === 'file') {
+              const file = await (fileEntry as FileSystemFileHandle).getFile();
+              opfsBytes += file.size;
+            }
+          }
+        }
+      }
+      return { bookCount, opfsBytes };
+    } catch {
+      return { bookCount: 0, opfsBytes: 0 };
+    }
+  }
+
+  private async ensureDir(
+    parent: FileSystemDirectoryHandle,
+    path: string[]
+  ): Promise<FileSystemDirectoryHandle> {
+    let dir = parent;
+    for (const segment of path) {
+      dir = await dir.getDirectoryHandle(segment, { create: true });
+    }
+    return dir;
+  }
+}

--- a/frontend/src/app/shared/service/recently-read.service.ts
+++ b/frontend/src/app/shared/service/recently-read.service.ts
@@ -1,0 +1,85 @@
+import { inject, Injectable } from '@angular/core';
+import { LocalSettingsService } from './local-settings.service';
+import { OfflineStorageService } from './offline-storage.service';
+import { OfflineIndexedDBService } from './offline-indexeddb.service';
+
+const STORAGE_KEY = 'recently_read_books';
+
+interface RecentlyReadItem {
+  bookId: number;
+  lastReadAt: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RecentlyReadService {
+  private localSettingsService = inject(LocalSettingsService);
+  private offlineStorage = inject(OfflineStorageService);
+  private indexedDB = inject(OfflineIndexedDBService);
+
+  getMaxBooks(): number {
+    return this.localSettingsService.get().maxOfflineBooks;
+  }
+
+  getRecentlyReadIds(): number[] {
+    const list = this.getList();
+    return list.map((item) => item.bookId);
+  }
+
+  recordBookOpened(
+    bookId: number,
+    meta?: { title?: string; author?: string; fileType?: string }
+  ): void {
+    const settings = this.localSettingsService.get();
+    const list = this.getList();
+
+    // Remove existing entry for this bookId
+    const filtered = list.filter((item) => item.bookId !== bookId);
+
+    // Insert at front
+    filtered.unshift({ bookId, lastReadAt: new Date().toISOString() });
+
+    const maxBooks = settings.maxOfflineBooks;
+
+    // Trim and evict
+    if (filtered.length > maxBooks) {
+      const evicted = filtered.splice(maxBooks);
+      if (settings.offlineReadingEnabled) {
+        for (const evict of evicted) {
+          this.offlineStorage.deleteBookFiles(evict.bookId).catch(() => undefined);
+          this.indexedDB.deleteRecentRead(evict.bookId).catch(() => undefined);
+        }
+      }
+    }
+
+    this.saveList(filtered);
+
+    // Persist metadata to IndexedDB
+    if (meta && settings.offlineReadingEnabled) {
+      this.indexedDB
+        .upsertRecentRead({
+          bookId,
+          title: meta.title ?? String(bookId),
+          author: meta.author ?? '',
+          fileType: meta.fileType ?? 'EPUB',
+          lastReadAt: new Date().toISOString(),
+        })
+          .catch(() => undefined);
+    }
+  }
+
+  private getList(): RecentlyReadItem[] {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return JSON.parse(raw) as RecentlyReadItem[];
+    } catch {
+      // ignore
+    }
+    return [];
+  }
+
+  private saveList(list: RecentlyReadItem[]): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  }
+}

--- a/frontend/src/i18n/en/settings-reader.json
+++ b/frontend/src/i18n/en/settings-reader.json
@@ -128,6 +128,25 @@
     "black": "Black",
     "white": "White"
   },
+  "offline": {
+    "title": "Offline Reading",
+    "description": "Read your books without an internet connection. Books are stored on your device via browser storage.",
+    "enabled": "Enable Offline Reading",
+    "enabledDesc": "Recently opened books are automatically cached for offline access using OPFS storage.",
+    "maxBooks": "Max Books to Cache",
+    "maxBooksDesc": "Books beyond this limit are removed starting with the least recently read.",
+    "unit": "books",
+    "storageLabel": "Storage",
+    "storageDesc": "Current storage usage for cached books.",
+    "storageNote": "iOS devices may enforce stricter storage limits for websites vs. installed PWAs.",
+    "clearButton": "Clear All Cached Books",
+    "clearButtonDesc": "Removes downloaded book files. Reading progress and preferences are preserved.",
+    "notAvailable": "Offline reading is not supported on this browser.",
+    "cleared": "Cached Books Cleared",
+    "clearedDetail": "All cached book files have been removed successfully.",
+    "clearError": "Clear Failed",
+    "clearErrorDetail": "Unable to clear cached books. Please try again."
+  },
   "toast": {
     "preferencesUpdated": "Preferences Updated",
     "preferencesUpdatedDetail": "Your preferences have been saved successfully."

--- a/frontend/src/i18n/es/settings-reader.json
+++ b/frontend/src/i18n/es/settings-reader.json
@@ -125,6 +125,25 @@
     "black": "Negro",
     "white": "Blanco"
   },
+  "offline": {
+    "title": "Lectura sin conexión",
+    "description": "Lee tus libros sin conexión a internet. Los libros se almacenan en tu dispositivo mediante el almacenamiento del navegador.",
+    "enabled": "Activar lectura sin conexión",
+    "enabledDesc": "Los libros abiertos recientemente se almacenan en caché automáticamente para acceso sin conexión mediante almacenamiento OPFS.",
+    "maxBooks": "Máximo de libros en caché",
+    "maxBooksDesc": "Los libros que superen este límite se eliminan empezando por los leídos menos recientemente.",
+    "unit": "libros",
+    "storageLabel": "Almacenamiento",
+    "storageDesc": "Uso actual de almacenamiento para libros en caché.",
+    "storageNote": "Los dispositivos iOS pueden aplicar límites de almacenamiento más estrictos para sitios web vs. PWAs instaladas.",
+    "clearButton": "Borrar todos los libros en caché",
+    "clearButtonDesc": "Elimina los archivos de libros descargados. El progreso de lectura y las preferencias se conservan.",
+    "notAvailable": "La lectura sin conexión no es compatible con este navegador.",
+    "cleared": "Libros en caché borrados",
+    "clearedDetail": "Todos los archivos de libros en caché se han eliminado correctamente.",
+    "clearError": "Error al borrar",
+    "clearErrorDetail": "No se pudieron borrar los libros en caché. Inténtalo de nuevo."
+  },
   "toast": {
     "preferencesUpdated": "Preferencias actualizadas",
     "preferencesUpdatedDetail": "Tus preferencias se han guardado correctamente."

--- a/frontend/src/i18n/fr/settings-reader.json
+++ b/frontend/src/i18n/fr/settings-reader.json
@@ -125,6 +125,25 @@
     "black": "Noir",
     "white": "Blanc"
   },
+  "offline": {
+    "title": "Lecture hors ligne",
+    "description": "Lisez vos livres sans connexion internet. Les livres sont stockés sur votre appareil via le stockage du navigateur.",
+    "enabled": "Activer la lecture hors ligne",
+    "enabledDesc": "Les livres récemment ouverts sont automatiquement mis en cache pour un accès hors ligne via le stockage OPFS.",
+    "maxBooks": "Max. de livres en cache",
+    "maxBooksDesc": "Les livres dépassant cette limite sont supprimés en commençant par les moins récemment lus.",
+    "unit": "livres",
+    "storageLabel": "Stockage",
+    "storageDesc": "Utilisation actuelle du stockage pour les livres mis en cache.",
+    "storageNote": "Les appareils iOS peuvent appliquer des limites de stockage plus strictes pour les sites web vs. les PWAs installées.",
+    "clearButton": "Effacer tous les livres en cache",
+    "clearButtonDesc": "Supprime les fichiers de livres téléchargés. La progression de lecture et les préférences sont conservées.",
+    "notAvailable": "La lecture hors ligne n'est pas prise en charge sur ce navigateur.",
+    "cleared": "Livres en cache effacés",
+    "clearedDetail": "Tous les fichiers de livres en cache ont été supprimés avec succès.",
+    "clearError": "Échec de l'effacement",
+    "clearErrorDetail": "Impossible d'effacer les livres en cache. Veuillez réessayer."
+  },
   "toast": {
     "preferencesUpdated": "Préférences mises à jour",
     "preferencesUpdatedDetail": "Vos préférences ont été enregistrées avec succès."


### PR DESCRIPTION
- OfflineStorageService: OPFS-based book content caching
- OfflineIndexedDBService: IndexedDB wrapper for recently_read, progress_queue, settings
- RecentlyReadService: LRU tracking with auto-eviction
- OfflineProgressQueueService: queues progress offline, syncs on online event
- BookFileService: OPFS-first path when offline reading is enabled
- Reader components (ebook/pdf/cbx): offline-aware progress saving + recently read tracking
- ProgressService: queues progress when offline instead of failing
- OfflineSettingsComponent: UI for enabling offline reading, max books, storage info, clear
- LocalSettings: added offlineReadingEnabled, maxOfflineBooks
- Translations: en/es/fr for offline settings
- ngsw-config: added book-content and book-covers data groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline reading with configurable storage limits and management interface.
  * Reading progress automatically syncs when connectivity is restored.
  * Books are tracked as recently read.
  * Service worker caching enhanced for improved performance.

* **Style**
  * Added offline settings interface styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->