### PR TITLE
fix(reader): prevent 'x' shortcut from closing reader while typing notes

### DIFF
--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -263,8 +263,10 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
       // Intercept 'x' key to prevent EmbedPDF from reloading the page;
       // instead close the reader via SPA navigation.
       const keydownHandler = (e: KeyboardEvent) => {
-        const tag = (e.target as HTMLElement)?.tagName;
-        const isEditing = tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement)?.isContentEditable;
+        const isEditing = e.composedPath().some((target) => {
+          const el = target as HTMLElement;
+          return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable;
+        });
 
         if (e.key === 'x' || e.key === 'X') {
           if (isEditing) return;


### PR DESCRIPTION
## Description

Fixed the keyboard event handling logic in the `PdfReaderComponent` to more accurately detect when the user is editing text fields, preventing unintended actions when pressing the 'x' key.


<!-- Required. Briefly explain what changed and why. -->

## Linked Issue

#1384 

<!-- Required. Example: Fixes #123 -->

## Changes


- Added  composedPath to  determine if the event originated from an editable element

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Opened the PDF viewer
2. Typed in a note with an X
3. Verified it was not closed

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut detection to prevent accidental triggering while typing in text input fields. Keyboard shortcuts now correctly identify when the user is actively editing content and avoid interfering with text input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->