### PR TITLE
fix(email): pass correct mail properties for SSL transport

### DIFF
--- a/backend/src/main/java/org/booklore/service/email/SendEmailV2Service.java
+++ b/backend/src/main/java/org/booklore/service/email/SendEmailV2Service.java
@@ -117,6 +117,15 @@ public class SendEmailV2Service {
                 .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException(bookFileId));
     }
 
+    /**
+     * Builds a configured {@link JavaMailSenderImpl} for the given provider.
+     *
+     * <p>Selects the Jakarta Mail property namespace ({@code mail.smtp.} or {@code mail.smtps.})
+     * from the resolved {@link ConnectionType} and writes authentication, SSL/STARTTLS,
+     * and timeout properties under that prefix so the active transport actually reads them.
+     *
+     * <p>Package-private to allow same-package unit tests to assert the resulting property map.
+     */
     JavaMailSenderImpl setupMailSender(EmailProviderV2Entity emailProvider) {
         JavaMailSenderImpl dynamicMailSender = new JavaMailSenderImpl();
         dynamicMailSender.setHost(emailProvider.getHost());
@@ -154,6 +163,13 @@ public class SendEmailV2Service {
         }
     }
 
+    /**
+     * Writes transport-protocol, SSL, and STARTTLS properties for the given connection type.
+     *
+     * <p>{@code mail.transport.protocol} is namespace-independent (it selects the transport
+     * implementation). All other keys are written under {@code prefix}, which must match the
+     * namespace the active transport reads from.
+     */
     private void configureConnectionType(Properties mailProps, ConnectionType connectionType, EmailProviderV2Entity emailProvider, String prefix) {
         switch (connectionType) {
             case SSL -> {
@@ -162,7 +178,6 @@ public class SendEmailV2Service {
                 mailProps.put(prefix + "ssl.trust", emailProvider.getHost());
                 mailProps.put(prefix + "starttls.enable", "false");
                 mailProps.put(prefix + "ssl.protocols", "TLSv1.2 TLSv1.3");
-                mailProps.put(prefix + "ssl.checkserveridentity", "false");
                 mailProps.put(prefix + "ssl.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
                 mailProps.put(prefix + "ssl.socketFactory.fallback", "false");
             }
@@ -180,10 +195,22 @@ public class SendEmailV2Service {
         }
     }
 
+    /**
+     * Writes connection, socket, and write timeout properties under {@code prefix}.
+     *
+     * <p>Default is 60s per timeout. JVM operators can override per-transport via
+     * {@code -D<prefix>connectiontimeout=...} or fall back to the legacy {@code mail.smtp.*}
+     * keys for backward compatibility with deployments that predate transport-aware overrides.
+     */
     private void configureTimeouts(Properties mailProps, String prefix) {
-        String connectionTimeout = System.getProperty("mail.smtp.connectiontimeout", "60000");
-        String socketTimeout = System.getProperty("mail.smtp.timeout", "60000");
-        String writeTimeout = System.getProperty("mail.smtp.writetimeout", "60000");
+        // Prefer transport-namespaced JVM overrides (e.g. -Dmail.smtps.connectiontimeout=...)
+        // and fall back to the unprefixed mail.smtp.* form for backward compatibility.
+        String connectionTimeout = System.getProperty(prefix + "connectiontimeout",
+                System.getProperty("mail.smtp.connectiontimeout", "60000"));
+        String socketTimeout = System.getProperty(prefix + "timeout",
+                System.getProperty("mail.smtp.timeout", "60000"));
+        String writeTimeout = System.getProperty(prefix + "writetimeout",
+                System.getProperty("mail.smtp.writetimeout", "60000"));
 
         mailProps.put(prefix + "connectiontimeout", connectionTimeout);
         mailProps.put(prefix + "timeout", socketTimeout);

--- a/backend/src/main/java/org/booklore/service/email/SendEmailV2Service.java
+++ b/backend/src/main/java/org/booklore/service/email/SendEmailV2Service.java
@@ -130,7 +130,7 @@ public class SendEmailV2Service {
         // SMTPTransport reads only mail.smtp.*, SMTPSSLTransport reads only mail.smtps.*.
         // Pick the prefix matching the active transport so auth/ssl/timeout settings apply.
         String prefix = connectionType == ConnectionType.SSL ? "mail.smtps." : "mail.smtp.";
-        mailProps.put(prefix + "auth", emailProvider.isAuth());
+        mailProps.put(prefix + "auth", String.valueOf(emailProvider.isAuth()));
         configureConnectionType(mailProps, connectionType, emailProvider, prefix);
         configureTimeouts(mailProps, prefix);
 
@@ -161,7 +161,7 @@ public class SendEmailV2Service {
                 mailProps.put(prefix + "ssl.enable", "true");
                 mailProps.put(prefix + "ssl.trust", emailProvider.getHost());
                 mailProps.put(prefix + "starttls.enable", "false");
-                mailProps.put(prefix + "ssl.protocols", "TLSv1.2,TLSv1.3");
+                mailProps.put(prefix + "ssl.protocols", "TLSv1.2 TLSv1.3");
                 mailProps.put(prefix + "ssl.checkserveridentity", "false");
                 mailProps.put(prefix + "ssl.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
                 mailProps.put(prefix + "ssl.socketFactory.fallback", "false");

--- a/backend/src/main/java/org/booklore/service/email/SendEmailV2Service.java
+++ b/backend/src/main/java/org/booklore/service/email/SendEmailV2Service.java
@@ -117,7 +117,7 @@ public class SendEmailV2Service {
                 .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException(bookFileId));
     }
 
-    private JavaMailSenderImpl setupMailSender(EmailProviderV2Entity emailProvider) {
+    JavaMailSenderImpl setupMailSender(EmailProviderV2Entity emailProvider) {
         JavaMailSenderImpl dynamicMailSender = new JavaMailSenderImpl();
         dynamicMailSender.setHost(emailProvider.getHost());
         dynamicMailSender.setPort(emailProvider.getPort());
@@ -125,11 +125,14 @@ public class SendEmailV2Service {
         dynamicMailSender.setPassword(emailProvider.getPassword());
 
         Properties mailProps = dynamicMailSender.getJavaMailProperties();
-        mailProps.put("mail.smtp.auth", emailProvider.isAuth());
-
         ConnectionType connectionType = determineConnectionType(emailProvider);
-        configureConnectionType(mailProps, connectionType, emailProvider);
-        configureTimeouts(mailProps);
+        // Jakarta Mail's smtp and smtps transports read properties from disjoint namespaces:
+        // SMTPTransport reads only mail.smtp.*, SMTPSSLTransport reads only mail.smtps.*.
+        // Pick the prefix matching the active transport so auth/ssl/timeout settings apply.
+        String prefix = connectionType == ConnectionType.SSL ? "mail.smtps." : "mail.smtp.";
+        mailProps.put(prefix + "auth", emailProvider.isAuth());
+        configureConnectionType(mailProps, connectionType, emailProvider, prefix);
+        configureTimeouts(mailProps, prefix);
 
         String debugMode = System.getProperty("mail.debug", "false");
         mailProps.put("mail.debug", debugMode);
@@ -151,40 +154,40 @@ public class SendEmailV2Service {
         }
     }
 
-    private void configureConnectionType(Properties mailProps, ConnectionType connectionType, EmailProviderV2Entity emailProvider) {
+    private void configureConnectionType(Properties mailProps, ConnectionType connectionType, EmailProviderV2Entity emailProvider, String prefix) {
         switch (connectionType) {
             case SSL -> {
                 mailProps.put("mail.transport.protocol", "smtps");
-                mailProps.put("mail.smtp.ssl.enable", "true");
-                mailProps.put("mail.smtp.ssl.trust", emailProvider.getHost());
-                mailProps.put("mail.smtp.starttls.enable", "false");
-                mailProps.put("mail.smtp.ssl.protocols", "TLSv1.2,TLSv1.3");
-                mailProps.put("mail.smtp.ssl.checkserveridentity", "false");
-                mailProps.put("mail.smtp.ssl.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
-                mailProps.put("mail.smtp.ssl.socketFactory.fallback", "false");
+                mailProps.put(prefix + "ssl.enable", "true");
+                mailProps.put(prefix + "ssl.trust", emailProvider.getHost());
+                mailProps.put(prefix + "starttls.enable", "false");
+                mailProps.put(prefix + "ssl.protocols", "TLSv1.2,TLSv1.3");
+                mailProps.put(prefix + "ssl.checkserveridentity", "false");
+                mailProps.put(prefix + "ssl.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+                mailProps.put(prefix + "ssl.socketFactory.fallback", "false");
             }
             case STARTTLS -> {
                 mailProps.put("mail.transport.protocol", "smtp");
-                mailProps.put("mail.smtp.starttls.enable", "true");
-                mailProps.put("mail.smtp.starttls.required", "true");
-                mailProps.put("mail.smtp.ssl.enable", "false");
+                mailProps.put(prefix + "starttls.enable", "true");
+                mailProps.put(prefix + "starttls.required", "true");
+                mailProps.put(prefix + "ssl.enable", "false");
             }
             case PLAIN -> {
                 mailProps.put("mail.transport.protocol", "smtp");
-                mailProps.put("mail.smtp.starttls.enable", "false");
-                mailProps.put("mail.smtp.ssl.enable", "false");
+                mailProps.put(prefix + "starttls.enable", "false");
+                mailProps.put(prefix + "ssl.enable", "false");
             }
         }
     }
 
-    private void configureTimeouts(Properties mailProps) {
+    private void configureTimeouts(Properties mailProps, String prefix) {
         String connectionTimeout = System.getProperty("mail.smtp.connectiontimeout", "60000");
         String socketTimeout = System.getProperty("mail.smtp.timeout", "60000");
         String writeTimeout = System.getProperty("mail.smtp.writetimeout", "60000");
 
-        mailProps.put("mail.smtp.connectiontimeout", connectionTimeout);
-        mailProps.put("mail.smtp.timeout", socketTimeout);
-        mailProps.put("mail.smtp.writetimeout", writeTimeout);
+        mailProps.put(prefix + "connectiontimeout", connectionTimeout);
+        mailProps.put(prefix + "timeout", socketTimeout);
+        mailProps.put(prefix + "writetimeout", writeTimeout);
     }
 
     private String generateEmailBody(String bookTitle) {

--- a/backend/src/main/java/org/booklore/service/email/SendEmailV2Service.java
+++ b/backend/src/main/java/org/booklore/service/email/SendEmailV2Service.java
@@ -140,7 +140,7 @@ public class SendEmailV2Service {
         // Pick the prefix matching the active transport so auth/ssl/timeout settings apply.
         String prefix = connectionType == ConnectionType.SSL ? "mail.smtps." : "mail.smtp.";
         mailProps.put(prefix + "auth", String.valueOf(emailProvider.isAuth()));
-        configureConnectionType(mailProps, connectionType, emailProvider, prefix);
+        configureConnectionType(mailProps, connectionType, emailProvider);
         configureTimeouts(mailProps, prefix);
 
         String debugMode = System.getProperty("mail.debug", "false");
@@ -167,30 +167,30 @@ public class SendEmailV2Service {
      * Writes transport-protocol, SSL, and STARTTLS properties for the given connection type.
      *
      * <p>{@code mail.transport.protocol} is namespace-independent (it selects the transport
-     * implementation). All other keys are written under {@code prefix}, which must match the
-     * namespace the active transport reads from.
+     * implementation). Each branch writes its remaining keys under the fixed namespace its
+     * transport reads from: {@code mail.smtps.*} for SSL, {@code mail.smtp.*} otherwise.
      */
-    private void configureConnectionType(Properties mailProps, ConnectionType connectionType, EmailProviderV2Entity emailProvider, String prefix) {
+    private void configureConnectionType(Properties mailProps, ConnectionType connectionType, EmailProviderV2Entity emailProvider) {
         switch (connectionType) {
             case SSL -> {
                 mailProps.put("mail.transport.protocol", "smtps");
-                mailProps.put(prefix + "ssl.enable", "true");
-                mailProps.put(prefix + "ssl.trust", emailProvider.getHost());
-                mailProps.put(prefix + "starttls.enable", "false");
-                mailProps.put(prefix + "ssl.protocols", "TLSv1.2 TLSv1.3");
-                mailProps.put(prefix + "ssl.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
-                mailProps.put(prefix + "ssl.socketFactory.fallback", "false");
+                mailProps.put("mail.smtps.ssl.enable", "true");
+                mailProps.put("mail.smtps.ssl.trust", emailProvider.getHost());
+                mailProps.put("mail.smtps.starttls.enable", "false");
+                mailProps.put("mail.smtps.ssl.protocols", "TLSv1.2 TLSv1.3");
+                mailProps.put("mail.smtps.ssl.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+                mailProps.put("mail.smtps.ssl.socketFactory.fallback", "false");
             }
             case STARTTLS -> {
                 mailProps.put("mail.transport.protocol", "smtp");
-                mailProps.put(prefix + "starttls.enable", "true");
-                mailProps.put(prefix + "starttls.required", "true");
-                mailProps.put(prefix + "ssl.enable", "false");
+                mailProps.put("mail.smtp.starttls.enable", "true");
+                mailProps.put("mail.smtp.starttls.required", "true");
+                mailProps.put("mail.smtp.ssl.enable", "false");
             }
             case PLAIN -> {
                 mailProps.put("mail.transport.protocol", "smtp");
-                mailProps.put(prefix + "starttls.enable", "false");
-                mailProps.put(prefix + "ssl.enable", "false");
+                mailProps.put("mail.smtp.starttls.enable", "false");
+                mailProps.put("mail.smtp.ssl.enable", "false");
             }
         }
     }

--- a/backend/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
@@ -310,6 +310,21 @@ class SendEmailV2ServiceTest {
         }
     }
 
+    /**
+     * Mirrors {@code SendEmailV2Service#configureTimeouts}'s JVM-property fallback chain
+     * so timeout assertions remain stable on machines that have set ambient
+     * {@code mail.smtp.*} or {@code mail.smtps.*} system properties.
+     */
+    private static String expectedTimeout(String prefix, String suffix) {
+        return System.getProperty(prefix + suffix,
+                System.getProperty("mail.smtp." + suffix, "60000"));
+    }
+
+    /**
+     * Verifies that an SSL provider (port 465) writes auth, SSL, and timeout properties
+     * under the {@code mail.smtps.*} namespace that {@code SMTPSSLTransport} actually reads.
+     * Regression guard for issue #1301.
+     */
     @Test
     void setupMailSender_sslProvider_writesSmtpsAuthAndSslProperties() {
         EmailProviderV2Entity sslProvider = EmailProviderV2Entity.builder()
@@ -333,13 +348,20 @@ class SendEmailV2ServiceTest {
         // Whitespace-separated, not comma-separated: Angus Mail's SocketFetcher
         // passes the raw string to SSLSocket.setEnabledProtocols which splits on whitespace.
         assertThat(props.get("mail.smtps.ssl.protocols")).isEqualTo("TLSv1.2 TLSv1.3");
-        assertThat(props.get("mail.smtps.connectiontimeout")).isEqualTo("60000");
-        assertThat(props.get("mail.smtps.timeout")).isEqualTo("60000");
-        assertThat(props.get("mail.smtps.writetimeout")).isEqualTo("60000");
+        assertThat(props.get("mail.smtps.connectiontimeout"))
+                .isEqualTo(expectedTimeout("mail.smtps.", "connectiontimeout"));
+        assertThat(props.get("mail.smtps.timeout"))
+                .isEqualTo(expectedTimeout("mail.smtps.", "timeout"));
+        assertThat(props.get("mail.smtps.writetimeout"))
+                .isEqualTo(expectedTimeout("mail.smtps.", "writetimeout"));
         // Guard against future regression that double-writes both prefixes.
         assertThat(props.get("mail.smtp.auth")).isNull();
     }
 
+    /**
+     * Verifies that a STARTTLS provider (port 587) writes properties under {@code mail.smtp.*}
+     * with {@code starttls.enable} and {@code starttls.required} both true.
+     */
     @Test
     void setupMailSender_starttlsProvider_writesSmtpProperties() {
         EmailProviderV2Entity starttlsProvider = EmailProviderV2Entity.builder()
@@ -359,9 +381,14 @@ class SendEmailV2ServiceTest {
         assertThat(props.get("mail.smtp.starttls.enable")).isEqualTo("true");
         assertThat(props.get("mail.smtp.starttls.required")).isEqualTo("true");
         assertThat(props.get("mail.smtp.ssl.enable")).isEqualTo("false");
-        assertThat(props.get("mail.smtp.connectiontimeout")).isEqualTo("60000");
+        assertThat(props.get("mail.smtp.connectiontimeout"))
+                .isEqualTo(expectedTimeout("mail.smtp.", "connectiontimeout"));
     }
 
+    /**
+     * Verifies that a plain SMTP provider writes properties under {@code mail.smtp.*}
+     * with both SSL and STARTTLS disabled.
+     */
     @Test
     void setupMailSender_plainProvider_writesSmtpProperties() {
         EmailProviderV2Entity plainProvider = EmailProviderV2Entity.builder()

--- a/backend/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
@@ -20,12 +20,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.Executor;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -305,6 +308,74 @@ class SendEmailV2ServiceTest {
             // Error is caught and logged, not rethrown
             verify(notificationService, atLeastOnce()).sendMessage(any(), any());
         }
+    }
+
+    @Test
+    void setupMailSender_sslProvider_writesSmtpsAuthAndSslProperties() {
+        EmailProviderV2Entity sslProvider = EmailProviderV2Entity.builder()
+                .host("smtp.gmail.com")
+                .port(465)
+                .username("user@gmail.com")
+                .password("password")
+                .auth(true)
+                .startTls(false)
+                .build();
+
+        JavaMailSenderImpl sender = sendEmailV2Service.setupMailSender(sslProvider);
+        Properties props = sender.getJavaMailProperties();
+
+        assertEquals("smtps", props.get("mail.transport.protocol"));
+        // Regression for #1301: SMTPSSLTransport reads only mail.smtps.*,
+        // so auth/ssl/timeout properties must be visible under that prefix.
+        assertEquals(true, props.get("mail.smtps.auth"));
+        assertEquals("true", props.get("mail.smtps.ssl.enable"));
+        assertEquals("smtp.gmail.com", props.get("mail.smtps.ssl.trust"));
+        assertEquals("TLSv1.2,TLSv1.3", props.get("mail.smtps.ssl.protocols"));
+        assertEquals("60000", props.get("mail.smtps.connectiontimeout"));
+        assertEquals("60000", props.get("mail.smtps.timeout"));
+        assertEquals("60000", props.get("mail.smtps.writetimeout"));
+    }
+
+    @Test
+    void setupMailSender_starttlsProvider_writesSmtpProperties() {
+        EmailProviderV2Entity starttlsProvider = EmailProviderV2Entity.builder()
+                .host("smtp.example.com")
+                .port(587)
+                .username("user@example.com")
+                .password("password")
+                .auth(true)
+                .startTls(true)
+                .build();
+
+        JavaMailSenderImpl sender = sendEmailV2Service.setupMailSender(starttlsProvider);
+        Properties props = sender.getJavaMailProperties();
+
+        assertEquals("smtp", props.get("mail.transport.protocol"));
+        assertEquals(true, props.get("mail.smtp.auth"));
+        assertEquals("true", props.get("mail.smtp.starttls.enable"));
+        assertEquals("true", props.get("mail.smtp.starttls.required"));
+        assertEquals("false", props.get("mail.smtp.ssl.enable"));
+        assertEquals("60000", props.get("mail.smtp.connectiontimeout"));
+    }
+
+    @Test
+    void setupMailSender_plainProvider_writesSmtpProperties() {
+        EmailProviderV2Entity plainProvider = EmailProviderV2Entity.builder()
+                .host("smtp.example.com")
+                .port(25)
+                .username("user@example.com")
+                .password("password")
+                .auth(false)
+                .startTls(false)
+                .build();
+
+        JavaMailSenderImpl sender = sendEmailV2Service.setupMailSender(plainProvider);
+        Properties props = sender.getJavaMailProperties();
+
+        assertEquals("smtp", props.get("mail.transport.protocol"));
+        assertEquals(false, props.get("mail.smtp.auth"));
+        assertEquals("false", props.get("mail.smtp.starttls.enable"));
+        assertEquals("false", props.get("mail.smtp.ssl.enable"));
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -324,16 +324,20 @@ class SendEmailV2ServiceTest {
         JavaMailSenderImpl sender = sendEmailV2Service.setupMailSender(sslProvider);
         Properties props = sender.getJavaMailProperties();
 
-        assertEquals("smtps", props.get("mail.transport.protocol"));
+        assertThat(props.get("mail.transport.protocol")).isEqualTo("smtps");
         // Regression for #1301: SMTPSSLTransport reads only mail.smtps.*,
         // so auth/ssl/timeout properties must be visible under that prefix.
-        assertEquals(true, props.get("mail.smtps.auth"));
-        assertEquals("true", props.get("mail.smtps.ssl.enable"));
-        assertEquals("smtp.gmail.com", props.get("mail.smtps.ssl.trust"));
-        assertEquals("TLSv1.2,TLSv1.3", props.get("mail.smtps.ssl.protocols"));
-        assertEquals("60000", props.get("mail.smtps.connectiontimeout"));
-        assertEquals("60000", props.get("mail.smtps.timeout"));
-        assertEquals("60000", props.get("mail.smtps.writetimeout"));
+        assertThat(props.get("mail.smtps.auth")).isEqualTo("true");
+        assertThat(props.get("mail.smtps.ssl.enable")).isEqualTo("true");
+        assertThat(props.get("mail.smtps.ssl.trust")).isEqualTo("smtp.gmail.com");
+        // Whitespace-separated, not comma-separated: Angus Mail's SocketFetcher
+        // passes the raw string to SSLSocket.setEnabledProtocols which splits on whitespace.
+        assertThat(props.get("mail.smtps.ssl.protocols")).isEqualTo("TLSv1.2 TLSv1.3");
+        assertThat(props.get("mail.smtps.connectiontimeout")).isEqualTo("60000");
+        assertThat(props.get("mail.smtps.timeout")).isEqualTo("60000");
+        assertThat(props.get("mail.smtps.writetimeout")).isEqualTo("60000");
+        // Guard against future regression that double-writes both prefixes.
+        assertThat(props.get("mail.smtp.auth")).isNull();
     }
 
     @Test
@@ -350,12 +354,12 @@ class SendEmailV2ServiceTest {
         JavaMailSenderImpl sender = sendEmailV2Service.setupMailSender(starttlsProvider);
         Properties props = sender.getJavaMailProperties();
 
-        assertEquals("smtp", props.get("mail.transport.protocol"));
-        assertEquals(true, props.get("mail.smtp.auth"));
-        assertEquals("true", props.get("mail.smtp.starttls.enable"));
-        assertEquals("true", props.get("mail.smtp.starttls.required"));
-        assertEquals("false", props.get("mail.smtp.ssl.enable"));
-        assertEquals("60000", props.get("mail.smtp.connectiontimeout"));
+        assertThat(props.get("mail.transport.protocol")).isEqualTo("smtp");
+        assertThat(props.get("mail.smtp.auth")).isEqualTo("true");
+        assertThat(props.get("mail.smtp.starttls.enable")).isEqualTo("true");
+        assertThat(props.get("mail.smtp.starttls.required")).isEqualTo("true");
+        assertThat(props.get("mail.smtp.ssl.enable")).isEqualTo("false");
+        assertThat(props.get("mail.smtp.connectiontimeout")).isEqualTo("60000");
     }
 
     @Test
@@ -372,10 +376,10 @@ class SendEmailV2ServiceTest {
         JavaMailSenderImpl sender = sendEmailV2Service.setupMailSender(plainProvider);
         Properties props = sender.getJavaMailProperties();
 
-        assertEquals("smtp", props.get("mail.transport.protocol"));
-        assertEquals(false, props.get("mail.smtp.auth"));
-        assertEquals("false", props.get("mail.smtp.starttls.enable"));
-        assertEquals("false", props.get("mail.smtp.ssl.enable"));
+        assertThat(props.get("mail.transport.protocol")).isEqualTo("smtp");
+        assertThat(props.get("mail.smtp.auth")).isEqualTo("false");
+        assertThat(props.get("mail.smtp.starttls.enable")).isEqualTo("false");
+        assertThat(props.get("mail.smtp.ssl.enable")).isEqualTo("false");
     }
 
     @Test


### PR DESCRIPTION
## Description

Email sending via SSL providers (e.g. Gmail on port 465) silently failed because Jakarta Mail's `SMTPSSLTransport` reads properties only from the `mail.smtps.*` namespace, while `SendEmailV2Service` was writing all properties under `mail.smtp.*`. The transport ignored those properties and providers dropped the unauthenticated message with no UI feedback.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
Fixes #1301 

## Changes

* Updates `configureConnectionType` and `configureTimeouts`  to accept `prefix` input to support `mail.smtp` and `mail.smtps` prefixes
* Updates `setupMailSender` to pass appropriate prefix based on `ConnectionType` 
* Adds unit tests to ensure that (only) appropriate fields are populated 

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Ran grimmory locally via `just dev-up` (off `develop` branch) 
2. Reproduced issue as described in repro steps in #1301
3. Ran locally from fix branch
4. Observed email being sent successfully

## Additional Context (Optional)

* Includes a related fix by ensuring `ssl.protocols` are space-separated. Previous comma-separated syntax was incorrect but never being hit due to the original bug we're fixing here.
 
## AI Disclosure

Cursor 4.7 used for local code review and writing unit tests.

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved email delivery configuration to pick the correct SMTP vs SMTPS settings per provider, write SSL-specific properties under the secure namespace, honor JVM timeout overrides per connection type, and normalize TLS protocol handling for more reliable secure connections.
* **Tests**
  * Added unit tests for SMTP over SSL, SMTP with STARTTLS, and plain SMTP to validate provider-specific behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->