### PR TITLE
ci(docker): rotate Docker Hub auth secrets for token-based publishing

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -102,8 +102,8 @@ jobs:
         if: ${{ vars.DOCKERHUB_REGISTRY != '' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Authenticate to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,8 +33,8 @@ jobs:
         if: ${{ vars.DOCKERHUB_REGISTRY != '' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Authenticate to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/docs/MAKING-A-RELEASE.md
+++ b/docs/MAKING-A-RELEASE.md
@@ -24,7 +24,7 @@ Before cutting a stable release, make sure:
 - The commits that should be released are already on `main`.
 - Those commits follow conventional commit semantics.
 - `RELEASE_BOT_TOKEN` is configured if branch protection requires more than the default `github.token`.
-- `DOCKER_USERNAME` and `DOCKER_PASSWORD` are configured for Docker Hub publishing.
+- If `DOCKERHUB_REGISTRY` is set, `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are configured for Docker Hub publishing.
 
 ## What Triggers a Stable Release
 


### PR DESCRIPTION
## Description

We were previously using a contributor's personal docker hub username + password pair for our deployments. This PR switches us from the deprecated/deactivated credentials, to using organization access tokens for Docker Hub actions.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/1178

## Changes

- Switch to using `DOCKERHUB_USERNAME` (`grimmory`) and `DOCKERHUB_TOKEN`
- Update README

## Manual Testing Steps

Nightly deployments are already broken- YOLO

## Additional Context (Optional)

This will also have the minor side effect of showing it being organization deployments, not personal deployments on our end

## AI Disclosure

None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Hub publishing authentication configuration in CI/CD workflows.

* **Documentation**
  * Updated release documentation with revised Docker Hub credential setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->