### PR TITLE
docs(api): add OpenAPI stability warning

### DIFF
--- a/backend/src/main/java/org/booklore/config/openapi/OpenApiConfig.java
+++ b/backend/src/main/java/org/booklore/config/openapi/OpenApiConfig.java
@@ -15,6 +15,13 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(name = "app.api-docs.enabled", havingValue = "true", matchIfMissing = false)
 public class OpenApiConfig {
 
+    static final String API_DESCRIPTION = """
+            > [!warning]
+            > This documentation is auto-generated and public, but the API is unstable; to join the conversation around changes to the API, visit our [GitHub](https://github.com/grimmory-tools/grimmory) or [Discord](https://discord.gg/9YJ7HB4n8T).
+
+            REST API documentation for managing libraries, readers, metadata, and device integrations in Grimmory.
+            """;
+
     private final AppProperties appProperties;
 
     @Bean
@@ -22,7 +29,7 @@ public class OpenApiConfig {
         return new OpenAPI()
                 .info(new Info()
                         .title("Grimmory API")
-                        .description("REST API documentation for managing libraries, readers, metadata, and device integrations in Grimmory.")
+                        .description(API_DESCRIPTION)
                         .version(appProperties.getVersion())
                         .contact(new Contact()
                                 .name("Grimmory")

--- a/backend/src/test/java/org/booklore/config/openapi/OpenApiConfigIntegrationTest.java
+++ b/backend/src/test/java/org/booklore/config/openapi/OpenApiConfigIntegrationTest.java
@@ -24,7 +24,10 @@ class OpenApiConfigIntegrationTest {
                     OpenAPI openAPI = context.getBean(OpenAPI.class);
                     assertThat(openAPI.getInfo().getTitle()).isEqualTo("Grimmory API");
                     assertThat(openAPI.getInfo().getDescription())
-                            .isEqualTo("REST API documentation for managing libraries, readers, metadata, and device integrations in Grimmory.");
+                            .startsWith("> [!warning]\n> This documentation is auto-generated and public, but the API is unstable")
+                            .contains("https://github.com/grimmory-tools/grimmory")
+                            .contains("https://discord.gg/9YJ7HB4n8T")
+                            .endsWith("REST API documentation for managing libraries, readers, metadata, and device integrations in Grimmory.\n");
                     assertThat(openAPI.getInfo().getVersion()).isEqualTo("9.9.9-test");
                     assertThat(openAPI.getInfo().getContact().getName()).isEqualTo("Grimmory");
                     assertThat(openAPI.getInfo().getContact().getUrl())


### PR DESCRIPTION
## Description

Adds a stability warning to the API docs, so it's transparent that the API is still a WIP.

## Linked Issue

N/A

## Changes

- Copy changes

## Manual Testing Steps

N/A

## Screenshots (Optional)

<img width="2880" height="1800" alt="Screen Shot 2026-05-14 at 17 53 19" src="https://github.com/user-attachments/assets/95ffcccf-4dd3-4ce7-9a56-cc26ebf9b6bc" />


## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced API documentation configuration with centralized content structure and added warning notification in API documentation display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1321)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->