### PR TITLE
fix(metadata): truncate review data before storage

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/BookReviewUpdateService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookReviewUpdateService.java
@@ -66,6 +66,7 @@ public class BookReviewUpdateService {
     }
 
     private BookReviewEntity createReviewEntity(BookReview review, BookMetadataEntity entity) {
+        // Some fields are truncated to properly fit in the entity field's max length.
         return BookReviewEntity.builder()
                 .bookMetadata(entity)
                 .metadataProvider(review.getMetadataProvider())

--- a/backend/src/main/java/org/booklore/service/metadata/BookReviewUpdateService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookReviewUpdateService.java
@@ -60,19 +60,24 @@ public class BookReviewUpdateService {
         entity.getReviews().addAll(newReviews);
     }
 
+    private static String truncate(String input, int maxLength) {
+        if (input == null) return null;
+        return input.length() <= maxLength ? input : input.substring(0, maxLength);
+    }
+
     private BookReviewEntity createReviewEntity(BookReview review, BookMetadataEntity entity) {
         return BookReviewEntity.builder()
                 .bookMetadata(entity)
                 .metadataProvider(review.getMetadataProvider())
-                .reviewerName(review.getReviewerName())
-                .title(review.getTitle())
+                .reviewerName(truncate(review.getReviewerName(), 512))
+                .title(truncate(review.getTitle(), 512))
                 .rating(review.getRating())
                 .date(review.getDate())
                 .body(review.getBody())
                 .spoiler(review.getSpoiler())
                 .followersCount(review.getFollowersCount())
                 .textReviewsCount(review.getTextReviewsCount())
-                .country(review.getCountry())
+                .country(truncate(review.getCountry(), 512))
                 .build();
     }
 

--- a/backend/src/test/java/org/booklore/service/metadata/BookReviewUpdateServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookReviewUpdateServiceTest.java
@@ -318,4 +318,42 @@ class BookReviewUpdateServiceTest {
         assertThat(created.getCountry()).isEqualTo("US");
         assertThat(created.getBookMetadata()).isSameAs(entity);
     }
+
+    @Test
+    void reviewEntityFieldsAreTruncatedCorrectly() {
+        BookMetadataEntity entity = entityWithReviews(new HashSet<>());
+        BookReview review = BookReview.builder()
+                .metadataProvider(MetadataProvider.Hardcover)
+                .reviewerName("A".repeat(1024))
+                .title("A".repeat(1024))
+                .country("A".repeat(1024))
+                .build();
+
+        BookMetadata metadata = BookMetadata.builder().bookReviews(List.of(review)).build();
+        service.updateBookReviews(metadata, entity, new MetadataClearFlags(), true);
+
+        BookReviewEntity created = entity.getReviews().iterator().next();
+        assertThat(created.getReviewerName()).hasSize(512);
+        assertThat(created.getTitle()).hasSize(512);
+        assertThat(created.getCountry()).hasSize(512);
+    }
+
+    @Test
+    void reviewEntityFieldsNullAreNotTruncated() {
+        BookMetadataEntity entity = entityWithReviews(new HashSet<>());
+        BookReview review = BookReview.builder()
+                .metadataProvider(MetadataProvider.Hardcover)
+                .reviewerName(null)
+                .title(null)
+                .country(null)
+                .build();
+
+        BookMetadata metadata = BookMetadata.builder().bookReviews(List.of(review)).build();
+        service.updateBookReviews(metadata, entity, new MetadataClearFlags(), true);
+
+        BookReviewEntity created = entity.getReviews().iterator().next();
+        assertThat(created.getReviewerName()).isNull();
+        assertThat(created.getTitle()).isNull();
+        assertThat(created.getCountry()).isNull();
+    }
 }

--- a/backend/src/test/java/org/booklore/service/metadata/BookReviewUpdateServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookReviewUpdateServiceTest.java
@@ -339,6 +339,25 @@ class BookReviewUpdateServiceTest {
     }
 
     @Test
+    void reviewEntityFieldsAtExactLengthAreTruncatedCorrectly() {
+        BookMetadataEntity entity = entityWithReviews(new HashSet<>());
+        BookReview review = BookReview.builder()
+                .metadataProvider(MetadataProvider.Hardcover)
+                .reviewerName("A".repeat(512))
+                .title("A".repeat(512))
+                .country("A".repeat(512))
+                .build();
+
+        BookMetadata metadata = BookMetadata.builder().bookReviews(List.of(review)).build();
+        service.updateBookReviews(metadata, entity, new MetadataClearFlags(), true);
+
+        BookReviewEntity created = entity.getReviews().iterator().next();
+        assertThat(created.getReviewerName()).hasSize(512);
+        assertThat(created.getTitle()).hasSize(512);
+        assertThat(created.getCountry()).hasSize(512);
+    }
+
+    @Test
     void reviewEntityFieldsNullAreNotTruncated() {
         BookMetadataEntity entity = entityWithReviews(new HashSet<>());
         BookReview review = BookReview.builder()


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
In some cases, reviews have data points that are outside our expected limits.  This change truncates reviewer names, titles, and country names to the size of the underlying column.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #516

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* add truncation of limited length text fields in `BookReviewUpdateService`
* update tests to verify behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

I am unable to find a case where this occurs in the wild but can validate in a controlled environment.

1. fetch reviews for a variety of books and observe no negative consequences
2. I manually crafted an example Amazon review page, set that up as an HTML proxy (eg, pointing `amazon.com` at `localhost` with a simple static HTML server in place to simulate the failure scenario).
3. I added tests that validate the behaviors & possible regressions

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
Not applicable.

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
While this was reported and makes sense I do want to note that I was unable to reproduce this error organically - I had to set up a controlled environment that served fake amazon HTML files.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced maximum length (512 chars) for reviewer name, title, and country fields when saving reviews to prevent oversized values.
* **Tests**
  * Added coverage verifying truncation for oversized inputs, preservation of exact-length values, and null handling for these fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->