### PR TITLE
feat(api): infer reading session data points when not specified

### DIFF
--- a/backend/src/main/java/org/booklore/model/dto/request/ReadingSessionRequest.java
+++ b/backend/src/main/java/org/booklore/model/dto/request/ReadingSessionRequest.java
@@ -23,7 +23,6 @@ public class ReadingSessionRequest {
     @NotNull
     private Instant endTime;
 
-    @NotNull
     private Integer durationSeconds;
 
     private String durationFormatted;

--- a/backend/src/main/java/org/booklore/service/ReadingSessionService.java
+++ b/backend/src/main/java/org/booklore/service/ReadingSessionService.java
@@ -14,6 +14,7 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookLoreUserEntity;
 import org.booklore.model.entity.CategoryEntity;
 import org.booklore.model.entity.ReadingSessionEntity;
+import org.booklore.model.enums.BookFileType;
 import org.booklore.model.enums.ReadStatus;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.ReadingSessionRepository;
@@ -26,11 +27,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.*;
 import java.time.format.TextStyle;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
@@ -90,32 +87,69 @@ public class ReadingSessionService {
         return (dow.getValue() % 7) + 1;
     }
 
+    private String getDurationFormatted(int duration) {
+        int hours = duration / 3600;
+        int minutes = (duration % 3600) / 60;
+        int seconds = duration % 60;
+
+        if (hours > 0) {
+            return String.format("%dh %dm %ds", hours, minutes, seconds);
+        } else if (minutes > 0) {
+            return String.format("%dm %ds", minutes, seconds);
+        } else {
+            return String.format("%ds", seconds);
+        }
+    }
+
     @Transactional
     public void recordSession(ReadingSessionRequest request) {
         BookLoreUser authenticatedUser = authenticationService.getAuthenticatedUser();
         Long userId = authenticatedUser.getId();
 
         BookLoreUserEntity userEntity = userRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("User not found with ID: " + userId));
-        BookEntity book = bookRepository.findById(request.getBookId()).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(request.getBookId()));
+        BookEntity book = bookRepository.findByIdWithBookFiles(request.getBookId()).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(request.getBookId()));
+
+        BookFileType bookType = request.getBookType();
+        if (bookType == null && book.getPrimaryBookFile() != null) {
+            bookType = book.getPrimaryBookFile().getBookType();
+        }
+
+        Integer durationSeconds = request.getDurationSeconds();
+        if (durationSeconds == null) {
+            // We don't need to check if request start / end time are non-null because
+            // that's enforced by the request model.
+            Duration duration = request.getStartTime().until(request.getEndTime());
+            durationSeconds = Math.abs(Math.toIntExact(duration.getSeconds()));
+        }
+
+        String durationFormatted = request.getDurationFormatted();
+        if (durationFormatted == null) {
+            durationFormatted = getDurationFormatted(durationSeconds);
+        }
+
+        Float progressDelta = request.getProgressDelta();
+        if (progressDelta == null && request.getStartProgress() != null && request.getEndProgress() != null) {
+            progressDelta = Math.abs(request.getEndProgress() - request.getStartProgress());
+        }
 
         ReadingSessionEntity session = ReadingSessionEntity.builder()
                 .user(userEntity)
                 .book(book)
-                .bookType(request.getBookType())
+                .bookType(bookType)
                 .startTime(request.getStartTime())
                 .endTime(request.getEndTime())
-                .durationSeconds(request.getDurationSeconds())
-                .durationFormatted(request.getDurationFormatted())
+                .durationSeconds(durationSeconds)
+                .durationFormatted(durationFormatted)
                 .startProgress(request.getStartProgress())
                 .endProgress(request.getEndProgress())
-                .progressDelta(request.getProgressDelta())
+                .progressDelta(progressDelta)
                 .startLocation(request.getStartLocation())
                 .endLocation(request.getEndLocation())
                 .build();
 
         readingSessionRepository.save(session);
 
