### PR TITLE
build: ensure gradle version does not have `v` prefix

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "org.booklore"
-version = System.getenv("APP_VERSION") ?: "0.0.1-SNAPSHOT"
+version = (System.getenv("APP_VERSION") ?: "0.0.1-SNAPSHOT").replace(Regex("^v"), "")
 
 val defaultFrontendDistDir = file("${rootDir}/../frontend/dist/grimmory/browser")
 val configuredFrontendDistDir = providers.gradleProperty("frontendDistDir")


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
our version tags are prefixed with `v` which get passed as `APP_VERSION` but gradle expects a non-prefixed version string

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1045

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
replaces `v` at the start of string in gradle version with an empty string

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Set env var `APP_VERSION` to `v0.0.5`
2. Build app jar
3. Inspect manifest file in jar for correct version
4. Run app & inspect logs

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
<img width="2202" height="178" alt="image" src="https://github.com/user-attachments/assets/30b42071-ba01-4452-8baa-5eb169d43d21" />


## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version string processing in the build configuration to ensure consistent handling of application versions across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->