### PR TITLE
feat(helm): support external MariaDB

### DIFF
--- a/deploy/helm/grimmory/Chart.yaml
+++ b/deploy/helm/grimmory/Chart.yaml
@@ -23,3 +23,4 @@ dependencies:
   - name: mariadb
     version: 0.16.0
     repository: oci://registry-1.docker.io/cloudpirates
+    condition: mariadb.enabled

--- a/deploy/helm/grimmory/templates/_database.tpl
+++ b/deploy/helm/grimmory/templates/_database.tpl
@@ -1,0 +1,119 @@
+{{/*
+Validation — database configuration preconditions.
+
+Ensures that the bundled MariaDB subchart and external database
+configuration are not both specified, and that at least one is set.
+*/}}
+{{- define "grimmory.validate-database" -}}
+	{{- if and .Values.mariadb.enabled .Values.externalDatabase.enabled }}
+		{{- fail "mariadb.enabled and externalDatabase.enabled are mutually exclusive: disable the bundled MariaDB subchart or remove the externalDatabase" }}
+	{{- end }}
+	{{- if and (not .Values.mariadb.enabled) (not .Values.externalDatabase.enabled) }}
+		{{- fail "At least one database must be set: enable mariadb or provide an externalDatabase" }}
+	{{- end }}
+	{{- if .Values.externalDatabase.enabled }}
+		{{- with .Values.externalDatabase }}
+			{{- if and (not .host) (or (not .existingSecret.enabled) (and .existingSecret.enabled (not .existingSecret.hostnameKey)))}}
+				{{- fail "No host is set for the externalDatabase." }}
+			{{- end }}
+			{{- if and (not .password) (or (not .existingSecret.enabled) (and .existingSecret.enabled (not .existingSecret.passwordKey)))}}
+				{{- fail "No password is set for the externalDatabase." }}
+			{{- end }}
+		{{- end }}
+	{{- end }}
+{{- end -}}
+
+{{/*
+Connection helpers — resolve a single database configuration value.
+
+Usage:  {{ include "grimmory.dbHostname" . }}
+*/}}
+{{- define "grimmory.dbHostname" -}}
+	{{- if .Values.externalDatabase.enabled }}
+		{{- with .Values.externalDatabase }}
+			{{- if and .existingSecret.enabled .existingSecret.hostnameKey }}
+				{{- fail "Chart bug, this helper should not be called when an existing secret is set" }}
+			{{- else }}
+				{{- .host }}
+			{{- end }}
+		{{- end }}
+	{{- else }}
+		{{- printf "%s-mariadb" .Release.Name }}
+	{{- end }}
+{{- end -}}
+
+{{- define "grimmory.dbPort" -}}
+	{{- if .Values.externalDatabase.enabled }}
+		{{- with .Values.externalDatabase }}
+			{{- if and .existingSecret.enabled .existingSecret.portKey }}
+				{{- fail "Chart bug, this helper should not be called when an existing secret is set" }}
+			{{- else }}
+				{{- .port }}
+			{{- end }}
+		{{- end }}
+	{{- else }}
+		{{- .Values.mariadb.service.port }}
+	{{- end }}
+{{- end -}}
+
+{{- define "grimmory.dbName" -}}
+	{{- if .Values.externalDatabase.enabled }}
+		{{- with .Values.externalDatabase }}
+			{{- if and .existingSecret.enabled .existingSecret.databaseKey }}
+				{{- fail "Chart bug, this helper should not be called when an existing secret is set" }}
+			{{- else }}
+				{{- .database }}
+			{{- end }}
+		{{- end }}
+	{{- else }}
+		{{- .Values.mariadb.auth.database }}
+	{{- end }}
+{{- end -}}
+
+{{- define "grimmory.dbUserName" -}}
+	{{- if .Values.externalDatabase.enabled }}
+		{{- with .Values.externalDatabase }}
+			{{- if and .existingSecret.enabled .existingSecret.usernameKey }}
+				{{- fail "Chart bug, this helper should not be called when an existing secret is set" }}
+			{{- else }}
+				{{- .username }}
+			{{- end }}
+		{{- end }}
+	{{- else }}
+		{{- .Values.mariadb.auth.username }}
+	{{- end }}
+{{- end -}}
+
+
+{{- define "grimmory.dbPasswordSecretName" -}}
+	{{- if .Values.externalDatabase.enabled }}
+		{{- with .Values.externalDatabase }}
+			{{- required "No secretName was set for the externalDatabase existingSecret." .existingSecret.secretName }}
+		{{- end }}
+	{{- else }}
+		{{- with .Values.mariadb.auth }}
+			{{- if .existingSecret }}
+				{{- .existingSecret }}
+			{{- else }}
+				{{- printf "%s-mariadb" $.Release.Name }}
+			{{- end }}
+		{{- end }}
+	{{- end }}
+{{- end -}}
+
+{{- define "grimmory.dbPasswordSecretKey" -}}
+	{{- if .Values.externalDatabase.enabled }}
+		{{- with .Values.externalDatabase }}
+			{{- required "No passwordKey was set for the externalDatabase existingSecret." .existingSecret.passwordKey }}
+		{{- end }}
+	{{- else }}
+		{{- with .Values.mariadb.auth }}
+			{{- if not .existingSecret }}
+				{{- "mariadb-password" }}
+			{{- else }}
+				{{- required "No userPasswordKey was set for the built-in database existingSecret" .secretKeys.userPasswordKey }}
+			{{- end }}
+		{{- end }}
+	{{- end }}
+{{- end -}}
+

