### PR TITLE
feat(streaming): implement HTTP Range support and Tomcat's sendfile optimization for large file transfers

### DIFF
--- a/backend/src/main/java/org/booklore/config/TomcatStreamingConfig.java
+++ b/backend/src/main/java/org/booklore/config/TomcatStreamingConfig.java
@@ -21,7 +21,7 @@ public class TomcatStreamingConfig {
             if (connector.getProtocolHandler() instanceof AbstractHttp11Protocol<?> protocol) {
                 protocol.setUseSendfile(true);
 
-                log.info("Tomcat sendfile enabled for HTTP/1.1 connections: {}", protocol.getUseSendfile());
+                log.info("Tomcat sendfile configured for HTTP/1.1 connections.");
             }
         };
     }

--- a/backend/src/main/java/org/booklore/config/TomcatStreamingConfig.java
+++ b/backend/src/main/java/org/booklore/config/TomcatStreamingConfig.java
@@ -1,0 +1,28 @@
+package org.booklore.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
+import org.springframework.boot.tomcat.TomcatConnectorCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Enables Tomcat's kernel-level sendfile for large file transfers.
+ */
+@Slf4j
+@Configuration
+public class TomcatStreamingConfig {
+
+    @Bean
+    TomcatConnectorCustomizer streamingTomcatCustomizer() {
+        return connector -> {
+            connector.setEnableLookups(false);
+
+            if (connector.getProtocolHandler() instanceof AbstractHttp11Protocol<?> protocol) {
+                protocol.setUseSendfile(true);
+
+                log.info("Tomcat sendfile enabled for HTTP/1.1 connections: {}", protocol.getUseSendfile());
+            }
+        };
+    }
+}

--- a/backend/src/main/java/org/booklore/controller/BookController.java
+++ b/backend/src/main/java/org/booklore/controller/BookController.java
@@ -158,11 +158,12 @@ public class BookController {
     })
     @GetMapping("/{bookId}/content")
     @CheckBookAccess(bookIdParam = "bookId")
