### PR TITLE
ci: use last release as nightly base tag

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          ref: develop
 
       - name: Record Resolved Commit
         id: resolve

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -39,22 +39,6 @@ jobs:
           nightly_tag="nightly-${build_date}-${short_sha}"
           base_tag="$(git describe --tags --abbrev=0 --match 'v*' origin/main)"
           from_ref="$base_tag"
-          previous_nightly_sha=""
-          if previous_nightly_json="$(
-            gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/publish-nightly.yml/runs?branch=develop&event=schedule&status=success&per_page=1"
-          )"; then
-            previous_nightly_sha="$(printf '%s' "$previous_nightly_json" | jq -r '.workflow_runs[0].head_sha // ""')"
-          else
-            echo "::warning::Unable to resolve previous nightly run; using ${base_tag}"
-          fi
-
-          if [ -n "$previous_nightly_sha" ] \
-            && git rev-parse --verify --quiet "${previous_nightly_sha}^{commit}" >/dev/null \
-            && git merge-base --is-ancestor "$previous_nightly_sha" HEAD; then
-            from_ref="$previous_nightly_sha"
-          elif [ -n "$previous_nightly_sha" ]; then
-            echo "::warning::Ignoring unusable nightly baseline ${previous_nightly_sha}; using ${base_tag}"
-          fi
 
           echo "base_tag=${base_tag}" >> "$GITHUB_OUTPUT"
           echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
The nightly predicted release version is often wrong because it's from the last nightly rather than from the release.

This change makes sure the base ref is always the last released tag.



## Linked Issue

<!-- Required. Example: Fixes #123 -->
Fixes #1156

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
Drops the previous nightly SHA calculation & just relies on the last release tag.

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Add `DISCORD_NIGHTLY_WEBHOOK=1` to fork
2. Run nightly build job
3. Observe changelog & the expected message

[Build can be seen here](https://github.com/imnotjames/grimmory/actions/runs/25590255183)

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
<img width="589" height="284" alt="image" src="https://github.com/user-attachments/assets/33e02c2b-766b-4417-b4c2-a4a1f2597127" />

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly build workflow process to streamline reference resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->