### PR TITLE
chore(docker): update docker-compose for Gradle caching and build volume management

### DIFF
--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - DATABASE_URL=jdbc:mariadb://backend_db:3306/grimmory
       - DATABASE_USERNAME=grimmory
       - DATABASE_PASSWORD=grimmory
+      - GRADLE_USER_HOME=/home/gradle/.gradle
+      - XDG_CACHE_HOME=/home/gradle/.cache
       - REMOTE_DEBUG_ENABLED=true
       - ALLOWED_ORIGINS=*
       - API_DOCS_ENABLED=true
@@ -25,8 +27,9 @@ services:
       - backend_db
     volumes:
       - './backend:/backend'
-      - /backend/build
-      - /backend/.gradle
+      - backend_build:/backend/build
+      - backend_gradle_cache:/home/gradle/.gradle
+      - backend_native_cache:/home/gradle/.cache
       - ./shared/data:/app/data
       - ./shared/books:/books
       - ./shared/bookdrop:/bookdrop
@@ -69,3 +72,6 @@ services:
 volumes:
   node_modules:
   backend_db:
+  backend_build:
+  backend_gradle_cache:
+  backend_native_cache:


### PR DESCRIPTION

## Description

The dev Docker Compose setup used anonymous volumes for /backend/build and /backend/.gradle, which are discarded on every container recreation, forcing a full cold Gradle build (re-download dependencies, recompile all sources) on every docker compose down && up. This replaces them with named volumes that persist across restarts, and adds a separate named volume for native/platform caches (libvips, libarchive etc.)

<!-- Required. Briefly explain what changed and why. -->

## Linked Issue

Fixes: #1311

<!-- Required. Example: Fixes #123 -->

## Changes

- Replaced anonymous volumes /backend/build and /backend/.gradle with named volumes backend_build, backend_gradle_cache, and backend_native_cache

- Added GRADLE_USER_HOME=/home/gradle/.gradle env var to redirect Gradle's dependency and metadata cache into the named volume

- Added XDG_CACHE_HOME=/home/gradle/.cache env var to redirect native/platform caches into the named volume

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Run just dev-up
2. Shutdown the container and restarted
3. Verified it was faster and did not compile libvips (on that branch of was working on that)

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose development environment configuration to use named volumes for build artifacts and cache persistence, improving consistency across container rebuilds and optimizing the development workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1312)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->