### PR TITLE
fix(koreader): use a timing-safe comparison for koreader password

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/filter/KoreaderAuthFilter.java
+++ b/backend/src/main/java/org/booklore/config/security/filter/KoreaderAuthFilter.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.security.MessageDigest;
+import java.util.HexFormat;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -45,7 +47,7 @@ public class KoreaderAuthFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (!user.getPasswordMD5().equalsIgnoreCase(key)) {
+        if (!MessageDigest.isEqual(HexFormat.of().parseHex(user.getPasswordMD5()), HexFormat.of().parseHex(key))) {
             log.info("KOReader user password not match");
             chain.doFilter(request, response);
             return;

--- a/backend/src/main/java/org/booklore/config/security/filter/KoreaderAuthFilter.java
+++ b/backend/src/main/java/org/booklore/config/security/filter/KoreaderAuthFilter.java
@@ -47,8 +47,17 @@ public class KoreaderAuthFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (!MessageDigest.isEqual(HexFormat.of().parseHex(user.getPasswordMD5()), HexFormat.of().parseHex(key))) {
-            log.info("KOReader user password not match");
+        try {
+            byte[] expectedMD5Bytes = HexFormat.of().parseHex(user.getPasswordMD5());
+            byte[] actualMD5Bytes = HexFormat.of().parseHex(key);
+
+            if (!MessageDigest.isEqual(expectedMD5Bytes, actualMD5Bytes)) {
+                log.info("KOReader user password not match");
+                chain.doFilter(request, response);
+                return;
+            }
+        } catch (IllegalArgumentException e) {
+            log.info("Problem comparing Koreader md5 checksums: {}", e.getMessage());
             chain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
The Koreader password comparison was flagged by Sonarcloud (at some point?  It's not flagging it now?) because it fails to use a timing-attack-resilient comparison method.  This means that it's possible - though unlikely - for an attacker to use the timing differences in a response to determine the value of a hidden secret.

To correct this, this PR brings in the `MessageDigest.isEqual` method which will use a constant time for comparing two strings, even if it's sub-optimal.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
Fixes #1115

## Changes 

<!-- Required. List the main changes. Use bullets if helpful. -->
* use `MessageDigest.isEqual` for comparing KoReader MD5s
 
## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Manually authenticated to the koreader endpoints with the expected auth key

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
N/A

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
N/A

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened authentication checks by improving how stored and provided credentials are validated, adding safer comparison and better error handling/logging for malformed or mismatched credentials. This reduces risk of incorrect matches and improves reliability of the login flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->