-        log.info("Reading session persisted successfully: sessionId={}, userId={}, bookId={}, duration={}s", session.getId(), userId, request.getBookId(), request.getDurationSeconds());
+        log.info("Reading session persisted successfully: sessionId={}, userId={}, bookId={}, duration={}s", session.getId(), userId, request.getBookId(), durationSeconds);
     }
 
     public List<ReadingSessionHeatmapResponse> getSessionHeatmapForYear(int year) {

--- a/backend/src/main/java/org/booklore/service/ReadingSessionService.java
+++ b/backend/src/main/java/org/booklore/service/ReadingSessionService.java
@@ -119,7 +119,7 @@ public class ReadingSessionService {
             // We don't need to check if request start / end time are non-null because
             // that's enforced by the request model.
             Duration duration = request.getStartTime().until(request.getEndTime());
-            durationSeconds = Math.abs(Math.toIntExact(duration.getSeconds()));
+            durationSeconds = Math.toIntExact(Math.abs(duration.getSeconds()));
         }
 
         String durationFormatted = request.getDurationFormatted();

--- a/backend/src/main/java/org/booklore/service/ReadingSessionService.java
+++ b/backend/src/main/java/org/booklore/service/ReadingSessionService.java
@@ -103,6 +103,17 @@ public class ReadingSessionService {
         }
     }
 
