### PR TITLE
refactor(api): rename KOReader sync references from booklore to grimmory

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/filter/KoreaderAuthFilter.java
+++ b/backend/src/main/java/org/booklore/config/security/filter/KoreaderAuthFilter.java
@@ -60,7 +60,7 @@ public class KoreaderAuthFilter extends OncePerRequestFilter {
                 user.getUsername(),
                 user.getPasswordMD5(),
                 user.isSyncEnabled(),
-                user.isSyncWithBookloreReader(),
+                user.isSyncWithGrimmoryReader(),
                 bookLoreUserId,
                 List.of(new SimpleGrantedAuthority("ROLE_USER"))
         );

--- a/backend/src/main/java/org/booklore/config/security/filter/KoreaderAuthFilter.java
+++ b/backend/src/main/java/org/booklore/config/security/filter/KoreaderAuthFilter.java
@@ -60,7 +60,7 @@ public class KoreaderAuthFilter extends OncePerRequestFilter {
                 user.getUsername(),
                 user.getPasswordMD5(),
                 user.isSyncEnabled(),
-                user.isSyncWithGrimmoryReader(),
+                user.isSyncWithWebReader(),
                 bookLoreUserId,
                 List.of(new SimpleGrantedAuthority("ROLE_USER"))
         );

--- a/backend/src/main/java/org/booklore/config/security/userdetails/KoreaderUserDetails.java
+++ b/backend/src/main/java/org/booklore/config/security/userdetails/KoreaderUserDetails.java
@@ -13,16 +13,16 @@ public class KoreaderUserDetails implements UserDetails {
     @Getter
     private final boolean syncEnabled;
     @Getter
-    private final boolean syncWithBookloreReader;
+    private final boolean syncWithGrimmoryReader;
     @Getter
     private final Long bookLoreUserId;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public KoreaderUserDetails(String username, String password, boolean syncEnabled, boolean syncWithBookloreReader, Long bookLoreUserId, Collection<? extends GrantedAuthority> authorities) {
+    public KoreaderUserDetails(String username, String password, boolean syncEnabled, boolean syncWithGrimmoryReader, Long bookLoreUserId, Collection<? extends GrantedAuthority> authorities) {
         this.username = username;
         this.password = password;
         this.syncEnabled = syncEnabled;
-        this.syncWithBookloreReader = syncWithBookloreReader;
+        this.syncWithGrimmoryReader = syncWithGrimmoryReader;
         this.bookLoreUserId = bookLoreUserId;
         this.authorities = authorities;
     }

--- a/backend/src/main/java/org/booklore/config/security/userdetails/KoreaderUserDetails.java
+++ b/backend/src/main/java/org/booklore/config/security/userdetails/KoreaderUserDetails.java
@@ -13,16 +13,16 @@ public class KoreaderUserDetails implements UserDetails {
     @Getter
     private final boolean syncEnabled;
     @Getter
-    private final boolean syncWithGrimmoryReader;
+    private final boolean syncWithWebReader;
     @Getter
     private final Long bookLoreUserId;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public KoreaderUserDetails(String username, String password, boolean syncEnabled, boolean syncWithGrimmoryReader, Long bookLoreUserId, Collection<? extends GrantedAuthority> authorities) {
+    public KoreaderUserDetails(String username, String password, boolean syncEnabled, boolean syncWithWebReader, Long bookLoreUserId, Collection<? extends GrantedAuthority> authorities) {
         this.username = username;
         this.password = password;
         this.syncEnabled = syncEnabled;
-        this.syncWithGrimmoryReader = syncWithGrimmoryReader;
+        this.syncWithWebReader = syncWithWebReader;
         this.bookLoreUserId = bookLoreUserId;
         this.authorities = authorities;
     }

--- a/backend/src/main/java/org/booklore/controller/KoreaderUserController.java
+++ b/backend/src/main/java/org/booklore/controller/KoreaderUserController.java
@@ -51,13 +51,26 @@ public class KoreaderUserController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Toggle sync progress with Grimmory reader", description = "Enable or disable syncing reading progress with Grimmory reader.")
+    @Operation(summary = "Toggle sync progress with web reader", description = "Enable or disable syncing reading progress with the web reader.")
     @ApiResponse(responseCode = "204", description = "Sync progress toggled successfully")
     @PatchMapping("/me/sync-progress-with-grimmory")
     @PreAuthorize("@securityUtil.canSyncKoReader() or @securityUtil.isAdmin()")
-    public ResponseEntity<Void> toggleSyncProgressWithGrimmory(
+    public ResponseEntity<Void> toggleSyncProgressWithWebReader(
             @Parameter(description = "Enable or disable sync progress") @RequestParam boolean enabled) {
-        koreaderUserService.toggleSyncProgressWithGrimmory(enabled);
+        koreaderUserService.toggleSyncProgressWithWebReader(enabled);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "[Deprecated] Toggle sync progress with web reader",
+            description = "Deprecated alias for /me/sync-progress-with-grimmory. Use the new endpoint; this one will be removed in a future release.",
+            deprecated = true)
+    @ApiResponse(responseCode = "204", description = "Sync progress toggled successfully")
+    @PatchMapping("/me/sync-progress-with-booklore")
+    @PreAuthorize("@securityUtil.canSyncKoReader() or @securityUtil.isAdmin()")
+    @Deprecated(forRemoval = true)
+    public ResponseEntity<Void> toggleSyncProgressWithBooklore(
+            @Parameter(description = "Enable or disable sync progress") @RequestParam boolean enabled) {
+        return toggleSyncProgressWithWebReader(enabled);
     }
 }

--- a/backend/src/main/java/org/booklore/controller/KoreaderUserController.java
+++ b/backend/src/main/java/org/booklore/controller/KoreaderUserController.java
@@ -51,13 +51,13 @@ public class KoreaderUserController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Toggle sync progress with Booklore reader", description = "Enable or disable syncing reading progress with Booklore reader.")
+    @Operation(summary = "Toggle sync progress with Grimmory reader", description = "Enable or disable syncing reading progress with Grimmory reader.")
     @ApiResponse(responseCode = "204", description = "Sync progress toggled successfully")
-    @PatchMapping("/me/sync-progress-with-booklore")
+    @PatchMapping("/me/sync-progress-with-grimmory")
     @PreAuthorize("@securityUtil.canSyncKoReader() or @securityUtil.isAdmin()")
-    public ResponseEntity<Void> toggleSyncProgressWithBooklore(
+    public ResponseEntity<Void> toggleSyncProgressWithGrimmory(
             @Parameter(description = "Enable or disable sync progress") @RequestParam boolean enabled) {
-        koreaderUserService.toggleSyncProgressWithBooklore(enabled);
+        koreaderUserService.toggleSyncProgressWithGrimmory(enabled);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/org/booklore/model/dto/KoreaderUser.java
+++ b/backend/src/main/java/org/booklore/model/dto/KoreaderUser.java
@@ -12,5 +12,5 @@ public class KoreaderUser {
     private String password;
     private String passwordMD5;
     private boolean syncEnabled;
-    private boolean syncWithBookloreReader;
+    private boolean syncWithGrimmoryReader;
 }

--- a/backend/src/main/java/org/booklore/model/dto/KoreaderUser.java
+++ b/backend/src/main/java/org/booklore/model/dto/KoreaderUser.java
@@ -12,5 +12,5 @@ public class KoreaderUser {
     private String password;
     private String passwordMD5;
     private boolean syncEnabled;
-    private boolean syncWithGrimmoryReader;
+    private boolean syncWithWebReader;
 }

--- a/backend/src/main/java/org/booklore/model/entity/KoreaderUserEntity.java
+++ b/backend/src/main/java/org/booklore/model/entity/KoreaderUserEntity.java
@@ -38,9 +38,9 @@ public class KoreaderUserEntity {
     @Builder.Default
     private boolean syncEnabled = false;
 
-    @Column(name = "sync_with_booklore_reader", nullable = false)
+    @Column(name = "sync_with_grimmory_reader", nullable = false)
     @Builder.Default
-    private boolean syncWithBookloreReader = false;
+    private boolean syncWithGrimmoryReader = false;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "booklore_user_id")

--- a/backend/src/main/java/org/booklore/model/entity/KoreaderUserEntity.java
+++ b/backend/src/main/java/org/booklore/model/entity/KoreaderUserEntity.java
@@ -38,9 +38,9 @@ public class KoreaderUserEntity {
     @Builder.Default
     private boolean syncEnabled = false;
 
-    @Column(name = "sync_with_grimmory_reader", nullable = false)
+    @Column(name = "sync_with_booklore_reader", nullable = false)
     @Builder.Default
-    private boolean syncWithGrimmoryReader = false;
+    private boolean syncWithWebReader = false;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "booklore_user_id")

--- a/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
+++ b/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
@@ -74,7 +74,7 @@ public class KoreaderService {
         UserBookProgressEntity userProgress = getOrCreateUserProgress(user, book);
         Float previousProgressPercent = userProgress.getKoreaderProgressPercent();
         ReadStatus previousReadStatus = userProgress.getReadStatus();
-        updateProgressData(userProgress, koProgress, authDetails.isSyncWithBookloreReader(), book);
+        updateProgressData(userProgress, koProgress, authDetails.isSyncWithGrimmoryReader(), book);
 
         progressRepository.save(userProgress);
 
@@ -128,14 +128,14 @@ public class KoreaderService {
         }
     }
 
-    private void updateProgressData(UserBookProgressEntity userProgress, KoreaderProgress koProgress, boolean syncWithBookloreReader, BookEntity book) {
+    private void updateProgressData(UserBookProgressEntity userProgress, KoreaderProgress koProgress, boolean syncWithGrimmoryReader, BookEntity book) {
         userProgress.setKoreaderProgress(koProgress.getProgress());
         userProgress.setKoreaderProgressPercent(koProgress.getPercentage());
         userProgress.setKoreaderDevice(koProgress.getDevice());
         userProgress.setKoreaderDeviceId(koProgress.getDevice_id());
         userProgress.setKoreaderLastSyncTime(Instant.now());
         userProgress.setLastReadTime(Instant.now());
-        if (syncWithBookloreReader && koProgress.getProgress() != null) {
+        if (syncWithGrimmoryReader && koProgress.getProgress() != null) {
             try {
                 String cfi = epubCfiService.convertXPointerToCfi(book.getFullFilePath(), koProgress.getProgress());
 

--- a/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
+++ b/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
@@ -74,7 +74,7 @@ public class KoreaderService {
         UserBookProgressEntity userProgress = getOrCreateUserProgress(user, book);
         Float previousProgressPercent = userProgress.getKoreaderProgressPercent();
         ReadStatus previousReadStatus = userProgress.getReadStatus();
-        updateProgressData(userProgress, koProgress, authDetails.isSyncWithGrimmoryReader(), book);
+        updateProgressData(userProgress, koProgress, authDetails.isSyncWithWebReader(), book);
 
         progressRepository.save(userProgress);
 
@@ -128,14 +128,14 @@ public class KoreaderService {
         }
     }
 
-    private void updateProgressData(UserBookProgressEntity userProgress, KoreaderProgress koProgress, boolean syncWithGrimmoryReader, BookEntity book) {
+    private void updateProgressData(UserBookProgressEntity userProgress, KoreaderProgress koProgress, boolean syncWithWebReader, BookEntity book) {
         userProgress.setKoreaderProgress(koProgress.getProgress());
         userProgress.setKoreaderProgressPercent(koProgress.getPercentage());
         userProgress.setKoreaderDevice(koProgress.getDevice());
         userProgress.setKoreaderDeviceId(koProgress.getDevice_id());
         userProgress.setKoreaderLastSyncTime(Instant.now());
         userProgress.setLastReadTime(Instant.now());
-        if (syncWithGrimmoryReader && koProgress.getProgress() != null) {
+        if (syncWithWebReader && koProgress.getProgress() != null) {
             try {
                 String cfi = epubCfiService.convertXPointerToCfi(book.getFullFilePath(), koProgress.getProgress());
 

--- a/backend/src/main/java/org/booklore/service/koreader/KoreaderUserService.java
+++ b/backend/src/main/java/org/booklore/service/koreader/KoreaderUserService.java
@@ -72,11 +72,11 @@ public class KoreaderUserService {
     }
 
     @Transactional
-    public void toggleSyncProgressWithBooklore(boolean enabled) {
+    public void toggleSyncProgressWithGrimmory(boolean enabled) {
         Long id = authService.getAuthenticatedUser().getId();
         KoreaderUserEntity user = koreaderUserRepository.findByBookLoreUserId(id)
                 .orElseThrow(() -> ApiError.GENERIC_NOT_FOUND.createException("Koreader user not found for BookLore user ID: " + id));
-        user.setSyncWithBookloreReader(enabled);
+        user.setSyncWithGrimmoryReader(enabled);
         koreaderUserRepository.save(user);
     }
 }

--- a/backend/src/main/java/org/booklore/service/koreader/KoreaderUserService.java
+++ b/backend/src/main/java/org/booklore/service/koreader/KoreaderUserService.java
@@ -72,11 +72,11 @@ public class KoreaderUserService {
     }
 
     @Transactional
-    public void toggleSyncProgressWithGrimmory(boolean enabled) {
+    public void toggleSyncProgressWithWebReader(boolean enabled) {
         Long id = authService.getAuthenticatedUser().getId();
         KoreaderUserEntity user = koreaderUserRepository.findByBookLoreUserId(id)
                 .orElseThrow(() -> ApiError.GENERIC_NOT_FOUND.createException("Koreader user not found for BookLore user ID: " + id));
-        user.setSyncWithGrimmoryReader(enabled);
+        user.setSyncWithWebReader(enabled);
         koreaderUserRepository.save(user);
     }
 }

--- a/backend/src/main/resources/db/migration/V141__Rename_sync_with_booklore_to_grimmory.sql
+++ b/backend/src/main/resources/db/migration/V141__Rename_sync_with_booklore_to_grimmory.sql
@@ -1,2 +1,0 @@
-ALTER TABLE koreader_user
-    CHANGE COLUMN sync_with_booklore_reader sync_with_grimmory_reader TINYINT(1) NOT NULL DEFAULT 0;

--- a/backend/src/main/resources/db/migration/V141__Rename_sync_with_booklore_to_grimmory.sql
+++ b/backend/src/main/resources/db/migration/V141__Rename_sync_with_booklore_to_grimmory.sql
@@ -1,0 +1,2 @@
+ALTER TABLE koreader_user
+    CHANGE COLUMN sync_with_booklore_reader sync_with_grimmory_reader TINYINT(1) NOT NULL DEFAULT 0;

--- a/backend/src/test/java/org/booklore/controller/KoreaderUserControllerTest.java
+++ b/backend/src/test/java/org/booklore/controller/KoreaderUserControllerTest.java
@@ -60,4 +60,12 @@ class KoreaderUserControllerTest {
         assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
         assertNull(resp.getBody());
     }
+
+    @Test
+    void toggleSyncProgressWithGrimmory_returnsNoContent() {
+        doNothing().when(koreaderUserService).toggleSyncProgressWithGrimmory(true);
+        ResponseEntity<Void> resp = controller.toggleSyncProgressWithGrimmory(true);
+        assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
+        assertNull(resp.getBody());
+    }
 }

--- a/backend/src/test/java/org/booklore/controller/KoreaderUserControllerTest.java
+++ b/backend/src/test/java/org/booklore/controller/KoreaderUserControllerTest.java
@@ -62,9 +62,17 @@ class KoreaderUserControllerTest {
     }
 
     @Test
-    void toggleSyncProgressWithGrimmory_returnsNoContent() {
-        doNothing().when(koreaderUserService).toggleSyncProgressWithGrimmory(true);
-        ResponseEntity<Void> resp = controller.toggleSyncProgressWithGrimmory(true);
+    void toggleSyncProgressWithWebReader_returnsNoContent() {
+        doNothing().when(koreaderUserService).toggleSyncProgressWithWebReader(true);
+        ResponseEntity<Void> resp = controller.toggleSyncProgressWithWebReader(true);
+        assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
+        assertNull(resp.getBody());
+    }
+
+    @Test
+    void toggleSyncProgressWithBooklore_delegatesToWebReader_andReturnsNoContent() {
+        doNothing().when(koreaderUserService).toggleSyncProgressWithWebReader(true);
+        ResponseEntity<Void> resp = controller.toggleSyncProgressWithBooklore(true);
         assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
         assertNull(resp.getBody());
     }

--- a/backend/src/test/java/org/booklore/service/KoreaderUserServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoreaderUserServiceTest.java
@@ -71,7 +71,7 @@ class KoreaderUserServiceTest {
 
         when(koreaderUserMapper.toDto(any(KoreaderUserEntity.class))).thenAnswer(invocation -> {
             KoreaderUserEntity u = invocation.getArgument(0);
-            return new KoreaderUser(u.getId(), u.getUsername(), u.getPassword(), u.getPasswordMD5(), u.isSyncEnabled(), u.isSyncWithGrimmoryReader());
+            return new KoreaderUser(u.getId(), u.getUsername(), u.getPassword(), u.getPasswordMD5(), u.isSyncEnabled(), u.isSyncWithWebReader());
         });
 
         KoreaderUser result = service.upsertUser("userA", "passA");

--- a/backend/src/test/java/org/booklore/service/KoreaderUserServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoreaderUserServiceTest.java
@@ -71,7 +71,7 @@ class KoreaderUserServiceTest {
 
         when(koreaderUserMapper.toDto(any(KoreaderUserEntity.class))).thenAnswer(invocation -> {
             KoreaderUserEntity u = invocation.getArgument(0);
-            return new KoreaderUser(u.getId(), u.getUsername(), u.getPassword(), u.getPasswordMD5(), u.isSyncEnabled(), u.isSyncWithBookloreReader());
+            return new KoreaderUser(u.getId(), u.getUsername(), u.getPassword(), u.getPasswordMD5(), u.isSyncEnabled(), u.isSyncWithGrimmoryReader());
         });
 
         KoreaderUser result = service.upsertUser("userA", "passA");

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.html
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.html
@@ -51,10 +51,10 @@
                 <div class="setting-label-row">
                   <span class="setting-label">{{ t('koreader.syncWithGrimmory') }}</span>
                   <p-toggle-switch
-                    name="syncWithGrimmoryReader"
-                    [(ngModel)]="syncWithGrimmoryReader"
-                    (ngModelChange)="onToggleSyncWithGrimmoryReader($event)"
-                    inputId="syncWithGrimmoryReader"
+                    name="syncWithWebReader"
+                    [(ngModel)]="syncWithWebReader"
+                    (ngModelChange)="onToggleSyncWithWebReader($event)"
+                    inputId="syncWithWebReader"
                     [disabled]="!credentialsSaved || !koReaderSyncEnabled">
                   </p-toggle-switch>
                 </div>

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.ts
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.ts
@@ -33,7 +33,7 @@ export class KoreaderSettingsComponent {
   editMode = true;
   showPassword = false;
   koReaderSyncEnabled = false;
-  syncWithGrimmoryReader = false;
+  syncWithWebReader = false;
   koReaderUsername = '';
   koReaderPassword = '';
   credentialsSaved = false;
@@ -70,7 +70,7 @@ export class KoreaderSettingsComponent {
         this.koReaderUsername = koreaderUser.username;
         this.koReaderPassword = koreaderUser.password;
         this.koReaderSyncEnabled = koreaderUser.syncEnabled;
-        this.syncWithGrimmoryReader = koreaderUser.syncWithGrimmoryReader ?? false;
+        this.syncWithWebReader = koreaderUser.syncWithWebReader ?? false;
         this.credentialsSaved = true;
       },
       error: err => {
@@ -113,12 +113,12 @@ export class KoreaderSettingsComponent {
     });
   }
 
-  onToggleSyncWithGrimmoryReader(enabled: boolean) {
-    this.koreaderService.toggleSyncProgressWithGrimmoryReader(enabled).pipe(
+  onToggleSyncWithWebReader(enabled: boolean) {
+    this.koreaderService.toggleSyncProgressWithWebReader(enabled).pipe(
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
       next: () => {
-        this.syncWithGrimmoryReader = enabled;
+        this.syncWithWebReader = enabled;
         this.messageService.add({
           severity: 'success',
           summary: this.t.translate('settingsDevice.koreader.syncUpdated'),

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.ts
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.ts
@@ -70,7 +70,7 @@ export class KoreaderSettingsComponent {
         this.koReaderUsername = koreaderUser.username;
         this.koReaderPassword = koreaderUser.password;
         this.koReaderSyncEnabled = koreaderUser.syncEnabled;
-        this.syncWithGrimmoryReader = koreaderUser.syncWithGrimmoryReader ?? koreaderUser.syncWithBookloreReader ?? false;
+        this.syncWithGrimmoryReader = koreaderUser.syncWithGrimmoryReader ?? false;
         this.credentialsSaved = true;
       },
       error: err => {

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader.service.spec.ts
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader.service.spec.ts
@@ -91,24 +91,19 @@ describe('KoreaderService', () => {
     request.flush(null);
   });
 
-  it('uses the Grimmory sync-progress endpoint before falling back to the legacy Booklore route', () => {
+  it('patches the Grimmory sync-progress toggle using the enabled query parameter', () => {
     let completed = false;
 
     service.toggleSyncProgressWithGrimmoryReader(false).subscribe(() => {
       completed = true;
     });
 
-    const grimmoryRequest = httpTestingController.expectOne(req =>
+    const request = httpTestingController.expectOne(req =>
       req.method === 'PATCH' && req.url.endsWith('/api/v1/koreader-users/me/sync-progress-with-grimmory')
     );
-    expect(grimmoryRequest.request.params.get('enabled')).toBe('false');
-    grimmoryRequest.flush('missing route', {status: 404, statusText: 'Not Found'});
-
-    const legacyRequest = httpTestingController.expectOne(req =>
-      req.method === 'PATCH' && req.url.endsWith('/api/v1/koreader-users/me/sync-progress-with-booklore')
-    );
-    expect(legacyRequest.request.params.get('enabled')).toBe('false');
-    legacyRequest.flush(null);
+    expect(request.request.params.get('enabled')).toBe('false');
+    expect(request.request.body).toBeNull();
+    request.flush(null);
 
     expect(completed).toBe(true);
   });

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader.service.spec.ts
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader.service.spec.ts
@@ -69,14 +69,14 @@ describe('KoreaderService', () => {
       username: 'reader',
       password: 'secret123',
       syncEnabled: false,
-      syncWithGrimmoryReader: true,
+      syncWithWebReader: true,
     });
 
     expect(responseBody).toEqual({
       username: 'reader',
       password: 'secret123',
       syncEnabled: false,
-      syncWithGrimmoryReader: true,
+      syncWithWebReader: true,
     });
   });
 
@@ -91,10 +91,10 @@ describe('KoreaderService', () => {
     request.flush(null);
   });
 
-  it('patches the Grimmory sync-progress toggle using the enabled query parameter', () => {
+  it('patches the web-reader sync-progress toggle using the enabled query parameter', () => {
     let completed = false;
 
-    service.toggleSyncProgressWithGrimmoryReader(false).subscribe(() => {
+    service.toggleSyncProgressWithWebReader(false).subscribe(() => {
       completed = true;
     });
 

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader.service.ts
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader.service.ts
@@ -2,7 +2,6 @@ import {inject, Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
 import {API_CONFIG} from '../../../../../core/config/api-config';
 import {HttpClient} from '@angular/common/http';
-import {catchError} from 'rxjs/operators';
 
 
 export interface KoreaderUser {
@@ -10,8 +9,6 @@ export interface KoreaderUser {
   password: string;
   syncEnabled: boolean;
   syncWithGrimmoryReader?: boolean;
-  // TODO(grimmory-cleanup): Remove once the backend no longer returns the legacy Booklore KOReader sync field.
-  syncWithBookloreReader?: boolean;
 }
 
 @Injectable({
@@ -41,11 +38,6 @@ export class KoreaderService {
   toggleSyncProgressWithGrimmoryReader(enabled: boolean): Observable<void> {
     return this.http.patch<void>(`${this.url}/me/sync-progress-with-grimmory`, null, {
       params: {enabled: enabled.toString()}
-    }).pipe(
-      // TODO(grimmory-cleanup): Remove the legacy endpoint fallback after all supported backends expose the Grimmory route.
-      catchError(() => this.http.patch<void>(`${this.url}/me/sync-progress-with-booklore`, null, {
-        params: {enabled: enabled.toString()}
-      }))
-    );
+    });
   }
 }

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader.service.ts
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader.service.ts
@@ -8,7 +8,7 @@ export interface KoreaderUser {
   username: string;
   password: string;
   syncEnabled: boolean;
-  syncWithGrimmoryReader?: boolean;
+  syncWithWebReader?: boolean;
 }
 
 @Injectable({
@@ -35,7 +35,7 @@ export class KoreaderService {
     });
   }
 
-  toggleSyncProgressWithGrimmoryReader(enabled: boolean): Observable<void> {
+  toggleSyncProgressWithWebReader(enabled: boolean): Observable<void> {
     return this.http.patch<void>(`${this.url}/me/sync-progress-with-grimmory`, null, {
       params: {enabled: enabled.toString()}
     });


### PR DESCRIPTION
# Description

Renames the KOReader sync-progress endpoint, database column, and all corresponding Java/TypeScript field, method, and DTO references from booklore to grimmory. Removes the legacy frontend endpoint fallback and the deprecated syncWithBookloreReader DTO field.

The KOReader endpoint was named /sync-progress-with-booklore and broke with a 405 after the project rename to Grimmory. The frontend already had a partial rename in place, syncWithGrimmoryReader with a catchError fallback to the legacy endpoint and TODO(grimmory-cleanup) comments anticipating this PR. This PR completes that cleanup.

This is a re-submission of #410 after rebase onto current develop, per the closing comment. Descopes #305 to just the rename, per the discussion in https://github.com/grimmory-tools/grimmory/pull/305#issuecomment-4189710157, the bidirectional sync (CFI ↔ XPointer conversion, writing web reader progress back to KOReader) is not included.

# Linked Issue

Fixes #191

# Changes

Backend (backend/)
- Renamed KoreaderUserEntity.syncWithBookloreReader → syncWithGrimmoryReader (field + @Column, with name = "sync_with_grimmory_reader")
- Renamed KoreaderUserDetails.syncWithBookloreReader → syncWithGrimmoryReader (field + constructor)
- Renamed KoreaderUser DTO field syncWithBookloreReader → syncWithGrimmoryReader
- Renamed KoreaderUserService.toggleSyncProgressWithBooklore() → toggleSyncProgressWithGrimmory()
- Renamed KoreaderService.updateProgressData() parameter syncWithBookloreReader → syncWithGrimmoryReader
- Renamed controller endpoint /me/sync-progress-with-booklore → /me/sync-progress-with-grimmory (and method + Swagger docs)
- Updated KoreaderAuthFilter to call isSyncWithGrimmoryReader()
- Added Flyway migration V141__Rename_sync_with_booklore_to_grimmory.sql to rename the database column
- Updated KoreaderUserServiceTest and added a controller test for the renamed endpoint

Frontend (frontend/)
- Removed the deprecated syncWithBookloreReader field from the KoreaderUser interface
- Removed the catchError fallback to /sync-progress-with-booklore in koreader.service.ts
- Removed the corresponding fallback in koreader-settings-component.ts
- Removed the TODO(grimmory-cleanup) comments tracking this cleanup
- Updated koreader.service.spec.ts to drop the legacy fallback test

# Manual Testing Steps

1. Run database migrations against an existing DB containing rows in koreader_user with sync_with_booklore_reader = 1 - verify V141 runs cleanly and values persist as
sync_with_grimmory_reader.
2. Open KOReader settings UI in the web app — toggle the "Sync with Grimmory reader" preference, refresh the page, confirm preference persists.
3. PATCH /api/v1/koreader-users/me/sync-progress-with-grimmory?enabled=true returns 204; the user's sync_with_grimmory_reader is updated in the DB.
4. PATCH /api/v1/koreader-users/me/sync-progress-with-booklore?enabled=true returns 404/405 (endpoint removed).
5. From a real KOReader device, perform a sync against the user — verify the auth filter accepts credentials and that KoreaderUserDetails.isSyncWithGrimmoryReader() is consulted (no
behaviour change, just the rename).

# Additional Context

- just ui check reports 3 pre-existing stylelint errors on files this PR doesn't touch: cbx-reader.component.scss:278 (empty block) and pdf-reader.component.scss:298,302 (redundant
overflow longhand). These reproduce on a clean origin/develop checkout and are unrelated to this change.
- The conflict resolution during rebase preserved develop's guard-clause refactor of KoreaderAuthFilter (#361), the rename was applied on top, no logic change.

# AI Disclosure

Claude Code assisted with the rebase onto current develop, resolving the conflict in KoreaderAuthFilter.java, renumbering the Flyway migration from V136 → V141, and drafting the PR description. I reviewed all changes; the logic in this PR is the same rename and cleanup originally authored in #410.

# Checklist

- This PR links and implements an accepted issue.
- This PR is a single focused change.
- There are new or updated tests validating this change.
- I ran just ui check and just api check.
- I have added screenshots if there were any UI changes. (No visible UI change)
- I have disclosed any AI usage as per the organization AI Policy above.
- I understand all of my submitted changes.

# Tests

```
just api check

BUILD SUCCESSFUL in 9s
6 actionable tasks: 6 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.1/userguide/configuration_cache_enabling.html
```

```
just api test

BUILD SUCCESSFUL in 5s
6 actionable tasks: 2 executed, 4 from cache
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.1/userguide/configuration_cache_enabling.html
```

```
just ui test

 Test Files  282 passed | 95 skipped (377)
      Tests  1515 passed | 156 skipped (1671)
   Start at  15:41:38
   Duration  37.26s (transform 16.22s, setup 103.65s, import 97.81s, tests 20.51s, environment 11.15s)

JUNIT report written to /home/mtanzer/grimmory/frontend/test-results/vitest-results.xml
```

```
just ui check

All files pass linting.

env YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=../.yarn/cache corepack yarn lint:styles

src/app/features/readers/cbx-reader/cbx-reader.component.scss
  278:26  ✖  Empty block  block-no-empty

src/app/features/readers/pdf-reader/pdf-reader.component.scss
  298:3  ✖  Expected shorthand property   declaration-block-no-redundant-longhand-properties
            "overflow"
  302:5  ✖  Expected shorthand property   declaration-block-no-redundant-longhand-properties
            "overflow"

✖ 3 problems (3 errors, 0 warnings)
  2 errors potentially fixable with the "--fix" option.

error: Recipe `stylelint` failed on line 71 with exit code 2
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WebReader sync progress endpoint for KOReader device synchronization.

* **Deprecations**
  * Previous sync progress endpoint marked for removal; users should use the new WebReader endpoint.

* **UI/UX**
  * Updated KOReader device settings labels and controls to reflect WebReader branding instead of legacy terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->