### PR TITLE
refactor(ui): remove mobile-specific grid size controls

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.html
@@ -121,33 +121,13 @@
                     <label for="collapse-series-checkbox" class="display-settings-label">{{ t('labels.collapseSeries') }}</label>
                   </div>
                 </div>
-                @if (isMobile()) {
-                  <div class="display-settings-section">
-                    <span class="display-settings-label">{{ t('labels.gridColumns') }}</span>
-                    <div class="browser-grid-options">
-                      <button
-                        type="button"
-                        class="browser-grid-option-btn"
-                        [class.active]="gridMobileColumnCount() === 2"
-                        (click)="setMobileColumns(2)">2</button>
-                      <button
-                        type="button"
-                        class="browser-grid-option-btn"
-                        [class.active]="gridMobileColumnCount() === 3"
-                        (click)="setMobileColumns(3)">3</button>
-                      <button
-                        type="button"
-                        class="browser-grid-option-btn"
-                        [class.active]="gridMobileColumnCount() === 4"
-                        (click)="setMobileColumns(4)">4</button>
-                    </div>
-                  </div>
-                } @else {
-                  <div class="display-settings-section">
-                    <span class="display-settings-label">{{ t('labels.gridItemSize') }}</span>
-                    <app-grid-density-buttons (densityChange)="adjustDesktopGridDensity($event)"/>
-                  </div>
-                }
+                <div class="display-settings-section">
+                  <span class="display-settings-label">{{ t('labels.gridItemSize') }}</span>
+                  <app-grid-density-buttons
+                    [smallerDisabled]="gridDensitySmallerDisabled()"
+                    [largerDisabled]="gridDensityLargerDisabled()"
+                    (densityChange)="adjustGridDensity($event)"/>
+                </div>
                 <div class="display-settings-section">
                   <div class="display-settings-checkbox-row">
                     <p-checkbox

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -1137,15 +1137,16 @@ export class BookBrowserComponent implements AfterViewInit {
 
   private adjustMobileGridDensity(direction: GridDensityDirection): void {
     const currentColumns = this.gridMobileColumnCount();
-    this.setMobileColumns(direction === 'smaller'
+    const nextColumns = direction === 'smaller'
       ? currentColumns + 1
-      : currentColumns - 1);
+      : currentColumns - 1;
+
+    this.setMobileColumns(this.toMobileGridColumns(nextColumns));
   }
 
-  private setMobileColumns(columns: unknown): void {
-    const normalizedColumns = this.toMobileGridColumns(columns);
-    this.gridMobileColumnCount.set(normalizedColumns);
-    this.localStorageService.set(MOBILE_COLUMNS_STORAGE_KEY, normalizedColumns);
+  private setMobileColumns(columns: number): void {
+    this.gridMobileColumnCount.set(columns);
+    this.localStorageService.set(MOBILE_COLUMNS_STORAGE_KEY, columns);
   }
 
   private adjustDesktopGridDensity(direction: GridDensityDirection): void {
@@ -1169,7 +1170,7 @@ export class BookBrowserComponent implements AfterViewInit {
   private loadMobileColumnsPreference(): void {
     const saved = this.localStorageService.get<unknown>(MOBILE_COLUMNS_STORAGE_KEY);
     if (saved !== null) {
-      this.setMobileColumns(saved);
+      this.setMobileColumns(this.toMobileGridColumns(saved));
     }
   }
 

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -55,7 +55,7 @@ import {SortService} from '../../service/sort.service';
 import {AppBooksApiService} from '../../service/app-books-api.service';
 import {AppBookFilters} from '../../model/app-book.model';
 import {createVirtualGrid, scaleForGridColumns, type VirtualGridMetrics} from '../../../../shared/util/virtual-grid.util';
-import {GridDensityButtonsComponent} from '../../../../shared/components/grid-density-buttons/grid-density-buttons.component';
+import {GridDensityButtonsComponent, type GridDensityDirection} from '../../../../shared/components/grid-density-buttons/grid-density-buttons.component';
 import {LayoutService} from '../../../../shared/layout/layout.service';
 
 export enum EntityType {
@@ -68,6 +68,8 @@ export enum EntityType {
 
 const INITIAL_LOADING_ROW_COUNT = 24;
 const DEFAULT_MOBILE_GRID_COLUMNS = 3;
+const MIN_MOBILE_GRID_COLUMNS = 2;
+const MAX_MOBILE_GRID_COLUMNS = 4;
 const MOBILE_COLUMNS_STORAGE_KEY = 'mobileColumnsPreference';
 
 @Component({
@@ -84,7 +86,6 @@ const MOBILE_COLUMNS_STORAGE_KEY = 'mobileColumnsPreference';
   providers: [SeriesCollapseFilter],
 })
 export class BookBrowserComponent implements AfterViewInit {
-
   protected userService = inject(UserService);
   protected coverScalePreferenceService = inject(CoverScalePreferenceService);
   protected columnPreferenceService = inject(TableColumnPreferenceService);
@@ -478,6 +479,12 @@ export class BookBrowserComponent implements AfterViewInit {
   }
 
   readonly isMobile = computed(() => this.screenWidth() < this.MOBILE_BREAKPOINT);
+  readonly gridDensitySmallerDisabled = computed(() =>
+    this.isMobile() && this.gridMobileColumnCount() >= MAX_MOBILE_GRID_COLUMNS
+  );
+  readonly gridDensityLargerDisabled = computed(() =>
+    this.isMobile() && this.gridMobileColumnCount() <= MIN_MOBILE_GRID_COLUMNS
+  );
 
   private cardSizeForWidth(width: number): { width: number; height: number } {
     const cardWidth = Math.round(width);
@@ -1119,12 +1126,29 @@ export class BookBrowserComponent implements AfterViewInit {
     return libraryIds.size === 1;
   }
 
-  setMobileColumns(columns: number): void {
-    this.gridMobileColumnCount.set(columns);
-    this.localStorageService.set(MOBILE_COLUMNS_STORAGE_KEY, columns);
+  adjustGridDensity(direction: GridDensityDirection): void {
+    if (this.isMobile()) {
+      this.adjustMobileGridDensity(direction);
+      return;
+    }
+
+    this.adjustDesktopGridDensity(direction);
   }
 
-  adjustDesktopGridDensity(direction: 'smaller' | 'larger'): void {
+  private adjustMobileGridDensity(direction: GridDensityDirection): void {
+    const currentColumns = this.gridMobileColumnCount();
+    this.setMobileColumns(direction === 'smaller'
+      ? currentColumns + 1
+      : currentColumns - 1);
+  }
+
+  private setMobileColumns(columns: number): void {
+    const clampedColumns = Math.min(MAX_MOBILE_GRID_COLUMNS, Math.max(MIN_MOBILE_GRID_COLUMNS, columns));
+    this.gridMobileColumnCount.set(clampedColumns);
+    this.localStorageService.set(MOBILE_COLUMNS_STORAGE_KEY, clampedColumns);
+  }
+
+  private adjustDesktopGridDensity(direction: GridDensityDirection): void {
     const currentColumns = this.virtualGrid.gridColumns();
     const columns = Math.max(1, direction === 'smaller'
       ? currentColumns + 1
@@ -1144,7 +1168,7 @@ export class BookBrowserComponent implements AfterViewInit {
 
   private loadMobileColumnsPreference(): void {
     const saved = this.localStorageService.get<number>(MOBILE_COLUMNS_STORAGE_KEY);
-    if (saved !== null && [2, 3, 4].includes(saved)) {
+    if (saved !== null && saved >= MIN_MOBILE_GRID_COLUMNS && saved <= MAX_MOBILE_GRID_COLUMNS) {
       this.gridMobileColumnCount.set(saved);
     }
   }

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -1142,10 +1142,10 @@ export class BookBrowserComponent implements AfterViewInit {
       : currentColumns - 1);
   }
 
-  private setMobileColumns(columns: number): void {
-    const clampedColumns = Math.min(MAX_MOBILE_GRID_COLUMNS, Math.max(MIN_MOBILE_GRID_COLUMNS, columns));
-    this.gridMobileColumnCount.set(clampedColumns);
-    this.localStorageService.set(MOBILE_COLUMNS_STORAGE_KEY, clampedColumns);
+  private setMobileColumns(columns: unknown): void {
+    const normalizedColumns = this.toMobileGridColumns(columns);
+    this.gridMobileColumnCount.set(normalizedColumns);
+    this.localStorageService.set(MOBILE_COLUMNS_STORAGE_KEY, normalizedColumns);
   }
 
   private adjustDesktopGridDensity(direction: GridDensityDirection): void {
@@ -1167,9 +1167,17 @@ export class BookBrowserComponent implements AfterViewInit {
   }
 
   private loadMobileColumnsPreference(): void {
-    const saved = this.localStorageService.get<number>(MOBILE_COLUMNS_STORAGE_KEY);
-    if (saved !== null && saved >= MIN_MOBILE_GRID_COLUMNS && saved <= MAX_MOBILE_GRID_COLUMNS) {
-      this.gridMobileColumnCount.set(saved);
+    const saved = this.localStorageService.get<unknown>(MOBILE_COLUMNS_STORAGE_KEY);
+    if (saved !== null) {
+      this.setMobileColumns(saved);
     }
+  }
+
+  private toMobileGridColumns(value: unknown): number {
+    const columns = Number(value);
+    if (!Number.isFinite(columns)) {
+      return DEFAULT_MOBILE_GRID_COLUMNS;
+    }
+    return Math.min(MAX_MOBILE_GRID_COLUMNS, Math.max(MIN_MOBILE_GRID_COLUMNS, Math.round(columns)));
   }
 }

--- a/frontend/src/app/shared/components/grid-density-buttons/grid-density-buttons.component.html
+++ b/frontend/src/app/shared/components/grid-density-buttons/grid-density-buttons.component.html
@@ -7,11 +7,13 @@
     class="browser-grid-option-btn"
     [attr.aria-label]="'common.decreaseCardSize' | transloco"
     [title]="'common.decreaseCardSize' | transloco"
+    [disabled]="smallerDisabled()"
     (click)="densityChange.emit('smaller')">−</button>
   <button
     type="button"
     class="browser-grid-option-btn"
     [attr.aria-label]="'common.increaseCardSize' | transloco"
     [title]="'common.increaseCardSize' | transloco"
+    [disabled]="largerDisabled()"
     (click)="densityChange.emit('larger')">+</button>
 </div>

--- a/frontend/src/app/shared/components/grid-density-buttons/grid-density-buttons.component.ts
+++ b/frontend/src/app/shared/components/grid-density-buttons/grid-density-buttons.component.ts
@@ -1,4 +1,4 @@
-import {Component, output} from '@angular/core';
+import {Component, input, output} from '@angular/core';
 import {TranslocoPipe} from '@jsverse/transloco';
 
 export type GridDensityDirection = 'smaller' | 'larger';
@@ -10,5 +10,7 @@ export type GridDensityDirection = 'smaller' | 'larger';
   templateUrl: './grid-density-buttons.component.html',
 })
 export class GridDensityButtonsComponent {
+  readonly smallerDisabled = input(false);
+  readonly largerDisabled = input(false);
   readonly densityChange = output<GridDensityDirection>();
 }

--- a/frontend/src/assets/styles/utilities.scss
+++ b/frontend/src/assets/styles/utilities.scss
@@ -73,8 +73,13 @@
   cursor: pointer;
   transition: all 0.15s ease;
 
-  &:hover {
+  &:hover:not(:disabled) {
     border-color: var(--primary-color);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
   }
 
   &.active {


### PR DESCRIPTION
## Description

This removes the mobile-specific grid size controls (2/3/4 columns) and uses the desktop + / - controls instead. 

## Linked Issue

Fixes #1098 

## Changes

- Removes the mobile-specific controls entirely, uses the desktop version
- Added a bound of min 2 and max 4 columns on mobile, matching existing behavior. Controls are greyed out at the bounds. 
- Default grid size remains at 3 for mobile. 

## Manual Testing Steps

Testing on desktop and mobile confirms they now correctly use the same controls, with bounds enforced at 2 and 4 columns on mobile while unchanged for desktop. 

## Screenshots (Optional)
<img width="493" height="271" alt="Screenshot 2026-05-04 at 13 58 16" src="https://github.com/user-attachments/assets/e75fa2fc-dc52-47db-a843-27aaeed210a8" />
<img width="495" height="286" alt="Screenshot 2026-05-04 at 13 58 22" src="https://github.com/user-attachments/assets/6c59de3a-04be-4e7e-ac1e-bfe2fd0ea30f" />

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified grid density control for consistent card-size adjustment across devices; changes apply immediately and predictably.
  * Mobile grid preferences are normalized and clamped when loaded or changed to stay within valid bounds.
* **Style**
  * Grid-size buttons show a clear disabled state (not-allowed cursor, reduced opacity).
* **Bug Fixes**
  * Disable logic prevents invalid or out-of-range grid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->