### PR TITLE
fix(api): expose version from jar at `/v1/version` endpoint

### DIFF
--- a/backend/src/main/java/org/booklore/controller/HealthcheckController.java
+++ b/backend/src/main/java/org/booklore/controller/HealthcheckController.java
@@ -1,23 +1,26 @@
 package org.booklore.controller;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.booklore.model.dto.HealthcheckResponse;
 import org.booklore.model.dto.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.booklore.service.VersionService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
+@Slf4j
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/healthcheck")
 @Tag(name = "Healthcheck", description = "Endpoints for checking the health of the application")
 public class HealthcheckController {
-
-  @Value("${app.version}")
-  private String appVersion;
+  private final VersionService versionService;
 
   @Operation(summary = "Get a ping response", description = "Check if the application is responding")
   @ApiResponse(responseCode = "200", description = "Health status returned successfully")
@@ -27,7 +30,7 @@ public class HealthcheckController {
     HealthcheckResponse healthData = HealthcheckResponse.builder()
             .status("UP")
             .message("Application is running smoothly.")
-            .version(appVersion) // ex) 'development' Insert
+            .version(versionService.getAppVersion()) // ex) 'development' Insert
             .timestamp(LocalDateTime.now())
             .build();
 

--- a/backend/src/main/java/org/booklore/service/VersionService.java
+++ b/backend/src/main/java/org/booklore/service/VersionService.java
@@ -13,14 +13,13 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
 public class VersionService {
-
-    @Value("${app.version:unknown}")
-    String appVersion;
-
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^\\d+\\.\\d+\\.\\d+$");
+    private static final String DEVELOPMENT_VERSION = "development";
     private static final String GITHUB_REPO = "grimmory-tools/grimmory";
     private static final String BASE_URI = "https://api.github.com/repos/" + GITHUB_REPO;
     private static final int MAX_RELEASES = 15;
@@ -30,6 +29,20 @@ public class VersionService {
             .build();
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    public String getAppVersion() {
+        String appVersion = getClass().getPackage().getImplementationVersion();
+
+        if (appVersion == null) {
+            return DEVELOPMENT_VERSION;
+        }
+
+        // If in X.Y.Z format, prefix with a `v` to match the tag.
+        if (VERSION_PATTERN.matcher(appVersion).matches()) {
+            appVersion = "v" + appVersion;
+        }
+
+        return appVersion;
+    }
 
     public VersionInfo getVersionInfo() {
         String latest = "unknown";
@@ -38,11 +51,12 @@ public class VersionService {
         } catch (Exception e) {
             log.warn("Error fetching latest release version");
         }
-        return new VersionInfo(appVersion, latest);
+
+        return new VersionInfo(getAppVersion(), latest);
     }
 
     public List<ReleaseNote> getChangelogSinceCurrentVersion() {
-        return fetchReleaseNotesSince(appVersion);
+        return fetchReleaseNotesSince(getAppVersion());
     }
 
 
@@ -63,7 +77,7 @@ public class VersionService {
     }
 
     public List<ReleaseNote> fetchReleaseNotesSince(String currentVersion) {
-        if ("development".equals(currentVersion)) {
+        if (DEVELOPMENT_VERSION.equals(currentVersion)) {
             log.warn("Skipping fetch of release notes because current version is '{}', which is a local development build.", currentVersion);
             return new ArrayList<>();
         }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,7 +1,6 @@
 app:
   path-config: '/app/data'
   bookdrop-folder: '/bookdrop'
-  version: ${APP_VERSION:development}
   api-docs:
     enabled: ${API_DOCS_ENABLED:false}
 

--- a/backend/src/test/java/org/booklore/service/VersionServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/VersionServiceTest.java
@@ -115,7 +115,21 @@ class VersionServiceTest {
             VersionInfo info = spyService.getVersionInfo();
 
             assertThat(info.getCurrent())
-                    .isEqualTo(service.appVersion);
+                    .isEqualTo(service.getAppVersion());
+            assertThat(info.getLatest())
+                    .isEqualTo("v9.9.9");
+        }
+
+        @Test
+        void usesFallbackIfMissingPackageVersion() {
+            Mockito.doReturn("v9.9.9")
+                    .when(spyService)
+                    .fetchLatestGitHubReleaseVersion();
+
+            VersionInfo info = spyService.getVersionInfo();
+
+            assertThat(info.getCurrent())
+                    .isEqualTo(service.getAppVersion());
             assertThat(info.getLatest())
                     .isEqualTo("v9.9.9");
         }
@@ -144,7 +158,7 @@ class VersionServiceTest {
 
             Mockito.doReturn(List.of(note))
                     .when(spyService)
-                    .fetchReleaseNotesSince(service.appVersion);
+                    .fetchReleaseNotesSince(service.getAppVersion());
 
             List<ReleaseNote> result = spyService.getChangelogSinceCurrentVersion();
             assertThat(result).hasSize(1).containsExactly(note);
@@ -154,7 +168,7 @@ class VersionServiceTest {
         void returnsEmptyListWhenNoNewReleases() {
             Mockito.doReturn(List.of())
                     .when(spyService)
-                    .fetchReleaseNotesSince(service.appVersion);
+                    .fetchReleaseNotesSince(service.getAppVersion());
 
             var result = spyService.getChangelogSinceCurrentVersion();
             assertThat(result).isEmpty();


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
The current `/api/v1/version` and `/api/v1/healthcheck` emit the version as defined in `application.yaml` which comes from the env var `APP_VERSION`.  In cases where this is omitted (or does not match the jar version) we end up not seeing the correct version.  This delays proper debugging & confuses developers.

This PR updates endpoints to use the version from the application jar file, instead.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
Fixes #1223 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* Use the package version in `VersionService`
* Use `VersionService` in the `HealthcheckController` to get a consistent version

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Start development server
2. Check `/api/v1/healthcheck`
3. Build docker image with `--build-arg APP_VERSION=1.2.3
4. Set `APP_VERSION=example` env var in compose
5. Run built docker image
6. Check `/api/v1/healthcheck`

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
Dev Server

<img width="413" height="213" alt="image" src="https://github.com/user-attachments/assets/ab6bb1ad-946b-4e8f-9106-3c33ae10cfe8" />

Built Image

<img width="452" height="230" alt="image" src="https://github.com/user-attachments/assets/78a7e30b-8341-4314-838d-55b9309feba9" />

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  - Version detection now reads from package metadata automatically instead of configuration
  - Version format improved to match GitHub release tags with "v" prefix for releases
  - Robust fallback to "development" status when version information is unavailable
  - Centralized version detection ensures consistency across all application components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->