### PR TITLE
chore(libraries): add new library probes for Gumbo, Image Codec, PugiXML, and UCharDet

### DIFF
--- a/backend/src/main/java/org/booklore/nativelib/NativeLibraries.java
+++ b/backend/src/main/java/org/booklore/nativelib/NativeLibraries.java
@@ -20,7 +20,11 @@ public final class NativeLibraries {
     public enum Library {
         PDFIUM,
         LIBARCHIVE,
-        EPUB4J_NATIVE
+        EPUB4J_NATIVE,
+        GUMBO,
+        IMAGE_CODEC,
+        PUGIXML,
+        UCHARDET
     }
 
     private static final Map<Library, Probe> PROBES;
@@ -37,8 +41,6 @@ public final class NativeLibraries {
             return true;
         }));
 
-        probes.put(Library.LIBARCHIVE, new Probe("libarchive", com.github.gotson.nightcompress.Archive::isAvailable));
-
         probes.put(Library.EPUB4J_NATIVE, new Probe("epub4j-native", () -> {
             Boolean clean = tryInvokeStaticBoolean(
                     "org.grimmory.epub4j.native_parsing.EpubNativeLibrary"
@@ -53,6 +55,24 @@ public final class NativeLibraries {
             );
             return true;
         }));
+
+        probes.put(Library.LIBARCHIVE, new Probe("libarchive", com.github.gotson.nightcompress.Archive::isAvailable));
+
+        probes.put(Library.GUMBO, new Probe("gumbo", () ->
+                Boolean.TRUE.equals(tryInvokeStaticBoolean("org.grimmory.epub4j.native_parsing.GumboLibrary"))
+        ));
+
+        probes.put(Library.IMAGE_CODEC, new Probe("image-codec", () ->
+                Boolean.TRUE.equals(tryInvokeStaticBoolean("org.grimmory.epub4j.native_parsing.ImageCodecLibrary"))
+        ));
+
+        probes.put(Library.PUGIXML, new Probe("pugixml", () ->
+                Boolean.TRUE.equals(tryInvokeStaticBoolean("org.grimmory.epub4j.native_parsing.PugixmlLibrary"))
+        ));
+
+        probes.put(Library.UCHARDET, new Probe("uchardet", () ->
+                Boolean.TRUE.equals(tryInvokeStaticBoolean("org.grimmory.epub4j.native_parsing.UchardetLibrary"))
+        ));
 
         PROBES = Collections.unmodifiableMap(probes);
     }
@@ -144,6 +164,22 @@ public final class NativeLibraries {
 
     public boolean isEpubNativeAvailable() {
         return isAvailable(Library.EPUB4J_NATIVE);
+    }
+
+    public boolean isGumboAvailable() {
+        return isAvailable(Library.GUMBO);
+    }
+
+    public boolean isImageCodecAvailable() {
+        return isAvailable(Library.IMAGE_CODEC);
+    }
+
+    public boolean isPugixmlAvailable() {
+        return isAvailable(Library.PUGIXML);
+    }
+
+    public boolean isUchardetAvailable() {
+        return isAvailable(Library.UCHARDET);
     }
 
     private record Probe(String name, CheckedBooleanSupplier fn) {}

--- a/backend/src/main/java/org/booklore/nativelib/NativeLibraryManager.java
+++ b/backend/src/main/java/org/booklore/nativelib/NativeLibraryManager.java
@@ -25,6 +25,22 @@ public class NativeLibraryManager {
         return libs.isEpubNativeAvailable();
     }
 
+    public boolean isGumboAvailable() {
+        return libs.isGumboAvailable();
+    }
+
+    public boolean isImageCodecAvailable() {
+        return libs.isImageCodecAvailable();
+    }
+
+    public boolean isPugixmlAvailable() {
+        return libs.isPugixmlAvailable();
+    }
+
+    public boolean isUchardetAvailable() {
+        return libs.isUchardetAvailable();
+    }
+
     public boolean isAvailable(NativeLibraries.Library library) {
         return libs.isAvailable(library);
     }


### PR DESCRIPTION

## Description

<!-- Required. Briefly explain what changed and why. -->

ONLY relevant after: #1090 otherwise it just fails CI.

This pull request extends the native library management system by adding support for several new native libraries. It introduces new enum values, probing logic, and availability-checking methods for these libraries, making it easier to detect and utilize them in the application.

## Linked Issue

<!-- Required. Example: Fixes #123 -->

* Added new native libraries to the `Library` enum: `GUMBO`, `IMAGE_CODEC`, `PUGIXML`, and `UCHARDET` in `NativeLibraries.java`.
* Implemented probe logic for the new libraries in the static initializer of `NativeLibraries.java`, allowing the system to check if each library is available.
* Added new public methods in `NativeLibraries.java` to check the availability of each new library (`isGumboAvailable`, `isImageCodecAvailable`, `isPugixmlAvailable`, `isUchardetAvailable`).
* Exposed the new availability check methods through `NativeLibraryManager.java`, so other parts of the application can easily query library availability.
## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. it compiles, natives work
2.
3.

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.
