### PR TITLE
test: drop redundant mockito-inline dependency

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -187,7 +187,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
     testImplementation("org.assertj:assertj-core:3.27.7")
-    testImplementation("org.mockito:mockito-inline:5.2.0")
     testRuntimeOnly("com.h2database:h2")
     add(openApiExportRuntimeOnly.name, "com.h2database:h2")
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
this was identified during creation of the docker lock file as a redundant dependency that lead to incompatible versions being brought in together

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #1118

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* drops redundant `mockito-inline` dep which is brought in transitively otherwise

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Clear out gradle build cache
2. `./gradlew dependencies`
3. `just api test`

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
Suggested via scan in #1119 

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
It was suggested by AI tools over in #1119

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend test dependencies configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->