### PR TITLE
chore: use valid unraid icon

### DIFF
--- a/unraid.xml
+++ b/unraid.xml
@@ -13,7 +13,7 @@
     <Overview>Grimmory is a self-hosted application for managing your entire book collection in one place: organize, read, annotate, sync across devices, and share without relying on third-party services.</Overview>
     <Category>MediaApp:Books MediaServer:Books</Category>
     <WebUI>http://[IP]:[PORT:6060]/</WebUI>
-    <Icon>https://raw.githubusercontent.com/grimmory-tools/grimmory/main/assets/favicons/apple-touch-icon-144x144.png</Icon>
+    <Icon>https://github.com/grimmory-tools/grimmory/blob/develop/frontend/public/icons/icon-144x144.png?raw=true</Icon>
     <ExtraParams>--restart=unless-stopped</ExtraParams>
     <PostArgs/>
     <CPUset/>

--- a/unraid.xml
+++ b/unraid.xml
@@ -13,7 +13,7 @@
     <Overview>Grimmory is a self-hosted application for managing your entire book collection in one place: organize, read, annotate, sync across devices, and share without relying on third-party services.</Overview>
     <Category>MediaApp:Books MediaServer:Books</Category>
     <WebUI>http://[IP]:[PORT:6060]/</WebUI>
-    <Icon>https://github.com/grimmory-tools/grimmory/blob/develop/frontend/public/icons/icon-144x144.png?raw=true</Icon>
+    <Icon>https://raw.githubusercontent.com/grimmory-tools/grimmory/main/frontend/public/icons/icon-144x144.png</Icon>
     <ExtraParams>--restart=unless-stopped</ExtraParams>
     <PostArgs/>
     <CPUset/>


### PR DESCRIPTION
## Description

Unraid.xml had the wrong icon url linked and was causing unraid to not populate a grimmory icon on docker build. I updated the file with the correct grimmory icon. 
## Linked Issue

fixes #1324


## Changes

Changed the unraid templet to point to the correct Grimmory icon url

https://github.com/grimmory-tools/grimmory/blob/develop/frontend/public/icons/icon-144x144.png?raw=true

## Manual Testing Steps


1. I updated the url
2. I ran the update on unraid
3. The icon populated in unraid UI

## Screenshots (Optional)


## Additional Context (Optional)


## AI Disclosure

No ai used in this

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] ~~There are new or updated tests validating this change.~~ N/A
- [x] ~~I ran `just ui check` and `just api check`.~~ N/A
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated icon resource location for improved asset delivery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1325)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->