### PR TITLE
fix(ui): mobile UI enhancements

### DIFF
--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.scss
@@ -1,9 +1,16 @@
+@use "../../../../../assets/layout/styles/layout/variables";
+
 .main-card {
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
   height: 100%;
   overflow: hidden;
   background: var(--page-background);
+
+  @media #{variables.$mobile-shell-media-query} {
+    padding: var(--space-4);
+  }
 }
 
 .header {
@@ -15,7 +22,7 @@
   border-bottom: 1px solid var(--p-content-border-color);
   gap: 1rem;
 
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     padding: 1rem;
   }
 }
@@ -39,7 +46,7 @@
     }
   }
 
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     flex-shrink: 1;
 
     p {
@@ -49,7 +56,7 @@
 }
 
 .header-actions {
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     display: flex;
   }
 }
@@ -158,7 +165,7 @@
     width: 8rem;
   }
 
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     width: 100%;
 
     label {
@@ -172,7 +179,7 @@
 }
 
 ::ng-deep .p-select-overlay {
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     max-width: 70vw;
 
     .p-select-option {
@@ -285,7 +292,7 @@ p-inputgroup.disabled {
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 10%);
   }
 
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     display: none !important;
   }
 }
@@ -305,7 +312,7 @@ div.cover-image {
   text-overflow: ellipsis;
   white-space: wrap;
 
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     max-width: 100%;
   }
 }
@@ -330,7 +337,7 @@ div.cover-image {
   justify-content: flex-end;
   align-items: center;
 
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     width: 100%;
   }
 }
@@ -339,7 +346,7 @@ div.cover-image {
 .path-select {
   width: 8rem;
 
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     flex-basis: 50%;
   }
 }
@@ -357,7 +364,7 @@ div.cover-image {
 }
 
 .footer {
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     flex-wrap: wrap;
 
     ::ng-deep .p-button-label {
@@ -405,7 +412,7 @@ div.cover-image {
     padding: 0;
   }
 
-  @media (width <= 768px) {
+  @media #{variables.$mobile-shell-media-query} {
     ::ng-deep .p-paginator .p-paginator-jtp-dropdown span {
       font-size: var(--p-select-sm-font-size);
       padding-block: var(--p-select-sm-padding-y);

--- a/frontend/src/app/features/command-palette/command-palette.component.html
+++ b/frontend/src/app/features/command-palette/command-palette.component.html
@@ -21,6 +21,14 @@
               (ngModelChange)="onQueryChange($event)"
               (keydown)="onKeydown($event)"
             />
+            <button
+              type="button"
+              class="command-palette-close-button"
+              [attr.aria-label]="'close' | transloco"
+              (click)="svc.hide()"
+            >
+              <i class="pi pi-times" aria-hidden="true"></i>
+            </button>
           </div>
         </form>
 

--- a/frontend/src/app/features/command-palette/command-palette.component.scss
+++ b/frontend/src/app/features/command-palette/command-palette.component.scss
@@ -1,3 +1,5 @@
+@use "../../../assets/layout/styles/layout/variables";
+
 :host {
   display: contents;
 }
@@ -12,11 +14,13 @@
   flex-direction: column;
   width: 100%;
   max-height: min(70vh, calc(100dvh - 4rem));
-  background: var(--surface-overlay);
+  background: color-mix(in srgb, var(--surface-overlay) 64%, var(--surface-card));
   color: var(--text-color);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-overlay);
+  box-shadow:
+    0 20px 64px rgb(0 0 0 / 32%),
+    var(--shadow-overlay);
   overflow: hidden;
 }
 
@@ -58,6 +62,34 @@
   &::-webkit-search-decoration {
     appearance: none;
     display: none;
+  }
+}
+
+.command-palette-close-button {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text-color);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--surface-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+
+  i {
+    font-size: 1.25rem;
   }
 }
 
@@ -228,17 +260,78 @@
   color: var(--text-color);
 }
 
