### PR TITLE
fix(ui): refine mobile sidebar layout

### DIFF
--- a/frontend/src/app/features/command-palette/command-palette.component.scss
+++ b/frontend/src/app/features/command-palette/command-palette.component.scss
@@ -224,7 +224,7 @@
   color: var(--text-color);
 }
 
-@media (width <= 991px) {
+@media (width <= 767px) {
   .command-palette-shell {
     width: 100vw;
   }

--- a/frontend/src/app/features/command-palette/command-palette.component.ts
+++ b/frontend/src/app/features/command-palette/command-palette.component.ts
@@ -13,7 +13,7 @@ import { IconDisplayComponent } from '../../shared/components/icon-display/icon-
 import { PaletteItem } from './command-palette.model';
 import { CommandPaletteService } from './command-palette.service';
 
-const MOBILE_MEDIA_QUERY = '(max-width: 991px)';
+const MOBILE_MEDIA_QUERY = '(max-width: 767px)';
 const MOBILE_TOPBAR_HEIGHT = '3.5rem';
 
 @Component({

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.html
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.html
@@ -10,7 +10,7 @@
       type="button"
       class="menu-item-link"
       [pTooltip]="currentItem.label"
-      [tooltipDisabled]="!desktopSidebarCollapsed()"
+      [tooltipDisabled]="!layoutService.desktopSidebarCollapsed()"
       tooltipPosition="right"
       (click)="runAction($event)"
     >
@@ -33,7 +33,7 @@
       [attr.aria-current]="isRouteActive() ? 'page' : null"
       [routerLink]="currentItem.routerLink"
       [pTooltip]="currentItem.label"
-      [tooltipDisabled]="!desktopSidebarCollapsed()"
+      [tooltipDisabled]="!layoutService.desktopSidebarCollapsed()"
       tooltipPosition="right"
       tabindex="0"
     >

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.html
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.html
@@ -10,7 +10,7 @@
       type="button"
       class="menu-item-link"
       [pTooltip]="currentItem.label"
-      [tooltipDisabled]="!layoutService.sidebarCollapsed()"
+      [tooltipDisabled]="!desktopSidebarCollapsed()"
       tooltipPosition="right"
       (click)="runAction($event)"
     >
@@ -33,7 +33,7 @@
       [attr.aria-current]="isRouteActive() ? 'page' : null"
       [routerLink]="currentItem.routerLink"
       [pTooltip]="currentItem.label"
-      [tooltipDisabled]="!layoutService.sidebarCollapsed()"
+      [tooltipDisabled]="!desktopSidebarCollapsed()"
       tooltipPosition="right"
       tabindex="0"
     >

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.ts
@@ -35,6 +35,9 @@ export class AppMenuItemRowComponent {
 
   private readonly userService = inject(UserService);
   readonly layoutService = inject(LayoutService);
+  readonly desktopSidebarCollapsed = computed(() =>
+    this.layoutService.isDesktop() && this.layoutService.sidebarCollapsed()
+  );
 
   readonly isRouteActive = computed(() => {
     const route = this.item().routerLink?.[0];

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.ts
@@ -35,9 +35,6 @@ export class AppMenuItemRowComponent {
 
   private readonly userService = inject(UserService);
   readonly layoutService = inject(LayoutService);
-  readonly desktopSidebarCollapsed = computed(() =>
-    this.layoutService.isDesktop() && this.layoutService.sidebarCollapsed()
-  );
 
   readonly isRouteActive = computed(() => {
     const route = this.item().routerLink?.[0];

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-section.component.scss
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-section.component.scss
@@ -93,7 +93,7 @@
   }
 }
 
-@media (width <= 991px) {
+@media (width <= 767px) {
   .expand-icon-button {
     opacity: 1;
     width: 2rem;

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-section.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-section.component.spec.ts
@@ -11,6 +11,7 @@ describe('AppMenuSectionComponent', () => {
 
   const layoutService = {
     sidebarCollapsed: signal(false),
+    isDesktop: signal(true),
     sidebarExpandedState: signal<Readonly<Record<string, boolean>>>({}),
     isSidebarExpanded: vi.fn((key: string, defaultExpanded: boolean) => {
       const value = layoutService.sidebarExpandedState()[key];
@@ -37,6 +38,8 @@ describe('AppMenuSectionComponent', () => {
     component = fixture.componentInstance;
 
     layoutService.sidebarExpandedState.set({});
+    layoutService.sidebarCollapsed.set(false);
+    layoutService.isDesktop.set(true);
     layoutService.isSidebarExpanded.mockClear();
     layoutService.setSidebarExpanded.mockClear();
   });

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-section.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-section.component.ts
@@ -36,7 +36,7 @@ export class AppMenuSectionComponent {
   }
 
   get submenuVisible(): boolean {
-    return this.layoutService.sidebarCollapsed() || this.expanded;
+    return (this.layoutService.isDesktop() && this.layoutService.sidebarCollapsed()) || this.expanded;
   }
 
   toggleExpand(): void {

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
@@ -63,7 +63,7 @@
       type="button"
       class="sidebar-action-link sidebar-search-button"
       [pTooltip]="t('search')"
-      [tooltipDisabled]="!desktopSidebarCollapsed()"
+      [tooltipDisabled]="!layoutService.desktopSidebarCollapsed()"
       tooltipPosition="right"
       (click)="openSearch()"
     >
@@ -133,7 +133,7 @@
           [attr.aria-label]="t('profile')"
           aria-haspopup="menu"
           [pTooltip]="user.name || user.username"
-          [tooltipDisabled]="!desktopSidebarCollapsed()"
+          [tooltipDisabled]="!layoutService.desktopSidebarCollapsed()"
           tooltipPosition="right"
           (click)="openSidebarOverlay($event, userMenu, 'below')"
         >
@@ -152,7 +152,7 @@
           [attr.aria-label]="layoutService.sidebarCollapsed() ? t('expandSidebar') : t('collapseSidebar')"
           [attr.aria-expanded]="!layoutService.sidebarCollapsed()"
           [pTooltip]="layoutService.sidebarCollapsed() ? t('expandSidebar') : t('collapseSidebar')"
-          [tooltipDisabled]="!desktopSidebarCollapsed()"
+          [tooltipDisabled]="!layoutService.desktopSidebarCollapsed()"
           tooltipPosition="right"
           (click)="layoutService.toggleSidebarCollapsed()"
         >
@@ -195,7 +195,7 @@
           [attr.aria-label]="layoutService.sidebarCollapsed() ? t('expandSidebar') : t('collapseSidebar')"
           [attr.aria-expanded]="!layoutService.sidebarCollapsed()"
           [pTooltip]="layoutService.sidebarCollapsed() ? t('expandSidebar') : t('collapseSidebar')"
-          [tooltipDisabled]="!desktopSidebarCollapsed()"
+          [tooltipDisabled]="!layoutService.desktopSidebarCollapsed()"
           tooltipPosition="right"
           (click)="layoutService.toggleSidebarCollapsed()"
         >

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
@@ -63,7 +63,7 @@
       type="button"
       class="sidebar-action-link sidebar-search-button"
       [pTooltip]="t('search')"
-      [tooltipDisabled]="!layoutService.sidebarCollapsed()"
+      [tooltipDisabled]="!desktopSidebarCollapsed()"
       tooltipPosition="right"
       (click)="openSearch()"
     >
@@ -133,7 +133,7 @@
           [attr.aria-label]="t('profile')"
           aria-haspopup="menu"
           [pTooltip]="user.name || user.username"
-          [tooltipDisabled]="!layoutService.sidebarCollapsed()"
+          [tooltipDisabled]="!desktopSidebarCollapsed()"
           tooltipPosition="right"
           (click)="openSidebarOverlay($event, userMenu, 'below')"
         >
@@ -152,7 +152,7 @@
           [attr.aria-label]="layoutService.sidebarCollapsed() ? t('expandSidebar') : t('collapseSidebar')"
           [attr.aria-expanded]="!layoutService.sidebarCollapsed()"
           [pTooltip]="layoutService.sidebarCollapsed() ? t('expandSidebar') : t('collapseSidebar')"
-          [tooltipDisabled]="!layoutService.sidebarCollapsed()"
+          [tooltipDisabled]="!desktopSidebarCollapsed()"
           tooltipPosition="right"
           (click)="layoutService.toggleSidebarCollapsed()"
         >
@@ -195,7 +195,7 @@
           [attr.aria-label]="layoutService.sidebarCollapsed() ? t('expandSidebar') : t('collapseSidebar')"
           [attr.aria-expanded]="!layoutService.sidebarCollapsed()"
           [pTooltip]="layoutService.sidebarCollapsed() ? t('expandSidebar') : t('collapseSidebar')"
-          [tooltipDisabled]="!layoutService.sidebarCollapsed()"
+          [tooltipDisabled]="!desktopSidebarCollapsed()"
           tooltipPosition="right"
           (click)="layoutService.toggleSidebarCollapsed()"
         >

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.scss
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.scss
@@ -351,7 +351,7 @@
   white-space: nowrap;
 }
 
-@media (width <= 991px) {
+@media (width <= 767px) {
   .sidebar-header {
     align-items: flex-start;
     margin-bottom: var(--space-3);

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.spec.ts
@@ -1,4 +1,4 @@
-import { signal, WritableSignal } from '@angular/core';
+import { computed, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -55,6 +55,7 @@ describe('AppMenuComponent', () => {
   const layoutService = {
     sidebarCollapsed: signal(false),
     isDesktop: signal(true),
+    desktopSidebarCollapsed: computed(() => layoutService.isDesktop() && layoutService.sidebarCollapsed()),
     librarySort: signal({ field: 'name', order: 'desc' }),
     shelfSort: signal({ field: 'name', order: 'asc' }),
     magicShelfSort: signal({ field: 'name', order: 'asc' }),

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.spec.ts
@@ -52,10 +52,12 @@ describe('AppMenuComponent', () => {
   let component: AppMenuComponent;
   let commandPaletteService: { open: ReturnType<typeof vi.fn> };
   let currentUser: WritableSignal<TestUser | null>;
+  const sidebarCollapsed = signal(false);
+  const isDesktop = signal(true);
   const layoutService = {
-    sidebarCollapsed: signal(false),
-    isDesktop: signal(true),
-    desktopSidebarCollapsed: computed(() => layoutService.isDesktop() && layoutService.sidebarCollapsed()),
+    sidebarCollapsed,
+    isDesktop,
+    desktopSidebarCollapsed: computed(() => isDesktop() && sidebarCollapsed()),
     librarySort: signal({ field: 'name', order: 'desc' }),
     shelfSort: signal({ field: 'name', order: 'asc' }),
     magicShelfSort: signal({ field: 'name', order: 'asc' }),

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
@@ -144,6 +144,9 @@ export class AppMenuComponent {
   });
 
   readonly hasUpdate = computed(() => hasAppUpdate(this.version()));
+  readonly desktopSidebarCollapsed = computed(() =>
+    this.layoutService.isDesktop() && this.layoutService.sidebarCollapsed()
+  );
 
   readonly userMenuItems = computed<MenuItem[]>(() => {
     this.activeLang();
@@ -215,7 +218,7 @@ export class AppMenuComponent {
 
     // `above` collapses to `below` when the sidebar is narrow, because the
     // anchored left offset assumes an expanded footer row.
-    const anchorAbove = anchor.placement === 'above' && !this.layoutService.sidebarCollapsed();
+    const anchorAbove = anchor.placement === 'above' && !this.desktopSidebarCollapsed();
     if (anchorAbove) {
       const bottom = Math.max(window.innerHeight - rect.top + 8, 8);
       panel.style.setProperty('--sidebar-popover-bottom', `${bottom}px`);

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
@@ -144,9 +144,6 @@ export class AppMenuComponent {
   });
 
   readonly hasUpdate = computed(() => hasAppUpdate(this.version()));
-  readonly desktopSidebarCollapsed = computed(() =>
-    this.layoutService.isDesktop() && this.layoutService.sidebarCollapsed()
-  );
 
   readonly userMenuItems = computed<MenuItem[]>(() => {
     this.activeLang();
@@ -218,7 +215,7 @@ export class AppMenuComponent {
 
     // `above` collapses to `below` when the sidebar is narrow, because the
     // anchored left offset assumes an expanded footer row.
-    const anchorAbove = anchor.placement === 'above' && !this.desktopSidebarCollapsed();
+    const anchorAbove = anchor.placement === 'above' && !this.layoutService.desktopSidebarCollapsed();
     if (anchorAbove) {
       const bottom = Math.max(window.innerHeight - rect.top + 8, 8);
       panel.style.setProperty('--sidebar-popover-bottom', `${bottom}px`);

--- a/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.scss
+++ b/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.scss
@@ -74,7 +74,7 @@
   }
 }
 
-@media (width <= 991px) {
+@media (width <= 767px) {
   .mobile-topbar {
     display: flex;
   }

--- a/frontend/src/app/shared/layout/layout.service.ts
+++ b/frontend/src/app/shared/layout/layout.service.ts
@@ -18,6 +18,7 @@ import {
 export const SIDEBAR_MIN_WIDTH = 175;
 export const SIDEBAR_MAX_WIDTH = 400;
 export const SIDEBAR_DEFAULT_WIDTH = 225;
+const DESKTOP_MIN_WIDTH = 768;
 const SIDEBAR_EXPANDED_STATE_KEY = 'sidebarExpandedState';
 const SIDEBAR_TRANSITION_MS = 220;
 
@@ -147,7 +148,7 @@ export class LayoutService {
   }
 
   private computeIsDesktop(): boolean {
-    return (this.document.defaultView?.innerWidth ?? 992) > 991;
+    return (this.document.defaultView?.innerWidth ?? DESKTOP_MIN_WIDTH) >= DESKTOP_MIN_WIDTH;
   }
 
   private readonly onResize = (): void => {

--- a/frontend/src/app/shared/layout/layout.service.ts
+++ b/frontend/src/app/shared/layout/layout.service.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { DestroyRef, effect, inject, Injectable, signal, WritableSignal } from '@angular/core';
+import { computed, DestroyRef, effect, inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs';
@@ -52,6 +52,7 @@ export class LayoutService {
   readonly sidebarCollapsed = signal(this.localStorage.get<boolean>('sidebarCollapsed') ?? false);
   readonly sidebarWidth = signal(this.clampSidebarWidth(this.localStorage.get<number>('sidebarWidth') ?? SIDEBAR_DEFAULT_WIDTH));
   readonly isDesktop = signal(this.computeIsDesktop());
+  readonly desktopSidebarCollapsed = computed(() => this.isDesktop() && this.sidebarCollapsed());
   readonly sidebarExpandedState = signal<Readonly<Record<string, boolean>>>(
     readBooleanRecord(this.localStorage, SIDEBAR_EXPANDED_STATE_KEY)
   );

--- a/frontend/src/assets/layout/styles/layout/_menu.scss
+++ b/frontend/src/assets/layout/styles/layout/_menu.scss
@@ -60,7 +60,7 @@
   display: none;
 }
 
-@media (width <= 991px) {
+@media (width <= 767px) {
   .layout-sidebar-resize-handle {
     display: none;
   }

--- a/frontend/src/assets/layout/styles/layout/_responsive.scss
+++ b/frontend/src/assets/layout/styles/layout/_responsive.scss
@@ -1,4 +1,4 @@
-@media (width >= 992px) {
+@media (width >= 768px) {
   .layout-wrapper {
     &.layout-sidebar-hidden {
       grid-template-columns: 0 minmax(0, 1fr);
@@ -16,7 +16,7 @@
   }
 }
 
-@media (width <= 991px) {
+@media (width <= 767px) {
   .blocked-scroll {
     overflow: hidden;
   }


### PR DESCRIPTION
## Description

Reduces the minimum width to trigger the mobile UI and fixes an edge case where mobile UI exhibited odd behaviour due to believing it was in its desktop minimised state. 

## Linked Issue

Fixes #1097 

## Changes

- Reduced mobile trigger width from 991px -> 767px. 
- Added a new `isDesktop` signal to correctly trigger desktop vs mobile behavior regardless of the desktop state. Fixes edge case where items wouldn't collapse and tooltips showed inadvertently in mobile view. 

## Manual Testing Steps

Tested widths across multiple sizes and devices, mobile UI now triggers at mobile size only. Tablet sizes now display desktop UI. 

Tested minimised sidebar > mobile width transition to confirm all functionality is working as intended. No tooltips in mobile sidebar, and items collapse correctly. 

## Screenshots (Optional)

<img width="783" height="750" alt="Screenshot 2026-05-04 at 11 44 39" src="https://github.com/user-attachments/assets/1810acd5-db42-43a4-99a3-45268f6c499b" />
780px width now displays desktop UI

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated responsive breakpoints so mobile layout now applies at 767px and below; layout, sidebar, menu, topbar and command-palette adapt accordingly.

* **Bug Fixes**
  * Tooltips, submenu visibility and overlay placement now respect desktop-specific sidebar state so sidebar/menu behavior is correct on desktop vs mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->