### PR TITLE
fix(ui): retrieve full size cover in series page component for hero banner

### DIFF
--- a/frontend/src/app/features/book/components/series-page/series-page.component.html
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.html
@@ -32,7 +32,7 @@
                 <div class="series-hero">
                   @if (coverBook(); as coverBook) {
                     <div class="hero-cover-section">
-                      @if (getBookThumbnailUrl(coverBook); as coverUrl) {
+                      @if (getBookCoverUrl(coverBook); as coverUrl) {
                         <img
                           [src]="coverUrl"
                           class="hero-cover-img"

--- a/frontend/src/app/features/book/components/series-page/series-page.component.ts
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.ts
@@ -471,6 +471,13 @@ export class SeriesPageComponent implements AfterViewChecked {
     }
   }
 
+  getBookCoverUrl(book: Book): string | null {
+    const isAudiobook = book.primaryFile?.bookType === 'AUDIOBOOK';
+    return isAudiobook
+      ? this.urlHelper.getAudiobookCoverUrl(book.id, book.metadata?.audiobookCoverUpdatedOn)
+      : this.urlHelper.getCoverUrl(book.id, book.metadata?.coverUpdatedOn);
+  }
+
   getBookThumbnailUrl(book: Book): string | null {
     const isAudiobook = book.primaryFile?.bookType === 'AUDIOBOOK';
     return isAudiobook


### PR DESCRIPTION
## Description

The series page displays the thumbnail image for the first comic of the series instead of the full size cover. This results in the image being upscaled and blurred. Using the original cover size will result in a cleaner interface.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/1238

## Changes

- Added `getBookCoverUrl` method in `series-page-component.ts`
- Substituted call to `getBookThumbnailUrl` for `getBookCoverUrl` in `series-page-component.html`, `series-hero` section.

## Manual Testing Steps

1. Load any series page

## Screenshots (Optional)
<img width="1884" height="926" alt="image" src="https://github.com/user-attachments/assets/c803c0d4-1308-455f-ba5c-0fcb00271c67" />
<img width="1254" height="932" alt="image" src="https://github.com/user-attachments/assets/f4360f66-8d07-4db2-b99b-417ccfb51297" />

## Additional Context (Optional)

Can compare screenshots with the ones added to #1174
Not marking `This PR links and implements an accepted issue.` below because I have just created the issue hasn't been triaged yet.

## AI Disclosure

Used Claude to quickly analyze the source code and surface method that retrieved the thumbnail image.

## Checklist

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cover image display logic on the series page to correctly render cover artwork for both audiobooks and regular books.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->