-@media (width <= 767px) {
+@media #{variables.$mobile-shell-media-query} {
   .command-palette-shell {
     width: 100vw;
   }
 
   .command-palette {
-    max-height: calc(100dvh - 3.5rem);
-    border-top: none;
-    border-left: none;
-    border-right: none;
+    max-height: 100dvh;
+    background: var(--app-background);
+    border: none;
     border-radius: 0;
+    box-shadow: none;
+  }
+
+  .command-palette-form {
+    box-sizing: border-box;
+    flex-shrink: 0;
+    height: 3.5rem;
+    background: var(--app-background);
+    border-bottom: 1px solid var(--border-color);
+
+    &:has(+ .command-palette-results) .command-palette-input-row {
+      border-bottom: none;
+    }
+  }
+
+  .command-palette-input-row {
+    box-sizing: border-box;
+    height: 100%;
+    gap: 0.5rem;
+    padding:
+      0
+      calc(0.75rem + env(safe-area-inset-right))
+      0
+      calc(0.75rem + env(safe-area-inset-left));
+
+    > .pi-search {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      width: 2.5rem;
+    }
+  }
+
+  .command-palette-input {
+    padding-right: 0.5rem;
+  }
+
+  .command-palette-close-button {
+    display: inline-flex;
+  }
+
+  .command-palette-results,
+  .command-palette-empty {
+    background: var(--page-background);
+  }
+
+  .command-palette-empty {
+    padding:
+      var(--space-6)
+      calc(var(--space-4) + env(safe-area-inset-right))
+      var(--space-6)
+      calc(var(--space-4) + env(safe-area-inset-left));
+  }
+
+  .command-palette-results {
+    padding:
+      var(--space-2)
+      calc(var(--space-3) + env(safe-area-inset-right))
+      var(--space-2)
+      calc(var(--space-3) + env(safe-area-inset-left));
+    border-bottom: 1px solid var(--border-color);
     box-shadow: 0 12px 24px rgb(0 0 0 / 18%);
   }
 

--- a/frontend/src/app/features/command-palette/command-palette.component.ts
+++ b/frontend/src/app/features/command-palette/command-palette.component.ts
@@ -1,27 +1,26 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { Overlay, OverlayModule, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
-import { Component, computed, DestroyRef, effect, ElementRef, inject, signal, TemplateRef, untracked, ViewContainerRef, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, ElementRef, inject, signal, TemplateRef, untracked, ViewContainerRef, viewChild } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
 import { filter, take } from 'rxjs/operators';
 import { FormsModule } from '@angular/forms';
-import { TranslocoDirective } from '@jsverse/transloco';
+import { TranslocoDirective, TranslocoPipe } from '@jsverse/transloco';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { CoverPlaceholderComponent } from '../../shared/components/cover-generator/cover-generator.component';
 import { IconDisplayComponent } from '../../shared/components/icon-display/icon-display.component';
+import { MOBILE_SHELL_ACTIVE_PROPERTY } from '../../shared/layout/layout.service';
 import { PaletteItem } from './command-palette.model';
 import { CommandPaletteService } from './command-palette.service';
-
-const MOBILE_MEDIA_QUERY = '(max-width: 767px)';
-const MOBILE_TOPBAR_HEIGHT = '3.5rem';
 
 @Component({
   selector: 'app-command-palette',
   standalone: true,
-  imports: [A11yModule, OverlayModule, FormsModule, TranslocoDirective, IconDisplayComponent, CoverPlaceholderComponent],
+  imports: [A11yModule, OverlayModule, FormsModule, TranslocoDirective, TranslocoPipe, IconDisplayComponent, CoverPlaceholderComponent],
   templateUrl: './command-palette.component.html',
   styleUrl: './command-palette.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CommandPaletteComponent {
   protected readonly svc = inject(CommandPaletteService);
@@ -45,12 +44,9 @@ export class CommandPaletteComponent {
   private overlayRef: OverlayRef | undefined;
   private focusAnimationFrameId: number | undefined;
   private focusTimeoutId: number | undefined;
-  private mobileMedia: MediaQueryList | undefined;
-  private readonly mobileMediaListener = () => {
-    this.applyPositionStrategy();
-    this.refreshAvailableHeight();
-  };
-  private readonly visualViewportListener = () => this.refreshAvailableHeight();
+  private viewportAnimationFrameId: number | undefined;
+  private readonly mobileStateListener = () => this.scheduleViewportRefresh();
+  private readonly visualViewportListener = () => this.scheduleViewportRefresh();
 
   constructor() {
     const unregisterOverlayController = this.svc.registerOverlayController({
@@ -162,7 +158,7 @@ export class CommandPaletteComponent {
       return;
     }
 
-    this.bindMobileMediaListener();
+    this.bindMobileStateListener();
     this.bindVisualViewportListener();
     this.refreshAvailableHeight();
     this.overlayRef = this.overlay.create({
@@ -180,7 +176,8 @@ export class CommandPaletteComponent {
 
   private closeOverlay(): void {
     this.clearPendingFocus();
-    this.unbindMobileMediaListener();
+    this.clearPendingViewportRefresh();
+    this.unbindMobileStateListener();
     this.unbindVisualViewportListener();
     this.availableHeightPx.set(null);
     this.overlayRef?.dispose();
@@ -190,7 +187,7 @@ export class CommandPaletteComponent {
   private buildPositionStrategy() {
     const position = this.overlay.position().global();
     if (this.isMobileViewport()) {
-      return position.left('0').top(MOBILE_TOPBAR_HEIGHT);
+      return position.left('0').top('0');
     }
     return position.centerHorizontally().top('15vh');
   }
@@ -201,18 +198,21 @@ export class CommandPaletteComponent {
   }
 
   private isMobileViewport(): boolean {
-    return this.mobileMedia?.matches ?? false;
+    if (typeof window === 'undefined') return false;
+    return window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue(MOBILE_SHELL_ACTIVE_PROPERTY)
+      .trim() === '1';
   }
 
-  private bindMobileMediaListener(): void {
-    if (typeof window === 'undefined' || this.mobileMedia) return;
-    this.mobileMedia = window.matchMedia(MOBILE_MEDIA_QUERY);
-    this.mobileMedia.addEventListener('change', this.mobileMediaListener);
+  private bindMobileStateListener(): void {
+    if (typeof window === 'undefined') return;
+    window.addEventListener('resize', this.mobileStateListener);
   }
 
-  private unbindMobileMediaListener(): void {
-    this.mobileMedia?.removeEventListener('change', this.mobileMediaListener);
-    this.mobileMedia = undefined;
+  private unbindMobileStateListener(): void {
+    if (typeof window === 'undefined') return;
+    window.removeEventListener('resize', this.mobileStateListener);
   }
 
   private bindVisualViewportListener(): void {
@@ -240,15 +240,24 @@ export class CommandPaletteComponent {
       this.availableHeightPx.set(null);
       return;
     }
-    const topbarPx = this.readTopbarHeightPx();
-    this.availableHeightPx.set(Math.max(0, Math.round(vv.height - topbarPx)));
+    this.availableHeightPx.set(Math.max(0, Math.round(vv.height)));
   }
 
-  private readTopbarHeightPx(): number {
-    const fontSize = typeof window !== 'undefined'
-      ? parseFloat(window.getComputedStyle(document.documentElement).fontSize)
-      : 16;
-    return (isNaN(fontSize) ? 16 : fontSize) * 3.5;
+  private scheduleViewportRefresh(): void {
+    if (typeof window === 'undefined' || this.viewportAnimationFrameId !== undefined) return;
+
+    this.viewportAnimationFrameId = window.requestAnimationFrame(() => {
+      this.viewportAnimationFrameId = undefined;
+      this.applyPositionStrategy();
+      this.refreshAvailableHeight();
+    });
+  }
+
+  private clearPendingViewportRefresh(): void {
+    if (typeof window !== 'undefined' && this.viewportAnimationFrameId !== undefined) {
+      window.cancelAnimationFrame(this.viewportAnimationFrameId);
+    }
+    this.viewportAnimationFrameId = undefined;
   }
 
   private scheduleInputFocus(): void {

--- a/frontend/src/app/features/metadata/component/metadata-manager/metadata-manager.component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-manager/metadata-manager.component.scss
@@ -1,3 +1,5 @@
+@use "../../../../../assets/layout/styles/layout/variables";
+
 .metadata-manager {
   padding: 1.5rem;
   display: flex;
@@ -120,6 +122,10 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
+
+  @media #{variables.$mobile-shell-media-query} {
+    padding: var(--space-4);
+  }
 }
 
 .enclosing-container {

--- a/frontend/src/app/features/notebook/components/notebook/notebook.component.scss
+++ b/frontend/src/app/features/notebook/components/notebook/notebook.component.scss
@@ -1,4 +1,5 @@
 @use '../../../../shared/styles/settings-shared' as settings;
+@use '../../../../../assets/layout/styles/layout/variables';
 
 // Page container — override mixin's overflow so only the content area scrolls
 .main-container {
@@ -22,14 +23,14 @@
   margin-top: 1.5rem;
 }
 
-@media (width <= 768px) {
+@media #{variables.$mobile-shell-media-query} {
   .main-container > .settings-header,
   .main-container > .settings-card {
-    margin-inline: 0.5rem;
+    margin-inline: var(--space-4);
   }
 
   .main-container > .settings-header {
-    margin-top: 0.5rem;
+    margin-top: var(--space-4);
   }
 }
 
@@ -43,8 +44,8 @@
   gap: 1.5rem;
   padding: 1.5rem 1.1rem 0;
 
-  @media (width <= 768px) {
-    padding: 1.5rem 0.5rem 0;
+  @media #{variables.$mobile-shell-media-query} {
+    padding: 1.5rem var(--space-4) 0;
   }
 }
 
@@ -357,7 +358,7 @@
 // ============================================================================
 // RESPONSIVE
 // ============================================================================
-@media (width <= 768px) {
+@media #{variables.$mobile-shell-media-query} {
   .filters-bar {
     flex-direction: column;
     align-items: stretch;

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.html
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.html
@@ -23,7 +23,12 @@
             [displayEmpty]="true"
           ></app-icon-display>
         </span>
-        <span class="layout-menuitem-text menu-item-text">{{ currentItem.label }}</span>
+        <span class="layout-menuitem-text menu-item-text">
+          <span class="menu-item-label">{{ currentItem.label }}</span>
+          @if (currentItem.bookCount) {
+            <span class="book-count book-count-inline">{{ formatCount(currentItem.bookCount) }}</span>
+          }
+        </span>
       </span>
     </button>
   } @else if (currentItem.routerLink) {
@@ -55,7 +60,12 @@
             [displayEmpty]="true"
           ></app-icon-display>
         </span>
-        <span class="layout-menuitem-text menu-item-text">{{ currentItem.label }}</span>
+        <span class="layout-menuitem-text menu-item-text">
+          <span class="menu-item-label">{{ currentItem.label }}</span>
+          @if (currentItem.bookCount) {
+            <span class="book-count book-count-inline">{{ formatCount(currentItem.bookCount) }}</span>
+          }
+        </span>
       </span>
     </a>
   }
@@ -74,9 +84,17 @@
           <span class="entity-menu-count">{{ formatCount(currentItem.bookCount) }}</span>
         </span>
       </button>
-      <p-menu #entitymenu [model]="currentItem.contextMenuItems" [popup]="true" appendTo="body" (onHide)="closeContextMenu()"></p-menu>
+      <p-menu
+        #entitymenu
+        [model]="currentItem.contextMenuItems"
+        [popup]="true"
+        appendTo="body"
+        styleClass="sidebar-entity-menu"
+        (onShow)="positionContextMenu(entitymenu)"
+        (onHide)="closeContextMenu()"
+      ></p-menu>
     } @else if (currentItem.bookCount) {
-      <p class="book-count">{{ formatCount(currentItem.bookCount) }}</p>
+      <p class="book-count book-count-end">{{ formatCount(currentItem.bookCount) }}</p>
     }
   </span>
 </div>

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.scss
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.scss
@@ -1,3 +1,5 @@
+@use "../../../../assets/layout/styles/layout/variables";
+
 :host {
   display: block;
   width: 100%;
@@ -15,9 +17,26 @@
   min-width: 0;
   border-radius: var(--sidebar-row-radius);
 
-  &:hover,
   &:focus-within {
     background-color: var(--surface-hover);
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .menu-item-container:hover {
+    background-color: var(--surface-hover);
+  }
+
+  .menu-item-container:hover .menu-item-chevron {
+    color: var(--text-color);
+  }
+
+  .menu-item-container:hover .entity-menu-icon {
+    display: inline;
+  }
+
+  .menu-item-container:hover .entity-menu-count {
+    display: none;
   }
 }
 
@@ -82,17 +101,23 @@ a.menu-item-link.active-route {
   transition: color var(--transition-fast);
 }
 
-.menu-item-container:hover .menu-item-chevron {
-  color: var(--text-color);
-}
-
-.menu-item-text {
+.layout-menuitem-text.menu-item-text {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: flex-start;
+  gap: var(--space-2);
   flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--text-base);
+}
+
+.menu-item-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .menu-item-leading {
@@ -163,21 +188,27 @@ a.menu-item-link.active-route {
   display: none;
 }
 
-.menu-item-container:hover .entity-menu-icon,
 .menu-item-container.menu-open .entity-menu-icon {
   display: inline;
 }
 
-.menu-item-container:hover .entity-menu-count,
 .menu-item-container.menu-open .entity-menu-count {
   display: none;
 }
 
 .book-count {
   color: var(--text-color-secondary);
-  padding-right: var(--space-3);
   font-size: var(--text-sm);
   font-variant-numeric: tabular-nums;
+}
+
+.book-count-end {
+  padding-right: var(--space-3);
+}
+
+.book-count-inline {
+  display: none;
+  flex-shrink: 0;
 }
 
 .library-health-dot {
@@ -190,6 +221,56 @@ a.menu-item-link.active-route {
   border-radius: 50%;
   background-color: #ef4444;
   animation: pulse 2s ease-in-out infinite;
+}
+
+@media #{variables.$mobile-shell-media-query} {
+  .menu-item-container:hover,
+  .menu-item-container:focus-within,
+  .menu-item-container:has(.menu-item-link:focus-visible),
+  .menu-item-container:has(:focus-visible) {
+    background-color: transparent;
+    box-shadow: none;
+  }
+
+  .menu-item-container.active-route-container {
+    background-color: color-mix(in srgb, var(--primary-color) 8%, transparent);
+  }
+
+  .menu-item-container:has(:focus-visible) {
+    outline: 2px solid var(--primary-color);
+    outline-offset: -2px;
+  }
+
+  .entity-menu-button:focus-visible {
+    background-color: transparent;
+    box-shadow: none;
+    outline: none;
+  }
+
+  .book-count-inline {
+    display: inline;
+  }
+
+  .menu-item-end-content:not(:has(.entity-menu-button)) {
+    display: none;
+  }
+
+  .book-count-end,
+  .entity-menu-count {
+    display: none;
+  }
+
+  .entity-menu-icon {
+    display: inline;
+  }
+
+  .menu-item-end-content {
+    padding-right: var(--sidebar-row-padding-inline-end);
+  }
+
+  .entity-menu-button {
+    margin-right: -0.25rem;
+  }
 }
 
 @keyframes pulse {

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Renderer2, RendererStyleFlags2, computed, inject, input, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { Menu } from 'primeng/menu';
 import { Tooltip } from 'primeng/tooltip';
@@ -35,6 +35,8 @@ export class AppMenuItemRowComponent {
 
   private readonly userService = inject(UserService);
   readonly layoutService = inject(LayoutService);
+  private readonly renderer = inject(Renderer2);
+  private contextMenuTrigger: HTMLElement | null = null;
 
   readonly isRouteActive = computed(() => {
     const route = this.item().routerLink?.[0];
@@ -56,13 +58,43 @@ export class AppMenuItemRowComponent {
   }
 
   openContextMenu(event: Event, menu: Menu): void {
+    this.contextMenuTrigger = event.currentTarget instanceof HTMLElement
+      ? event.currentTarget
+      : null;
     menu.toggle(event);
     this.menuOpen.update((open) => !open);
     event.stopPropagation();
   }
 
+  positionContextMenu(menu: Menu): void {
+    if (this.layoutService.isDesktop()) return;
+
+    const trigger = this.contextMenuTrigger;
+    const panel = menu.container;
+    if (!trigger || !(panel instanceof HTMLElement)) return;
+
+    const gutter = 8;
+    const rect = trigger.getBoundingClientRect();
+    const panelWidth = panel.offsetWidth;
+    const panelHeight = panel.offsetHeight;
+    const spaceAbove = rect.top - gutter;
+    const spaceBelow = window.innerHeight - rect.bottom - gutter;
+    const placeBelow = spaceBelow >= panelHeight || spaceBelow >= spaceAbove;
+    const availableHeight = Math.max(placeBelow ? spaceBelow : spaceAbove, 0);
+    const left = Math.max(Math.min(rect.right + gutter, window.innerWidth - panelWidth - gutter), gutter);
+    const top = placeBelow
+      ? rect.bottom + gutter
+      : rect.top - Math.min(panelHeight, availableHeight) - gutter;
+
+    const flags = RendererStyleFlags2.DashCase;
+    this.renderer.setStyle(panel, '--sidebar-popover-left', `${left}px`, flags);
+    this.renderer.setStyle(panel, '--sidebar-popover-top', `${Math.max(top, gutter)}px`, flags);
+    this.renderer.setStyle(panel, '--sidebar-popover-max-height', `${availableHeight}px`, flags);
+  }
+
   closeContextMenu(): void {
     this.menuOpen.set(false);
+    this.contextMenuTrigger = null;
   }
 
   getIconSelection(): IconSelection | null {

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-item-row.component.ts
@@ -62,11 +62,11 @@ export class AppMenuItemRowComponent {
       ? event.currentTarget
       : null;
     menu.toggle(event);
-    this.menuOpen.update((open) => !open);
     event.stopPropagation();
   }
 
   positionContextMenu(menu: Menu): void {
+    this.menuOpen.set(true);
     if (this.layoutService.isDesktop()) return;
 
     const trigger = this.contextMenuTrigger;

--- a/frontend/src/app/shared/layout/layout-menu/app.menu-section.component.scss
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu-section.component.scss
@@ -1,3 +1,5 @@
+@use "../../../../assets/layout/styles/layout/variables";
+
 :host {
   display: block;
   list-style: none;
@@ -52,9 +54,20 @@
 
 .expand-icon {
   color: var(--surface-500);
+}
 
-  &:hover {
+@media (hover: hover) and (pointer: fine) {
+  .expand-icon:hover {
     color: var(--surface-200);
+  }
+}
+
+@media #{variables.$mobile-shell-media-query} {
+  .root-item-with-dropdown:focus-visible {
+    background-color: transparent;
+    box-shadow: none;
+    outline: 2px solid var(--primary-color);
+    outline-offset: -2px;
   }
 }
 
@@ -93,7 +106,7 @@
   }
 }
 
-@media (width <= 767px) {
+@media #{variables.$mobile-shell-media-query} {
   .expand-icon-button {
     opacity: 1;
     width: 2rem;

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
@@ -1,5 +1,30 @@
 <ng-container *transloco="let t; prefix: 'layout.menu'">
 <div class="menu-container">
+  <ng-template #sidebarUserMenuStart>
+    @if (currentUser(); as menuUser) {
+      <div class="sidebar-user-menu-header">
+        <span class="sidebar-user-avatar" aria-hidden="true">{{ userInitials() }}</span>
+        <span class="sidebar-user-meta">
+          <span class="sidebar-user-name">{{ menuUser.name || menuUser.username }}</span>
+          @if (menuUser.name) {
+            <span class="sidebar-user-handle">&#64;{{ menuUser.username }}</span>
+          }
+        </span>
+      </div>
+    }
+  </ng-template>
+
+  <ng-template #sidebarUserMenuEnd>
+    @if (version(); as v) {
+      <div class="sidebar-user-menu-footer">
+        <span>Grimmory v{{ v.current }}</span>
+        @if (hasUpdate()) {
+          <span class="sidebar-user-update">{{ t('update') }}</span>
+        }
+      </div>
+    }
+  </ng-template>
+
   <div class="sidebar-header">
     <a class="sidebar-brand" [routerLink]="['/dashboard']" [attr.aria-label]="t('goToDashboard')">
       <span class="sidebar-brand-mark" aria-hidden="true">
@@ -50,6 +75,75 @@
 
     <button
       type="button"
+      class="sidebar-icon-button sidebar-mobile-landscape-action"
+      [pTooltip]="t('add')"
+      [tooltipDisabled]="!layoutService.isDesktop()"
+      tooltipPosition="bottom"
+      [attr.aria-label]="t('add')"
+      aria-haspopup="menu"
+      [attr.aria-expanded]="addMenu.visible ? 'true' : 'false'"
+      (click)="openSidebarOverlay($event, addMenu, 'below')"
+    >
+      <i class="pi pi-plus" aria-hidden="true"></i>
+    </button>
+
+    <button
+      type="button"
+      class="sidebar-icon-button sidebar-mobile-landscape-action"
+      [attr.aria-label]="t('notifications')"
+      [pTooltip]="t('notifications')"
+      [tooltipDisabled]="!layoutService.isDesktop()"
+      tooltipPosition="bottom"
+      aria-haspopup="dialog"
+      [attr.aria-expanded]="notificationsPopover.overlayVisible ? 'true' : 'false'"
+      (click)="openSidebarOverlay($event, notificationsPopover, 'below')"
+    >
+      <i class="pi pi-bell" aria-hidden="true"></i>
+    </button>
+
+    <button
+      type="button"
+      class="sidebar-icon-button sidebar-mobile-landscape-action"
+      [attr.aria-label]="t('more')"
+      [pTooltip]="t('more')"
+      [tooltipDisabled]="!layoutService.isDesktop()"
+      tooltipPosition="bottom"
+      aria-haspopup="menu"
+      [attr.aria-expanded]="moreMenu.visible ? 'true' : 'false'"
+      (click)="openSidebarOverlay($event, moreMenu, 'below')"
+    >
+      <i class="pi pi-ellipsis-h" aria-hidden="true"></i>
+    </button>
+
+    <p-menu #addMenu [model]="addMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-more-menu sidebar-footer-popover" (onShow)="applySidebarOverlayPosition(addMenu)"/>
+    <p-popover #notificationsPopover appendTo="body" styleClass="sidebar-flyout-popover" (onShow)="applySidebarOverlayPosition(notificationsPopover)">
+      <app-unified-notification-popover-component></app-unified-notification-popover-component>
+    </p-popover>
+    <p-menu #moreMenu [model]="moreMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-more-menu sidebar-footer-popover" (onShow)="applySidebarOverlayPosition(moreMenu)"/>
+
+    @if (currentUser(); as user) {
+      <button
+        type="button"
+        class="sidebar-icon-button sidebar-mobile-user-button"
+        [attr.aria-label]="t('profile')"
+        aria-haspopup="menu"
+        (click)="openSidebarOverlay($event, mobileUserMenu, 'below')"
+      >
+        <span class="sidebar-user-avatar" aria-hidden="true">{{ userInitials() }}</span>
+      </button>
+
+      <p-menu #mobileUserMenu [model]="userMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-user-menu" (onShow)="applySidebarOverlayPosition(mobileUserMenu)">
+        <ng-template pTemplate="start">
+          <ng-container [ngTemplateOutlet]="sidebarUserMenuStart"></ng-container>
+        </ng-template>
+        <ng-template pTemplate="end">
+          <ng-container [ngTemplateOutlet]="sidebarUserMenuEnd"></ng-container>
+        </ng-template>
+      </p-menu>
+    }
+
+    <button
+      type="button"
       class="sidebar-icon-button sidebar-mobile-close-button"
       [attr.aria-label]="'layout.closeNavigation' | transloco"
       (click)="closeMobileSidebar()"
@@ -87,6 +181,7 @@
         type="button"
         class="sidebar-action-link sidebar-footer-action sidebar-toolbar-button"
         [pTooltip]="t('add')"
+        [tooltipDisabled]="!layoutService.isDesktop()"
         tooltipPosition="top"
         [attr.aria-label]="t('add')"
         (click)="openSidebarOverlay($event, addMenu, 'above')"
@@ -100,6 +195,7 @@
         class="sidebar-action-link sidebar-footer-action"
         [attr.aria-label]="t('notifications')"
         [pTooltip]="t('notifications')"
+        [tooltipDisabled]="!layoutService.isDesktop()"
         tooltipPosition="top"
         (click)="openSidebarOverlay($event, notificationsPopover, layoutService.isDesktop() ? 'below' : 'above')"
       >
@@ -112,6 +208,7 @@
         class="sidebar-action-link sidebar-footer-action"
         [attr.aria-label]="t('more')"
         [pTooltip]="t('more')"
+        [tooltipDisabled]="!layoutService.isDesktop()"
         tooltipPosition="top"
         (click)="openSidebarOverlay($event, moreMenu, 'above')"
       >
@@ -119,12 +216,6 @@
         <span>{{ t('more') }}</span>
       </button>
     </div>
-    <p-menu #addMenu [model]="addMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-more-menu sidebar-footer-popover" (onShow)="applyOverlayBottom(addMenu)"/>
-    <p-popover #notificationsPopover appendTo="body" styleClass="sidebar-flyout-popover" (onShow)="applyOverlayBottom(notificationsPopover)">
-      <app-unified-notification-popover-component></app-unified-notification-popover-component>
-    </p-popover>
-    <p-menu #moreMenu [model]="moreMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-more-menu sidebar-footer-popover" (onShow)="applyOverlayBottom(moreMenu)"/>
-
     @if (currentUser(); as user) {
       <div class="sidebar-footer-bottom">
         <button
@@ -164,27 +255,12 @@
           ></i>
         </button>
       </div>
-      <p-menu #userMenu [model]="userMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-user-menu" (onShow)="applyOverlayBottom(userMenu)">
+      <p-menu #userMenu [model]="userMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-user-menu" (onShow)="applySidebarOverlayPosition(userMenu)">
         <ng-template pTemplate="start">
-          <div class="sidebar-user-menu-header">
-            <span class="sidebar-user-avatar" aria-hidden="true">{{ userInitials() }}</span>
-            <span class="sidebar-user-meta">
-              <span class="sidebar-user-name">{{ user.name || user.username }}</span>
-              @if (user.name) {
-                <span class="sidebar-user-handle">&#64;{{ user.username }}</span>
-              }
-            </span>
-          </div>
+          <ng-container [ngTemplateOutlet]="sidebarUserMenuStart"></ng-container>
         </ng-template>
         <ng-template pTemplate="end">
-          @if (version(); as v) {
-            <div class="sidebar-user-menu-footer">
-              <span>Grimmory v{{ v.current }}</span>
-              @if (hasUpdate()) {
-                <span class="sidebar-user-update">{{ t('update') }}</span>
-              }
-            </div>
-          }
+          <ng-container [ngTemplateOutlet]="sidebarUserMenuEnd"></ng-container>
         </ng-template>
       </p-menu>
     } @else {

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.html
@@ -81,7 +81,7 @@
       tooltipPosition="bottom"
       [attr.aria-label]="t('add')"
       aria-haspopup="menu"
-      [attr.aria-expanded]="addMenu.visible ? 'true' : 'false'"
+      [attr.aria-expanded]="addMenuOpen() ? 'true' : 'false'"
       (click)="openSidebarOverlay($event, addMenu, 'below')"
     >
       <i class="pi pi-plus" aria-hidden="true"></i>
@@ -95,7 +95,7 @@
       [tooltipDisabled]="!layoutService.isDesktop()"
       tooltipPosition="bottom"
       aria-haspopup="dialog"
-      [attr.aria-expanded]="notificationsPopover.overlayVisible ? 'true' : 'false'"
+      [attr.aria-expanded]="notificationsOpen() ? 'true' : 'false'"
       (click)="openSidebarOverlay($event, notificationsPopover, 'below')"
     >
       <i class="pi pi-bell" aria-hidden="true"></i>
@@ -109,17 +109,17 @@
       [tooltipDisabled]="!layoutService.isDesktop()"
       tooltipPosition="bottom"
       aria-haspopup="menu"
-      [attr.aria-expanded]="moreMenu.visible ? 'true' : 'false'"
+      [attr.aria-expanded]="moreMenuOpen() ? 'true' : 'false'"
       (click)="openSidebarOverlay($event, moreMenu, 'below')"
     >
       <i class="pi pi-ellipsis-h" aria-hidden="true"></i>
     </button>
 
-    <p-menu #addMenu [model]="addMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-more-menu sidebar-footer-popover" (onShow)="applySidebarOverlayPosition(addMenu)"/>
-    <p-popover #notificationsPopover appendTo="body" styleClass="sidebar-flyout-popover" (onShow)="applySidebarOverlayPosition(notificationsPopover)">
+    <p-menu #addMenu [model]="addMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-more-menu sidebar-footer-popover" (onShow)="addMenuOpen.set(true); applySidebarOverlayPosition(addMenu)" (onHide)="addMenuOpen.set(false)"/>
+    <p-popover #notificationsPopover appendTo="body" styleClass="sidebar-flyout-popover" (onShow)="notificationsOpen.set(true); applySidebarOverlayPosition(notificationsPopover)" (onHide)="notificationsOpen.set(false)">
       <app-unified-notification-popover-component></app-unified-notification-popover-component>
     </p-popover>
-    <p-menu #moreMenu [model]="moreMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-more-menu sidebar-footer-popover" (onShow)="applySidebarOverlayPosition(moreMenu)"/>
+    <p-menu #moreMenu [model]="moreMenuItems()" [popup]="true" appendTo="body" styleClass="sidebar-more-menu sidebar-footer-popover" (onShow)="moreMenuOpen.set(true); applySidebarOverlayPosition(moreMenu)" (onHide)="moreMenuOpen.set(false)"/>
 
     @if (currentUser(); as user) {
       <button

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.scss
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.scss
@@ -1,3 +1,5 @@
+@use "../../../../assets/layout/styles/layout/variables";
+
 .menu-container {
   display: flex;
   flex-direction: column;
@@ -12,6 +14,11 @@
   gap: var(--space-2);
   padding: var(--sidebar-header-padding-block) 0;
   margin-bottom: var(--sidebar-header-gap-after);
+}
+
+.sidebar-header > p-menu,
+.sidebar-header > p-popover {
+  display: none;
 }
 
 .sidebar-brand {
@@ -90,6 +97,14 @@
 }
 
 .sidebar-icon-button.sidebar-mobile-close-button {
+  display: none;
+}
+
+.sidebar-icon-button.sidebar-mobile-user-button {
+  display: none;
+}
+
+.sidebar-icon-button.sidebar-mobile-landscape-action {
   display: none;
 }
 
@@ -353,21 +368,37 @@
   white-space: nowrap;
 }
 
-@media (width <= 767px) {
+@media #{variables.$mobile-shell-media-query} {
   .sidebar-header {
-    align-items: flex-start;
-    margin-bottom: var(--space-3);
+    box-sizing: border-box;
+    align-items: center;
+    min-height: 3.5rem;
+    height: 3.5rem;
+    gap: 0.5rem;
+    padding:
+      0
+      calc(var(--sidebar-shell-padding-inline-end) + env(safe-area-inset-right))
+      0
+      calc(var(--sidebar-shell-padding-inline-start) + env(safe-area-inset-left));
+    margin:
+      calc(0px - var(--space-3) - env(safe-area-inset-top))
+      calc(0px - var(--sidebar-shell-padding-inline-end) - env(safe-area-inset-right))
+      var(--space-3)
+      calc(0px - var(--sidebar-shell-padding-inline-start) - env(safe-area-inset-left));
   }
 
   .sidebar-brand {
     width: auto;
     flex: 1 1 auto;
+    min-height: 3.5rem;
+    padding: 0 var(--space-3);
+    align-self: stretch;
   }
 
   .sidebar-icon-button.sidebar-mobile-close-button {
     display: inline-flex;
-    width: 3rem;
-    height: 3rem;
+    width: 2.5rem;
+    height: 2.5rem;
     border-radius: var(--radius-pill);
     background-color: var(--surface-hover);
     color: var(--text-color);
@@ -379,6 +410,19 @@
 
   .sidebar-nav-top {
     display: none;
+  }
+
+  .sidebar-nav {
+    margin-inline:
+      calc(0px - var(--sidebar-shell-padding-inline-start) - env(safe-area-inset-left))
+      calc(0px - var(--sidebar-shell-padding-inline-end) - env(safe-area-inset-right));
+  }
+
+  .sidebar-nav > .layout-menu {
+    box-sizing: border-box;
+    padding-inline:
+      calc(var(--sidebar-shell-padding-inline-start) + env(safe-area-inset-left))
+      calc(var(--sidebar-shell-padding-inline-end) + env(safe-area-inset-right));
   }
 
   .sidebar-search-shortcut {
@@ -434,5 +478,103 @@
 
   .sidebar-collapse-button {
     display: none;
+  }
+
+  @media (orientation: landscape) {
+    .sidebar-header {
+      gap: 0.5rem;
+      min-height: 4rem;
+      height: 4rem;
+      padding:
+        var(--space-2)
+        var(--sidebar-shell-padding-inline-end)
+        0
+        calc(var(--sidebar-shell-padding-inline-start) + env(safe-area-inset-left));
+      margin:
+        calc(0px - var(--space-3) - env(safe-area-inset-top))
+        calc(0px - var(--sidebar-shell-padding-inline-end))
+        var(--space-3)
+        calc(0px - var(--sidebar-shell-padding-inline-start) - env(safe-area-inset-left));
+    }
+
+    .sidebar-brand {
+      flex: 0 0 auto;
+      grid-template-columns: var(--sidebar-row-icon-size);
+      min-height: 4rem;
+    }
+
+    .sidebar-brand-mark {
+      display: inline-flex;
+    }
+
+    .sidebar-brand-wordmark {
+      display: none;
+    }
+
+    .sidebar-nav {
+      margin-inline:
+        calc(0px - var(--sidebar-shell-padding-inline-start) - env(safe-area-inset-left))
+        calc(0px - var(--sidebar-shell-padding-inline-end));
+    }
+
+    .sidebar-nav > .layout-menu {
+      padding-inline:
+        calc(var(--sidebar-shell-padding-inline-start) + env(safe-area-inset-left))
+        var(--sidebar-shell-padding-inline-end);
+    }
+
+    .sidebar-icon-button.sidebar-mobile-close-button {
+      width: 3rem;
+      height: 3rem;
+      background: none;
+
+      &:hover {
+        background-color: var(--surface-hover);
+      }
+    }
+
+    .sidebar-icon-button.sidebar-mobile-user-button {
+      display: inline-flex;
+      width: 3rem;
+      height: 3rem;
+      border-radius: var(--radius-pill);
+      background: none;
+
+      &:hover {
+        background: none;
+
+        .sidebar-user-avatar {
+          background-color: color-mix(in srgb, var(--primary-color) 24%, transparent);
+        }
+      }
+
+      .sidebar-user-avatar {
+        width: 2rem;
+        height: 2rem;
+        margin-left: 0;
+        font-size: var(--text-sm);
+      }
+    }
+
+    .sidebar-icon-button.sidebar-mobile-landscape-action {
+      display: inline-flex;
+      width: 3rem;
+      height: 3rem;
+      border-radius: var(--radius-pill);
+      background: none;
+      color: var(--text-color);
+
+      &:hover {
+        background-color: var(--surface-hover);
+      }
+    }
+
+    .sidebar-footer {
+      display: none;
+    }
+
+    .sidebar-footer-bottom {
+      display: none;
+    }
   }
 }

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.spec.ts
@@ -109,6 +109,10 @@ describe('AppMenuComponent', () => {
     component = fixture.componentInstance;
     layoutService.isDesktop.set(true);
     layoutService.closeMobileSidebar.mockReset();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback): number => {
+      callback(0);
+      return 0;
+    });
   });
 
   afterEach(() => {

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.spec.ts
@@ -133,13 +133,13 @@ describe('AppMenuComponent', () => {
     vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue(createRect(100, 148, 40));
     const container = document.createElement('div');
     const overlay = { container, toggle: vi.fn() };
-    const menuHarness = component as unknown as { applyOverlayBottom(overlay: MenuOverlay): void };
+    const menuHarness = component as unknown as { applySidebarOverlayPosition(overlay: MenuOverlay): void };
 
     component.openSidebarOverlay({ currentTarget: trigger } as unknown as MouseEvent, overlay as never, 'above');
-    menuHarness.applyOverlayBottom(overlay);
+    menuHarness.applySidebarOverlayPosition(overlay);
 
     expect(overlay.toggle).toHaveBeenCalled();
-    expect(container.style.getPropertyValue('--sidebar-popover-bottom')).toBe(`${window.innerHeight - 100 + 8}px`);
+    expect(container.style.getPropertyValue('--sidebar-popover-top')).toBe('92px');
     expect(container.style.getPropertyValue('--sidebar-popover-left')).toBe('40px');
   });
 
@@ -148,12 +148,12 @@ describe('AppMenuComponent', () => {
     vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue(createRect(220, 260, 24));
     const container = document.createElement('div');
     const overlay = { container, toggle: vi.fn() };
-    const menuHarness = component as unknown as { applyOverlayBottom(overlay: MenuOverlay): void };
+    const menuHarness = component as unknown as { applySidebarOverlayPosition(overlay: MenuOverlay): void };
 
     component.openSidebarOverlay({ currentTarget: trigger } as unknown as MouseEvent, overlay as never, 'below');
-    menuHarness.applyOverlayBottom(overlay);
+    menuHarness.applySidebarOverlayPosition(overlay);
 
-    expect(container.style.getPropertyValue('--sidebar-popover-bottom')).toBe(`${window.innerHeight - 260}px`);
+    expect(container.style.getPropertyValue('--sidebar-popover-top')).toBe('268px');
     expect(container.style.getPropertyValue('--sidebar-popover-left')).toBe('');
   });
 
@@ -189,12 +189,12 @@ describe('AppMenuComponent', () => {
     const container = document.createElement('div');
     Object.defineProperty(container, 'offsetWidth', { value: 120, configurable: true });
     const overlay = { container, toggle: vi.fn() };
-    const menuHarness = component as unknown as { applyOverlayBottom(overlay: MenuOverlay): void };
+    const menuHarness = component as unknown as { applySidebarOverlayPosition(overlay: MenuOverlay): void };
 
     component.openSidebarOverlay({ currentTarget: trigger } as unknown as MouseEvent, overlay as never, 'above');
-    menuHarness.applyOverlayBottom(overlay);
+    menuHarness.applySidebarOverlayPosition(overlay);
 
-    expect(container.style.getPropertyValue('--sidebar-popover-bottom')).toBe(`${window.innerHeight - 220 + 8}px`);
+    expect(container.style.getPropertyValue('--sidebar-popover-top')).toBe('212px');
     expect(container.style.getPropertyValue('--sidebar-popover-left')).toBe(`${window.innerWidth - 128}px`);
   });
 });

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, Renderer2, RendererStyleFlags2, computed, inject } from '@angular/core';
+import { Component, Renderer2, RendererStyleFlags2, computed, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { AppMenuSectionComponent } from './app.menu-section.component';
 import { Popover } from 'primeng/popover';
@@ -146,6 +146,9 @@ export class AppMenuComponent {
   });
 
   readonly hasUpdate = computed(() => hasAppUpdate(this.version()));
+  protected readonly addMenuOpen = signal(false);
+  protected readonly notificationsOpen = signal(false);
+  protected readonly moreMenuOpen = signal(false);
 
   readonly userMenuItems = computed<MenuItem[]>(() => {
     this.activeLang();
@@ -208,6 +211,15 @@ export class AppMenuComponent {
     const panel = overlay.container;
     if (!anchor || !panel) return;
 
+    window.requestAnimationFrame(() => {
+      this.positionSidebarOverlay(anchor, panel);
+    });
+  }
+
+  private positionSidebarOverlay(
+    anchor: { trigger: HTMLElement; placement: 'above' | 'below' },
+    panel: HTMLElement,
+  ): void {
     const rect = anchor.trigger.getBoundingClientRect();
     const panelWidth = panel.offsetWidth;
     const panelHeight = panel.offsetHeight;

--- a/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
+++ b/frontend/src/app/shared/layout/layout-menu/app.menu.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, inject } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, Renderer2, RendererStyleFlags2, computed, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { AppMenuSectionComponent } from './app.menu-section.component';
 import { Popover } from 'primeng/popover';
@@ -55,7 +56,7 @@ function detectSearchShortcut(userAgent: string): string {
 
 @Component({
   selector: 'app-menu',
-  imports: [AppMenuSectionComponent, Popover, Menu, UnifiedNotificationBoxComponent, RouterLink, TranslocoDirective, TranslocoPipe, Tooltip],
+  imports: [AppMenuSectionComponent, Popover, Menu, UnifiedNotificationBoxComponent, RouterLink, TranslocoDirective, TranslocoPipe, Tooltip, NgTemplateOutlet],
   templateUrl: './app.menu.component.html',
   styleUrl: './app.menu.component.scss',
 })
@@ -76,6 +77,7 @@ export class AppMenuComponent {
   private readonly authorService = inject(AuthorService);
   private readonly versionService = inject(VersionService);
   private readonly t = inject(TranslocoService);
+  private readonly renderer = inject(Renderer2);
 
   readonly currentUser = this.userService.currentUser;
   readonly version = toSignal<AppVersion | null>(
@@ -199,35 +201,33 @@ export class AppMenuComponent {
     this.layoutService.closeMobileSidebar();
   }
 
-  // Each overlay remembers its own trigger so the position can be re-read when the
-  // panel renders. Scoping the offset to each panel (instead of a shared variable on
-  // <html>) means a closing overlay holds its place while a new one opens elsewhere.
   private readonly anchorByOverlay = new WeakMap<Menu | Popover, { trigger: HTMLElement; placement: 'above' | 'below' }>();
 
-  protected applyOverlayBottom(overlay: Menu | Popover): void {
+  protected applySidebarOverlayPosition(overlay: Menu | Popover): void {
     const anchor = this.anchorByOverlay.get(overlay);
     const panel = overlay.container;
     if (!anchor || !panel) return;
 
     const rect = anchor.trigger.getBoundingClientRect();
     const panelWidth = panel.offsetWidth;
+    const panelHeight = panel.offsetHeight;
     const left = Math.max(Math.min(rect.left, window.innerWidth - panelWidth - 8), 8);
+    const maxTop = Math.max(window.innerHeight - panelHeight - 8, 8);
 
-    // `above` collapses to `below` when the sidebar is narrow, because the
-    // anchored left offset assumes an expanded footer row.
     const anchorAbove = anchor.placement === 'above' && !this.layoutService.desktopSidebarCollapsed();
-    if (anchorAbove) {
-      const bottom = Math.max(window.innerHeight - rect.top + 8, 8);
-      panel.style.setProperty('--sidebar-popover-bottom', `${bottom}px`);
-      panel.style.setProperty('--sidebar-popover-left', `${left}px`);
+    const requestedTop = anchorAbove
+      ? rect.top - panelHeight - 8
+      : rect.bottom + 8;
+    const top = Math.max(Math.min(requestedTop, maxTop), 8);
+
+    const flags = RendererStyleFlags2.DashCase;
+    this.renderer.setStyle(panel, '--sidebar-popover-top', `${top}px`, flags);
+    this.renderer.setStyle(panel, '--sidebar-popover-max-height', `${Math.max(window.innerHeight - top - 8, 0)}px`, flags);
+
+    if (anchorAbove || !this.layoutService.isDesktop()) {
+      this.renderer.setStyle(panel, '--sidebar-popover-left', `${left}px`, flags);
     } else {
-      const bottom = Math.max(window.innerHeight - rect.bottom, 8);
-      panel.style.setProperty('--sidebar-popover-bottom', `${bottom}px`);
-      if (this.layoutService.isDesktop()) {
-        panel.style.removeProperty('--sidebar-popover-left');
-      } else {
-        panel.style.setProperty('--sidebar-popover-left', `${left}px`);
-      }
+      this.renderer.removeStyle(panel, '--sidebar-popover-left', flags);
     }
   }
 

--- a/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.scss
+++ b/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.scss
@@ -1,3 +1,5 @@
+@use "../../../../assets/layout/styles/layout/variables";
+
 :host {
   display: contents;
 }
@@ -8,11 +10,16 @@
   top: 0;
   left: 0;
   right: 0;
+  box-sizing: border-box;
   height: 3.5rem;
   z-index: 100;
   background-color: var(--app-background);
   border-bottom: 1px solid var(--content-border-color);
-  padding: 0 0.75rem;
+  padding:
+    0
+    calc(0.75rem + env(safe-area-inset-right))
+    0
+    calc(0.75rem + env(safe-area-inset-left));
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
@@ -74,7 +81,7 @@
   }
 }
 
-@media (width <= 767px) {
+@media #{variables.$mobile-shell-media-query} {
   .mobile-topbar {
     display: flex;
   }

--- a/frontend/src/app/shared/layout/layout.service.spec.ts
+++ b/frontend/src/app/shared/layout/layout.service.spec.ts
@@ -20,6 +20,8 @@ describe('LayoutService', () => {
     },
   } as never);
   const updateUserSetting = vi.fn();
+  let resizeListener: (() => void) | undefined;
+  let mobileShellActive = false;
   const localStorageService = {
     get: vi.fn((key: string) => {
       if (key === 'sidebarCollapsed') {
@@ -35,6 +37,18 @@ describe('LayoutService', () => {
 
   beforeEach(() => {
     routerEvents = new Subject<unknown>();
+    resizeListener = undefined;
+    mobileShellActive = false;
+    vi.spyOn(window, 'addEventListener').mockImplementation((type, listener) => {
+      if (type === 'resize') {
+        resizeListener = listener as () => void;
+      }
+    });
+    vi.spyOn(window, 'removeEventListener').mockImplementation(vi.fn());
+    vi.spyOn(window, 'getComputedStyle').mockImplementation(() => ({
+      getPropertyValue: (property: string) =>
+        property === '--mobile-shell-active' && mobileShellActive ? '1' : '',
+    }) as CSSStyleDeclaration);
     TestBed.configureTestingModule({
       providers: [
         LayoutService,
@@ -79,6 +93,21 @@ describe('LayoutService', () => {
     service.onMenuToggle();
     expect(service.mobileDrawerOpen()).toBe(true);
     service.onMenuToggle();
+    expect(service.mobileDrawerOpen()).toBe(false);
+  });
+
+  it('derives desktop state from the mobile shell CSS state', () => {
+    expect(service.isDesktop()).toBe(true);
+
+    mobileShellActive = true;
+    resizeListener?.();
+    expect(service.isDesktop()).toBe(false);
+
+    service.mobileDrawerOpen.set(true);
+    mobileShellActive = false;
+    resizeListener?.();
+
+    expect(service.isDesktop()).toBe(true);
     expect(service.mobileDrawerOpen()).toBe(false);
   });
 
@@ -145,12 +174,10 @@ describe('LayoutService', () => {
   });
 
   it('cleans up global listeners and router events when destroyed', () => {
-    const removeEventListener = vi.spyOn(window, 'removeEventListener');
-
     TestBed.resetTestingModule();
     routerEvents.next(new NavigationEnd(1, '/series', '/series'));
 
-    expect(removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(window.removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
     expect(service.currentPath()).toBe('/dashboard');
   });
 });

--- a/frontend/src/app/shared/layout/layout.service.ts
+++ b/frontend/src/app/shared/layout/layout.service.ts
@@ -18,9 +18,9 @@ import {
 export const SIDEBAR_MIN_WIDTH = 175;
 export const SIDEBAR_MAX_WIDTH = 400;
 export const SIDEBAR_DEFAULT_WIDTH = 225;
-const DESKTOP_MIN_WIDTH = 768;
 const SIDEBAR_EXPANDED_STATE_KEY = 'sidebarExpandedState';
 const SIDEBAR_TRANSITION_MS = 220;
+export const MOBILE_SHELL_ACTIVE_PROPERTY = '--mobile-shell-active';
 
 function readBooleanRecord(storage: LocalStorageService, key: string): Record<string, boolean> {
   const stored = storage.get<unknown>(key);
@@ -149,11 +149,21 @@ export class LayoutService {
   }
 
   private computeIsDesktop(): boolean {
-    return (this.document.defaultView?.innerWidth ?? DESKTOP_MIN_WIDTH) >= DESKTOP_MIN_WIDTH;
+    const view = this.document.defaultView;
+    if (!view) return true;
+
+    return view
+      .getComputedStyle(this.document.documentElement)
+      .getPropertyValue(MOBILE_SHELL_ACTIVE_PROPERTY)
+      .trim() !== '1';
   }
 
   private readonly onResize = (): void => {
-    this.isDesktop.set(this.computeIsDesktop());
+    const isDesktop = this.computeIsDesktop();
+    this.isDesktop.set(isDesktop);
+    if (isDesktop) {
+      this.closeMobileSidebar();
+    }
   };
 
   private setSidebarCollapsed(collapsed: boolean): void {

--- a/frontend/src/assets/layout/styles/layout/_menu.scss
+++ b/frontend/src/assets/layout/styles/layout/_menu.scss
@@ -1,4 +1,5 @@
 @use "mixins";
+@use "variables";
 
 :root {
   --sidebar-collapsed-width: 61px;
@@ -60,7 +61,7 @@
   display: none;
 }
 
-@media (width <= 767px) {
+@media #{variables.$mobile-shell-media-query} {
   .layout-sidebar-resize-handle {
     display: none;
   }

--- a/frontend/src/assets/layout/styles/layout/_responsive.scss
+++ b/frontend/src/assets/layout/styles/layout/_responsive.scss
@@ -1,34 +1,39 @@
-@media (width >= 768px) {
-  .layout-wrapper {
-    &.layout-sidebar-hidden {
-      grid-template-columns: 0 minmax(0, 1fr);
+@use "variables";
 
-      .layout-sidebar {
-        transform: translateX(-100%);
-        pointer-events: none;
-        visibility: hidden;
-      }
-    }
+.layout-wrapper {
+  &.layout-sidebar-hidden {
+    grid-template-columns: 0 minmax(0, 1fr);
 
-    .layout-mask {
-      display: none;
+    .layout-sidebar {
+      transform: translateX(-100%);
+      pointer-events: none;
+      visibility: hidden;
     }
+  }
+
+  .layout-mask {
+    display: none;
   }
 }
 
-@media (width <= 767px) {
+@media #{variables.$mobile-shell-media-query} {
   .blocked-scroll {
     overflow: hidden;
   }
 
   .layout-wrapper {
     display: block;
+    background-color: var(--page-background);
 
     .layout-main {
       --mobile-topbar-height: 3.5rem;
 
       box-sizing: border-box;
-      padding-top: var(--mobile-topbar-height);
+      padding:
+        var(--mobile-topbar-height)
+        env(safe-area-inset-right)
+        0
+        env(safe-area-inset-left);
     }
 
     .layout-sidebar {
@@ -57,9 +62,9 @@
       top: 0;
       left: 0;
       box-sizing: border-box;
-      width: min(24rem, calc(100vw - 1rem));
-      max-width: 100vw;
+      width: 100dvw;
       height: 100dvh;
+      border-right: 0;
       padding:
         calc(var(--space-3) + env(safe-area-inset-top))
         calc(var(--sidebar-shell-padding-inline-end) + env(safe-area-inset-right))
@@ -80,6 +85,7 @@
       --mobile-sidebar-fade-duration: 220ms;
 
       position: fixed;
+      display: block;
       top: 0;
       left: 0;
       z-index: 998;
@@ -114,11 +120,19 @@
   }
 }
 
-@media (width <= 768px) {
-  .layout-wrapper {
-    .layout-sidebar {
-      width: 100vw;
-      border-right: 0;
+@media #{variables.$mobile-shell-media-query} {
+  @media (orientation: landscape) {
+    .layout-wrapper {
+      .layout-sidebar {
+        width: fit-content;
+        max-width: calc(100dvw - 1rem);
+        border-right: 1px solid var(--border-color);
+        padding:
+          calc(var(--space-3) + env(safe-area-inset-top))
+          var(--sidebar-shell-padding-inline-end)
+          var(--space-3)
+          calc(var(--sidebar-shell-padding-inline-start) + env(safe-area-inset-left));
+      }
     }
   }
 }

--- a/frontend/src/assets/layout/styles/layout/_variables.scss
+++ b/frontend/src/assets/layout/styles/layout/_variables.scss
@@ -2,3 +2,4 @@
 $scale: 14px;                    /* main font size */ 
 $border-radius: 12px;            /* border radius of layout element e.g. card, sidebar */ 
 $transition-duration: .2s;       /* transition duration of layout elements e.g. sidebar */
+$mobile-shell-media-query: "(width <= 599px), ((width <= 959px) and (height <= 500px) and (pointer: coarse) and (hover: none))";

--- a/frontend/src/assets/styles/base.scss
+++ b/frontend/src/assets/styles/base.scss
@@ -1,3 +1,5 @@
+@use "../layout/styles/layout/variables";
+
 /*
  * Document defaults.
  *
@@ -8,6 +10,8 @@
  */
 
 html {
+  --mobile-shell-active: 0;
+
   height: 100%;
   font-family: var(--font-family), "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
   font-size: var(--font-size-root);
@@ -22,6 +26,17 @@ body {
   font-family: var(--font-family), serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+@media #{variables.$mobile-shell-media-query} {
+  html {
+    --mobile-shell-active: 1;
+  }
+
+  html,
+  body {
+    background-color: var(--page-background);
+  }
 }
 
 a {

--- a/frontend/src/assets/styles/overlays.scss
+++ b/frontend/src/assets/styles/overlays.scss
@@ -1,3 +1,5 @@
+@use "../layout/styles/layout/variables";
+
 /*
  * Native CDK overlay hooks.
  *
@@ -6,15 +8,15 @@
  */
 
 .command-palette-backdrop {
-  background: rgb(0 0 0 / 50%);
+  background: rgb(0 0 0 / 56%);
 }
 
-.command-palette-panel {
+.cdk-overlay-pane.command-palette-panel {
   display: flex;
   pointer-events: auto;
 }
 
-@media (width <= 991px) {
+@media #{variables.$mobile-shell-media-query} {
   .cdk-overlay-backdrop.command-palette-backdrop {
     top: 3.5rem;
   }

--- a/frontend/src/assets/styles/prime-compat.scss
+++ b/frontend/src/assets/styles/prime-compat.scss
@@ -1,3 +1,5 @@
+@use "../layout/styles/layout/variables";
+
 /*
  * PrimeNG compatibility layer.
  *
@@ -9,6 +11,17 @@
  * Native app/page/layout CSS should use app-owned tokens from tokens.css.
  * PrimeNG components can continue to use Prime's --p-* tokens.
  */
+
+@mixin sidebar-fixed-overlay {
+  position: fixed !important;
+  top: var(--sidebar-popover-top, 0.75rem) !important;
+  bottom: auto !important;
+  left: var(--sidebar-popover-left, calc(var(--sidebar-width, 225px) + 0.5rem)) !important;
+  max-height: var(--sidebar-popover-max-height, calc(100vh - 1rem)) !important;
+  margin: 0 !important;
+  overflow: auto !important;
+  transform: none !important;
+}
 
 .p-dialog {
   --card-background: var(--surface-content);
@@ -156,12 +169,7 @@
 .sidebar-flyout-popover.p-popover,
 .sidebar-more-menu.p-menu,
 .sidebar-user-menu.p-menu {
-  position: fixed !important;
-  top: auto !important;
-  bottom: var(--sidebar-popover-bottom, 0.75rem) !important;
-  left: var(--sidebar-popover-left, calc(var(--sidebar-width, 225px) + 0.5rem)) !important;
-  margin: 0 !important;
-  transform: none !important;
+  @include sidebar-fixed-overlay;
 
   &::before,
   &::after {
@@ -246,5 +254,41 @@
   .sidebar-user-update {
     color: var(--primary-color);
     font-weight: 500;
+  }
+}
+
+@media #{variables.$mobile-shell-media-query} {
+  .sidebar-entity-menu.p-menu {
+    @include sidebar-fixed-overlay;
+  }
+
+  .sidebar-entity-menu.p-menu,
+  .sidebar-more-menu.p-menu,
+  .sidebar-user-menu.p-menu,
+  .sidebar-flyout-popover.p-popover .p-menu,
+  .sidebar-flyout-popover.p-popover .p-tieredmenu {
+    > .p-menu-list,
+    .p-menu-list,
+    > .p-tieredmenu-root-list,
+    .p-tieredmenu-root-list,
+    .p-tieredmenu-submenu {
+      padding-block: var(--space-2) !important;
+    }
+
+    .p-menu-item-content > .p-menu-item-link,
+    .p-menu-item-link,
+    .p-tieredmenu-item-content > .p-tieredmenu-item-link,
+    .p-tieredmenu-item-link {
+      min-height: 3rem !important;
+      padding: var(--space-3) var(--space-4) !important;
+      gap: var(--space-3) !important;
+    }
+  }
+
+  .sidebar-user-menu.p-menu {
+    .sidebar-user-menu-header,
+    .sidebar-user-menu-footer {
+      padding: var(--space-3) var(--space-4);
+    }
   }
 }

--- a/frontend/src/assets/styles/prime-compat.scss
+++ b/frontend/src/assets/styles/prime-compat.scss
@@ -260,6 +260,10 @@
 @media #{variables.$mobile-shell-media-query} {
   .sidebar-entity-menu.p-menu {
     @include sidebar-fixed-overlay;
+
+    .p-menu-submenu-label {
+      display: none !important;
+    }
   }
 
   .sidebar-entity-menu.p-menu,


### PR DESCRIPTION
## Description

PR focused on improving the mobile CSS for a better experience using the mobile topbar, sidebar and search. 

<!-- Required. Briefly explain what changed and why. -->

## Linked Issue

Fixes #1151 (among many other mobile points mentioned on Discord)

## Changes

Various mobile enhancements: 
- New mobile variable to better trigger mobile UI (E.g. what pointer you're using), not just width
- Moved mobile search to use the topbar space, fixes issue where keyboard was too tall to show the search box at all on landscape. 
- Added iOS safe areas for landscape, avoiding any clipping. 
- Mobile landscape styling for sidebar
- Mobile landscape now shows menu buttons at all times
- Improved positioning of menus and popovers in the sidebar to avoid clipping off the edge of the screen. 
- Larger -p-menu padding for mobile
- Removed desktop-specific styling for mobile sidebar such as hover colours and tooltips
- Fixed nonexistent mobile spacing on a few pages (Notebook, Bookdrop etc)


## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1.
2.
3.

## Screenshots (Optional)

Landscape sidebar and iOS safe areas
<img width="2868" height="1320" alt="image" src="https://github.com/user-attachments/assets/000dfd5a-743d-442d-a007-9cda931cdb10" />

Desktop narrow width preserved: 
<img width="808" height="982" alt="Screenshot 2026-05-07 at 12 27 16" src="https://github.com/user-attachments/assets/2bd524be-4226-4f74-af13-396f563da5e8" />

Larger menu padding on mobile
<img width="187" height="345" alt="Screenshot 2026-05-07 at 12 28 23" src="https://github.com/user-attachments/assets/9ec17ecd-0be9-43e2-a6bf-140a824f631a" />

Mobile search in the topbar: 
<img width="342" height="328" alt="Screenshot 2026-05-07 at 12 31 48" src="https://github.com/user-attachments/assets/c4a4808e-97db-465e-a5e0-b218f3a1f38f" />


## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Close (X) button added to the command palette for quicker dismissal.
  * Sidebar/popover positioning improved for more reliable above/below placement.

* **Bug Fixes**
  * Improved mobile layout, spacing, and safe-area inset support for notched devices.
  * Reduced overlay clipping and ensured popovers stay within the viewport.

* **Style**
  * Unified mobile breakpoint and consolidated responsive behavior across the app.
  * Slightly darker command-palette backdrop and refined menu/item focus states.

* **Tests**
  * Updated overlay/positioning tests and requestAnimationFrame handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->