### PR TITLE
ci(nightly): make Discord notification optional for manual runs

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
+    inputs:
+      post_discord:
+        description: 'Post the Discord nightly announcement'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   resolve_ref:
@@ -155,7 +161,7 @@ jobs:
 
   generate-notes:
     name: Nightly Changelog
-    if: ${{ always() && needs.test-suite.result == 'success' }}
+    if: ${{ always() && needs.test-suite.result == 'success' && (github.event_name == 'schedule' || inputs.post_discord) }}
     needs: [resolve_ref, test-suite]
     runs-on: ubuntu-latest
     permissions:
@@ -200,7 +206,7 @@ jobs:
 
   notify-discord:
     name: Notify Discord (Nightly)
-    if: ${{ always() && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' && needs.export-openapi.result == 'success' && needs.generate-notes.outputs.available == 'true' && needs.generate-notes.outputs.predicted_version != '' }}
+    if: ${{ always() && (github.event_name == 'schedule' || inputs.post_discord) && needs.generate-notes.result == 'success' && needs.build-and-push.result == 'success' && needs.export-openapi.result == 'success' && needs.generate-notes.outputs.available == 'true' && needs.generate-notes.outputs.predicted_version != '' }}
     needs: [resolve_ref, build-and-push, export-openapi, generate-notes]
     permissions: {}
     uses: ./.github/workflows/notify-discord-release-notes.yml

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -161,7 +161,7 @@ jobs:
 
   generate-notes:
     name: Nightly Changelog
-    if: ${{ always() && needs.test-suite.result == 'success' && (github.event_name == 'schedule' || inputs.post_discord) }}
+    if: ${{ always() && needs.test-suite.result == 'success' }}
     needs: [resolve_ref, test-suite]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Description

This PR adds a manual input option when triggering nightly releases to skip the Discord message. This can be useful when we want to publish a nightly that only has minor changes in it for a hotfix, etc., and don't need to ping every testing user.

## Linked Issue

N/A

## Changes

- Add optional field to send a discord message on triggering manual nightlies. Scheduled nightlies always post.

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nightly publish workflow to add an optional input for controlling Discord notifications. When manually triggering the workflow, users can now choose whether to post a Discord notification, while scheduled runs will continue to post notifications by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1322)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->