### PR TITLE
docs: Fix Link to Quick Start Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/grimmory/grimmory?color=2496ED&style=flat-square&logo=docker&logoColor=white)](https://hub.docker.com/r/grimmory/grimmory)
 [![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/9YJ7HB4n8T)
 
-[Documentation](https://grimmory.org/docs) · [Quick Start](docs/QUICKSTART.md) · [Discord](https://discord.gg/9YJ7HB4n8T) · [Releases](https://github.com/grimmory-tools/grimmory/releases)
+[Documentation](https://grimmory.org/docs) · [Quick Start](#quick-start) · [Discord](https://discord.gg/9YJ7HB4n8T) · [Releases](https://github.com/grimmory-tools/grimmory/releases)
 
 <!-- ![Grimmory Demo](assets/demo.gif) -->
 


### PR DESCRIPTION
## Description

This PR fixes a link to the Quick Start Guide in the README, which linked a doc that was deprecated. New link points to Quick Start section in README.

## Linked Issue

No Linked Issue - simple documentation fix.

## Changes

* Fixes link that previously pointed to "docs/QUICKSTART.md", which is now missing. Repointed link to "Quick Start" section in README.

## Manual Testing Steps

1. Pushed branch to my own fork.
2. Clicked link to "Quick Start" in README intro, which successfully scrolled me down to the "Quick Start" section of the README.

## AI Disclosure

No AI was used.

## Checklist

- [ ] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start navigation link in the README to point to the in-page Quick Start section, improving access and streamlining navigation for users browsing the documentation.
  * No other content changes to the README; this is a small documentation tweak with minimal review effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->