--- a/deploy/helm/grimmory/templates/deployment.yaml
+++ b/deploy/helm/grimmory/templates/deployment.yaml
@@ -1,5 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
+{{- include "grimmory.validate-database" . }}
 metadata:
   name: {{ include "grimmory.fullname" . }}
   labels:
@@ -32,23 +33,41 @@ spec:
       initContainers:
         - name: wait-for-database
           image: busybox:1.36
+          env:
+          - name: GRIMMORY_DB_HOST
+            {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.enabled .Values.externalDatabase.existingSecret.hostnameKey }}
+            {{- with .Values.externalDatabase.existingSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .secretName }}
+                key: {{ .hostnameKey }}
+            {{- end }}
+            {{- else }}
+            value: {{ include "grimmory.dbHostname" . | quote }}
+            {{- end }}
+          - name: GRIMMORY_DB_PORT
+            {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.enabled .Values.externalDatabase.existingSecret.portKey }}
+            {{- with .Values.externalDatabase.existingSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .secretName }}
+                key: {{ .portKey }}
+            {{- end }}
+            {{- else }}
+            value: {{ include "grimmory.dbPort" . | quote }}
+            {{- end }}
           command:
             - /bin/sh
             - -c
             - |
-              echo "Waiting for database on port {{ .Values.mariadb.service.port }}..."
-              until nc -z -v -w5 {{ .Release.Name }}-mariadb {{ .Values.mariadb.service.port }}; do
+              echo "Waiting for database at $GRIMMORY_DB_HOST:$GRIMMORY_DB_PORT ..."
+              until nc -z -v -w5 "$GRIMMORY_DB_HOST" "$GRIMMORY_DB_PORT"; do
                 echo "Waiting for database..."
                 sleep 2
               done
               echo "Database is available!"
           resources:
