### PR TITLE
fix(koreader): web reader to koreader progress sync

### DIFF
--- a/backend/src/main/java/org/booklore/service/kobo/KoboReadingStateService.java
+++ b/backend/src/main/java/org/booklore/service/kobo/KoboReadingStateService.java
@@ -17,6 +17,7 @@ import org.booklore.model.entity.UserBookProgressEntity;
 import org.booklore.model.enums.ReadStatus;
 import org.booklore.repository.*;
 import org.booklore.service.hardcover.HardcoverSyncService;
+import org.booklore.service.koreader.KoreaderService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +57,7 @@ public class KoboReadingStateService {
     private final KoboSettingsService koboSettingsService;
     private final KoboReadingStateBuilder readingStateBuilder;
     private final HardcoverSyncService hardcoverSyncService;
+    private final KoreaderService koreaderService;
 
     @Transactional
     public KoboReadingStateResponse saveReadingState(List<KoboReadingState> readingStates) {
@@ -251,6 +253,7 @@ public class KoboReadingStateService {
                     && progress.getKoboProgressPercent() != null
                     && (!progress.getKoboProgressPercent().equals(previousKoboProgressPercent)
                     || progress.getReadStatus() != previousReadStatus)) {
+                koreaderService.syncProgressToKoreader(book.getId(), progress.getKoboProgressPercent(), userId);
                 hardcoverSyncService.syncProgressToHardcover(book.getId(), progress.getKoboProgressPercent(), userId);
             }
         } catch (NumberFormatException e) {

--- a/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
+++ b/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
@@ -6,6 +6,7 @@ import org.booklore.config.security.userdetails.KoreaderUserDetails;
 import org.booklore.exception.ApiError;
 import org.booklore.model.dto.progress.KoreaderProgress;
 import org.booklore.model.entity.*;
+import org.booklore.model.enums.BookFileType;
 import org.booklore.model.enums.ReadStatus;
 import org.booklore.repository.*;
 import org.booklore.service.hardcover.HardcoverSyncService;
@@ -90,6 +91,40 @@ public class KoreaderService {
             Float progressPercent = normalizeProgressPercent(koProgress.getPercentage());
             hardcoverSyncService.syncProgressToHardcover(book.getId(), progressPercent, authDetails.getBookLoreUserId());
         }
+    }
+
+    @Transactional
+    public void syncProgressToKoreader(Long bookId, Float percentage, Long userId) {
+        if (percentage == null) return;
+
+        koreaderUserRepository.findByBookLoreUserId(userId)
+                .filter(KoreaderUserEntity::isSyncEnabled)
+                .filter(KoreaderUserEntity::isSyncWithBookloreReader)
+                .ifPresent(koreaderUser -> {
+                    BookEntity book = bookRepository.findById(bookId).orElse(null);
+                    BookLoreUserEntity user = userRepository.findById(userId).orElse(null);
+                    if (book == null || user == null) return;
+
+                    UserBookProgressEntity progress = getOrCreateUserProgress(user, book);
+
+                    float koreaderPercent = percentage / 100.0f;
+                    progress.setKoreaderProgressPercent(koreaderPercent);
+                    progress.setKoreaderLastSyncTime(Instant.now());
+
+                    BookFileEntity primaryFile = book.getPrimaryBookFile();
+                    if (primaryFile != null && primaryFile.getBookType() == BookFileType.EPUB
+                            && progress.getEpubProgress() != null) {
+                        try {
+                            String xpointer = epubCfiService.convertCfiToProgressXPointer(
+                                    book.getFullFilePath(), progress.getEpubProgress());
+                            progress.setKoreaderProgress(xpointer);
+                        } catch (Exception e) {
+                            log.warn("Failed to convert CFI to XPointer for KOReader sync", e);
+                        }
+                    }
+
+                    progressRepository.save(progress);
+                });
     }
 
     private void saveToFileProgress(BookLoreUserEntity user, BookEntity book, UserBookProgressEntity progress) {

--- a/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
+++ b/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
@@ -12,8 +12,10 @@ import org.booklore.repository.*;
 import org.booklore.service.hardcover.HardcoverSyncService;
 import org.booklore.util.koreader.EpubCfiService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -93,38 +95,46 @@ public class KoreaderService {
         }
     }
 
-    @Transactional
-    public void syncProgressToKoreader(Long bookId, Float percentage, Long userId) {
-        if (percentage == null) return;
-
-        koreaderUserRepository.findByBookLoreUserId(userId)
-                .filter(KoreaderUserEntity::isSyncEnabled)
-                .filter(KoreaderUserEntity::isSyncWithBookloreReader)
-                .ifPresent(koreaderUser -> {
-                    BookEntity book = bookRepository.findById(bookId).orElse(null);
-                    BookLoreUserEntity user = userRepository.findById(userId).orElse(null);
-                    if (book == null || user == null) return;
-
-                    UserBookProgressEntity progress = getOrCreateUserProgress(user, book);
-
-                    float koreaderPercent = percentage / 100.0f;
-                    progress.setKoreaderProgressPercent(koreaderPercent);
-                    progress.setKoreaderLastSyncTime(Instant.now());
-
-                    BookFileEntity primaryFile = book.getPrimaryBookFile();
-                    if (primaryFile != null && primaryFile.getBookType() == BookFileType.EPUB
-                            && progress.getEpubProgress() != null) {
-                        try {
-                            String xpointer = epubCfiService.convertCfiToProgressXPointer(
-                                    book.getFullFilePath(), progress.getEpubProgress());
-                            progress.setKoreaderProgress(xpointer);
-                        } catch (Exception e) {
-                            log.warn("Failed to convert CFI to XPointer for KOReader sync", e);
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void syncProgressToKoreader(long bookId, float percentage, long userId) {
+        try {
+            koreaderUserRepository.findByBookLoreUserId(userId)
+                    .filter(KoreaderUserEntity::isSyncEnabled)
+                    .filter(KoreaderUserEntity::isSyncWithWebReader)
+                    .ifPresent(koreaderUser -> {
+                        BookEntity book = bookRepository.findById(bookId).orElse(null);
+                        BookLoreUserEntity user = userRepository.findById(userId).orElse(null);
+                        if (book == null || user == null) {
+                            log.warn("KOReader sync skipped: bookId={} or userId={} was not found", bookId, userId);
+                            return;
                         }
-                    }
 
-                    progressRepository.save(progress);
-                });
+                        UserBookProgressEntity progress = getOrCreateUserProgress(user, book);
+
+                        float koreaderPercent = percentage / 100.0f;
+                        progress.setKoreaderProgressPercent(koreaderPercent);
+                        progress.setKoreaderLastSyncTime(Instant.now());
+                        progress.setKoreaderProgress(null);
+
+                        BookFileEntity primaryFile = book.getPrimaryBookFile();
+                        if (primaryFile != null && primaryFile.getBookType() == BookFileType.EPUB
+                                && progress.getEpubProgress() != null) {
+                            try {
+                                String xpointer = epubCfiService.convertCfiToProgressXPointer(
+                                        primaryFile.getFullFilePath(), progress.getEpubProgress());
+                                progress.setKoreaderProgress(xpointer);
+                            } catch (Exception e) {
+                                progress.setKoreaderProgress(null);
+                                log.warn("Failed to convert CFI to XPointer for KOReader sync", e);
+                            }
+                        }
+
+                        progressRepository.save(progress);
+                    });
+        } catch (Exception e) {
+            log.warn("Failed to sync progress to KOReader for userId={} bookId={}", userId, bookId, e);
+        }
     }
 
     private void saveToFileProgress(BookLoreUserEntity user, BookEntity book, UserBookProgressEntity progress) {

--- a/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -20,7 +20,7 @@ import org.booklore.model.enums.UserPermission;
 import org.booklore.repository.*;
 import org.booklore.service.hardcover.HardcoverSyncService;
 import org.booklore.service.kobo.KoboReadingStateService;
-import org.booklore.util.koreader.EpubCfiService;
+import org.booklore.service.koreader.KoreaderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -47,8 +47,7 @@ public class ReadingProgressService {
     private final UserRepository userRepository;
     private final AuthenticationService authenticationService;
     private final KoboReadingStateService koboReadingStateService;
-    private final KoreaderUserRepository koreaderUserRepository;
-    private final EpubCfiService epubCfiService;
+    private final KoreaderService koreaderService;
     private final HardcoverSyncService hardcoverSyncService;
 
     // ==================== Methods from UserProgressService ====================
@@ -273,7 +272,7 @@ public class ReadingProgressService {
         userBookProgressRepository.save(progress);
 
         if (percentage != null) {
-            syncKoreaderFromBookloreProgress(userEntity, book, progress, percentage);
+            koreaderService.syncProgressToKoreader(book.getId(), percentage, user.getId());
             hardcoverSyncService.syncProgressToHardcover(book.getId(), percentage, user.getId());
         }
     }
@@ -504,31 +503,6 @@ public class ReadingProgressService {
                         .dateFinished(null)
                         .build())
                 .toList();
-    }
-
-    private void syncKoreaderFromBookloreProgress(BookLoreUserEntity user, BookEntity book,
-                                                   UserBookProgressEntity progress, float percentage) {
-
-        koreaderUserRepository.findByBookLoreUserId(user.getId())
-                .filter(KoreaderUserEntity::isSyncEnabled)
-                .filter(KoreaderUserEntity::isSyncWithBookloreReader)
-                .ifPresent(koreaderUser -> {
-                    float koreaderPercent = percentage / 100.0f;
-                    progress.setKoreaderProgressPercent(koreaderPercent);
-                    progress.setKoreaderLastSyncTime(Instant.now());
-
-                    BookFileEntity primaryFile = book.getPrimaryBookFile();
-                    if (primaryFile != null && primaryFile.getBookType() == BookFileType.EPUB
-                            && progress.getEpubProgress() != null) {
-                        try {
-                            String xpointer = epubCfiService.convertCfiToProgressXPointer(
-                                    book.getFullFilePath(), progress.getEpubProgress());
-                            progress.setKoreaderProgress(xpointer);
-                        } catch (Exception e) {
-                            log.warn("Failed to convert CFI to XPointer for KOReader sync", e);
-                        }
-                    }
-                });
     }
 
     private BookLoreUserEntity findUserOrThrow(Long userId) {

--- a/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -512,6 +512,7 @@ public class ReadingProgressService {
         if (percentage == null) return;
 
         koreaderUserRepository.findByBookLoreUserId(user.getId())
+                .filter(KoreaderUserEntity::isSyncEnabled)
                 .filter(KoreaderUserEntity::isSyncWithBookloreReader)
                 .ifPresent(koreaderUser -> {
                     float koreaderPercent = percentage / 100.0f;
@@ -526,7 +527,7 @@ public class ReadingProgressService {
                                     book.getFullFilePath(), progress.getEpubProgress());
                             progress.setKoreaderProgress(xpointer);
                         } catch (Exception e) {
-                            log.warn("Failed to convert CFI to XPointer for KOReader sync: {}", e.getMessage());
+                            log.warn("Failed to convert CFI to XPointer for KOReader sync", e);
                         }
                     }
                 });

--- a/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -18,8 +18,10 @@ import org.booklore.model.enums.ReadStatus;
 import org.booklore.model.enums.ResetProgressType;
 import org.booklore.model.enums.UserPermission;
 import org.booklore.repository.*;
+import org.booklore.repository.KoreaderUserRepository;
 import org.booklore.service.hardcover.HardcoverSyncService;
 import org.booklore.service.kobo.KoboReadingStateService;
+import org.booklore.util.koreader.EpubCfiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -46,6 +48,8 @@ public class ReadingProgressService {
     private final UserRepository userRepository;
     private final AuthenticationService authenticationService;
     private final KoboReadingStateService koboReadingStateService;
+    private final KoreaderUserRepository koreaderUserRepository;
+    private final EpubCfiService epubCfiService;
     private final HardcoverSyncService hardcoverSyncService;
 
     // ==================== Methods from UserProgressService ====================
@@ -266,6 +270,8 @@ public class ReadingProgressService {
         if (request.getDateFinished() != null) {
             progress.setDateFinished(request.getDateFinished());
         }
+
+        syncKoreaderFromBookloreProgress(userEntity, book, progress, percentage);
 
         userBookProgressRepository.save(progress);
 
@@ -500,6 +506,31 @@ public class ReadingProgressService {
                         .dateFinished(null)
                         .build())
                 .toList();
+    }
+
+    private void syncKoreaderFromBookloreProgress(BookLoreUserEntity user, BookEntity book,
+                                                   UserBookProgressEntity progress, Float percentage) {
+        if (percentage == null) return;
+
+        koreaderUserRepository.findByBookLoreUserId(user.getId())
+                .filter(KoreaderUserEntity::isSyncWithBookloreReader)
+                .ifPresent(koreaderUser -> {
+                    float koreaderPercent = percentage / 100.0f;
+                    progress.setKoreaderProgressPercent(koreaderPercent);
+                    progress.setKoreaderLastSyncTime(Instant.now());
+
+                    BookFileEntity primaryFile = book.getPrimaryBookFile();
+                    if (primaryFile != null && primaryFile.getBookType() == BookFileType.EPUB
+                            && progress.getEpubProgress() != null) {
+                        try {
+                            String xpointer = epubCfiService.convertCfiToProgressXPointer(
+                                    book.getFullFilePath(), progress.getEpubProgress());
+                            progress.setKoreaderProgress(xpointer);
+                        } catch (Exception e) {
+                            log.warn("Failed to convert CFI to XPointer for KOReader sync: {}", e.getMessage());
+                        }
+                    }
+                });
     }
 
     private BookLoreUserEntity findUserOrThrow(Long userId) {

--- a/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -270,11 +270,10 @@ public class ReadingProgressService {
             progress.setDateFinished(request.getDateFinished());
         }
 
-        syncKoreaderFromBookloreProgress(userEntity, book, progress, percentage);
-
         userBookProgressRepository.save(progress);
 
         if (percentage != null) {
+            syncKoreaderFromBookloreProgress(userEntity, book, progress, percentage);
             hardcoverSyncService.syncProgressToHardcover(book.getId(), percentage, user.getId());
         }
     }
@@ -508,8 +507,7 @@ public class ReadingProgressService {
     }
 
     private void syncKoreaderFromBookloreProgress(BookLoreUserEntity user, BookEntity book,
-                                                   UserBookProgressEntity progress, Float percentage) {
-        if (percentage == null) return;
+                                                   UserBookProgressEntity progress, float percentage) {
 
         koreaderUserRepository.findByBookLoreUserId(user.getId())
                 .filter(KoreaderUserEntity::isSyncEnabled)

--- a/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -18,7 +18,6 @@ import org.booklore.model.enums.ReadStatus;
 import org.booklore.model.enums.ResetProgressType;
 import org.booklore.model.enums.UserPermission;
 import org.booklore.repository.*;
-import org.booklore.repository.KoreaderUserRepository;
 import org.booklore.service.hardcover.HardcoverSyncService;
 import org.booklore.service.kobo.KoboReadingStateService;
 import org.booklore.util.koreader.EpubCfiService;

--- a/backend/src/test/java/org/booklore/service/KoboReadingStateServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoboReadingStateServiceTest.java
@@ -20,6 +20,7 @@ import org.booklore.service.hardcover.HardcoverSyncService;
 import org.booklore.service.kobo.KoboReadingStateBuilder;
 import org.booklore.service.kobo.KoboReadingStateService;
 import org.booklore.service.kobo.KoboSettingsService;
+import org.booklore.service.koreader.KoreaderService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,6 +74,9 @@ class KoboReadingStateServiceTest {
 
     @Mock
     private HardcoverSyncService hardcoverSyncService;
+
+    @Mock
+    private KoreaderService koreaderService;
 
     @Mock
     private UserBookFileProgressRepository fileProgressRepository;
@@ -1229,6 +1233,7 @@ class KoboReadingStateServiceTest {
 
         service.saveReadingState(List.of(readingState));
 
+        verify(koreaderService).syncProgressToKoreader(eq(100L), eq(50f), eq(1L));
         verify(hardcoverSyncService).syncProgressToHardcover(eq(100L), eq(50f), eq(1L));
     }
 

--- a/backend/src/test/java/org/booklore/service/KoboStatusSyncProtectionTest.java
+++ b/backend/src/test/java/org/booklore/service/KoboStatusSyncProtectionTest.java
@@ -18,6 +18,7 @@ import org.booklore.service.hardcover.HardcoverSyncService;
 import org.booklore.service.kobo.KoboReadingStateBuilder;
 import org.booklore.service.kobo.KoboReadingStateService;
 import org.booklore.service.kobo.KoboSettingsService;
+import org.booklore.service.koreader.KoreaderService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -61,6 +62,9 @@ class KoboStatusSyncProtectionTest {
 
     @Mock
     private HardcoverSyncService hardcoverSyncService;
+
+    @Mock
+    private KoreaderService koreaderService;
 
     @InjectMocks
     private KoboReadingStateService service;

--- a/backend/src/test/java/org/booklore/service/KoreaderServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoreaderServiceTest.java
@@ -8,16 +8,21 @@ import org.booklore.config.security.userdetails.KoreaderUserDetails;
 import org.booklore.exception.APIException;
 import org.booklore.model.dto.progress.KoreaderProgress;
 import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.BookLoreUserEntity;
 import org.booklore.model.entity.KoreaderUserEntity;
+import org.booklore.model.entity.LibraryPathEntity;
 import org.booklore.model.entity.UserBookProgressEntity;
+import org.booklore.model.enums.BookFileType;
 import org.booklore.model.enums.ReadStatus;
 import org.booklore.repository.BookRepository;
+import org.booklore.repository.UserBookFileProgressRepository;
 import org.booklore.repository.UserBookProgressRepository;
 import org.booklore.repository.UserRepository;
 import org.booklore.repository.KoreaderUserRepository;
 import org.booklore.service.hardcover.HardcoverSyncService;
 import org.booklore.service.koreader.KoreaderService;
+import org.booklore.util.koreader.EpubCfiService;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
@@ -29,7 +34,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.*;
 
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,6 +47,8 @@ class KoreaderServiceTest {
     @Mock
     UserBookProgressRepository progressRepo;
     @Mock
+    UserBookFileProgressRepository fileProgressRepo;
+    @Mock
     BookRepository bookRepo;
     @Mock
     UserRepository userRepo;
@@ -47,6 +56,8 @@ class KoreaderServiceTest {
     KoreaderUserRepository koreaderUserRepo;
     @Mock
     HardcoverSyncService hardcoverSyncService;
+    @Mock
+    EpubCfiService epubCfiService;
 
     @InjectMocks
     KoreaderService service;
@@ -266,6 +277,103 @@ class KoreaderServiceTest {
     }
 
     @Test
+    void syncProgressToKoreader_whenEnabled_updatesPercentAndXPointer() {
+        BookEntity book = epubBook(11L);
+        BookLoreUserEntity user = user(42L);
+        UserBookProgressEntity progress = new UserBookProgressEntity();
+        progress.setEpubProgress("epubcfi(/6/8!/4/2/6)");
+        when(koreaderUserRepo.findByBookLoreUserId(42L)).thenReturn(Optional.of(koreaderUser(true, true)));
+        when(bookRepo.findById(11L)).thenReturn(Optional.of(book));
+        when(userRepo.findById(42L)).thenReturn(Optional.of(user));
+        when(progressRepo.findByUserIdAndBookId(42L, 11L)).thenReturn(Optional.of(progress));
+        when(epubCfiService.convertCfiToProgressXPointer(any(Path.class), eq("epubcfi(/6/8!/4/2/6)")))
+                .thenReturn("/6/8!/4/2/6/1:15");
+
+        service.syncProgressToKoreader(11L, 75f, 42L);
+
+        assertEquals(0.75f, progress.getKoreaderProgressPercent());
+        assertEquals("/6/8!/4/2/6/1:15", progress.getKoreaderProgress());
+        assertNotNull(progress.getKoreaderLastSyncTime());
+        verify(progressRepo).save(progress);
+        verify(epubCfiService).convertCfiToProgressXPointer(any(Path.class), eq("epubcfi(/6/8!/4/2/6)"));
+    }
+
+    @Test
+    void syncProgressToKoreader_whenConversionFails_clearsStaleXPointerButKeepsPercent() {
+        BookEntity book = epubBook(11L);
+        BookLoreUserEntity user = user(42L);
+        UserBookProgressEntity progress = new UserBookProgressEntity();
+        progress.setEpubProgress("epubcfi(/6/8!/4/2/6)");
+        progress.setKoreaderProgress("/old/xpointer");
+        when(koreaderUserRepo.findByBookLoreUserId(42L)).thenReturn(Optional.of(koreaderUser(true, true)));
+        when(bookRepo.findById(11L)).thenReturn(Optional.of(book));
+        when(userRepo.findById(42L)).thenReturn(Optional.of(user));
+        when(progressRepo.findByUserIdAndBookId(42L, 11L)).thenReturn(Optional.of(progress));
+        when(epubCfiService.convertCfiToProgressXPointer(any(Path.class), eq("epubcfi(/6/8!/4/2/6)")))
+                .thenThrow(new RuntimeException("conversion failed"));
+
+        service.syncProgressToKoreader(11L, 100f, 42L);
+
+        assertEquals(1.0f, progress.getKoreaderProgressPercent());
+        assertNull(progress.getKoreaderProgress());
+        assertNotNull(progress.getKoreaderLastSyncTime());
+        verify(progressRepo).save(progress);
+        verify(epubCfiService).convertCfiToProgressXPointer(any(Path.class), eq("epubcfi(/6/8!/4/2/6)"));
+    }
+
+    @Test
+    void syncProgressToKoreader_whenGlobalSyncDisabled_skipsUpdate() {
+        when(koreaderUserRepo.findByBookLoreUserId(42L)).thenReturn(Optional.of(koreaderUser(false, true)));
+
+        service.syncProgressToKoreader(11L, 75f, 42L);
+
+        verifyNoInteractions(bookRepo, userRepo, epubCfiService);
+        verify(progressRepo, never()).save(any());
+    }
+
+    @Test
+    void syncProgressToKoreader_whenWebReaderSyncDisabled_skipsUpdate() {
+        when(koreaderUserRepo.findByBookLoreUserId(42L)).thenReturn(Optional.of(koreaderUser(true, false)));
+
+        service.syncProgressToKoreader(11L, 75f, 42L);
+
+        verifyNoInteractions(bookRepo, userRepo, epubCfiService);
+        verify(progressRepo, never()).save(any());
+    }
+
+    @Test
+    void syncProgressToKoreader_whenBookOrUserMissing_logsAndSkipsSave() {
+        when(koreaderUserRepo.findByBookLoreUserId(42L)).thenReturn(Optional.of(koreaderUser(true, true)));
+        when(bookRepo.findById(11L)).thenReturn(Optional.empty());
+        when(userRepo.findById(42L)).thenReturn(Optional.of(user(42L)));
+
+        assertDoesNotThrow(() -> service.syncProgressToKoreader(11L, 75f, 42L));
+
+        verify(progressRepo, never()).save(any());
+    }
+
+    @Test
+    void syncProgressToKoreader_whenNotEpub_clearsStaleXPointer() {
+        BookEntity book = bookWithPrimaryFile(11L, BookFileType.PDF);
+        BookLoreUserEntity user = user(42L);
+        UserBookProgressEntity progress = new UserBookProgressEntity();
+        progress.setEpubProgress("epubcfi(/6/8!/4/2/6)");
+        progress.setKoreaderProgress("/old/xpointer");
+        when(koreaderUserRepo.findByBookLoreUserId(42L)).thenReturn(Optional.of(koreaderUser(true, true)));
+        when(bookRepo.findById(11L)).thenReturn(Optional.of(book));
+        when(userRepo.findById(42L)).thenReturn(Optional.of(user));
+        when(progressRepo.findByUserIdAndBookId(42L, 11L)).thenReturn(Optional.of(progress));
+
+        service.syncProgressToKoreader(11L, 50f, 42L);
+
+        assertEquals(0.5f, progress.getKoreaderProgressPercent());
+        assertNull(progress.getKoreaderProgress());
+        assertNotNull(progress.getKoreaderLastSyncTime());
+        verifyNoInteractions(epubCfiService);
+        verify(progressRepo).save(progress);
+    }
+
+    @Test
     void normalizeProgressPercent_handlesNullAndRanges() throws Exception {
         Method method = KoreaderService.class.getDeclaredMethod("normalizeProgressPercent", Float.class);
         method.setAccessible(true);
@@ -274,5 +382,39 @@ class KoreaderServiceTest {
         assertEquals(50.0f, (Float) method.invoke(service, 0.5f));
         assertEquals(100.0f, (Float) method.invoke(service, 1.0f));
         assertEquals(42.0f, (Float) method.invoke(service, 42.0f));
+    }
+
+    private KoreaderUserEntity koreaderUser(boolean syncEnabled, boolean syncWithWebReader) {
+        return KoreaderUserEntity.builder()
+                .syncEnabled(syncEnabled)
+                .syncWithWebReader(syncWithWebReader)
+                .build();
+    }
+
+    private BookLoreUserEntity user(long userId) {
+        BookLoreUserEntity user = new BookLoreUserEntity();
+        user.setId(userId);
+        return user;
+    }
+
+    private BookEntity epubBook(long bookId) {
+        return bookWithPrimaryFile(bookId, BookFileType.EPUB);
+    }
+
+    private BookEntity bookWithPrimaryFile(long bookId, BookFileType bookFileType) {
+        BookEntity book = new BookEntity();
+        book.setId(bookId);
+        LibraryPathEntity libraryPath = new LibraryPathEntity();
+        libraryPath.setPath("/library");
+        book.setLibraryPath(libraryPath);
+
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setId(1L);
+        primaryFile.setBook(book);
+        primaryFile.setBookType(bookFileType);
+        primaryFile.setFileSubPath("subdir");
+        primaryFile.setFileName("book.epub");
+        book.setBookFiles(List.of(primaryFile));
+        return book;
     }
 }

--- a/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 
@@ -290,6 +291,102 @@ class ReadingProgressServiceTest {
         assertEquals(5, progress.getPdfProgress());
         assertEquals(ReadStatus.READING, progress.getReadStatus());
         assertEquals(50f, progress.getPdfProgressPercent());
+    }
+
+    @Test
+    void updateReadProgress_shouldSyncToKoreaderWhenEnabled() {
+        long bookId = 1L;
+        BookEntity book = new BookEntity();
+        book.setId(bookId);
+
+        LibraryPathEntity libraryPath = new LibraryPathEntity();
+        libraryPath.setPath("/library");
+        book.setLibraryPath(libraryPath);
+
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setId(1L);
+        primaryFile.setBook(book);
+        primaryFile.setBookType(BookFileType.EPUB);
+        primaryFile.setFileName("book.epub");
+        primaryFile.setFileSubPath("subdir");
+        book.setBookFiles(List.of(primaryFile));
+
+        BookLoreUser user = mock(BookLoreUser.class);
+        when(user.getId()).thenReturn(2L);
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
+
+        BookLoreUserEntity userEntity = new BookLoreUserEntity();
+        userEntity.setId(2L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
+
+        KoreaderUserEntity koreaderUser = KoreaderUserEntity.builder()
+                .syncWithBookloreReader(true)
+                .build();
+        when(koreaderUserRepository.findByBookLoreUserId(2L)).thenReturn(Optional.of(koreaderUser));
+
+        when(epubCfiService.convertCfiToProgressXPointer(any(Path.class), eq("cfi")))
+                .thenReturn("/6/8!/4/2/6/1:15");
+
+        UserBookProgressEntity progress = new UserBookProgressEntity();
+        when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.of(progress));
+
+        when(userBookFileProgressRepository.findByUserIdAndBookFileId(2L, 1L)).thenReturn(Optional.empty());
+
+        ReadProgressRequest req = new ReadProgressRequest();
+        req.setBookId(bookId);
+        EpubProgress epubProgress = EpubProgress.builder().cfi("cfi").percentage(100f).build();
+        req.setEpubProgress(epubProgress);
+
+        readingProgressService.updateReadProgress(req);
+
+        assertEquals(1.0f, progress.getKoreaderProgressPercent());
+        assertEquals("/6/8!/4/2/6/1:15", progress.getKoreaderProgress());
+        assertNotNull(progress.getKoreaderLastSyncTime());
+        verify(epubCfiService).convertCfiToProgressXPointer(any(Path.class), eq("cfi"));
+    }
+
+    @Test
+    void updateReadProgress_shouldNotSyncToKoreaderWhenDisabled() {
+        long bookId = 1L;
+        BookEntity book = new BookEntity();
+        book.setId(bookId);
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setId(1L);
+        primaryFile.setBook(book);
+        primaryFile.setBookType(BookFileType.EPUB);
+        book.setBookFiles(List.of(primaryFile));
+
+        BookLoreUser user = mock(BookLoreUser.class);
+        when(user.getId()).thenReturn(2L);
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
+
+        BookLoreUserEntity userEntity = new BookLoreUserEntity();
+        userEntity.setId(2L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
+
+        KoreaderUserEntity koreaderUser = KoreaderUserEntity.builder()
+                .syncWithBookloreReader(false)
+                .build();
+        when(koreaderUserRepository.findByBookLoreUserId(2L)).thenReturn(Optional.of(koreaderUser));
+
+        UserBookProgressEntity progress = new UserBookProgressEntity();
+        when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.of(progress));
+
+        when(userBookFileProgressRepository.findByUserIdAndBookFileId(2L, 1L)).thenReturn(Optional.empty());
+
+        ReadProgressRequest req = new ReadProgressRequest();
+        req.setBookId(bookId);
+        EpubProgress epubProgress = EpubProgress.builder().cfi("cfi").percentage(100f).build();
+        req.setEpubProgress(epubProgress);
+
+        readingProgressService.updateReadProgress(req);
+
+        assertNull(progress.getKoreaderProgressPercent());
+        assertNull(progress.getKoreaderProgress());
+        assertNull(progress.getKoreaderLastSyncTime());
+        verify(epubCfiService, never()).convertCfiToProgressXPointer(any(Path.class), anyString());
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
@@ -321,6 +321,7 @@ class ReadingProgressServiceTest {
         when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
 
         KoreaderUserEntity koreaderUser = KoreaderUserEntity.builder()
+                .syncEnabled(true)
                 .syncWithBookloreReader(true)
                 .build();
         when(koreaderUserRepository.findByBookLoreUserId(2L)).thenReturn(Optional.of(koreaderUser));
@@ -368,6 +369,50 @@ class ReadingProgressServiceTest {
 
         KoreaderUserEntity koreaderUser = KoreaderUserEntity.builder()
                 .syncWithBookloreReader(false)
+                .build();
+        when(koreaderUserRepository.findByBookLoreUserId(2L)).thenReturn(Optional.of(koreaderUser));
+
+        UserBookProgressEntity progress = new UserBookProgressEntity();
+        when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.of(progress));
+
+        when(userBookFileProgressRepository.findByUserIdAndBookFileId(2L, 1L)).thenReturn(Optional.empty());
+
+        ReadProgressRequest req = new ReadProgressRequest();
+        req.setBookId(bookId);
+        EpubProgress epubProgress = EpubProgress.builder().cfi("cfi").percentage(100f).build();
+        req.setEpubProgress(epubProgress);
+
+        readingProgressService.updateReadProgress(req);
+
+        assertNull(progress.getKoreaderProgressPercent());
+        assertNull(progress.getKoreaderProgress());
+        assertNull(progress.getKoreaderLastSyncTime());
+        verify(epubCfiService, never()).convertCfiToProgressXPointer(any(Path.class), anyString());
+    }
+
+    @Test
+    void updateReadProgress_shouldNotSyncToKoreaderWhenGlobalSyncDisabled() {
+        long bookId = 1L;
+        BookEntity book = new BookEntity();
+        book.setId(bookId);
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setId(1L);
+        primaryFile.setBook(book);
+        primaryFile.setBookType(BookFileType.EPUB);
+        book.setBookFiles(List.of(primaryFile));
+
+        BookLoreUser user = mock(BookLoreUser.class);
+        when(user.getId()).thenReturn(2L);
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
+
+        BookLoreUserEntity userEntity = new BookLoreUserEntity();
+        userEntity.setId(2L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
+
+        KoreaderUserEntity koreaderUser = KoreaderUserEntity.builder()
+                .syncEnabled(false)
+                .syncWithBookloreReader(true)
                 .build();
         when(koreaderUserRepository.findByBookLoreUserId(2L)).thenReturn(Optional.of(koreaderUser));
 

--- a/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
@@ -16,14 +16,13 @@ import org.booklore.model.enums.ResetProgressType;
 import org.booklore.repository.*;
 import org.booklore.service.kobo.KoboReadingStateService;
 import org.booklore.service.hardcover.HardcoverSyncService;
-import org.booklore.util.koreader.EpubCfiService;
+import org.booklore.service.koreader.KoreaderService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 
@@ -49,9 +48,7 @@ class ReadingProgressServiceTest {
     @Mock
     private HardcoverSyncService hardcoverSyncService;
     @Mock
-    private KoreaderUserRepository koreaderUserRepository;
-    @Mock
-    private EpubCfiService epubCfiService;
+    private KoreaderService koreaderService;
 
     @InjectMocks
     private ReadingProgressService readingProgressService;
@@ -59,7 +56,6 @@ class ReadingProgressServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        when(koreaderUserRepository.findByBookLoreUserId(anyLong())).thenReturn(Optional.empty());
     }
 
     @Test
@@ -294,21 +290,14 @@ class ReadingProgressServiceTest {
     }
 
     @Test
-    void updateReadProgress_shouldSyncToKoreaderWhenEnabled() {
+    void updateReadProgress_shouldDelegateKoreaderSync() {
         long bookId = 1L;
         BookEntity book = new BookEntity();
         book.setId(bookId);
-
-        LibraryPathEntity libraryPath = new LibraryPathEntity();
-        libraryPath.setPath("/library");
-        book.setLibraryPath(libraryPath);
-
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setId(1L);
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.EPUB);
-        primaryFile.setFileName("book.epub");
-        primaryFile.setFileSubPath("subdir");
         book.setBookFiles(List.of(primaryFile));
 
         BookLoreUser user = mock(BookLoreUser.class);
@@ -319,15 +308,6 @@ class ReadingProgressServiceTest {
         BookLoreUserEntity userEntity = new BookLoreUserEntity();
         userEntity.setId(2L);
         when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
-
-        KoreaderUserEntity koreaderUser = KoreaderUserEntity.builder()
-                .syncEnabled(true)
-                .syncWithBookloreReader(true)
-                .build();
-        when(koreaderUserRepository.findByBookLoreUserId(2L)).thenReturn(Optional.of(koreaderUser));
-
-        when(epubCfiService.convertCfiToProgressXPointer(any(Path.class), eq("cfi")))
-                .thenReturn("/6/8!/4/2/6/1:15");
 
         UserBookProgressEntity progress = new UserBookProgressEntity();
         when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.of(progress));
@@ -341,21 +321,18 @@ class ReadingProgressServiceTest {
 
         readingProgressService.updateReadProgress(req);
 
-        assertEquals(1.0f, progress.getKoreaderProgressPercent());
-        assertEquals("/6/8!/4/2/6/1:15", progress.getKoreaderProgress());
-        assertNotNull(progress.getKoreaderLastSyncTime());
-        verify(epubCfiService).convertCfiToProgressXPointer(any(Path.class), eq("cfi"));
+        verify(koreaderService).syncProgressToKoreader(bookId, 100f, 2L);
     }
 
     @Test
-    void updateReadProgress_shouldNotSyncToKoreaderWhenDisabled() {
+    void updateReadProgress_shouldDelegateKoreaderSyncWithCorrectPercentage() {
         long bookId = 1L;
         BookEntity book = new BookEntity();
         book.setId(bookId);
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setId(1L);
         primaryFile.setBook(book);
-        primaryFile.setBookType(BookFileType.EPUB);
+        primaryFile.setBookType(BookFileType.PDF);
         book.setBookFiles(List.of(primaryFile));
 
         BookLoreUser user = mock(BookLoreUser.class);
@@ -367,11 +344,6 @@ class ReadingProgressServiceTest {
         userEntity.setId(2L);
         when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
 
-        KoreaderUserEntity koreaderUser = KoreaderUserEntity.builder()
-                .syncWithBookloreReader(false)
-                .build();
-        when(koreaderUserRepository.findByBookLoreUserId(2L)).thenReturn(Optional.of(koreaderUser));
-
         UserBookProgressEntity progress = new UserBookProgressEntity();
         when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.of(progress));
 
@@ -379,19 +351,16 @@ class ReadingProgressServiceTest {
 
         ReadProgressRequest req = new ReadProgressRequest();
         req.setBookId(bookId);
-        EpubProgress epubProgress = EpubProgress.builder().cfi("cfi").percentage(100f).build();
-        req.setEpubProgress(epubProgress);
+        PdfProgress pdfProgress = PdfProgress.builder().page(10).percentage(50f).build();
+        req.setPdfProgress(pdfProgress);
 
         readingProgressService.updateReadProgress(req);
 
-        assertNull(progress.getKoreaderProgressPercent());
-        assertNull(progress.getKoreaderProgress());
-        assertNull(progress.getKoreaderLastSyncTime());
-        verify(epubCfiService, never()).convertCfiToProgressXPointer(any(Path.class), anyString());
+        verify(koreaderService).syncProgressToKoreader(bookId, 50f, 2L);
     }
 
     @Test
-    void updateReadProgress_shouldNotSyncToKoreaderWhenGlobalSyncDisabled() {
+    void updateReadProgress_shouldNotDelegateKoreaderSyncWhenPercentageNull() {
         long bookId = 1L;
         BookEntity book = new BookEntity();
         book.setId(bookId);
@@ -410,28 +379,14 @@ class ReadingProgressServiceTest {
         userEntity.setId(2L);
         when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
 
-        KoreaderUserEntity koreaderUser = KoreaderUserEntity.builder()
-                .syncEnabled(false)
-                .syncWithBookloreReader(true)
-                .build();
-        when(koreaderUserRepository.findByBookLoreUserId(2L)).thenReturn(Optional.of(koreaderUser));
-
-        UserBookProgressEntity progress = new UserBookProgressEntity();
-        when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.of(progress));
-
-        when(userBookFileProgressRepository.findByUserIdAndBookFileId(2L, 1L)).thenReturn(Optional.empty());
+        when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.empty());
 
         ReadProgressRequest req = new ReadProgressRequest();
         req.setBookId(bookId);
-        EpubProgress epubProgress = EpubProgress.builder().cfi("cfi").percentage(100f).build();
-        req.setEpubProgress(epubProgress);
 
         readingProgressService.updateReadProgress(req);
 
-        assertNull(progress.getKoreaderProgressPercent());
-        assertNull(progress.getKoreaderProgress());
-        assertNull(progress.getKoreaderLastSyncTime());
-        verify(epubCfiService, never()).convertCfiToProgressXPointer(any(Path.class), anyString());
+        verify(koreaderService, never()).syncProgressToKoreader(anyLong(), anyFloat(), anyLong());
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
@@ -16,6 +16,7 @@ import org.booklore.model.enums.ResetProgressType;
 import org.booklore.repository.*;
 import org.booklore.service.kobo.KoboReadingStateService;
 import org.booklore.service.hardcover.HardcoverSyncService;
+import org.booklore.util.koreader.EpubCfiService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -46,6 +47,10 @@ class ReadingProgressServiceTest {
     private KoboReadingStateService koboReadingStateService;
     @Mock
     private HardcoverSyncService hardcoverSyncService;
+    @Mock
+    private KoreaderUserRepository koreaderUserRepository;
+    @Mock
+    private EpubCfiService epubCfiService;
 
     @InjectMocks
     private ReadingProgressService readingProgressService;
@@ -53,6 +58,7 @@ class ReadingProgressServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        when(koreaderUserRepository.findByBookLoreUserId(anyLong())).thenReturn(Optional.empty());
     }
 
     @Test


### PR DESCRIPTION
Fixes #414 

### a description of why you made this change

Kosync is an existing feature that promises 2 way sync, but it currently only syncs from the koreader app to grimmory and not the other way around. There have been multiple people complaining of this, myself one of them, and this PR fixes that issue. 

### how it fixes the issue you'd linked
#414 
Created a new functoin called `syncKoreaderFromBookloreProgress` which is called when new progress is made, and the correct settings are enabled. It uses all existing functionality to achieve getting the right location and setting the sync.

### how you tested this

1. Put up dev environment
2. add a book
4. enable OPDS
5. enable kosync
6. download the book to my kindle w/ koreader installed so the hashes match
7. make progress in koreader, view the progress matched on grimmory
8. make progress in grimmory, view the progress on koreader



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KOReader sync now triggers when read progress includes a percentage and saves converted EPUB position when applicable.
  * Stores per-user KOReader progress and updates last-sync timestamp for synced users.

* **Tests**
  * Added tests ensuring KOReader sync runs when a percentage is present (EPUB/PDF cases) and is skipped when percentage is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->