### PR TITLE
feat: Allow setting book status to read without a finished date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ backend/src/main/resources/application-local.yaml
 /tools/release/node_modules
 /tools/release/.yarn/
 .worktrees/
+.claude/settings.local.json

--- a/backend/src/main/java/org/booklore/model/dto/request/ReadProgressRequest.java
+++ b/backend/src/main/java/org/booklore/model/dto/request/ReadProgressRequest.java
@@ -26,9 +26,10 @@ public class ReadProgressRequest {
     private AudiobookProgress audiobookProgress;
 
     private Instant dateFinished;
+    private boolean clearDateFinished;
 
     @AssertTrue(message = "At least one progress field must be provided")
     public boolean isProgressValid() {
-        return fileProgress != null || epubProgress != null || pdfProgress != null || cbxProgress != null || audiobookProgress != null || dateFinished != null;
+        return fileProgress != null || epubProgress != null || pdfProgress != null || cbxProgress != null || audiobookProgress != null || dateFinished != null || clearDateFinished;
     }
 }

--- a/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
+++ b/backend/src/main/java/org/booklore/service/progress/ReadingProgressService.java
@@ -265,6 +265,8 @@ public class ReadingProgressService {
         }
         if (request.getDateFinished() != null) {
             progress.setDateFinished(request.getDateFinished());
+        } else if (request.isClearDateFinished()) {
+            progress.setDateFinished(null);
         }
 
         userBookProgressRepository.save(progress);

--- a/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
@@ -287,6 +287,75 @@ class ReadingProgressServiceTest {
     }
 
     @Test
