### PR TITLE
test(helm): lint helm charts with ct

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -28,6 +28,7 @@ jobs:
 
   chart-validation:
     name: Helm Chart Validation
+    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -26,6 +26,26 @@ jobs:
           path: ${{ github.event_path }}
           retention-days: 7
 
+  chart-validation:
+    name: Helm Chart Validation
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Install chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+
+      - name: Run ct lint
+        run: ct lint --config deploy/helm/ct.yaml
+
   migration-check:
     name: Flyway Migration Check
     if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}

--- a/deploy/helm/ct.yaml
+++ b/deploy/helm/ct.yaml
@@ -1,0 +1,5 @@
+target-branch: develop
+chart-dirs:
+  - deploy/helm
+all: true
+validate-maintainers: false

--- a/deploy/helm/grimmory/.helmignore
+++ b/deploy/helm/grimmory/.helmignore
@@ -1,0 +1,2 @@
+# Exclude CI tests 
+ci/

--- a/deploy/helm/grimmory/ci/default-values.yaml
+++ b/deploy/helm/grimmory/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Default chart path

--- a/deploy/helm/grimmory/ci/existing-claim-values.yaml
+++ b/deploy/helm/grimmory/ci/existing-claim-values.yaml
@@ -1,0 +1,8 @@
+# Pre-existing PVC claims
+# Database: bundled MariaDB
+# Persistence: both volumes use existingClaim, PVC templates suppressed
+persistence:
+  dataVolume:
+    existingClaim: my-existing-data-claim
+  booksVolume:
+    existingClaim: my-existing-books-claim

--- a/deploy/helm/grimmory/ci/external-database-secret-values.yaml
+++ b/deploy/helm/grimmory/ci/external-database-secret-values.yaml
@@ -1,0 +1,17 @@
+# External database with credentials from an existing Kubernetes secret.
+# Database: external, all connection values come from secretKeyRef
+# Persistence: both PVCs enabled, created by chart
+mariadb:
+  enabled: false
+externalDatabase:
+  enabled: true
+  host: ""
+  password: ""
+  existingSecret:
+    enabled: true
+    secretName: db-credentials
+    hostnameKey: db-host
+    portKey: db-port
+    usernameKey: db-user
+    passwordKey: db-pass
+    databaseKey: db-name

--- a/deploy/helm/grimmory/ci/external-database-values.yaml
+++ b/deploy/helm/grimmory/ci/external-database-values.yaml
@@ -1,0 +1,12 @@
+# External database with plain-text credentials.
+# Database: external credentials in env vars
+# Persistence: both PVCs enabled, created by chart
+mariadb:
+  enabled: false
+externalDatabase:
+  enabled: true
+  host: my-cluster
+  port: 3306
+  username: app_user
+  password: my-password
+  database: grimmory

--- a/deploy/helm/grimmory/ci/ingress-values.yaml
+++ b/deploy/helm/grimmory/ci/ingress-values.yaml
@@ -1,0 +1,13 @@
+# Ingress enabled on top of the default configuration.
+# Database: bundled MariaDB
+# Persistence: both PVCs enabled, created by chart
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: grimmory.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/deploy/helm/grimmory/ci/no-persistence-values.yaml
+++ b/deploy/helm/grimmory/ci/no-persistence-values.yaml
@@ -1,0 +1,8 @@
+# No persistent volumes — all storage disabled.
+# Database: bundled MariaDB
+# Persistence: both PVCs disabled
+persistence:
+  dataVolume:
+    enabled: false
+  booksVolume:
+    enabled: false


### PR DESCRIPTION
## Description

This PR adds linting for the helm chart. It relies on `ct` to do so, because it paves the way for actual deployment tests on a `k3d` or `kind` with `ct install`.

It relies on several `-values.yaml` files that go through the various logic paths of the chart.

After giving it a second thought, I didn't find a lot of value in setting up kubeconform since we're not setting up any CRDs.

This PR doesn't tackle documentation. I thought it made sense to have a separate PR for that.

## Linked Issue

Contributes to #1390

## Changes

- Add value files to go through the various logic paths of the chart when linting it
- Run `ct lint` in CI to lint the charts

## Manual Testing Steps

I ran the tests locally with `ct` and ran them against my fork by opening a PR against my own `develop` branch.

## Screenshots (Optional)

None

## Additional Context (Optional)

`ct` made sense to me to keep the CI clean and avoid homemade scripts iterating through test files in a directory.

It's also a foundation we can build on later so we can

1. Add a step to spin up a k3d cluster
2. Add a step to provision PVCs, Secrets and even an actual database to test against
3. Use `ct lint-and-install` instead of only `ct lint`, so we can check that the various test cases do work

## AI Disclosure

None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Helm chart validation to CI to lint and verify charts on pull requests and pushes.
  * Added CI Helm configurations covering external-database setups, secret-based DB credentials, ingress with TLS, persistent and no-persistence storage scenarios, and support for existing PVCs (plus packaging exclusions for CI tests).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->