### PR TITLE
chore: Update default settings tab from reader to view

### DIFF
--- a/frontend/src/app/features/settings/settings.component.html
+++ b/frontend/src/app/features/settings/settings.component.html
@@ -4,11 +4,11 @@
       <div class="settings-container">
         <p-tabs [(value)]="activeTab" scrollable>
           <p-tablist>
-            <p-tab [value]="SettingsTab.ReaderSettings">
-              <i class="pi pi-book"></i> {{ t('reader') }}
-            </p-tab>
             <p-tab [value]="SettingsTab.ViewPreferences">
               <i class="pi pi-desktop"></i> {{ t('view') }}
+            </p-tab>
+            <p-tab [value]="SettingsTab.ReaderSettings">
+              <i class="pi pi-book"></i> {{ t('reader') }}
             </p-tab>
             @if (currentUser.permissions.admin || currentUser.permissions.canManageMetadataConfig) {
               <p-tab [value]="SettingsTab.MetadataSettings">

--- a/frontend/src/app/features/settings/settings.component.ts
+++ b/frontend/src/app/features/settings/settings.component.ts
@@ -20,8 +20,8 @@ import {EmailV2Component} from './email-v2/email-v2.component';
 import {TranslocoDirective} from '@jsverse/transloco';
 
 export enum SettingsTab {
-  ReaderSettings = 'reader',
   ViewPreferences = 'view',
+  ReaderSettings = 'reader',
   DeviceSettings = 'device',
   UserManagement = 'user',
   EmailSettingsV2 = 'email-v2',
@@ -71,7 +71,7 @@ export class SettingsComponent implements OnInit {
   SettingsTab = SettingsTab;
 
   private validTabs = Object.values(SettingsTab);
-  private _activeTab = signal<SettingsTab>(SettingsTab.ReaderSettings);
+  private _activeTab = signal<SettingsTab>(SettingsTab.ViewPreferences);
 
   visitedTabs = signal<Set<SettingsTab>>(new Set([
     SettingsTab.UserManagement,
@@ -120,7 +120,7 @@ export class SettingsComponent implements OnInit {
       if (this.validTabs.includes(tabParam)) {
         this._activeTab.set(tabParam as SettingsTab);
       } else {
-        const defaultTab = SettingsTab.ReaderSettings;
+        const defaultTab = SettingsTab.ViewPreferences;
         this._activeTab.set(defaultTab);
         this.router.navigate([], {
           relativeTo: this.route,


### PR DESCRIPTION
## Description

With the new sidebar and having moved language + theme to settings, it makes more sense for the settings hierarchy for high level app wide customization options to be the first tab, instead of reader specific customization. This PR simply changes that default tab order.

## Linked Issue

Resolves https://github.com/grimmory-tools/grimmory/issues/1170

## Changes

- Modifies the tab header order to place view first
- Modifies the default settings tab from `ReaderSettings` to `ViewPreferences`
- No spec coverage for this F/E component, so I won't add any. As per https://github.com/grimmory-tools/grimmory/issues/813, I think we should evaluate refactoring all of our tab UIs to use a cleaner abstracted component that can handle more high level tab responsibilities 

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Verifies the tab header shows the new order, and reloads of the page w/o a URL param fall back to view now.

## Screenshots (Optional)

<img width="1277" height="1485" alt="Screenshot 2026-05-06 at 5 36 08 PM" src="https://github.com/user-attachments/assets/a68418f9-e06f-4918-9acc-121146fcb114" />

## Additional Context (Optional)

N/A

## AI Disclosure

None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered settings tabs with ViewPreferences now displayed before ReaderSettings.
  * Updated the default active tab to ViewPreferences instead of ReaderSettings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->