+    void updateReadProgress_withClearDateFinished_shouldSetDateFinishedToNull() {
+        long bookId = 1L;
+        BookEntity book = new BookEntity();
+        book.setId(bookId);
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setId(1L);
+        primaryFile.setBook(book);
+        primaryFile.setBookType(BookFileType.EPUB);
+        book.setBookFiles(List.of(primaryFile));
+
+        BookLoreUser user = mock(BookLoreUser.class);
+        when(user.getId()).thenReturn(2L);
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
+
+        BookLoreUserEntity userEntity = new BookLoreUserEntity();
+        userEntity.setId(2L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
+
+        UserBookProgressEntity progress = new UserBookProgressEntity();
+        progress.setDateFinished(Instant.now().minusSeconds(3600));
+        when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.of(progress));
+
+        ReadProgressRequest req = new ReadProgressRequest();
+        req.setBookId(bookId);
+        req.setClearDateFinished(true);
+
+        readingProgressService.updateReadProgress(req);
+
+        assertNull(progress.getDateFinished());
+        verify(userBookProgressRepository).save(progress);
+    }
+
+    @Test
+    void updateReadProgress_withoutClearFlag_shouldNotTouchExistingDateFinished() {
+        long bookId = 1L;
+        BookEntity book = new BookEntity();
+        book.setId(bookId);
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setId(1L);
+        primaryFile.setBook(book);
+        primaryFile.setBookType(BookFileType.EPUB);
+        book.setBookFiles(List.of(primaryFile));
+
+        BookLoreUser user = mock(BookLoreUser.class);
+        when(user.getId()).thenReturn(2L);
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
+
+        BookLoreUserEntity userEntity = new BookLoreUserEntity();
+        userEntity.setId(2L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(userEntity));
+
+        Instant existingDate = Instant.now().minusSeconds(3600);
+        UserBookProgressEntity progress = new UserBookProgressEntity();
+        progress.setDateFinished(existingDate);
+        when(userBookProgressRepository.findByUserIdAndBookId(2L, bookId)).thenReturn(Optional.of(progress));
+        when(userBookFileProgressRepository.findByUserIdAndBookFileId(2L, 1L)).thenReturn(Optional.empty());
+
+        ReadProgressRequest req = new ReadProgressRequest();
+        req.setBookId(bookId);
+        req.setEpubProgress(EpubProgress.builder().cfi("cfi").percentage(50f).build());
+
+        readingProgressService.updateReadProgress(req);
+
+        assertEquals(existingDate, progress.getDateFinished());
+    }
+
+    @Test
     void resetProgress_booklore_shouldCallBulkReset() {
         BookLoreUser user = mock(BookLoreUser.class);
         when(authenticationService.getAuthenticatedUser()).thenReturn(user);

--- a/frontend/src/app/features/book/service/book-patch.service.spec.ts
+++ b/frontend/src/app/features/book/service/book-patch.service.spec.ts
@@ -119,6 +119,18 @@ describe('BookPatchService', () => {
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({queryKey: ['books', 'detail', 5]});
   });
 
+  it('sends clearDateFinished flag when date is null', () => {
+    service.updateDateFinished(5, null).subscribe();
+
+    const request = httpTestingController.expectOne(req => req.url.endsWith('/api/v1/books/progress'));
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({
+      bookId: 5,
+      clearDateFinished: true,
+    });
+    request.flush(null);
+  });
+
   it('updates the read status for multiple books and patches cached fields', () => {
     service.updateBookReadStatus([1, 2], ReadStatus.READ).subscribe();
 

--- a/frontend/src/app/features/book/service/book-patch.service.ts
+++ b/frontend/src/app/features/book/service/book-patch.service.ts
@@ -193,10 +193,10 @@ export class BookPatchService {
   }
 
   updateDateFinished(bookId: number, dateFinished: string | null): Observable<void> {
-    return this.http.post<void>(`${this.url}/progress`, {
-      bookId,
-      dateFinished
-    }).pipe(
+    const body = dateFinished != null
+      ? {bookId, dateFinished}
+      : {bookId, clearDateFinished: true};
+    return this.http.post<void>(`${this.url}/progress`, body).pipe(
       tap(() => {
         patchBookFieldsInCache(this.queryClient, [{bookId, fields: {dateFinished: dateFinished || undefined}}]);
       })

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -524,30 +524,28 @@
               </div>
             }
 
-            @if (selectedReadStatus === ReadStatus.READ) {
+            @if (selectedReadStatus === ReadStatus.READ && book?.dateFinished) {
               <div class="metadata-item">
-                @if (book?.dateFinished) {
-                  <span class="metadata-key">{{ t('finishedOnLabel') }}</span>
-                  @if (!isEditingDateFinished) {
-                    <span class="metadata-value-group">
-                      <span class="metadata-value">{{ formatDate(book.dateFinished) }}</span>
-                      <i class="pi pi-pencil edit-icon" role="button" tabindex="0" (click)="toggleDateFinishedEdit(book)" (keydown.enter)="toggleDateFinishedEdit(book)"></i>
-                    </span>
-                  } @else {
-                    <span class="metadata-value-group">
-                      <p-datepicker
-                        [(ngModel)]="editDateFinished"
-                        dateFormat="dd-M-yy"
-                        size="small"
-                        [showIcon]="true"
-                        [iconDisplay]="'input'"
-                        appendTo="body"
-                        [style]="{ 'width': '125px', 'font-size': '12px' }">
-                      </p-datepicker>
-                      <p-button rounded icon="pi pi-check" size="small" severity="success" text (onClick)="saveDateFinished(book)" [pTooltip]="t('saveDate')"></p-button>
-                      <p-button rounded icon="pi pi-times" size="small" severity="danger" text (onClick)="cancelDateFinishedEdit()" [pTooltip]="'common.cancel' | transloco"></p-button>
-                    </span>
-                  }
+                <span class="metadata-key">{{ t('finishedOnLabel') }}</span>
+                @if (!isEditingDateFinished) {
+                  <span class="metadata-value-group">
+                    <span class="metadata-value">{{ formatDate(book.dateFinished) }}</span>
+                    <i class="pi pi-pencil edit-icon" role="button" tabindex="0" (click)="toggleDateFinishedEdit(book)" (keydown.enter)="toggleDateFinishedEdit(book)"></i>
+                  </span>
+                } @else {
+                  <span class="metadata-value-group">
+                    <p-datepicker
+                      [(ngModel)]="editDateFinished"
+                      dateFormat="dd-M-yy"
+                      size="small"
+                      [showIcon]="true"
+                      [iconDisplay]="'input'"
+                      appendTo="body"
+                      [style]="{ 'width': '125px', 'font-size': '12px' }">
+                    </p-datepicker>
+                    <p-button rounded icon="pi pi-check" size="small" severity="success" text (onClick)="saveDateFinished(book)" [pTooltip]="t('saveDate')"></p-button>
+                    <p-button rounded icon="pi pi-times" size="small" severity="danger" text (onClick)="cancelDateFinishedEdit()" [pTooltip]="'common.cancel' | transloco"></p-button>
+                  </span>
                 }
               </div>
             }


### PR DESCRIPTION
## Description

This change makes the "dateFinished" field optional (i.e. nullable) even when the "read" status is set to READ. This means that the book is counted against books that have been read, but does not mess with statistics. Ref: #713 

## Linked Issue

Fixes #713 

## Changes

* Updates `updateDateFinished` to pass an extra parameter `clearDateFinished` to indicate that dateFinished being null is explicit instead of just being unset.
* Updates `updateReadProgress` to set the `dateFinished` to null if `clearDateFinished` is set
* Updates `isProgressValid` to accept `dateFinished` being null if `clearDateFinished` is set

## Manual Testing Steps

1. Open a book that has status set to read and a valid "FInished on" date
2. Edit the "Finished on" date and clear it
3. Click the tick to accept the change
4. The "Finished on" date will disappear

## Screenshot

<img width="1766" height="512" alt="Screenshot 2026-05-09 080810" src="https://github.com/user-attachments/assets/850a7beb-e415-4a40-a912-fddf3a5d0b04" />

## AI Disclosure

Claude helped me understand the code and trace call sites. It also validated my assumptions about the code. It also wrote the tests. I understand all changes made (to the best of my ability) and I've verified them myself.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now explicitly clear the finished date for a book, providing more flexibility in managing reading progress.

* **Bug Fixes**
  * The "finished on" metadata display now correctly shows only when a finished date is set and the book status is marked as read.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1228)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->