### PR TITLE
refactor(docker): consolidate JVM options into JAVA_TOOL_OPTIONS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,9 @@ ARG KEPUBIFY_VERSION="4.0.4"
 ARG KEPUBIFY_AMD64_CHECKSUM="sha256:37d7628d26c5c906f607f24b36f781f306075e7073a6fe7820a751bb60431fc5"
 
 ADD \
-      --checksum="${KEPUBIFY_AMD64_CHECKSUM}" \
-      --chmod=755 \
-      https://github.com/pgaskin/kepubify/releases/download/v${KEPUBIFY_VERSION}/kepubify-linux-64bit /kepubify
+    --checksum="${KEPUBIFY_AMD64_CHECKSUM}" \
+    --chmod=755 \
+    https://github.com/pgaskin/kepubify/releases/download/v${KEPUBIFY_VERSION}/kepubify-linux-64bit /kepubify
 
 FROM scratch AS kepubify-layer-arm64
 
@@ -57,9 +57,9 @@ ARG KEPUBIFY_VERSION="4.0.4"
 ARG KEPUBIFY_ARM64_CHECKSUM="sha256:5a15b8f6f6a96216c69330601bca29638cfee50f7bf48712795cff88ae2d03a3"
 
 ADD \
-      --checksum="${KEPUBIFY_ARM64_CHECKSUM}" \
-      --chmod=755 \
-      https://github.com/pgaskin/kepubify/releases/download/v${KEPUBIFY_VERSION}/kepubify-linux-arm64 /kepubify
+    --checksum="${KEPUBIFY_ARM64_CHECKSUM}" \
+    --chmod=755 \
+    https://github.com/pgaskin/kepubify/releases/download/v${KEPUBIFY_VERSION}/kepubify-linux-arm64 /kepubify
 
 FROM kepubify-layer-${TARGETARCH} AS kepubify-layer
 
@@ -103,14 +103,14 @@ ARG APP_VERSION=development
 ARG APP_REVISION=unknown
 
 LABEL org.opencontainers.image.title="Grimmory" \
-      org.opencontainers.image.description="Grimmory: a self-hosted, multi-user digital library with smart shelves, auto metadata, Kobo and KOReader sync, BookDrop imports, OPDS support, and a built-in reader for EPUB, PDF, and comics." \
-      org.opencontainers.image.source="https://github.com/grimmory-tools/grimmory" \
-      org.opencontainers.image.url="https://github.com/grimmory-tools/grimmory" \
-      org.opencontainers.image.documentation="https://grimmory.org/docs/getting-started" \
-      org.opencontainers.image.version=$APP_VERSION \
-      org.opencontainers.image.revision=$APP_REVISION \
-      org.opencontainers.image.licenses="AGPL-3.0" \
-      org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:25-jre-alpine"
+    org.opencontainers.image.description="Grimmory: a self-hosted, multi-user digital library with smart shelves, auto metadata, Kobo and KOReader sync, BookDrop imports, OPDS support, and a built-in reader for EPUB, PDF, and comics." \
+    org.opencontainers.image.source="https://github.com/grimmory-tools/grimmory" \
+    org.opencontainers.image.url="https://github.com/grimmory-tools/grimmory" \
+    org.opencontainers.image.documentation="https://grimmory.org/docs/getting-started" \
+    org.opencontainers.image.version=$APP_VERSION \
+    org.opencontainers.image.revision=$APP_REVISION \
+    org.opencontainers.image.licenses="AGPL-3.0" \
+    org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:25-jre-alpine"
 
 ENV APP_VERSION=${APP_VERSION} \
     APP_REVISION=${APP_REVISION}
@@ -119,4 +119,4 @@ ARG BOOKLORE_PORT=6060
 EXPOSE ${BOOKLORE_PORT}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["java", "-jar", "/app/app.jar"]
+CMD ["java", "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,9 @@ ENV JAVA_TOOL_OPTIONS="-XX:+UseShenandoahGC \
     -XX:+UseStringDeduplication \
     -XX:ShenandoahUncommitDelay=5000 \
     -XX:ShenandoahGuaranteedGCInterval=30000 \
-    -XX:MaxDirectMemorySize=256m"
+    -XX:MaxDirectMemorySize=256m \
+    --enable-native-access=ALL-UNNAMED \
+    --enable-preview"
 
 RUN apk add --no-cache su-exec libstdc++ libgcc libarchive && \
     mkdir -p /bookdrop
@@ -117,4 +119,4 @@ ARG BOOKLORE_PORT=6060
 EXPOSE ${BOOKLORE_PORT}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["java", "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-jar", "/app/app.jar"]
+CMD ["java", "-jar", "/app/app.jar"]

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - REMOTE_DEBUG_ENABLED=true
       - ALLOWED_ORIGINS=*
       - API_DOCS_ENABLED=true
-      - JAVA_TOOL_OPTIONS=-XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=8.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=48m -Xss512k -XX:CICompilerCount=2 -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -XX:ShenandoahUncommitDelay=5000 -XX:ShenandoahGuaranteedGCInterval=30000 -XX:MaxDirectMemorySize=256m
+      - JAVA_TOOL_OPTIONS=-XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=8.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=48m -Xss512k -XX:CICompilerCount=2 -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -XX:ShenandoahUncommitDelay=5000 -XX:ShenandoahGuaranteedGCInterval=30000 -XX:MaxDirectMemorySize=256m --enable-native-access=ALL-UNNAMED --enable-preview
     stdin_open: true
     tty: true
     restart: unless-stopped


### PR DESCRIPTION

## Description

<!-- What does this PR do? -->

**Linked Issue:** Fixes #<!-- issue number leave empty if none -->

## Changes

Consolidating JVM options into a single environment variable simplifies the configuration for end-users, especially on platforms like unRAID and Synology. 

These platforms often have Docker GUIs that make it difficult or confusing to manage both environment variables and command-line overrides simultaneously. By moving everything to JAVA_TOOL_OPTIONS, users can easily customize or append flags via a single environment variable without needing to override the entire CMD instruction.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized container runtime configuration by adding JVM preview and native-access flags to the environment and development service settings, ensuring consistent JVM options across runtime and dev setups for improved compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->