### PR TITLE
feat(oidc): add configurable mobile redirect URI to the admin settings UI

### DIFF
--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -217,7 +217,7 @@
         </p>
         <div class="config-item full-width">
           <label for="mobileRedirectUriInput">{{ t('mobileRedirectUris.label') }}</label>
-          <div class="redirect-uri-input" [class.has-error]="mobileRedirectUriErrorKey">
+          <div class="redirect-uri-input">
             <div class="redirect-uri-chip-list">
               @for (redirectUri of mobileRedirectUris; track redirectUri; let index = $index) {
                 <p-chip
@@ -245,9 +245,6 @@
             {{ '. ' + t('mobileRedirectUris.hintSuffix') }}
             <code>{{ wildcardMobileRedirectUri }}</code>
           </span>
-          @if (mobileRedirectUriErrorKey) {
-            <span class="field-error">{{ t(mobileRedirectUriErrorKey) }}</span>
-          }
         </div>
       </div>
 

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -243,7 +243,7 @@
             {{ t('mobileRedirectUris.hintPrefix') }}
             <code>{{ defaultMobileRedirectUri }}</code>
             {{ '. ' + t('mobileRedirectUris.hintSuffix') }}
-            <code>*</code>
+            <code>{{ wildcardMobileRedirectUri }}</code>
           </span>
           @if (mobileRedirectUriErrorKey) {
             <span class="field-error">{{ t(mobileRedirectUriErrorKey) }}</span>

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -210,6 +210,47 @@
         </div>
       </div>
 
+      <div class="claims-section">
+        <h4 class="subsection-title">{{ t('mobileRedirectUris.title') }}</h4>
+        <p class="subsection-description">
+          {{ t('mobileRedirectUris.description') }}
+        </p>
+        <div class="config-item full-width">
+          <label for="mobileRedirectUriInput">{{ t('mobileRedirectUris.label') }}</label>
+          <div class="redirect-uri-input" [class.has-error]="mobileRedirectUriErrorKey">
+            <div class="redirect-uri-chip-list">
+              @for (redirectUri of mobileRedirectUris; track redirectUri; let index = $index) {
+                <p-chip
+                  class="redirect-uri-chip"
+                  [label]="redirectUri"
+                  [removable]="true"
+                  [attr.aria-label]="t('mobileRedirectUris.removeLabel', {uri: redirectUri})"
+                  (onRemove)="removeMobileRedirectUri(index)">
+                </p-chip>
+              }
+              <input
+                pInputText
+                pSize="small"
+                id="mobileRedirectUriInput"
+                [(ngModel)]="mobileRedirectUriInput"
+                [placeholder]="mobileRedirectUris.length === 0 ? t('mobileRedirectUris.placeholder') : ''"
+                (keydown)="onMobileRedirectUriKeydown($event)"
+                (blur)="addMobileRedirectUriFromInput()"
+              />
+            </div>
+          </div>
+          <span class="field-hint">
+            {{ t('mobileRedirectUris.hintPrefix') }}
+            <code>{{ defaultMobileRedirectUri }}</code>
+            {{ '. ' + t('mobileRedirectUris.hintSuffix') }}
+            <code>*</code>
+          </span>
+          @if (mobileRedirectUriErrorKey) {
+            <span class="field-error">{{ t(mobileRedirectUriErrorKey) }}</span>
+          }
+        </div>
+      </div>
+
       <div class="provider-actions-row">
         <div class="test-results-inline">
           @if (testConnectionResult) {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.scss
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.scss
@@ -230,6 +230,12 @@
   line-height: 1.4;
 }
 
+.field-error {
+  font-size: 0.75rem;
+  color: var(--p-red-400);
+  line-height: 1.4;
+}
+
 // Claims Section
 .claims-section {
   margin-top: 1rem;
@@ -249,6 +255,71 @@
   color: var(--p-text-muted-color);
   line-height: 1.4;
   margin: 0 0 0.75rem;
+}
+
+.redirect-uri-input {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 2.25rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 6px;
+  background: var(--p-inputtext-background);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:focus-within {
+    border-color: var(--p-primary-color);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--p-primary-color) 35%, transparent);
+  }
+
+  &.has-error {
+    border-color: var(--p-red-400);
+  }
+
+  input {
+    border: 0;
+    box-shadow: none;
+    background: transparent;
+    min-width: 11rem;
+    flex: 1 1 11rem;
+    padding: 0.25rem 0;
+
+    &:focus {
+      box-shadow: none;
+    }
+  }
+}
+
+.redirect-uri-chip-list {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.redirect-uri-chip {
+  max-width: 100%;
+  flex-shrink: 1;
+  font-size: 0.8125rem;
+
+  ::ng-deep .p-chip {
+    padding: 0.1563rem 0.4063rem;
+    border-radius: 0.375rem;
+    line-height: 1.125rem;
+  }
+
+  ::ng-deep .p-chip-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  ::ng-deep .p-chip-remove-icon {
+    font-size: 0.65rem;
+    opacity: 0.6;
+  }
 }
 
 .claims-grid {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
@@ -18,7 +18,7 @@ function createSettings(overrides: Partial<AppSettings> = {}): AppSettings {
     oidcEnabled: false,
     oidcAutoProvisionDetails: undefined,
     oidcProviderDetails: undefined,
-    oidcMobileRedirectUris: ['grimmory://oauth2-callback'],
+    oidcRedirectUris: ['grimmory://oauth2-callback'],
     oidcSessionDurationHours: null,
     oidcGroupSyncMode: null,
     oidcForceOnlyMode: false,
@@ -287,7 +287,7 @@ describe('AuthenticationSettingsComponent', () => {
         newValue: component.oidcProvider,
       },
       {
-        key: AppSettingKey.OIDC_MOBILE_REDIRECT_URIS,
+        key: AppSettingKey.OIDC_REDIRECT_URIS,
         newValue: ['grimmory://oauth2-callback', 'grimmory://auth/return'],
       }
     ]);
@@ -301,7 +301,7 @@ describe('AuthenticationSettingsComponent', () => {
         newValue: component.oidcProvider,
       },
       {
-        key: AppSettingKey.OIDC_MOBILE_REDIRECT_URIS,
+        key: AppSettingKey.OIDC_REDIRECT_URIS,
         newValue: ['grimmory://oauth2-callback', 'grimmory://auth/return'],
       },
       {
@@ -319,78 +319,23 @@ describe('AuthenticationSettingsComponent', () => {
 
     expect(component.mobileRedirectUris).toEqual(['grimmory://oauth2-callback', 'grimmory://auth/return']);
     expect(component.mobileRedirectUriInput).toBe('');
-    expect(component.mobileRedirectUriErrorKey).toBeNull();
   });
 
-  it('rejects duplicate mobile redirect URIs before saving', () => {
+  it('adds the pending mobile redirect URI before saving', () => {
+    appSettingsService.saveSettings.mockReturnValue(of(void 0));
     component.oidcProvider = completeProvider();
     component.mobileRedirectUris = ['grimmory://oauth2-callback'];
-    component.mobileRedirectUriInput = 'grimmory://oauth2-callback';
+    component.mobileRedirectUriInput = 'grimmory://auth/return';
 
     component.saveOidcProvider();
 
-    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.duplicate');
-    expect(appSettingsService.saveSettings).not.toHaveBeenCalled();
-  });
-
-  it('rejects wildcard mixed with specific redirect URIs', () => {
-    component.mobileRedirectUris = [component.wildcardMobileRedirectUri];
-    component.mobileRedirectUriInput = 'grimmory://oauth2-callback';
-
-    component.addMobileRedirectUriFromInput();
-
-    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.wildcardOnly');
-    expect(component.mobileRedirectUris).toEqual([component.wildcardMobileRedirectUri]);
-  });
-
-  it('rejects blank mobile redirect URIs already present in the array being saved', () => {
-    component.oidcProvider = completeProvider();
-    component.mobileRedirectUris = ['grimmory://oauth2-callback', ' '];
-
-    component.saveOidcProvider();
-
-    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.blank');
-    expect(appSettingsService.saveSettings).not.toHaveBeenCalled();
-  });
-
-  it('rejects malformed mobile redirect URIs', () => {
-    component.mobileRedirectUris = [];
-    component.mobileRedirectUriInput = 'grimmory://oauth2 callback';
-
-    component.addMobileRedirectUriFromInput();
-
-    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.invalid');
-    expect(component.mobileRedirectUris).toEqual([]);
-  });
-
-  it('rejects mobile redirect URIs without a scheme', () => {
-    component.mobileRedirectUris = [];
-    component.mobileRedirectUriInput = 'oauth2-callback';
-
-    component.addMobileRedirectUriFromInput();
-
-    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.schemeRequired');
-    expect(component.mobileRedirectUris).toEqual([]);
-  });
-
-  it('rejects http and https mobile redirect URIs', () => {
-    component.mobileRedirectUris = [];
-    component.mobileRedirectUriInput = 'https://example.com/oauth2-callback';
-
-    component.addMobileRedirectUriFromInput();
-
-    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.customSchemeRequired');
-    expect(component.mobileRedirectUris).toEqual([]);
-  });
-
-  it('rejects mobile redirect URIs with fragments', () => {
-    component.mobileRedirectUris = [];
-    component.mobileRedirectUriInput = 'grimmory://oauth2-callback#done';
-
-    component.addMobileRedirectUriFromInput();
-
-    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.fragmentNotAllowed');
-    expect(component.mobileRedirectUris).toEqual([]);
+    expect(appSettingsService.saveSettings).toHaveBeenCalledWith(expect.arrayContaining([
+      {
+        key: AppSettingKey.OIDC_REDIRECT_URIS,
+        newValue: ['grimmory://oauth2-callback', 'grimmory://auth/return'],
+      }
+    ]));
+    expect(component.mobileRedirectUriInput).toBe('');
   });
 
   it('removes the last mobile redirect URI when delete is pressed on an empty input', () => {
@@ -404,6 +349,24 @@ describe('AuthenticationSettingsComponent', () => {
 
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(component.mobileRedirectUris).toEqual(['grimmory://oauth2-callback']);
+  });
+
+  it('surfaces backend redirect URI validation failures in the toast', () => {
+    component.oidcProvider = completeProvider();
+    component.mobileRedirectUris = ['grimmory://oauth2-callback'];
+    appSettingsService.saveSettings.mockReturnValue(
+      throwError(() => new HttpErrorResponse({
+        status: 400,
+        error: {message: 'Wildcard redirect URI must be the only value'}
+      }))
+    );
+
+    component.saveOidcProvider();
+
+    expect(messageService.add).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'error',
+      detail: 'Wildcard redirect URI must be the only value',
+    }));
   });
 
   it('saves the group sync mode and reports failures', () => {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
@@ -18,6 +18,7 @@ function createSettings(overrides: Partial<AppSettings> = {}): AppSettings {
     oidcEnabled: false,
     oidcAutoProvisionDetails: undefined,
     oidcProviderDetails: undefined,
+    oidcMobileRedirectUris: ['grimmory://oauth2-callback'],
     oidcSessionDurationHours: null,
     oidcGroupSyncMode: null,
     oidcForceOnlyMode: false,
@@ -127,6 +128,7 @@ describe('AuthenticationSettingsComponent', () => {
       name: 'given_name',
       groups: '',
     });
+    expect(component.mobileRedirectUris).toEqual(['grimmory://oauth2-callback']);
     expect(groupMappingService.getAll).not.toHaveBeenCalled();
   });
 
@@ -174,6 +176,7 @@ describe('AuthenticationSettingsComponent', () => {
       name: 'displayName',
       groups: 'memberOf',
     });
+    expect(component.mobileRedirectUris).toEqual(['grimmory://oauth2-callback']);
     expect(component.groupMappings).toEqual(mappings);
     expect(groupMappingService.getAll).toHaveBeenCalledOnce();
   });
@@ -272,6 +275,7 @@ describe('AuthenticationSettingsComponent', () => {
   it('saves OIDC provider settings with the session duration only when OIDC is enabled', () => {
     appSettingsService.saveSettings.mockReturnValue(of(void 0));
     component.oidcProvider = completeProvider();
+    component.mobileRedirectUris = ['grimmory://oauth2-callback', 'grimmory://auth/return'];
     component.oidcEnabled = false;
     component.sessionDurationHours = 24;
 
@@ -281,6 +285,10 @@ describe('AuthenticationSettingsComponent', () => {
       {
         key: AppSettingKey.OIDC_PROVIDER_DETAILS,
         newValue: component.oidcProvider,
+      },
+      {
+        key: AppSettingKey.OIDC_MOBILE_REDIRECT_URIS,
+        newValue: ['grimmory://oauth2-callback', 'grimmory://auth/return'],
       }
     ]);
 
@@ -293,10 +301,109 @@ describe('AuthenticationSettingsComponent', () => {
         newValue: component.oidcProvider,
       },
       {
+        key: AppSettingKey.OIDC_MOBILE_REDIRECT_URIS,
+        newValue: ['grimmory://oauth2-callback', 'grimmory://auth/return'],
+      },
+      {
         key: AppSettingKey.OIDC_SESSION_DURATION_HOURS,
         newValue: 24,
       }
     ]);
+  });
+
+  it('adds a mobile redirect URI from input and clears the field', () => {
+    component.mobileRedirectUris = ['grimmory://oauth2-callback'];
+    component.mobileRedirectUriInput = 'grimmory://auth/return';
+
+    component.addMobileRedirectUriFromInput();
+
+    expect(component.mobileRedirectUris).toEqual(['grimmory://oauth2-callback', 'grimmory://auth/return']);
+    expect(component.mobileRedirectUriInput).toBe('');
+    expect(component.mobileRedirectUriErrorKey).toBeNull();
+  });
+
+  it('rejects duplicate mobile redirect URIs before saving', () => {
+    component.oidcProvider = completeProvider();
+    component.mobileRedirectUris = ['grimmory://oauth2-callback'];
+    component.mobileRedirectUriInput = 'grimmory://oauth2-callback';
+
+    component.saveOidcProvider();
+
+    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.duplicate');
+    expect(appSettingsService.saveSettings).not.toHaveBeenCalled();
+  });
+
+  it('rejects wildcard mixed with specific redirect URIs', () => {
+    component.mobileRedirectUris = ['*'];
+    component.mobileRedirectUriInput = 'grimmory://oauth2-callback';
+
+    component.addMobileRedirectUriFromInput();
+
+    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.wildcardOnly');
+    expect(component.mobileRedirectUris).toEqual(['*']);
+  });
+
+  it('rejects blank mobile redirect URIs already present in the array being saved', () => {
+    component.oidcProvider = completeProvider();
+    component.mobileRedirectUris = ['grimmory://oauth2-callback', ' '];
+
+    component.saveOidcProvider();
+
+    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.blank');
+    expect(appSettingsService.saveSettings).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed mobile redirect URIs', () => {
+    component.mobileRedirectUris = [];
+    component.mobileRedirectUriInput = 'grimmory://oauth2 callback';
+
+    component.addMobileRedirectUriFromInput();
+
+    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.invalid');
+    expect(component.mobileRedirectUris).toEqual([]);
+  });
+
+  it('rejects mobile redirect URIs without a scheme', () => {
+    component.mobileRedirectUris = [];
+    component.mobileRedirectUriInput = 'oauth2-callback';
+
+    component.addMobileRedirectUriFromInput();
+
+    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.schemeRequired');
+    expect(component.mobileRedirectUris).toEqual([]);
+  });
+
+  it('rejects http and https mobile redirect URIs', () => {
+    component.mobileRedirectUris = [];
+    component.mobileRedirectUriInput = 'https://example.com/oauth2-callback';
+
+    component.addMobileRedirectUriFromInput();
+
+    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.customSchemeRequired');
+    expect(component.mobileRedirectUris).toEqual([]);
+  });
+
+  it('rejects mobile redirect URIs with fragments', () => {
+    component.mobileRedirectUris = [];
+    component.mobileRedirectUriInput = 'grimmory://oauth2-callback#done';
+
+    component.addMobileRedirectUriFromInput();
+
+    expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.fragmentNotAllowed');
+    expect(component.mobileRedirectUris).toEqual([]);
+  });
+
+  it('removes the last mobile redirect URI when delete is pressed on an empty input', () => {
+    component.mobileRedirectUris = ['grimmory://oauth2-callback', 'grimmory://auth/return'];
+    const preventDefault = vi.fn();
+
+    component.onMobileRedirectUriKeydown({
+      key: 'Delete',
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(component.mobileRedirectUris).toEqual(['grimmory://oauth2-callback']);
   });
 
   it('saves the group sync mode and reports failures', () => {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
@@ -334,13 +334,13 @@ describe('AuthenticationSettingsComponent', () => {
   });
 
   it('rejects wildcard mixed with specific redirect URIs', () => {
-    component.mobileRedirectUris = ['*'];
+    component.mobileRedirectUris = [component.wildcardMobileRedirectUri];
     component.mobileRedirectUriInput = 'grimmory://oauth2-callback';
 
     component.addMobileRedirectUriFromInput();
 
     expect(component.mobileRedirectUriErrorKey).toBe('mobileRedirectUris.validation.wildcardOnly');
-    expect(component.mobileRedirectUris).toEqual(['*']);
+    expect(component.mobileRedirectUris).toEqual([component.wildcardMobileRedirectUri]);
   });
 
   it('rejects blank mobile redirect URIs already present in the array being saved', () => {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -46,6 +46,7 @@ import {Chip} from 'primeng/chip';
 })
 export class AuthenticationSettingsComponent {
   readonly defaultMobileRedirectUri = 'grimmory://oauth2-callback';
+  readonly wildcardMobileRedirectUri = '*';
   availablePermissions = [
     {label: 'Upload Books', value: 'permissionUpload', selected: false, translationKey: 'perms.uploadBooks'},
     {label: 'Download Books', value: 'permissionDownload', selected: false, translationKey: 'perms.downloadBooks'},
@@ -342,7 +343,7 @@ export class AuthenticationSettingsComponent {
       return 'mobileRedirectUris.validation.blank';
     }
 
-    if (nonBlankUris.includes('*') && nonBlankUris.length > 1) {
+    if (nonBlankUris.includes(this.wildcardMobileRedirectUri) && nonBlankUris.length > 1) {
       return 'mobileRedirectUris.validation.wildcardOnly';
     }
 
@@ -353,7 +354,7 @@ export class AuthenticationSettingsComponent {
       }
       uniqueUris.add(uri);
 
-      if (uri !== '*') {
+      if (uri !== this.wildcardMobileRedirectUri) {
         const validationError = this.getMobileRedirectUriShapeError(uri);
         if (validationError) {
           return validationError;

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -18,6 +18,7 @@ import {Select} from 'primeng/select';
 import {TableModule} from 'primeng/table';
 import {Dialog} from 'primeng/dialog';
 import {TagComponent} from '../../../shared/components/tag/tag.component';
+import {Chip} from 'primeng/chip';
 
 @Component({
   selector: 'app-authentication-settings',
@@ -38,11 +39,13 @@ import {TagComponent} from '../../../shared/components/tag/tag.component';
     Select,
     TableModule,
     Dialog,
-    TagComponent
+    TagComponent,
+    Chip
   ],
   styleUrls: ['./authentication-settings.component.scss']
 })
 export class AuthenticationSettingsComponent {
+  readonly defaultMobileRedirectUri = 'grimmory://oauth2-callback';
   availablePermissions = [
     {label: 'Upload Books', value: 'permissionUpload', selected: false, translationKey: 'perms.uploadBooks'},
     {label: 'Download Books', value: 'permissionDownload', selected: false, translationKey: 'perms.downloadBooks'},
@@ -82,6 +85,9 @@ export class AuthenticationSettingsComponent {
   sessionDurationHours: number | null = null;
   backchannelLogoutUri = `${window.location.origin}/api/v1/auth/oidc/backchannel-logout`;
   oidcForceOnlyMode = false;
+  mobileRedirectUris: string[] = [this.defaultMobileRedirectUri];
+  mobileRedirectUriInput = '';
+  mobileRedirectUriErrorKey: string | null = null;
 
   infoItems = [
     {labelKey: 'infoPanel.redirectUri', value: `${window.location.origin}/oauth2-callback`},
@@ -158,6 +164,11 @@ export class AuthenticationSettingsComponent {
     this.sessionDurationHours = settings.oidcSessionDurationHours ?? null;
     this.groupSyncMode = settings.oidcGroupSyncMode ?? 'DISABLED';
     this.oidcForceOnlyMode = settings.oidcForceOnlyMode ?? false;
+    this.mobileRedirectUris = settings.oidcMobileRedirectUris?.length
+      ? [...settings.oidcMobileRedirectUris]
+      : [this.defaultMobileRedirectUri];
+    this.mobileRedirectUriInput = '';
+    this.mobileRedirectUriErrorKey = null;
 
     this.oidcProvider = {
       providerName: settings.oidcProviderDetails?.providerName || '',
@@ -198,10 +209,18 @@ export class AuthenticationSettingsComponent {
   }
 
   saveOidcProvider(): void {
+    if (!this.validateMobileRedirectUris()) {
+      return;
+    }
+
     const payload: {key: AppSettingKey; newValue: unknown}[] = [
       {
         key: AppSettingKey.OIDC_PROVIDER_DETAILS,
         newValue: this.oidcProvider
+      },
+      {
+        key: AppSettingKey.OIDC_MOBILE_REDIRECT_URIS,
+        newValue: this.mobileRedirectUris
       }
     ];
     if (this.oidcEnabled) {
@@ -257,6 +276,112 @@ export class AuthenticationSettingsComponent {
         detail: this.t.translate('settingsAuth.toast.sessionDurationError')
       })
     });
+  }
+
+  addMobileRedirectUriFromInput(): void {
+    const value = this.mobileRedirectUriInput.trim();
+    if (!value) {
+      this.mobileRedirectUriInput = '';
+      return;
+    }
+
+    const nextUris = [...this.mobileRedirectUris, value];
+    const validationError = this.getMobileRedirectUriValidationError(nextUris);
+    if (validationError) {
+      this.mobileRedirectUriErrorKey = validationError;
+      return;
+    }
+
+    this.mobileRedirectUris = nextUris;
+    this.mobileRedirectUriInput = '';
+    this.mobileRedirectUriErrorKey = null;
+  }
+
+  removeMobileRedirectUri(index: number): void {
+    this.mobileRedirectUris = this.mobileRedirectUris.filter((_, currentIndex) => currentIndex !== index);
+    this.mobileRedirectUriErrorKey = this.getMobileRedirectUriValidationError(this.mobileRedirectUris);
+  }
+
+  onMobileRedirectUriKeydown(event: KeyboardEvent): void {
+    if ((event.key === 'Enter' || event.key === ',') && this.mobileRedirectUriInput.trim()) {
+      event.preventDefault();
+      this.addMobileRedirectUriFromInput();
+      return;
+    }
+
+    if ((event.key === 'Backspace' || event.key === 'Delete')
+      && !this.mobileRedirectUriInput
+      && this.mobileRedirectUris.length > 0) {
+      event.preventDefault();
+      this.removeMobileRedirectUri(this.mobileRedirectUris.length - 1);
+    }
+  }
+
+  validateMobileRedirectUris(): boolean {
+    const pendingInput = this.mobileRedirectUriInput.trim();
+    if (pendingInput) {
+      const validationError = this.getMobileRedirectUriValidationError([...this.mobileRedirectUris, pendingInput]);
+      if (validationError) {
+        this.mobileRedirectUriErrorKey = validationError;
+        return false;
+      }
+
+      this.mobileRedirectUris = [...this.mobileRedirectUris, pendingInput];
+      this.mobileRedirectUriInput = '';
+    }
+
+    this.mobileRedirectUriErrorKey = this.getMobileRedirectUriValidationError(this.mobileRedirectUris);
+    return this.mobileRedirectUriErrorKey === null;
+  }
+
+  private getMobileRedirectUriValidationError(uris: string[]): string | null {
+    const normalizedUris = uris.map(uri => uri.trim());
+    const nonBlankUris = normalizedUris.filter(Boolean);
+
+    if (normalizedUris.some(uri => uri.length === 0)) {
+      return 'mobileRedirectUris.validation.blank';
+    }
+
+    if (nonBlankUris.includes('*') && nonBlankUris.length > 1) {
+      return 'mobileRedirectUris.validation.wildcardOnly';
+    }
+
+    const uniqueUris = new Set<string>();
+    for (const uri of nonBlankUris) {
+      if (uniqueUris.has(uri)) {
+        return 'mobileRedirectUris.validation.duplicate';
+      }
+      uniqueUris.add(uri);
+
+      if (uri !== '*') {
+        const validationError = this.getMobileRedirectUriShapeError(uri);
+        if (validationError) {
+          return validationError;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private getMobileRedirectUriShapeError(value: string): string | null {
+    const hasScheme = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value);
+    if (!hasScheme) {
+      return 'mobileRedirectUris.validation.schemeRequired';
+    }
+
+    try {
+      const uri = new URL(value);
+      if (uri.protocol === 'http:' || uri.protocol === 'https:') {
+        return 'mobileRedirectUris.validation.customSchemeRequired';
+      }
+      if (uri.hash) {
+        return 'mobileRedirectUris.validation.fragmentNotAllowed';
+      }
+      return null;
+    } catch {
+      return 'mobileRedirectUris.validation.invalid';
+    }
   }
 
   saveOidcAutoProvisionSettings(): void {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -1,3 +1,4 @@
+import {HttpErrorResponse} from '@angular/common/http';
 import {Component, effect, inject} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {InputText} from 'primeng/inputtext';
@@ -88,7 +89,6 @@ export class AuthenticationSettingsComponent {
   oidcForceOnlyMode = false;
   mobileRedirectUris: string[] = [this.defaultMobileRedirectUri];
   mobileRedirectUriInput = '';
-  mobileRedirectUriErrorKey: string | null = null;
 
   infoItems = [
     {labelKey: 'infoPanel.redirectUri', value: `${window.location.origin}/oauth2-callback`},
@@ -165,11 +165,10 @@ export class AuthenticationSettingsComponent {
     this.sessionDurationHours = settings.oidcSessionDurationHours ?? null;
     this.groupSyncMode = settings.oidcGroupSyncMode ?? 'DISABLED';
     this.oidcForceOnlyMode = settings.oidcForceOnlyMode ?? false;
-    this.mobileRedirectUris = settings.oidcMobileRedirectUris?.length
-      ? [...settings.oidcMobileRedirectUris]
+    this.mobileRedirectUris = settings.oidcRedirectUris?.length
+      ? [...settings.oidcRedirectUris]
       : [this.defaultMobileRedirectUri];
     this.mobileRedirectUriInput = '';
-    this.mobileRedirectUriErrorKey = null;
 
     this.oidcProvider = {
       providerName: settings.oidcProviderDetails?.providerName || '',
@@ -210,9 +209,7 @@ export class AuthenticationSettingsComponent {
   }
 
   saveOidcProvider(): void {
-    if (!this.validateMobileRedirectUris()) {
-      return;
-    }
+    this.addMobileRedirectUriFromInput();
 
     const payload: {key: AppSettingKey; newValue: unknown}[] = [
       {
@@ -220,7 +217,7 @@ export class AuthenticationSettingsComponent {
         newValue: this.oidcProvider
       },
       {
-        key: AppSettingKey.OIDC_MOBILE_REDIRECT_URIS,
+        key: AppSettingKey.OIDC_REDIRECT_URIS,
         newValue: this.mobileRedirectUris
       }
     ];
@@ -236,10 +233,10 @@ export class AuthenticationSettingsComponent {
         summary: this.t.translate('settingsAuth.toast.saved'),
         detail: this.t.translate('settingsAuth.toast.providerSaved')
       }),
-      error: () => this.messageService.add({
+      error: (error: HttpErrorResponse) => this.messageService.add({
         severity: 'error',
         summary: this.t.translate('common.error'),
-        detail: this.t.translate('settingsAuth.toast.providerError')
+        detail: error?.error?.message || this.t.translate('settingsAuth.toast.providerError')
       })
     });
   }
@@ -286,21 +283,12 @@ export class AuthenticationSettingsComponent {
       return;
     }
 
-    const nextUris = [...this.mobileRedirectUris, value];
-    const validationError = this.getMobileRedirectUriValidationError(nextUris);
-    if (validationError) {
-      this.mobileRedirectUriErrorKey = validationError;
-      return;
-    }
-
-    this.mobileRedirectUris = nextUris;
+    this.mobileRedirectUris = [...this.mobileRedirectUris, value];
     this.mobileRedirectUriInput = '';
-    this.mobileRedirectUriErrorKey = null;
   }
 
   removeMobileRedirectUri(index: number): void {
     this.mobileRedirectUris = this.mobileRedirectUris.filter((_, currentIndex) => currentIndex !== index);
-    this.mobileRedirectUriErrorKey = this.getMobileRedirectUriValidationError(this.mobileRedirectUris);
   }
 
   onMobileRedirectUriKeydown(event: KeyboardEvent): void {
@@ -315,73 +303,6 @@ export class AuthenticationSettingsComponent {
       && this.mobileRedirectUris.length > 0) {
       event.preventDefault();
       this.removeMobileRedirectUri(this.mobileRedirectUris.length - 1);
-    }
-  }
-
-  validateMobileRedirectUris(): boolean {
-    const pendingInput = this.mobileRedirectUriInput.trim();
-    if (pendingInput) {
-      const validationError = this.getMobileRedirectUriValidationError([...this.mobileRedirectUris, pendingInput]);
-      if (validationError) {
-        this.mobileRedirectUriErrorKey = validationError;
-        return false;
-      }
-
-      this.mobileRedirectUris = [...this.mobileRedirectUris, pendingInput];
-      this.mobileRedirectUriInput = '';
-    }
-
-    this.mobileRedirectUriErrorKey = this.getMobileRedirectUriValidationError(this.mobileRedirectUris);
-    return this.mobileRedirectUriErrorKey === null;
-  }
-
-  private getMobileRedirectUriValidationError(uris: string[]): string | null {
-    const normalizedUris = uris.map(uri => uri.trim());
-    const nonBlankUris = normalizedUris.filter(Boolean);
-
-    if (normalizedUris.some(uri => uri.length === 0)) {
-      return 'mobileRedirectUris.validation.blank';
-    }
-
-    if (nonBlankUris.includes(this.wildcardMobileRedirectUri) && nonBlankUris.length > 1) {
-      return 'mobileRedirectUris.validation.wildcardOnly';
-    }
-
-    const uniqueUris = new Set<string>();
-    for (const uri of nonBlankUris) {
-      if (uniqueUris.has(uri)) {
-        return 'mobileRedirectUris.validation.duplicate';
-      }
-      uniqueUris.add(uri);
-
-      if (uri !== this.wildcardMobileRedirectUri) {
-        const validationError = this.getMobileRedirectUriShapeError(uri);
-        if (validationError) {
-          return validationError;
-        }
-      }
-    }
-
-    return null;
-  }
-
-  private getMobileRedirectUriShapeError(value: string): string | null {
-    const hasScheme = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value);
-    if (!hasScheme) {
-      return 'mobileRedirectUris.validation.schemeRequired';
-    }
-
-    try {
-      const uri = new URL(value);
-      if (uri.protocol === 'http:' || uri.protocol === 'https:') {
-        return 'mobileRedirectUris.validation.customSchemeRequired';
-      }
-      if (uri.hash) {
-        return 'mobileRedirectUris.validation.fragmentNotAllowed';
-      }
-      return null;
-    } catch {
-      return 'mobileRedirectUris.validation.invalid';
     }
   }
 

--- a/frontend/src/app/shared/model/app-settings.model.ts
+++ b/frontend/src/app/shared/model/app-settings.model.ts
@@ -184,6 +184,7 @@ export interface AppSettings {
   remoteAuthEnabled: boolean;
   oidcEnabled: boolean;
   oidcProviderDetails: OidcProviderDetails;
+  oidcMobileRedirectUris: string[];
   oidcAutoProvisionDetails: OidcAutoProvisionDetails;
   maxFileUploadSizeInMb: number;
   metadataProviderSettings: MetadataProviderSettings;
@@ -233,6 +234,7 @@ export enum AppSettingKey {
   KOMGA_GROUP_UNKNOWN = 'KOMGA_GROUP_UNKNOWN',
   OIDC_ENABLED = 'OIDC_ENABLED',
   OIDC_PROVIDER_DETAILS = 'OIDC_PROVIDER_DETAILS',
+  OIDC_MOBILE_REDIRECT_URIS = 'OIDC_MOBILE_REDIRECT_URIS',
   OIDC_AUTO_PROVISION_DETAILS = 'OIDC_AUTO_PROVISION_DETAILS',
   MAX_FILE_UPLOAD_SIZE_IN_MB = 'MAX_FILE_UPLOAD_SIZE_IN_MB',
   METADATA_PROVIDER_SETTINGS = 'METADATA_PROVIDER_SETTINGS',

--- a/frontend/src/app/shared/model/app-settings.model.ts
+++ b/frontend/src/app/shared/model/app-settings.model.ts
@@ -184,7 +184,7 @@ export interface AppSettings {
   remoteAuthEnabled: boolean;
   oidcEnabled: boolean;
   oidcProviderDetails: OidcProviderDetails;
-  oidcMobileRedirectUris: string[];
+  oidcRedirectUris: string[];
   oidcAutoProvisionDetails: OidcAutoProvisionDetails;
   maxFileUploadSizeInMb: number;
   metadataProviderSettings: MetadataProviderSettings;
@@ -234,7 +234,7 @@ export enum AppSettingKey {
   KOMGA_GROUP_UNKNOWN = 'KOMGA_GROUP_UNKNOWN',
   OIDC_ENABLED = 'OIDC_ENABLED',
   OIDC_PROVIDER_DETAILS = 'OIDC_PROVIDER_DETAILS',
-  OIDC_MOBILE_REDIRECT_URIS = 'OIDC_MOBILE_REDIRECT_URIS',
+  OIDC_REDIRECT_URIS = 'OIDC_REDIRECT_URIS',
   OIDC_AUTO_PROVISION_DETAILS = 'OIDC_AUTO_PROVISION_DETAILS',
   MAX_FILE_UPLOAD_SIZE_IN_MB = 'MAX_FILE_UPLOAD_SIZE_IN_MB',
   METADATA_PROVIDER_SETTINGS = 'METADATA_PROVIDER_SETTINGS',

--- a/frontend/src/app/shared/service/app-settings.service.spec.ts
+++ b/frontend/src/app/shared/service/app-settings.service.spec.ts
@@ -43,6 +43,7 @@ function buildAppSettings(overrides: Partial<AppSettings> = {}): AppSettings {
     remoteAuthEnabled: publicSettings.remoteAuthEnabled,
     oidcEnabled: publicSettings.oidcEnabled,
     oidcProviderDetails: publicSettings.oidcProviderDetails,
+    oidcMobileRedirectUris: ['grimmory://oauth2-callback'],
     oidcAutoProvisionDetails: {
       enableAutoProvisioning: false,
       allowLocalAccountLinking: false,

--- a/frontend/src/app/shared/service/app-settings.service.spec.ts
+++ b/frontend/src/app/shared/service/app-settings.service.spec.ts
@@ -43,7 +43,7 @@ function buildAppSettings(overrides: Partial<AppSettings> = {}): AppSettings {
     remoteAuthEnabled: publicSettings.remoteAuthEnabled,
     oidcEnabled: publicSettings.oidcEnabled,
     oidcProviderDetails: publicSettings.oidcProviderDetails,
-    oidcMobileRedirectUris: ['grimmory://oauth2-callback'],
+    oidcRedirectUris: ['grimmory://oauth2-callback'],
     oidcAutoProvisionDetails: {
       enableAutoProvisioning: false,
       allowLocalAccountLinking: false,

--- a/frontend/src/i18n/en/settings-auth.json
+++ b/frontend/src/i18n/en/settings-auth.json
@@ -54,16 +54,7 @@
     "placeholder": "Add a redirect URI or *",
     "hintPrefix": "The default redirect URI is",
     "hintSuffix": "To allow any URI, just use",
-    "removeLabel": "Remove {{uri}}",
-    "validation": {
-      "blank": "Redirect URI cannot be blank.",
-      "invalid": "Enter a valid mobile redirect URI.",
-      "schemeRequired": "Redirect URI must include a scheme.",
-      "customSchemeRequired": "Redirect URI must use a custom mobile scheme.",
-      "fragmentNotAllowed": "Redirect URI must not contain a fragment.",
-      "duplicate": "This redirect URI has already been added.",
-      "wildcardOnly": "If * is present, it must be the only value."
-    }
+    "removeLabel": "Remove {{uri}}"
   },
   "provisioning": {
     "sectionTitle": "User Provisioning",

--- a/frontend/src/i18n/en/settings-auth.json
+++ b/frontend/src/i18n/en/settings-auth.json
@@ -47,6 +47,24 @@
     "backchannelLogoutUri": "Back-Channel Logout URI",
     "backchannelLogoutHint": "Configure this URI in your OIDC provider to enable server-initiated session revocation."
   },
+  "mobileRedirectUris": {
+    "title": "Mobile Redirect URIs",
+    "description": "Whitelist the mobile redirect URIs your OIDC flow is allowed to return to.",
+    "label": "Allowed Mobile Redirect URIs",
+    "placeholder": "Add a redirect URI or *",
+    "hintPrefix": "The default redirect URI is",
+    "hintSuffix": "To allow any URI, just use",
+    "removeLabel": "Remove {{uri}}",
+    "validation": {
+      "blank": "Redirect URI cannot be blank.",
+      "invalid": "Enter a valid mobile redirect URI.",
+      "schemeRequired": "Redirect URI must include a scheme.",
+      "customSchemeRequired": "Redirect URI must use a custom mobile scheme.",
+      "fragmentNotAllowed": "Redirect URI must not contain a fragment.",
+      "duplicate": "This redirect URI has already been added.",
+      "wildcardOnly": "If * is present, it must be the only value."
+    }
+  },
   "provisioning": {
     "sectionTitle": "User Provisioning",
     "sectionDesc": "Configure how new OIDC users are created and what permissions they receive.",


### PR DESCRIPTION
## Description

This PR adds frontend support for configuring OIDC mobile redirect URIs on the OIDC settings page. It introduces a chip-based redirect URI input, aligns frontend validation with the backend, and updates the UI to use Prime chips so the redirect URI pills behave consistently with the current theme

## Linked Issue

Closes #300

## Changes

- Added `OIDC_MOBILE_REDIRECT_URIS` to the frontend app settings model and settings wiring.
- Added a mobile redirect URI input/copy to Settings
- Added frontend validation and validation copy for:
  - blank values already present in the saved array
  - duplicate values
  - `*` mixed with other values
  - missing scheme
  - `http` and `https` URIs
  - fragment-bearing URIs
  - otherwise malformed URIs
- Added frontend specs

## Manual Testing Steps

1. Open Settings -> OIDC, and verify the mobile redirect URI input appears with the expected helper copy
2. Add and remove redirect URIs, including valid custom-scheme values and invalid cases such as duplicates, `https://...`, missing-scheme values, fragments, and mixed `*` arrays, and verify the correct inline validation message is shown
3. Save valid redirect URI values, reload the page, and verify the saved values are restored and rendered correctly

## Screenshots (Optional)

<img width="992" height="752" alt="Screenshot 2026-05-12 at 1 08 25 AM" src="https://github.com/user-attachments/assets/8ddf5c7c-29e2-4119-965a-15370fc241e4" />


Sample inline validation:
<img width="1252" height="720" alt="Screenshot 2026-05-13 at 2 02 02 AM" src="https://github.com/user-attachments/assets/c76d7363-0f62-4387-b575-3a081b9e2c75" />



## Additional Context (Optional)

I err towards f/e inline validations- I think it's a better UX, but I understand the risk of duplicating validation logic across FE/BE. Happy to kill the FE validations and rely on the BE validations in the previous PR, but if so, I think we should get better alignment as a team on our philosophy towards surfacing validation errors served from the BE in forms- I think there's a lot of value in doing so

## AI Disclosure

Codex - helped fix the prime ng chip styling + helped gen boilerplate specs

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile redirect URI management to OAuth2/OIDC authentication settings. Users can now add, view, and remove redirect URI entries through an intuitive input interface.

* **Tests**
  * Added comprehensive test coverage for mobile redirect URI functionality and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1287)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->