### PR TITLE
fix(ui): sidebar active outline consistency

### DIFF
--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.scss
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.scss
@@ -53,7 +53,7 @@ a.menu-item-link {
   }
 }
 
-.menu-item-link:focus-visible .menu-item-chrome {
+.menu-item-container:has(.menu-item-link:focus-visible) {
   background-color: var(--surface-hover);
   box-shadow: var(--sidebar-focus-ring);
   border-radius: var(--sidebar-row-radius);
@@ -155,6 +155,10 @@ a.menu-item-link.active-route {
   justify-content: center;
 }
 
+.entity-menu-count {
+  font-variant-numeric: tabular-nums;
+}
+
 .entity-menu-icon {
   display: none;
 }
@@ -173,6 +177,7 @@ a.menu-item-link.active-route {
   color: var(--text-color-secondary);
   padding-right: var(--space-3);
   font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
 }
 
 .library-health-dot {


### PR DESCRIPTION
## Description

Fixes sidebar item outlines from clipping at the top of the page and not including item counts in the active area. 


## Linked Issue

<!-- Required. Example: Fixes #123 -->
Fixes #1092

## Changes

Moved the outline to the overall sidebar item shape rather than the individual component within. Also made the sidebar count numbers display with equal width to help align the shape for the active area. 

## Manual Testing Steps

Tested returning from search, using keyboard controls to navigate the sidebar, etc, all showing the visual bug is now gone. 

## Screenshots (Optional)

<img width="223" height="121" alt="Screenshot 2026-05-04 at 10 22 38" src="https://github.com/user-attachments/assets/29b543e7-856a-4a93-b61e-279f9b46300f" />

And
<img width="227" height="101" alt="Screenshot 2026-05-04 at 10 22 31" src="https://github.com/user-attachments/assets/2228dcc1-b56f-4666-a2d2-02e5e29d971a" />
## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure
N/A
<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined menu item focus and hover styling to improve visual feedback
  * Enhanced numeric alignment consistency in menu counters and displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->