### PR TITLE
fix(ui): fix upload books height and scroll issue

### DIFF
--- a/frontend/src/app/shared/components/book-uploader/book-uploader.component.scss
+++ b/frontend/src/app/shared/components/book-uploader/book-uploader.component.scss
@@ -3,6 +3,7 @@
 .book-uploader {
   width: 700px;
   max-width: 700px;
+  max-height: 90vh;
   display: flex;
   flex-direction: column;
 
@@ -19,9 +20,12 @@
 }
 
 .upload-container {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-height: 0;
+  overflow-y: auto;
   padding: 1.75rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
@@ -262,8 +266,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    max-height: 400px;
-    overflow-y: auto;
     padding-right: 0.25rem;
 
     .file-item-card {


### PR DESCRIPTION
## Description

Fixes two issues with the upload books dialog not displaying or scrolling correctly. 

## Linked Issue

Fixes #1102 

## Changes

- Moves the scroll area into the main dialog content area, stopping the header from scrolling
- Sets dialog height to avoid max height clipping beyond the window. 

## Manual Testing Steps

Browser tests confirm the issue is resolved, as per screenshots below

## Screenshots (Optional)

Correct height and scrolling behaviour: 
<img width="1624" height="982" alt="Screenshot 2026-05-04 at 13 18 49" src="https://github.com/user-attachments/assets/cfd3f83a-e05e-4436-9d2b-2b4580c768f4" />
<img width="1624" height="982" alt="Screenshot 2026-05-04 at 13 19 15" src="https://github.com/user-attachments/assets/050a37e9-9349-4822-aa32-4d1fc2b6ba56" />


## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced book uploader layout with improved viewport height constraints ensuring better responsiveness across screen sizes. Reorganized scrolling behavior for file lists with vertical scrolling now managed at the container level for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->