### PR TITLE
chore(deps): add 3 day npm release age gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
       day: "friday"
       time: "03:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -48,6 +50,8 @@ updates:
       day: "friday"
       time: "03:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,3 +2,4 @@ nodeLinker: node-modules
 nmMode: hardlinks-local
 enableGlobalCache: false
 cacheFolder: .yarn/cache
+npmMinimalAgeGate: 4320

--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -2,3 +2,4 @@ nodeLinker: node-modules
 nmMode: hardlinks-local
 enableGlobalCache: false
 cacheFolder: .yarn/cache
+npmMinimalAgeGate: 4320


### PR DESCRIPTION
## Description

Adds a 3-day minimum age for npm packages

## Linked Issue

Fixes #1269 

## Changes

Adds a 3-day minimum age in the yarn config
Adds a 3-day cooldown to the dependabot config to match

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration settings.
  * Adjusted package manager settings for improved stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1270)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->