### PR TITLE
feat(deploy): add healthchecks to docker, docker compose, podman quadlet, and helm chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,11 @@ ENV APP_VERSION=${APP_VERSION} \
     APP_REVISION=${APP_REVISION}
 
 ARG BOOKLORE_PORT=6060
+ENV BOOKLORE_PORT=${BOOKLORE_PORT}
 EXPOSE ${BOOKLORE_PORT}
+
+HEALTHCHECK --interval=60s --timeout=10s --start-period=60s --retries=5 \
+  CMD wget -q --spider http://localhost:${BOOKLORE_PORT}/api/v1/healthcheck
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["java", "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-jar", "/app/app.jar"]

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -33,12 +33,17 @@ services:
       - ./data:/app/data
       - ./books:/books
       - ./bookdrop:/bookdrop
-    healthcheck:
-      test: wget -q -O - http://localhost:6060/api/v1/healthcheck
-      interval: 60s
-      retries: 5
-      start_period: 60s
-      timeout: 10s
+    # Uncomment the block below if you need to override the defaults:
+    #healthcheck:
+    #  test: wget -q --spider http://localhost:6060/api/v1/healthcheck
+    #  interval: 60s
+    #  retries: 5
+    #  start_period: 60s
+    #  timeout: 10s
+    #
+    # Uncomment the block below if you want to disable healthchecks:
+    #healthcheck:
+    #  disable: true
     restart: unless-stopped
 
   mariadb:

--- a/deploy/helm/grimmory/templates/deployment.yaml
+++ b/deploy/helm/grimmory/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
                   name: {{ .Release.Name }}-mariadb
                   {{- end }}
                   key: mariadb-password
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/grimmory/values.yaml
+++ b/deploy/helm/grimmory/values.yaml
@@ -89,13 +89,28 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
-# # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+# This is to setup the startup, liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+startupProbe:
+  httpGet:
+    path: /api/v1/healthcheck
+    port: http
+  failureThreshold: 5
+  periodSeconds: 30
+  timeoutSeconds: 5
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /api/v1/healthcheck
     port: http
+  failureThreshold: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
 readinessProbe:
-  tcpSocket:
+  httpGet:
+    path: /api/v1/healthcheck
     port: http
+  failureThreshold: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
 # If you want to bring your own persistence (such as a hostPath),
 # disable these and do so in extraVolumes/extraVolumeMounts
 persistence:

--- a/deploy/podman/quadlet/grimmory.container
+++ b/deploy/podman/quadlet/grimmory.container
@@ -20,7 +20,7 @@ Environment=TZ=Etc/UTC
 Secret=grimmory_db_pass,type=env,target=DATABASE_PASSWORD
 Environment=DATABASE_URL=jdbc:mariadb://localhost:3306/grimmory
 Environment=DATABASE_USERNAME=grimmory
-HealthCmd=wget -q -O - http://localhost:6060/api/v1/healthcheck
+HealthCmd=CMD-SHELL wget -q --spider http://localhost:${BOOKLORE_PORT:-6060}/api/v1/healthcheck
 HealthInterval=1m
 HealthRetries=5
 HealthStartPeriod=1m


### PR DESCRIPTION
## Description

This PR adds healthchecks in the OCI image and the various deployments that rely on it, namely docker-compose, podman quadlets, and helm chart.

It doesn't fine tune default values and reuses the ones in the pre-existing docker-compose.

## Linked Issue

Fixes #1134

## Changes

- Change the global health check command to `wget -q --spider http://localhost:6060/api/v1/healthcheck` to avoid littering the logs with json
- Add `HEALTHCHECK` instruction in `Dockerfile`
- Comment out `healthcheck:` override in `docker-compose.yaml`
- Update the `HealthCmd` command in `podman/quadlet/grimmory.container` for consistency
- Add `startupProbe`, `livenessProbe`, and `readinessProbe` in the helm chart (both in `values.yaml` and `templates/deployment.yaml`)

## Manual Testing Steps

Admittedly, I only tested the helm chart deployment, without rebuilding the Docker image.

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change. <---- I think?
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Added a container healthcheck that regularly probes the app health endpoint.
  * Standardized liveness/readiness probes to HTTP health checks and tuned timing/retry settings.
  * Added an optional startup probe to improve startup handling.

* **Configuration**
  * Persisted the runtime port setting and explicitly exposed the configured port.
  * Made container health probe behavior configurable in compose/units (can be enabled, overridden, or disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->