### PR TITLE
fix(ui): add square audiobook artwork in command palette

### DIFF
--- a/frontend/src/app/features/command-palette/command-palette.component.html
+++ b/frontend/src/app/features/command-palette/command-palette.component.html
@@ -51,7 +51,7 @@
                   >
                     @if (item.kind === 'book' && item.bookMeta; as bookMeta) {
                       <ng-container *transloco="let tb; prefix: 'book.searcher'">
-                        <div class="command-palette-book-cover">
+                        <div class="command-palette-book-cover" [class.square-cover]="bookMeta.isAudiobook">
                           @if (bookMeta.thumbnailUrl) {
                             <img [src]="bookMeta.thumbnailUrl" alt="" />
                           } @else {

--- a/frontend/src/app/features/command-palette/command-palette.component.scss
+++ b/frontend/src/app/features/command-palette/command-palette.component.scss
@@ -134,6 +134,10 @@
   background: var(--surface-800);
   box-shadow: var(--shadow-sm);
 
+  &.square-cover {
+    height: 32px;
+  }
+
   img {
     width: 100%;
     height: 100%;

--- a/frontend/src/app/features/command-palette/command-palette.model.ts
+++ b/frontend/src/app/features/command-palette/command-palette.model.ts
@@ -16,6 +16,7 @@ export interface PaletteBookMeta {
   seriesName: string | null;
   seriesNumber: number | null;
   year: string | null;
+  isAudiobook: boolean;
 }
 
 export interface PaletteItem {

--- a/frontend/src/app/features/command-palette/command-palette.service.spec.ts
+++ b/frontend/src/app/features/command-palette/command-palette.service.spec.ts
@@ -18,15 +18,17 @@ import { DialogLauncherService } from '../../shared/services/dialog-launcher.ser
 
 import { CommandPaletteService } from './command-palette.service';
 
-function makeBook(id: number, title: string, authors: string[] = []): Book {
+function makeBook(id: number, title: string, authors: string[] = [], overrides: Partial<Book> = {}): Book {
   return {
     id,
     libraryId: 1,
     libraryName: 'Library',
+    ...overrides,
     metadata: {
       bookId: id,
       title,
       authors,
+      ...overrides.metadata,
     },
   } as Book;
 }
@@ -34,6 +36,10 @@ function makeBook(id: number, title: string, authors: string[] = []): Book {
 describe('CommandPaletteService', () => {
   let service: CommandPaletteService;
   let books = signal<Book[]>([]);
+  let urlHelper: {
+    getThumbnailUrl: ReturnType<typeof vi.fn>;
+    getAudiobookThumbnailUrl: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -45,6 +51,10 @@ describe('CommandPaletteService', () => {
       makeBook(2, 'The Fellowship of the Ring', ['J.R.R. Tolkien']),
       makeBook(3, 'Dune', ['Frank Herbert']),
     ]);
+    urlHelper = {
+      getThumbnailUrl: vi.fn(() => null),
+      getAudiobookThumbnailUrl: vi.fn(() => null),
+    };
 
     TestBed.configureTestingModule({
       imports: [getTranslocoModule()],
@@ -55,7 +65,7 @@ describe('CommandPaletteService', () => {
         { provide: MagicShelfService, useValue: { shelves: signal([]) } },
         { provide: LibraryService, useValue: { libraries: signal([]) } },
         { provide: UserService, useValue: { currentUser: signal({ permissions: {} }) } },
-        { provide: UrlHelperService, useValue: { getThumbnailUrl: vi.fn(() => null) } },
+        { provide: UrlHelperService, useValue: urlHelper },
         { provide: IconService, useValue: { getSvgIconContent: vi.fn(() => of('')) } },
         {
           provide: DialogLauncherService,
@@ -114,5 +124,32 @@ describe('CommandPaletteService', () => {
 
     expect(service.groups()).toEqual([]);
     expect(service.visibleItems()).toEqual([]);
+  });
+
+  it('uses square audiobook metadata and audiobook thumbnails for audiobook results', async () => {
+    urlHelper.getAudiobookThumbnailUrl.mockReturnValue('/audio-thumb.jpg');
+    books.set([
+      makeBook(4, 'Audio Sample', ['Narrator'], {
+        primaryFile: { id: 4, bookId: 4, bookType: 'AUDIOBOOK' },
+        metadata: {
+          bookId: 4,
+          title: 'Audio Sample',
+          authors: ['Narrator'],
+          audiobookCoverUpdatedOn: 'audio-updated',
+        },
+      }),
+    ]);
+
+    service.query.set('audio');
+    TestBed.flushEffects();
+    await vi.advanceTimersByTimeAsync(200);
+    TestBed.flushEffects();
+
+    const book = service.groups().find((group) => group.kind === 'book')?.items[0];
+
+    expect(book?.bookMeta?.isAudiobook).toBe(true);
+    expect(book?.bookMeta?.thumbnailUrl).toBe('/audio-thumb.jpg');
+    expect(urlHelper.getAudiobookThumbnailUrl).toHaveBeenCalledWith(4, 'audio-updated');
+    expect(urlHelper.getThumbnailUrl).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/command-palette/command-palette.service.ts
+++ b/frontend/src/app/features/command-palette/command-palette.service.ts
@@ -286,6 +286,7 @@ export class CommandPaletteService {
     const publishedDate = metadata?.publishedDate ?? '';
     const year = publishedDate && /^\d{4}/.test(publishedDate) ? publishedDate.slice(0, 4) : null;
     const haystack = [title, metadata?.seriesName ?? '', ...authors].filter(Boolean).join(' ');
+    const isAudiobook = book.primaryFile?.bookType === 'AUDIOBOOK';
 
     return {
       id: `book:${book.id}`,
@@ -296,11 +297,14 @@ export class CommandPaletteService {
       route: ['/book', book.id],
       queryParams: { tab: 'view' },
       bookMeta: {
-        thumbnailUrl: this.urlHelper.getThumbnailUrl(book.id, metadata?.coverUpdatedOn),
+        thumbnailUrl: isAudiobook
+          ? this.urlHelper.getAudiobookThumbnailUrl(book.id, metadata?.audiobookCoverUpdatedOn)
+          : this.urlHelper.getThumbnailUrl(book.id, metadata?.coverUpdatedOn),
         authors,
         seriesName: metadata?.seriesName ?? null,
         seriesNumber: metadata?.seriesNumber ?? null,
         year,
+        isAudiobook,
       },
     };
   }


### PR DESCRIPTION
## Description

Adjusts the new command palette's book previews to display correct book vs audiobook artwork sizing. 

## Linked Issue

Fixes #1095 

## Changes

Wires up the palette's artwork previews to differentiate between book and audiobook aspect ratios, uses the same approach as the book and series cards. 

## Manual Testing Steps

Tested the command palette with both books and audiobooks, both now correctly receive the needed aspect ratio for preview images. Audiobooks are given a vertically centered square aspect ratio. 

## Screenshots (Optional)

<img width="647" height="312" alt="Screenshot 2026-05-04 at 11 23 22" src="https://github.com/user-attachments/assets/4349eb40-ae06-41b1-b5bf-595878a49a69" />
Two books and an audiobook - artwork now correctly displayed. 

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

Used Codex to help align approach with other FE instances of book vs audiobook artwork display. Also used to expand tests. I've reviewed everything myself. 

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audiobooks in the command palette now display with square cover artwork for better visual distinction.

* **Bug Fixes**
  * Fixed thumbnail loading for audiobooks to use the correct image format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->