### PR TITLE
fix(ui): fix metadata lock patch

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.spec.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.spec.ts
@@ -43,10 +43,10 @@ describe('BookTableComponent', () => {
   let component: BookTableComponent;
   let bookSelectionService: BookSelectionService;
   let bookMetadataManageService: { toggleAllLock: ReturnType<typeof vi.fn> };
-  let queryClient: { setQueriesData: ReturnType<typeof vi.fn> };
+  let queryClient: { setQueryData: ReturnType<typeof vi.fn>; setQueriesData: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
-    queryClient = {setQueriesData: vi.fn()};
+    queryClient = {setQueryData: vi.fn(), setQueriesData: vi.fn()};
     bookMetadataManageService = {
       toggleAllLock: vi.fn(() => of(null)),
     };

--- a/frontend/src/app/features/book/service/book-query-cache.ts
+++ b/frontend/src/app/features/book/service/book-query-cache.ts
@@ -131,6 +131,7 @@ export function patchAppBooksCoverInCache(
 }
 
 export function patchAppBooksMetadataLockInCache(queryClient: QueryClient, bookId: number, allMetadataLocked: boolean): void {
+  // Do not create the legacy full-books cache when only the paginated app-books cache exists.
   queryClient.setQueryData<Book[]>(BOOKS_QUERY_KEY, current =>
     current?.map(book =>
       book.id === bookId

--- a/frontend/src/app/features/book/service/book-query-cache.ts
+++ b/frontend/src/app/features/book/service/book-query-cache.ts
@@ -131,6 +131,20 @@ export function patchAppBooksCoverInCache(
 }
 
 export function patchAppBooksMetadataLockInCache(queryClient: QueryClient, bookId: number, allMetadataLocked: boolean): void {
+  queryClient.setQueryData<Book[]>(BOOKS_QUERY_KEY, current =>
+    current?.map(book =>
+      book.id === bookId
+        ? {
+          ...book,
+          metadata: {
+            ...(book.metadata ?? {bookId}),
+            allMetadataLocked,
+          },
+        }
+        : book
+    ) ?? current
+  );
+
   queryClient.setQueriesData<InfiniteData<AppPageResponse<AppBookSummary>>>(
     {queryKey: APP_BOOKS_QUERY_PREFIX},
     current => {


### PR DESCRIPTION
## Description

Fixes a regression in the book table after reverting the pagination, the lock icon would not update without a full cache refresh. 

## Linked Issue

Fixes #1264 

## Changes

Updates `patchAppBooksMetadataLockInCache` to update the main books cache, and ignores the paginated endpoint cache unless present. 

## Manual Testing Steps

Tested and confirmed the regression is fixed. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test infrastructure for query client mocking.
  * Improved cache handling for book metadata to optimize data management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1265)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->