### PR TITLE
build(ui): drop `ngx-extended-pdf-viewer` angular asset config

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -38,11 +38,6 @@
               },
               {
                 "glob": "**/*",
-                "input": "node_modules/ngx-extended-pdf-viewer/assets/",
-                "output": "/assets/"
-              },
-              {
-                "glob": "**/*",
                 "input": "libs/foliate-js",
                 "output": "/assets/foliate/"
               },


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
This asset config is no longer in use and can be safely dropped

## Linked Issue

<!-- Required. Example: Fixes #123 -->
Fixes #1139

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* drops unused angular asset config

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. run build
2. click around the UI, no logged issues, no UI

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
no change

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
this was from a legacy PDF viewer that we no longer use and has no impact on the build aside from cleaning things up

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an asset mapping from the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->