+    private int getDuration(ReadingSessionRequest request) {
+        if (request.getDurationSeconds() == null) {
+            // We don't need to check if request start / end time are non-null because
+            // that's enforced by the request model.
+            Duration duration = request.getStartTime().until(request.getEndTime());
+            return Math.toIntExact(Math.abs(duration.getSeconds()));
+        }
+
+        return request.getDurationSeconds();
+    }
+
     @Transactional
     public void recordSession(ReadingSessionRequest request) {
         BookLoreUser authenticatedUser = authenticationService.getAuthenticatedUser();
@@ -116,13 +127,7 @@ public class ReadingSessionService {
             bookType = book.getPrimaryBookFile().getBookType();
         }
 
-        Integer durationSeconds = request.getDurationSeconds();
-        if (durationSeconds == null) {
-            // We don't need to check if request start / end time are non-null because
-            // that's enforced by the request model.
-            Duration duration = request.getStartTime().until(request.getEndTime());
-            durationSeconds = Math.toIntExact(Math.abs(duration.getSeconds()));
-        }
+        int durationSeconds = getDuration(request);
 
         String durationFormatted = request.getDurationFormatted();
         if (durationFormatted == null) {

--- a/backend/src/main/java/org/booklore/service/ReadingSessionService.java
+++ b/backend/src/main/java/org/booklore/service/ReadingSessionService.java
@@ -87,10 +87,12 @@ public class ReadingSessionService {
         return (dow.getValue() % 7) + 1;
     }
 
-    private String getDurationFormatted(int duration) {
-        int hours = duration / 3600;
-        int minutes = (duration % 3600) / 60;
-        int seconds = duration % 60;
+    private String getDurationFormatted(int durationSeconds) {
+        Duration duration = Duration.ofSeconds(durationSeconds);
+
+        long hours = duration.toHours();
+        int minutes = duration.toMinutesPart();
+        int seconds = duration.toSecondsPart();
 
         if (hours > 0) {
             return String.format("%dh %dm %ds", hours, minutes, seconds);

--- a/backend/src/test/java/org/booklore/service/ReadingSessionServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/ReadingSessionServiceTest.java
@@ -1,0 +1,287 @@
+package org.booklore.service;
+
+import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.model.dto.request.ReadingSessionRequest;
+import org.booklore.model.entity.*;
+import org.booklore.model.enums.BookFileType;
+import org.booklore.repository.*;
+import org.booklore.model.dto.BookLoreUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReadingSessionServiceTest {
+    @Mock
+    private AuthenticationService authenticationService;
+
+    @Mock
+    private ReadingSessionRepository readingSessionRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserBookProgressRepository userBookProgressRepository;
+
+    @InjectMocks
+    private ReadingSessionService service;
+
+    private BookLoreUser user;
+    private BookLoreUserEntity userEntity;
+    private BookEntity bookEntity;
+
+    @BeforeEach
+    void setUp() {
+        user = BookLoreUser.builder().id(1L).build();
+        userEntity = BookLoreUserEntity.builder().id(1L).build();
+
+        BookFileEntity bookFileEntity = BookFileEntity.builder().bookType(BookFileType.EPUB).build();
+        bookEntity = BookEntity.builder().id(1L).bookFiles(List.of(bookFileEntity)).build();
+    }
+
+    @Test
+    void recordSession_allowsDurationOverrides() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+        request.setDurationSeconds(100);
+        request.setDurationFormatted("Something Else");
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertEquals(100, saved.getDurationSeconds());
+        assertEquals("Something Else", saved.getDurationFormatted());
+    }
+
+    @Test
+    void recordSession_infersDuration() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertEquals(128, saved.getDurationSeconds());
+        assertEquals("2m 8s", saved.getDurationFormatted());
+    }
+
+    @Test
+    void recordSession_infersDurationInverted() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173128));
+        request.setEndTime(Instant.ofEpochSecond(1778173000));
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertEquals(128, saved.getDurationSeconds());
+        assertEquals("2m 8s", saved.getDurationFormatted());
+    }
+
+    @Test
+    void recordSession_overridesBookType() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+        request.setBookType(BookFileType.FB2);
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertEquals(BookFileType.FB2, saved.getBookType());
+    }
+
+    @Test
+    void recordSession_ignoresBookTypeNoFiles() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+
+        // Clear out the books attached
+        bookEntity.setBookFiles(List.of());
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertNull(saved.getBookType());
+    }
+
+    @Test
+    void recordSession_infersBookType() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertEquals(BookFileType.EPUB, saved.getBookType());
+    }
+
+    @Test
+    void recordSession_overridesProgressDelta() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+
+        request.setStartProgress(12.0f);
+        request.setEndProgress(14.3f);
+
+        // Wow, you read a lot of that book!
+        request.setProgressDelta(123.0f);
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertEquals(123.0f, saved.getProgressDelta());
+    }
+
+    @Test
+    void recordSession_ignoresMissingProgress() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertNull(saved.getProgressDelta());
+    }
+
+    @Test
+    void recordSession_infersProgressDelta() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+
+        request.setStartProgress(12.0f);
+        request.setEndProgress(14.3f);
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertEquals(2.3f, saved.getProgressDelta(), 0.001f);
+    }
+
+    @Test
+    void recordSession_infersProgressDeltaInverted() {
+        ReadingSessionRequest request = new ReadingSessionRequest();
+
+        request.setBookId(1L);
+        request.setStartTime(Instant.ofEpochSecond(1778173000));
+        request.setEndTime(Instant.ofEpochSecond(1778173128));
+
+        request.setStartProgress(14.3f);
+        request.setEndProgress(12.0f);
+
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(userEntity));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
+
+        service.recordSession(request);
+
+        ArgumentCaptor<ReadingSessionEntity> captor = ArgumentCaptor.forClass(ReadingSessionEntity.class);
+        verify(readingSessionRepository).save(captor.capture());
+
+        ReadingSessionEntity saved = captor.getValue();
+        assertEquals(2.3f, saved.getProgressDelta(), 0.001f);
+    }
+}


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
The reading session recording endpoint has a number of redundant fields that can be inferred.  This adds difficulty for integrations to use the endpoints & can lead to incorrect data being published.

Instead, allow API clients to omit these fields, but use the inferred values so we don't lose fidelity of data.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
Fixes #1190

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* allow omission of `durationSeconds` in reading session recording request
* update `ReadingSessionService` to fill in progress delta, duration, duration seconds, and book type if not specified
* adds tests for changed behavior in `ReadingSessionService`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Send request to API with progress delta, duration seconds, duration seconds format, and book type present
2. Check recorded session information has the specified data
3. Send request to API without data
4. Check recorded session information has inferred data

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
N/A

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
This came out of investigations into integrating third party reading tools with Grimmory & while it's not required does make the use of the API easier.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced that reading sessions must include a non-null end time.

* **New Features**
  * Automatically compute missing duration, human-readable formatted duration, and progress delta from start/end when not provided.
  * Infer book type from associated book file when not supplied.

* **Tests**
  * Added unit tests validating duration/progress inference, book-type inference, and persistence behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1194)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->