-    public ResponseEntity<Resource> getBookContent(
+    public void getBookContent(
             @Parameter(description = "ID of the book") @PathVariable long bookId,
-            @Parameter(description = "Optional book type for alternative format (e.g., EPUB, PDF, MOBI)") @RequestParam(required = false) String bookType
-            ) {
-        return bookService.getBookContent(bookId, bookType);
+            @Parameter(description = "Optional book type for alternative format (e.g., EPUB, PDF, MOBI)") @RequestParam(required = false) String bookType,
+            HttpServletRequest request,
+            HttpServletResponse response) throws IOException {
+        bookService.streamBookContent(bookId, bookType, request, response);
     }
 
     @Operation(summary = "Replace book content", description = "Overwrite the primary PDF file for a book with the uploaded content. Used by the document viewer to persist annotation changes.")

--- a/backend/src/main/java/org/booklore/service/FileStreamingService.java
+++ b/backend/src/main/java/org/booklore/service/FileStreamingService.java
@@ -9,12 +9,15 @@ import org.springframework.web.context.request.async.AsyncRequestNotUsableExcept
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.EOFException;
 import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -32,10 +35,21 @@ public class FileStreamingService {
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
             .withZone(ZoneId.of("GMT"));
 
+    private static final int BUFFER_SIZE = 128 * 1024; // 128 KB
+    private static final int MIN_SENDFILE_SIZE = 48 * 1024; // 48 KB
+
+    // Tomcat sendfile attribute keys (org.apache.catalina.connector.Request)
+    private static final String SENDFILE_SUPPORTED = "org.apache.tomcat.sendfile.support";
+    private static final String SENDFILE_FILENAME  = "org.apache.tomcat.sendfile.filename";
+    private static final String SENDFILE_START     = "org.apache.tomcat.sendfile.start";
+    private static final String SENDFILE_END       = "org.apache.tomcat.sendfile.end";
+
     /**
      * Streams a file with HTTP Range support for seeking.
-     * Uses Java NIO FileChannel for zero-copy transfer (sendfile) where supported.
-     * Supports conditional requests via ETag / If-None-Match and If-Range (RFC 7233).
+     * Uses Java NIO FileChannel or Tomcat sendfile where supported.
+     * Supports conditional requests via strong ETag / If-None-Match,
+     * If-Modified-Since, and If-Range validation for efficient caching and seeking.
+     * Multi-range requests are intentionally served as full 200 OK responses
      */
     public void streamWithRangeSupport(
             Path filePath,
@@ -44,63 +58,81 @@ public class FileStreamingService {
             HttpServletResponse response
     ) throws IOException {
 
-        // Single syscall: existence check + size + last-modified
+        // Atomic retrieval of file metadata
         BasicFileAttributes attrs;
         try {
             attrs = Files.readAttributes(filePath, BasicFileAttributes.class);
         } catch (NoSuchFileException _) {
             throw ApiError.FILE_NOT_FOUND.createException(filePath.toString());
+        } catch (AccessDeniedException e) {
+            throw ApiError.PERMISSION_DENIED.createException(e.getMessage());
         }
 
         long fileSize = attrs.size();
-        Instant lastModified = attrs.lastModifiedTime().toInstant();
+        long lastModified = attrs.lastModifiedTime().toMillis();
         String etag = generateETag(fileSize, lastModified);
         String rangeHeader = request.getHeader("Range");
 
-        // Standard headers for media streaming
+        // Initialize response buffer size and headers for media streaming
+        response.setBufferSize(BUFFER_SIZE);
         response.setHeader("Accept-Ranges", "bytes");
         response.setContentType(contentType);
         response.setHeader("ETag", etag);
-        response.setDateHeader("Last-Modified", lastModified.toEpochMilli());
+        response.setDateHeader("Last-Modified", lastModified);
         // Allow caching with mandatory revalidation via ETag eliminates
         // redundant byte transfers on seeks while keeping access-control checks.
-        response.setHeader("Cache-Control", "no-cache");
+        response.setHeader("Cache-Control", "private, no-cache, must-revalidate");
         response.setHeader("Content-Disposition", "inline");
 
-        // Conditional: If-None-Match, 304
+        // Handle ETag-based conditional revalidation
         String ifNoneMatch = request.getHeader("If-None-Match");
         if (evaluateIfNoneMatch(ifNoneMatch, etag)) {
             response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
             return;
         }
 
-        // HEAD request 200 with Content-Length, no body
-        if ("HEAD".equalsIgnoreCase(request.getMethod())) {
+        // Handle date-based conditional revalidation
+        // Only defined for GET and HEAD
+        String method = request.getMethod();
+        boolean isGet = "GET".equalsIgnoreCase(method);
+        boolean isHead = "HEAD".equalsIgnoreCase(method);
+
+        if ((ifNoneMatch == null || ifNoneMatch.isBlank()) && (isGet || isHead)) {
+            long ifModifiedSince = request.getDateHeader("If-Modified-Since");
+            if (ifModifiedSince != -1 && lastModified / 1000 <= ifModifiedSince / 1000) {
+                response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+                return;
+            }
+        }
+
+        // Respond to HEAD requests with metadata only
+        if (isHead) {
             response.setStatus(HttpServletResponse.SC_OK);
             response.setContentLengthLong(fileSize);
             return;
         }
 
-        try (var fileChannel = FileChannel.open(filePath, StandardOpenOption.READ)) {
-
+        try {
             String ifRange = request.getHeader("If-Range");
             if (rangeHeader != null && ifRange != null && !validateIfRange(ifRange, etag, lastModified)) {
-                // If-Range failed: return full file
-                response.setStatus(HttpServletResponse.SC_OK);
-                response.setContentLengthLong(fileSize);
-                transferFile(fileChannel, 0, fileSize, response.getOutputStream());
+                // Precondition failed: fall back to full content delivery
+                streamFullContent(request, response, filePath, fileSize);
                 return;
             }
 
-            // NO RANGE
+            // Full content delivery
             if (rangeHeader == null) {
-                response.setStatus(HttpServletResponse.SC_OK);
-                response.setContentLengthLong(fileSize);
-                transferFile(fileChannel, 0, fileSize, response.getOutputStream());
+                streamFullContent(request, response, filePath, fileSize);
                 return;
             }
 
-            // RANGE
+            // Serve full content for multi-range requests
+            if (hasMultipleRanges(rangeHeader)) {
+                streamFullContent(request, response, filePath, fileSize);
+                return;
+            }
+
+            // Partial content delivery
             Range range = parseRange(rangeHeader, fileSize);
             if (range == null) {
                 response.setStatus(HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE);
@@ -113,10 +145,13 @@ public class FileStreamingService {
             response.setHeader("Content-Range", "bytes " + range.start + "-" + range.end + "/" + fileSize);
             response.setContentLengthLong(length);
 
-            transferFile(fileChannel, range.start, length, response.getOutputStream());
+            streamContent(request, response, filePath, range.start, length);
 
-        } catch (NoSuchFileException _) {
-            throw ApiError.FILE_NOT_FOUND.createException(filePath.toString());
+        } catch (AccessDeniedException e) {
+            log.warn("Access denied during file streaming: {}", filePath, e);
+            if (!response.isCommitted()) {
+                throw ApiError.PERMISSION_DENIED.createException(e.getMessage());
+            }
         } catch (IOException e) {
             if (isClientDisconnect(e)) {
                 log.debug("Client disconnected during streaming: {}", e.getMessage());
@@ -129,20 +164,92 @@ public class FileStreamingService {
         }
     }
 
+    private static void streamFullContent(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Path filePath,
+            long fileSize
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentLengthLong(fileSize);
+        streamContent(request, response, filePath, 0, fileSize);
+    }
+
+    private static void streamContent(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Path filePath,
+            long start,
+            long length
+    ) throws IOException {
+        if (length >= MIN_SENDFILE_SIZE && tryTomcatSendfile(request, filePath, start, length)) {
+            return;
+        }
+        OutputStream out = response.getOutputStream();
+        try (var fileChannel = FileChannel.open(filePath, StandardOpenOption.READ)) {
+            copyToResponse(fileChannel, start, length, out);
+        }
+    }
+
+    private static boolean tryTomcatSendfile(
+            HttpServletRequest request,
+            Path filePath,
+            long start,
+            long length
+    ) {
+        Object supported = request.getAttribute(SENDFILE_SUPPORTED);
+        if (!Boolean.TRUE.equals(supported)) {
+            return false;
+        }
+
+        // Once sendfile attributes are set, the application MUST NOT 
+        // write any data to the response body. Tomcat will handle the transfer.
+        try {
+            request.setAttribute(SENDFILE_FILENAME, filePath.toRealPath().toString());
+            request.setAttribute(SENDFILE_START, start);
+            request.setAttribute(SENDFILE_END, Math.addExact(start, length));
+            return true;
+        } catch (IOException | ArithmeticException e) {
+            log.debug("Sendfile fallback: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private static boolean hasMultipleRanges(String header) {
+        if (header == null || header.length() < 7 || !header.regionMatches(true, 0, "bytes=", 0, 6)) {
+            return false;
+        }
+        // Skip whitespace after "bytes="
+        int pos = 6;
+        while (pos < header.length() && header.charAt(pos) <= ' ') pos++;
+        
+        // Find comma
+        while (pos < header.length()) {
+            if (header.charAt(pos) == ',') {
+                // Found a comma, check if there's anything after it
+                do pos++;
+                while (pos < header.length() && header.charAt(pos) <= ' ');
+                return pos < header.length();
+            }
+            pos++;
+        }
+        return false;
+    }
+
     /**
      * Validates the If-Range header against current ETag and lastModified.
-     * RFC 7233: If-Range can be a strong ETag OR an HTTP-date.
+     * If-Range can be a strong ETag OR an HTTP-date.
      */
-    private boolean validateIfRange(String ifRange, String etag, Instant lastModified) {
-        if (!ifRange.isEmpty() && ifRange.charAt(0) == '\"') {
-            // ETag comparison (Strong match required)
+    private static boolean validateIfRange(String ifRange, String etag, long lastModified) {
+        if (!ifRange.isBlank() && ifRange.charAt(0) == '"') {
+            // If-Range MUST use strong comparison only.
+            // Do NOT use isWeakMatch() here.
             return etag.equals(ifRange);
         } else {
-            // HTTP-date comparison
             try {
                 Instant ifRangeDate = Instant.from(HTTP_DATE_FORMAT.parse(ifRange));
-                // Exact match on seconds required by RFC
-                return lastModified.getEpochSecond() == ifRangeDate.getEpochSecond();
+                // Exact second-precision equality is required for If-Range date validators.
+                return lastModified / 1000 == ifRangeDate.getEpochSecond();
             } catch (DateTimeParseException e) {
                 log.trace("Failed to parse If-Range date: {}", ifRange);
                 return false;
@@ -152,69 +259,97 @@ public class FileStreamingService {
 
     /**
      * Evaluates the If-None-Match header against the current ETag.
-     * RFC 7232: If-None-Match can be "*", a single entity-tag, or a list of them.
+     * If-None-Match can be "*", a single entity-tag, or a list of them.
      */
-    private boolean evaluateIfNoneMatch(String ifNoneMatch, String currentEtag) {
-        if (ifNoneMatch == null || ifNoneMatch.isBlank()) {
-            return false;
-        }
+    private static boolean evaluateIfNoneMatch(String ifNoneMatch, String currentEtag) {
+        if (ifNoneMatch == null || ifNoneMatch.isBlank()) return false;
 
-        String trimmedValue = ifNoneMatch.trim();
-        if ("*".equals(trimmedValue)) {
-            return true;
-        }
+        int start = 0, len = ifNoneMatch.length();
+        while (start < len) {
+            int end = ifNoneMatch.indexOf(',', start);
+            if (end == -1) end = len;
 
-        // Split by comma. Entity-tags are [weak] opaque-tag.
-        String[] parts = trimmedValue.split(",");
-        for (String part : parts) {
-            String tag = part.trim();
-            if (tag.isEmpty()) {
-                continue;
+            // Trim whitespace
+            int s = start, e = end;
+            while (s < e && ifNoneMatch.charAt(s) <= ' ') s++;
+            while (e > s && ifNoneMatch.charAt(e - 1) <= ' ') e--;
+
+            if (e > s) {
+                if (e - s == 1 && ifNoneMatch.charAt(s) == '*') return true;
+                if (isWeakMatch(ifNoneMatch, s, e, currentEtag)) return true;
             }
-            if (isWeakMatch(tag, currentEtag)) {
-                return true;
-            }
+            start = end + 1;
         }
         return false;
     }
 
-    /**
-     * Weak comparison of two ETags.
-     * RFC 7232 Section 2.3.2: Two entity-tags are a weak match if their opaque-tags are equal,
-     * regardless of whether either or both have a "W/" prefix.
-     */
-    private boolean isWeakMatch(String tag1, String tag2) {
-        String opaque1 = tag1.startsWith("W/") ? tag1.substring(2) : tag1;
-        String opaque2 = tag2.startsWith("W/") ? tag2.substring(2) : tag2;
-        return opaque1.equals(opaque2);
+    private static boolean isWeakMatch(String input, int start, int end, String etag) {
+        // Strip optional W/ prefix from both sides before comparing opaque-tags
+        int s = (end - start >= 2 && input.charAt(start) == 'W' && input.charAt(start + 1) == '/') ? start + 2 : start;
+        int cs = etag.startsWith("W/") ? 2 : 0;
+        int matchLen = end - s;
+        return matchLen == etag.length() - cs && input.regionMatches(s, etag, cs, matchLen);
     }
 
-    /**
-     * Zero-copy transfer from file channel to output stream via NIO.
-     * Delegates to sendfile(2) on Linux / equivalent on macOS when the
-     * servlet container's OutputStream maps to a socket channel.
-     * Closes the output stream upon completion as the channel wrapper propagates close.
-     */
-    private void transferFile(FileChannel source, long position, long count, OutputStream out) throws IOException {
-        try (WritableByteChannel destination = Channels.newChannel(out)) {
-            long remaining = count;
-            long currentPos = position;
-            int zeroTransferCount = 0;
 
-            while (remaining > 0) {
-                long transferred = source.transferTo(currentPos, remaining, destination);
-                if (transferred <= 0) {
-                    ++zeroTransferCount;
-                    if (zeroTransferCount > 100) {
-                        throw new IOException("File transfer stalled with " + remaining + " bytes remaining");
-                    }
-                    Thread.onSpinWait();
-                    continue;
-                }
-                zeroTransferCount = 0;
-                currentPos += transferred;
-                remaining -= transferred;
+    private static void copyToResponse(
+            FileChannel source,
+            long position,
+            long count,
+            OutputStream out
+    ) throws IOException {
+        if (count < 8192) {
+            copyWithHeapBuffer(source, position, count, out);
+            out.flush();
+            return;
+        }
+        WritableByteChannel outChannel = Channels.newChannel(out);
+        long remaining = count;
+        long offset = position;
+        int zeroCount = 0;
+
+        // Try zero-copy first (works on many servlet containers)
+        while (remaining > 0) {
+            long n = source.transferTo(offset, remaining, outChannel);
+            if (n > 0) {
+                offset += n;
+                remaining -= n;
+                zeroCount = 0;
+                continue;
             }
+
+            if (++zeroCount >= 3) {
+                // transferTo repeatedly returned 0 - fall back to heap copy.
+                copyWithHeapBuffer(source, offset, remaining, out);
+                break;
+            }
+        }
+        out.flush();
+    }
+
+    private static void copyWithHeapBuffer(
+            FileChannel source,
+            long position,
+            long count,
+            OutputStream out
+    ) throws IOException {
+        byte[] buf = new byte[BUFFER_SIZE];
+        ByteBuffer bb = ByteBuffer.wrap(buf);
+        long remaining = count;
+        long offset = position;
+
+        while (remaining > 0) {
+            bb.clear();
+            bb.limit((int) Math.min(buf.length, remaining));
+
+            int read = source.read(bb, offset);
+            if (read < 0) {
+                throw new EOFException("Unexpected EOF at position " + offset);
+            }
+
+            out.write(buf, 0, read);
+            offset += read;
+            remaining -= read;
         }
     }
 
@@ -222,64 +357,59 @@ public class FileStreamingService {
      * Strong ETag derived from file size and last-modified epoch millis.
      * Sufficient for static-file identity without content hashing overhead.
      */
-    String generateETag(long fileSize, Instant lastModified) {
-        return "\"" + Long.toHexString(fileSize) + "-" + Long.toHexString(lastModified.toEpochMilli()) + "\"";
+
+    public static String generateETag(long fileSize, long lastModified) {
+        return "\"%x-%x\"".formatted(fileSize, lastModified);
     }
 
-    // RANGE PARSER (not) RFC 7233 compliant
-    Range parseRange(String header, long size) {
-        if (header == null || !header.startsWith("bytes=")) {
-            return null;
-        }
+    // Byte-range parser
+    static Range parseRange(String header, long size) {
+        if (size <= 0) return null;
+        if (header == null || header.length() < 6 || !header.regionMatches(true, 0, "bytes=", 0, 6)) return null;
 
-        String value = header.substring(6).trim();
-        String[] parts = value.split(",", 2);
-        String range = parts[0].trim();
+        int startPos = 6, len = header.length();
+        while (startPos < len && header.charAt(startPos) <= ' ') startPos++;
+        if (startPos >= len) return null;
 
-        int dash = range.indexOf('-');
-        if (dash < 0) return null;
+        // Only parse the first range if multiple are provided
+        int comma = header.indexOf(',', startPos);
+        int endPos = (comma >= 0) ? comma : len;
+        while (endPos > startPos && header.charAt(endPos - 1) <= ' ') endPos--;
+
+        int dash = header.indexOf('-', startPos);
+        if (dash < 0 || dash >= endPos) return null;
 
         try {
-            // suffix-byte-range-spec: "-<length>"
-            if (dash == 0) {
-                long suffix = Long.parseLong(range.substring(1));
-                if (suffix <= 0) return null;
-                suffix = Math.min(suffix, size);
-                return new Range(size - suffix, size - 1);
+            if (dash == startPos) { // Suffix: "-N"
+                long suffix = Long.parseLong(header, dash + 1, endPos, 10);
+                return suffix <= 0 ? null : new Range(size - Math.min(suffix, size), size - 1);
             }
 
-            long start = Long.parseLong(range.substring(0, dash));
-
-            // open-ended: "<start>-"
-            if (dash == range.length() - 1) {
-                if (start >= size) return null;
-                return new Range(start, size - 1);
+            long start = Long.parseLong(header, startPos, dash, 10);
+            if (dash == endPos - 1) { // Open-ended: "N-"
+                return start >= size ? null : new Range(start, size - 1);
             }
 
-            // "<start>-<end>"
-            long end = Long.parseLong(range.substring(dash + 1));
-            if (start > end || start >= size) return null;
-            end = Math.min(end, size - 1);
-
-            return new Range(start, end);
-
+            long end = Long.parseLong(header, dash + 1, endPos, 10); // Bounded: "N-M"
+            if (start > end) return null;
+            return (start >= size) ? null : new Range(start, Math.min(end, size - 1));
         } catch (NumberFormatException e) {
             return null;
         }
     }
 
-    // DISCONNECT DETECTION
-    boolean isClientDisconnect(IOException e) {
+    // Client disconnection detection
+    static boolean isClientDisconnect(IOException e) {
         return switch (e) {
-            case SocketTimeoutException _, AsyncRequestNotUsableException _ -> true;
+            case EOFException _, SocketTimeoutException _, AsyncRequestNotUsableException _ -> true;
             case IOException io when io.getMessage() != null -> {
-                String msg = io.getMessage();
-                yield msg.contains("Broken pipe")
-                        || msg.contains("Connection reset")
+                String msg = io.getMessage().toLowerCase(Locale.ROOT);
+                yield msg.contains("broken pipe")
+                        || msg.contains("connection reset")
                         || msg.contains("connection was aborted")
-                        || msg.contains("An established connection was aborted")
-                        || msg.contains("Response not usable")
-                        || msg.contains("SocketTimeout")
+                        || msg.contains("an established connection was aborted")
+                        || msg.contains("response not usable")
+                        || msg.contains("sockettimeout")
                         || msg.contains("timed out");
             }
             default -> false;

--- a/backend/src/main/java/org/booklore/service/FileStreamingService.java
+++ b/backend/src/main/java/org/booklore/service/FileStreamingService.java
@@ -1,5 +1,6 @@
 package org.booklore.service;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +42,16 @@ public class FileStreamingService {
 
     @Value("${app.streaming.min-sendfile-size:49152}")
     private int minSendfileSize = 49152; // 48 KB
+
+    @PostConstruct
+    public void validateProperties() {
+        if (bufferSize <= 0) {
+            throw new IllegalArgumentException("app.streaming.buffer-size must be greater than 0");
+        }
+        if (minSendfileSize < 0) {
+            throw new IllegalArgumentException("app.streaming.min-sendfile-size must be non-negative");
+        }
+    }
 
     /**
      * Streams a file with HTTP Range support for seeking.
@@ -96,7 +107,12 @@ public class FileStreamingService {
         boolean isHead = "HEAD".equalsIgnoreCase(method);
 
         if ((ifNoneMatch == null || ifNoneMatch.isBlank()) && (isGet || isHead)) {
-            long ifModifiedSince = request.getDateHeader("If-Modified-Since");
+            long ifModifiedSince;
+            try {
+                ifModifiedSince = request.getDateHeader("If-Modified-Since");
+            } catch (IllegalArgumentException _) {
+                ifModifiedSince = -1;
+            }
             if (ifModifiedSince != -1 && lastModified / 1000 <= ifModifiedSince / 1000) {
                 response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
                 return;

--- a/backend/src/main/java/org/booklore/service/FileStreamingService.java
+++ b/backend/src/main/java/org/booklore/service/FileStreamingService.java
@@ -1,6 +1,5 @@
 package org.booklore.service;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -37,14 +36,19 @@ public class FileStreamingService {
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
             .withZone(ZoneId.of("GMT"));
 
-    @Value("${app.streaming.buffer-size:131072}")
-    private int bufferSize = 131072; // 128 KB
+    private final int bufferSize;
+    private final int minSendfileSize;
 
-    @Value("${app.streaming.min-sendfile-size:49152}")
-    private int minSendfileSize = 49152; // 48 KB
+    public FileStreamingService(
+            @Value("${app.streaming.buffer-size:131072}") int bufferSize,
+            @Value("${app.streaming.min-sendfile-size:49152}") int minSendfileSize
+    ) {
+        this.bufferSize = bufferSize;
+        this.minSendfileSize = minSendfileSize;
+        validateProperties();
+    }
 
-    @PostConstruct
-    public void validateProperties() {
+    void validateProperties() {
         if (bufferSize <= 0) {
             throw new IllegalArgumentException("app.streaming.buffer-size must be greater than 0");
         }
@@ -253,12 +257,14 @@ public class FileStreamingService {
     /**
      * Validates the If-Range header against current ETag and lastModified.
      * If-Range can be a strong ETag OR an HTTP-date.
+     * Since we use weak ETags, If-Range comparison against ETag will always fail,
+     * forcing a full content delivery.
      */
     private static boolean validateIfRange(String ifRange, String etag, long lastModified) {
         if (!ifRange.isBlank() && ifRange.charAt(0) == '"') {
             // If-Range MUST use strong comparison only.
-            // Do NOT use isWeakMatch() here.
-            return etag.equals(ifRange);
+            // Weak ETags (starting with W/) never match a strong validator.
+            return !etag.isEmpty() && etag.charAt(0) == '\"' && etag.equals(ifRange);
         } else {
             try {
                 Instant ifRangeDate = Instant.from(HTTP_DATE_FORMAT.parse(ifRange));

--- a/backend/src/main/java/org/booklore/service/FileStreamingService.java
+++ b/backend/src/main/java/org/booklore/service/FileStreamingService.java
@@ -374,12 +374,11 @@ public class FileStreamingService {
     }
 
     /**
-     * Strong ETag derived from file size and last-modified epoch millis.
-     * Sufficient for static-file identity without content hashing overhead.
+     * Weak ETag derived from file size and last-modified epoch millis.
+     * Suitable for cache revalidation; not a byte-identity validator.
      */
-
     public static String generateETag(long fileSize, long lastModified) {
-        return "\"%x-%x\"".formatted(fileSize, lastModified);
+        return "W/\"%x-%x\"".formatted(fileSize, lastModified);
     }
 
     // Byte-range parser

--- a/backend/src/main/java/org/booklore/service/FileStreamingService.java
+++ b/backend/src/main/java/org/booklore/service/FileStreamingService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.booklore.exception.ApiError;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -35,14 +36,11 @@ public class FileStreamingService {
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
             .withZone(ZoneId.of("GMT"));
 
-    private static final int BUFFER_SIZE = 128 * 1024; // 128 KB
-    private static final int MIN_SENDFILE_SIZE = 48 * 1024; // 48 KB
+    @Value("${app.streaming.buffer-size:131072}")
+    private int bufferSize = 131072; // 128 KB
 
-    // Tomcat sendfile attribute keys (org.apache.catalina.connector.Request)
-    private static final String SENDFILE_SUPPORTED = "org.apache.tomcat.sendfile.support";
-    private static final String SENDFILE_FILENAME  = "org.apache.tomcat.sendfile.filename";
-    private static final String SENDFILE_START     = "org.apache.tomcat.sendfile.start";
-    private static final String SENDFILE_END       = "org.apache.tomcat.sendfile.end";
+    @Value("${app.streaming.min-sendfile-size:49152}")
+    private int minSendfileSize = 49152; // 48 KB
 
     /**
      * Streams a file with HTTP Range support for seeking.
@@ -74,7 +72,7 @@ public class FileStreamingService {
         String rangeHeader = request.getHeader("Range");
 
         // Initialize response buffer size and headers for media streaming
-        response.setBufferSize(BUFFER_SIZE);
+        response.setBufferSize(bufferSize);
         response.setHeader("Accept-Ranges", "bytes");
         response.setContentType(contentType);
         response.setHeader("ETag", etag);
@@ -164,7 +162,7 @@ public class FileStreamingService {
         }
     }
 
-    private static void streamFullContent(
+    private void streamFullContent(
             HttpServletRequest request,
             HttpServletResponse response,
             Path filePath,
@@ -175,14 +173,14 @@ public class FileStreamingService {
         streamContent(request, response, filePath, 0, fileSize);
     }
 
-    private static void streamContent(
+    private void streamContent(
             HttpServletRequest request,
             HttpServletResponse response,
             Path filePath,
             long start,
             long length
     ) throws IOException {
-        if (length >= MIN_SENDFILE_SIZE && tryTomcatSendfile(request, filePath, start, length)) {
+        if (length >= minSendfileSize && tryTomcatSendfile(request, filePath, start, length)) {
             return;
         }
         OutputStream out = response.getOutputStream();
@@ -191,13 +189,13 @@ public class FileStreamingService {
         }
     }
 
-    private static boolean tryTomcatSendfile(
+    private boolean tryTomcatSendfile(
             HttpServletRequest request,
             Path filePath,
             long start,
             long length
     ) {
-        Object supported = request.getAttribute(SENDFILE_SUPPORTED);
+        Object supported = request.getAttribute("org.apache.tomcat.sendfile.support");
         if (!Boolean.TRUE.equals(supported)) {
             return false;
         }
@@ -205,9 +203,9 @@ public class FileStreamingService {
         // Once sendfile attributes are set, the application MUST NOT 
         // write any data to the response body. Tomcat will handle the transfer.
         try {
-            request.setAttribute(SENDFILE_FILENAME, filePath.toRealPath().toString());
-            request.setAttribute(SENDFILE_START, start);
-            request.setAttribute(SENDFILE_END, Math.addExact(start, length));
+            request.setAttribute("org.apache.tomcat.sendfile.filename", filePath.toRealPath().toString());
+            request.setAttribute("org.apache.tomcat.sendfile.start", start);
+            request.setAttribute("org.apache.tomcat.sendfile.end", Math.addExact(start, length));
             return true;
         } catch (IOException | ArithmeticException e) {
             log.debug("Sendfile fallback: {}", e.getMessage());
@@ -292,7 +290,7 @@ public class FileStreamingService {
     }
 
 
-    private static void copyToResponse(
+    private void copyToResponse(
             FileChannel source,
             long position,
             long count,
@@ -327,13 +325,13 @@ public class FileStreamingService {
         out.flush();
     }
 
-    private static void copyWithHeapBuffer(
+    private void copyWithHeapBuffer(
             FileChannel source,
             long position,
             long count,
             OutputStream out
     ) throws IOException {
-        byte[] buf = new byte[BUFFER_SIZE];
+        byte[] buf = new byte[bufferSize];
         ByteBuffer bb = ByteBuffer.wrap(buf);
         long remaining = count;
         long offset = position;

--- a/backend/src/main/java/org/booklore/service/book/BookService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookService.java
@@ -29,7 +29,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.MediaTypeFactory;
@@ -518,14 +517,14 @@ public class BookService {
                 for (File file : files) {
                     try {
                         Files.delete(file.toPath());
-                        log.info("Deleted ignored file: {}", file.getAbsolutePath());
+                        log.debug("Deleted ignored file: {}", file.getAbsolutePath());
                     } catch (IOException e) {
                         log.warn("Failed to delete ignored file: {}", file.getAbsolutePath());
                     }
                 }
                 try {
                     Files.delete(dir);
-                    log.info("Deleted empty directory: {}", dir);
+                    log.debug("Deleted empty directory: {}", dir);
                 } catch (IOException e) {
                     log.warn("Failed to delete directory: {}", dir, e);
                     break;

--- a/backend/src/main/java/org/booklore/service/book/BookService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookService.java
@@ -287,7 +287,7 @@ public class BookService {
             if (Files.exists(thumbnailPath)) {
                 return new UrlResource(thumbnailPath.toUri());
             } else {
-                return new ClassPathResource("static/images/missing-cover.jpg");
+                return getMissingCoverResource();
             }
         } catch (MalformedURLException e) {
             throw new RuntimeException("Failed to load book cover for bookId=" + bookId, e);

--- a/backend/src/main/java/org/booklore/service/book/BookService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookService.java
@@ -1,5 +1,6 @@
 package org.booklore.service.book;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,17 +25,21 @@ import org.booklore.util.FileService;
 import org.booklore.util.FileUtils;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.MediaTypeFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,7 +47,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.io.InputStream;
 
 @Slf4j
 @AllArgsConstructor
@@ -352,38 +356,28 @@ public class BookService {
         bookDownloadService.downloadAllBookFiles(bookId, response);
     }
 
-    public ResponseEntity<Resource> getBookContent(long bookId) {
-        return getBookContent(bookId, null);
-    }
+    public void streamBookContent(long bookId, String bookType, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        BookEntity bookEntity = bookRepository.findByIdWithBookFiles(bookId)
+                .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
 
-    public ResponseEntity<Resource> getBookContent(long bookId, String bookType) {
-        BookEntity bookEntity = bookRepository.findByIdWithBookFiles(bookId).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
-        String filePath;
+        Path filePath;
         if (bookType != null) {
-            BookFileType requestedType = BookFileType.valueOf(bookType.toUpperCase());
+            BookFileType requestedType = BookFileType.fromName(bookType)
+                    .orElseThrow(() -> ApiError.INVALID_INPUT.createException("Invalid book type: " + bookType));
             BookFileEntity bookFile = bookEntity.getBookFiles().stream()
                     .filter(bf -> bf.getBookType() == requestedType)
                     .findFirst()
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
-            filePath = bookFile.getFullFilePath().toString();
+            filePath = bookFile.getFullFilePath();
         } else {
-            filePath = FileUtils.getBookFullPath(bookEntity).toString();
-        }
-        File file = new File(filePath);
-        if (!file.exists()) {
-            throw ApiError.FILE_NOT_FOUND.createException(filePath);
-        }
-        Long lastModified = FileUtils.getFileLastModified(Path.of(filePath));
-        ResponseEntity.BodyBuilder builder = ResponseEntity.ok();
-
-        if (lastModified != null) {
-            builder.lastModified(lastModified);
+            filePath = FileUtils.getBookFullPath(bookEntity);
         }
 
-        return builder
-                .cacheControl(CacheControl.noCache().cachePrivate())
-                .contentType(MediaTypeFactory.getMediaType(filePath).orElse(MediaType.APPLICATION_OCTET_STREAM))
-                .body(new FileSystemResource(file));
+        String contentType = MediaTypeFactory.getMediaType(filePath.getFileName().toString())
+                .map(MediaType::toString)
+                .orElse(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+
+        fileStreamingService.streamWithRangeSupport(filePath, contentType, request, response);
     }
 
     public void replaceBookContent(long bookId, String bookType, InputStream content) throws IOException {

--- a/backend/src/test/java/org/booklore/service/FileStreamingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/FileStreamingServiceTest.java
@@ -256,7 +256,7 @@ class FileStreamingServiceTest {
         var response = mock(HttpServletResponse.class);
 
         String etag = computeExpectedETag(testFile);
-        String weakEtag = "W/" + etag;
+        String weakEtag = etag.startsWith("W/") ? etag : "W/" + etag;
         when(request.getHeader("If-None-Match")).thenReturn(weakEtag);
 
         fileStreamingService.streamWithRangeSupport(testFile, "audio/mp4", request, response);

--- a/backend/src/test/java/org/booklore/service/FileStreamingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/FileStreamingServiceTest.java
@@ -36,7 +36,7 @@ class FileStreamingServiceTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        fileStreamingService = new FileStreamingService();
+        fileStreamingService = new FileStreamingService(131072, 49152);
 
         // Create a test file with known content
         testContent = new byte[10000];
@@ -280,7 +280,7 @@ class FileStreamingServiceTest {
     }
 
     @Test
-    void streamWithRangeSupport_ifRangeMatchingEtag_servesRange() throws IOException {
+    void streamWithRangeSupport_ifRangeMatchingEtag_servesFullContentDueToWeakEtag() throws IOException {
         var request = mock(HttpServletRequest.class);
         var response = mock(HttpServletResponse.class);
         var outputStream = new ByteArrayOutputStream();
@@ -293,9 +293,10 @@ class FileStreamingServiceTest {
 
         fileStreamingService.streamWithRangeSupport(testFile, "audio/mp4", request, response);
 
-        verify(response).setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
-        verify(response).setContentLengthLong(100);
-        assertEquals(100, outputStream.size());
+        // Weak ETag does NOT match for If-Range, should serve full content (200 OK)
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        verify(response).setContentLengthLong(testContent.length);
+        assertArrayEquals(testContent, outputStream.toByteArray());
     }
 
     @Test
@@ -607,27 +608,16 @@ class FileStreamingServiceTest {
 
     @Test
     void validateProperties_invalidBufferSize_throwsException() {
-        // Use reflection or a setter if available, but here I'll use a new instance and manual call
-        // since I can't easily set private fields without reflection or spring.
-        // Actually, I can just use reflection since it's a test.
-        assertThrows(IllegalArgumentException.class, () -> {
-            FileStreamingService service = new FileStreamingService();
-            java.lang.reflect.Field field = FileStreamingService.class.getDeclaredField("bufferSize");
-            field.setAccessible(true);
-            field.set(service, 0);
-            service.validateProperties();
-        });
+        assertThrows(IllegalArgumentException.class, () -> 
+            new FileStreamingService(0, 49152)
+        );
     }
 
     @Test
     void validateProperties_invalidMinSendfileSize_throwsException() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            FileStreamingService service = new FileStreamingService();
-            java.lang.reflect.Field field = FileStreamingService.class.getDeclaredField("minSendfileSize");
-            field.setAccessible(true);
-            field.set(service, -1);
-            service.validateProperties();
-        });
+        assertThrows(IllegalArgumentException.class, () -> 
+            new FileStreamingService(131072, -1)
+        );
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/FileStreamingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/FileStreamingServiceTest.java
@@ -587,6 +587,50 @@ class FileStreamingServiceTest {
     }
 
     @Test
+    void streamWithRangeSupport_ifModifiedSinceMalformed_streamsNormally() throws IOException {
+        var request = mock(HttpServletRequest.class);
+        var response = mock(HttpServletResponse.class);
+        var outputStream = new ByteArrayOutputStream();
+        var servletOutputStream = createServletOutputStream(outputStream);
+
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getDateHeader("If-Modified-Since")).thenThrow(new IllegalArgumentException("Invalid date"));
+        when(request.getHeader("If-None-Match")).thenReturn(null);
+        when(request.getHeader("Range")).thenReturn(null);
+        when(response.getOutputStream()).thenReturn(servletOutputStream);
+
+        fileStreamingService.streamWithRangeSupport(testFile, "audio/mp4", request, response);
+
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        assertArrayEquals(testContent, outputStream.toByteArray());
+    }
+
+    @Test
+    void validateProperties_invalidBufferSize_throwsException() {
+        // Use reflection or a setter if available, but here I'll use a new instance and manual call
+        // since I can't easily set private fields without reflection or spring.
+        // Actually, I can just use reflection since it's a test.
+        assertThrows(IllegalArgumentException.class, () -> {
+            FileStreamingService service = new FileStreamingService();
+            java.lang.reflect.Field field = FileStreamingService.class.getDeclaredField("bufferSize");
+            field.setAccessible(true);
+            field.set(service, 0);
+            service.validateProperties();
+        });
+    }
+
+    @Test
+    void validateProperties_invalidMinSendfileSize_throwsException() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            FileStreamingService service = new FileStreamingService();
+            java.lang.reflect.Field field = FileStreamingService.class.getDeclaredField("minSendfileSize");
+            field.setAccessible(true);
+            field.set(service, -1);
+            service.validateProperties();
+        });
+    }
+
+    @Test
     void streamWithRangeSupport_sendfileSupported_setsRequestAttributesAndWritesNoBody() throws IOException {
         var request = mock(HttpServletRequest.class);
         var response = mock(HttpServletResponse.class);

--- a/backend/src/test/java/org/booklore/service/FileStreamingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/FileStreamingServiceTest.java
@@ -189,7 +189,7 @@ class FileStreamingServiceTest {
 
         String expectedETag = computeExpectedETag(testFile);
         verify(response).setHeader("ETag", expectedETag);
-        verify(response).setHeader("Cache-Control", "no-cache");
+        verify(response).setHeader("Cache-Control", "private, no-cache, must-revalidate");
         verify(response, never()).setHeader(eq("Pragma"), any());
     }
 
@@ -529,12 +529,96 @@ class FileStreamingServiceTest {
         assertArrayEquals(expected, outputStream.toByteArray());
     }
 
+    @Test
+    void streamWithRangeSupport_multiRangeHeader_streamsFullFile() throws IOException {
+        var request = mock(HttpServletRequest.class);
+        var response = mock(HttpServletResponse.class);
+        var outputStream = new ByteArrayOutputStream();
+        var servletOutputStream = createServletOutputStream(outputStream);
+
+        when(request.getHeader("Range")).thenReturn("bytes=0-99,200-299");
+        when(response.getOutputStream()).thenReturn(servletOutputStream);
+
+        fileStreamingService.streamWithRangeSupport(testFile, "application/octet-stream", request, response);
+
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        verify(response).setContentLengthLong(testContent.length);
+        assertArrayEquals(testContent, outputStream.toByteArray());
+    }
+
+    @Test
+    void streamWithRangeSupport_ifModifiedSinceMatching_returns304() throws IOException {
+        var request = mock(HttpServletRequest.class);
+        var response = mock(HttpServletResponse.class);
+
+        var attrs = Files.readAttributes(testFile, BasicFileAttributes.class);
+        long lastModifiedSec = attrs.lastModifiedTime().toInstant().getEpochSecond();
+
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getDateHeader("If-Modified-Since")).thenReturn(lastModifiedSec * 1000);
+        when(request.getHeader("If-None-Match")).thenReturn(null);
+
+        fileStreamingService.streamWithRangeSupport(testFile, "audio/mp4", request, response);
+
+        verify(response).setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+        verify(response, never()).getOutputStream();
+    }
+
+    @Test
+    void streamWithRangeSupport_ifModifiedSinceStale_streamsNormally() throws IOException {
+        var request = mock(HttpServletRequest.class);
+        var response = mock(HttpServletResponse.class);
+        var outputStream = new ByteArrayOutputStream();
+        var servletOutputStream = createServletOutputStream(outputStream);
+
+        var attrs = Files.readAttributes(testFile, BasicFileAttributes.class);
+        long lastModifiedSec = attrs.lastModifiedTime().toInstant().getEpochSecond();
+
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getDateHeader("If-Modified-Since")).thenReturn((lastModifiedSec - 10) * 1000);
+        when(request.getHeader("If-None-Match")).thenReturn(null);
+        when(request.getHeader("Range")).thenReturn(null);
+        when(response.getOutputStream()).thenReturn(servletOutputStream);
+
+        fileStreamingService.streamWithRangeSupport(testFile, "audio/mp4", request, response);
+
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        assertArrayEquals(testContent, outputStream.toByteArray());
+    }
+
+    @Test
+    void streamWithRangeSupport_sendfileSupported_setsRequestAttributesAndWritesNoBody() throws IOException {
+        var request = mock(HttpServletRequest.class);
+        var response = mock(HttpServletResponse.class);
+
+        when(request.getAttribute("org.apache.tomcat.sendfile.support")).thenReturn(Boolean.TRUE);
+        when(request.getHeader("Range")).thenReturn(null);
+
+        // Ensure file size is larger than MIN_SENDFILE_SIZE (48KB) for sendfile to activate
+        byte[] largeContent = new byte[100 * 1024]; // 100 KB
+        Path largeFile = tempDir.resolve("large.bin");
+        Files.write(largeFile, largeContent);
+
+        fileStreamingService.streamWithRangeSupport(largeFile, "application/octet-stream", request, response);
+
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        verify(response).setContentLengthLong(largeContent.length);
+
+        // Verify the sendfile attributes are set
+        verify(request).setAttribute(eq("org.apache.tomcat.sendfile.filename"), anyString());
+        verify(request).setAttribute("org.apache.tomcat.sendfile.start", 0L);
+        verify(request).setAttribute("org.apache.tomcat.sendfile.end", (long) largeContent.length);
+
+        // Verify no response output stream is fetched (since Tomcat sendfile handles content transfer)
+        verify(response, never()).getOutputStream();
+    }
+
     // ==================== Helpers ====================
 
     private String computeExpectedETag(Path file) throws IOException {
         var attrs = Files.readAttributes(file, BasicFileAttributes.class);
-        return fileStreamingService.generateETag(
-                attrs.size(), attrs.lastModifiedTime().toInstant());
+        return FileStreamingService.generateETag(
+                attrs.size(), attrs.lastModifiedTime().toMillis());
     }
 
     private ServletOutputStream createServletOutputStream(ByteArrayOutputStream outputStream) {

--- a/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -284,7 +284,7 @@ class BookServiceTest {
     void getBookThumbnail_fileMissing_returnsDefault() {
         when(fileService.getThumbnailFile(1L)).thenReturn("/tmp/nonexistent.jpg");
         Resource res = bookService.getBookThumbnail(1L);
-        assertNotNull(res);
+        assertTrue(res instanceof ByteArrayResource);
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -1,7 +1,5 @@
 package org.booklore.service.book;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.exception.APIException;
 import org.booklore.mapper.BookMapper;
@@ -15,6 +13,9 @@ import org.booklore.repository.*;
 import org.booklore.service.audit.AuditService;
 import org.booklore.service.monitoring.MonitoringRegistrationService;
 import org.booklore.service.progress.ReadingProgressService;
+import org.booklore.service.FileStreamingService;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.booklore.util.FileService;
 import org.booklore.util.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,10 +26,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.nio.file.Files;
@@ -75,6 +74,8 @@ class BookServiceTest {
     private BookUpdateService bookUpdateService;
     @Mock
     private AuditService auditService;
+    @Mock
+    private FileStreamingService fileStreamingService;
 
     @InjectMocks
     private BookService bookService;
@@ -283,6 +284,7 @@ class BookServiceTest {
     void getBookThumbnail_fileMissing_returnsDefault() {
         when(fileService.getThumbnailFile(1L)).thenReturn("/tmp/nonexistent.jpg");
         Resource res = bookService.getBookThumbnail(1L);
+        assertNotNull(res);
     }
 
     @Test
@@ -325,40 +327,6 @@ class BookServiceTest {
         ResponseEntity<Resource> result = bookService.downloadBook(1L);
 
         assertEquals(response, result);
-    }
-
-    @Test
-    void getBookContent_returnsResource() throws Exception {
-        BookEntity entity = new BookEntity();
-        entity.setId(10L);
-        when(bookRepository.findByIdWithBookFiles(10L)).thenReturn(Optional.of(entity));
-        Path path = Paths.get("/tmp/bookcontent.txt");
-        Files.write(path, "hello".getBytes());
-        try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(path);
-            ResponseEntity<Resource> response = bookService.getBookContent(10L);
-            assertEquals(HttpStatus.OK, response.getStatusCode());
-            assertArrayEquals("hello".getBytes(), response.getBody().getInputStream().readAllBytes());
-        } finally {
-            Files.deleteIfExists(path);
-        }
-    }
-
-    @Test
-    void getBookContent_bookNotFound_throwsException() {
-        when(bookRepository.findByIdWithBookFiles(404L)).thenReturn(Optional.empty());
-        assertThrows(APIException.class, () -> bookService.getBookContent(404L));
-    }
-
-    @Test
-    void getBookContent_fileNotFound_throwsException() {
-        BookEntity entity = new BookEntity();
-        entity.setId(12L);
-        when(bookRepository.findByIdWithBookFiles(12L)).thenReturn(Optional.of(entity));
-        try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
-            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(Path.of("/tmp/nonexistentfile.txt"));
-            assertThrows(APIException.class, () -> bookService.getBookContent(12L));
-        }
     }
 
     @Test
@@ -465,5 +433,79 @@ class BookServiceTest {
         Set<Shelf> result = bookService.filterShelvesByUserId(null, 1L);
         assertTrue(result.isEmpty());
     }
-    
+
+    @Test
+    void streamBookContent_happyPath_success() throws Exception {
+        long bookId = 1L;
+        BookEntity entity = new BookEntity();
+        entity.setId(bookId);
+        // bookType is null → primary path via FileUtils.getBookFullPath, bookFiles not accessed
+        entity.setBookFiles(List.of());
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(entity));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        try (MockedStatic<FileUtils> fileUtilsMock = mockStatic(FileUtils.class)) {
+            fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(pdfPath);
+
+            bookService.streamBookContent(bookId, null, request, response);
+
+            verify(fileStreamingService).streamWithRangeSupport(
+                    eq(pdfPath),
+                    eq("application/pdf"),
+                    eq(request),
+                    eq(response)
+            );
+        }
+    }
+
+    @Test
+    void streamBookContent_bookNotFound_throwsException() {
+        long bookId = 99L;
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.empty());
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThrows(APIException.class, () -> 
+            bookService.streamBookContent(bookId, null, request, response)
+        );
+    }
+
+    @Test
+    void streamBookContent_specificTypeNotFound_throwsException() {
+        long bookId = 1L;
+        BookEntity entity = new BookEntity();
+        entity.setId(bookId);
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setBook(entity);
+        primaryFile.setBookType(BookFileType.PDF);
+        entity.setBookFiles(List.of(primaryFile));
+
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(entity));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThrows(APIException.class, () -> 
+            bookService.streamBookContent(bookId, "epub", request, response)
+        );
+    }
+
+    @Test
+    void streamBookContent_invalidBookType_throwsException() {
+        long bookId = 1L;
+        BookEntity entity = new BookEntity();
+        entity.setId(bookId);
+
+        when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(entity));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThrows(APIException.class, () -> 
+            bookService.streamBookContent(bookId, "invalid_type", request, response)
+        );
+    }
 }


### PR DESCRIPTION


## Description

Improved the book media delivery pipeline by replacing the heap-allocated streaming path with a HttpServletResponse-based pipeline. This introduces support for Tomcat kernel-level sendfile zero-copy transfers.


<!-- Required. Briefly explain what changed and why. -->

## Linked Issue


- Made buffer sizes configurable in the streaming service.
- Added HTTP Range support for partial content transfers.
- Enabled Tomcat's `sendfile` feature to optimize large file handling.



Part of: #1346

<!-- Required. Example: Fixes #123 -->

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Verify correct application in streaming functionality.
2. Test HTTP Range requests to ensure partial content responses work as expected. (via console dev logs)
3. Perform large file transfers via Tomcat. (e.g., large files going through successfuly)


## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoints now stream book content with HTTP range support and correct HEAD responses.

* **Performance**
  * Tomcat sendfile support and improved NIO streaming for faster, lower-CPU file transfers.

* **Behavior & Reliability**
  * Stronger ETag/Last-Modified and Cache-Control handling, better conditional-request semantics, multi-range requests return full responses, improved client-disconnect and permission handling, and more robust missing-cover fallback.

* **Tests**
  * Expanded tests for range/conditional logic, sendfile paths, validation, and constructor checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->