-            requests:
-              cpu: 10m
-              memory: 16Mi
-            limits:
-              cpu: 50m
-              memory: 32Mi
+            {{- toYaml .Values.initContainer.resources | nindent 12 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
@@ -62,23 +81,59 @@ spec:
               containerPort: {{ .Values.service.port }}
               #protocol: TCP
           env:
-            - name: DATABASE_URL
-              value: jdbc:mariadb://{{ .Release.Name }}-mariadb:{{ .Values.mariadb.service.port }}/{{ .Values.mariadb.auth.database }}
-            - name: DATABASE_USERNAME
-              value: {{ .Values.mariadb.auth.username }}
-            - name: DATABASE_PASSWORD
+            - name: DATABASE_HOST
+              {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.enabled .Values.externalDatabase.existingSecret.hostnameKey }}
+              {{- with .Values.externalDatabase.existingSecret }}
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.mariadb.auth.existingSecret }}
-                  name: {{ .Values.mariadb.auth.existingSecret }}
-                  {{- else }}
-                  name: {{ .Release.Name }}-mariadb
-                  {{- end }}
-                  key: mariadb-password
-          {{- with .Values.startupProbe }}
-          startupProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+                  name: {{ .secretName }}
+                  key: {{ .hostnameKey }}
+              {{- end }}
+              {{- else }}
+              value: {{ include "grimmory.dbHostname" . | quote }}
+              {{- end }}
+            - name: DATABASE_PORT
+              {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.enabled .Values.externalDatabase.existingSecret.portKey }}
+              {{- with .Values.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .portKey }}
+              {{- end }}
+              {{- else }}
+              value: {{ include "grimmory.dbPort" . | quote }}
+              {{- end }}
+            - name: DATABASE_USERNAME
+              {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.enabled .Values.externalDatabase.existingSecret.usernameKey }}
+              {{- with .Values.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .usernameKey }}
+              {{- end }}
+              {{- else }}
+              value: {{ include "grimmory.dbUserName" . }}
+              {{- end }}
+            - name: DATABASE_PASSWORD
+              {{- if or (and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.enabled) (not .Values.externalDatabase.enabled) }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "grimmory.dbPasswordSecretName" . }}
+                  key: {{ include "grimmory.dbPasswordSecretKey" . }}
+              {{- else }}
+              value: {{ .Values.externalDatabase.password | quote }}
+              {{- end }}
+            - name: DATABASE_NAME
+              {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.enabled .Values.externalDatabase.existingSecret.databaseKey }}
+              {{- with .Values.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .databaseKey }}
+              {{- end }}
+              {{- else }}
+              value: {{ include "grimmory.dbName" . | quote }}
+              {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/grimmory/values.yaml
+++ b/deploy/helm/grimmory/values.yaml
@@ -15,6 +15,37 @@ mariadb:
     #   userPasswordKey: mariadb-password
   service:
     port: 3306
+
+# Mutually exclusive with the bundled mariadb subchart above.
+# Set mariadb.enabled to false and externalDatabase.enabled to true to use this.
+externalDatabase:
+  enabled: false
+
+  ## Database host
+  host: ""
+
+  ## Database port
+  port: 3306
+
+  ## Database user
+  username: grimmory
+
+  ## Database password
+  password: ""
+
+  ## Database name
+  database: grimmory
+
+  ## Use an existing secret
+  existingSecret:
+    enabled: false
+    # secretName: nameofsecret
+    # usernameKey: db-username
+    # passwordKey: db-password
+    # hostnameKey: db-hostname
+    # portKey: db-port
+    # databaseKey: db-name
+
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   repository: grimmory/grimmory

--- a/deploy/helm/grimmory/values.yaml
+++ b/deploy/helm/grimmory/values.yaml
@@ -155,6 +155,16 @@ persistence:
     existingClaim: ""
 extraVolumes: []
 extraVolumeMounts: []
+
+initContainer:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 50m
+      memory: 32Mi
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
## Description

This PR adds support for an external MariaDB database.

**Linked Issue:** Fixes #1059

## Changes

- Add an `externalDatabse` block in the values file
- Check that the chart either uses the MariaDB subchart or the externalDatabase but not both
- Check that the chart uses at least one of the MariaDB subchart or the externalDatabase
- Update the deployment template to connect to the correct database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to use an external database instead of the bundled MariaDB.
  * Commented example configuration included to show external DB connection fields.
  * MariaDB can be conditionally enabled or disabled via deployment settings.

* **Bug Fixes / Validation**
  * Deployment-time validation added to prevent conflicting or missing database configurations.
  * Connection parameters now resolve from the selected database source and fail early if required values are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->