### PR TITLE
refactor(metadata): Normalize language field to ISO 639-1

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -205,6 +205,9 @@ dependencies {
     // --- JSON & Web Scraping ---
     implementation("org.jsoup:jsoup:1.22.2")
 
+    // --- i18n / Language Normalization ---
+    implementation("com.neovisionaries:nv-i18n:1.29")
+
     // --- Mapping (DTOs & Entities) ---
     implementation("org.mapstruct:mapstruct:1.6.3")
     annotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")

--- a/backend/gradle.lockfile
+++ b/backend/gradle.lockfile
@@ -18,6 +18,7 @@ com.google.code.findbugs:jsr305:3.0.2=compileClasspath,productionRuntimeClasspat
 com.google.errorprone:error_prone_annotations:2.49.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.h2database:h2:2.4.240=openApiExportRuntimeOnly,testRuntimeClasspath
 com.jayway.jsonpath:json-path:2.10.0=testCompileClasspath,testRuntimeClasspath
+com.neovisionaries:nv-i18n:1.29=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.nimbusds:nimbus-jose-jwt:10.9=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.squareup.okio:okio-jvm:3.17.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.squareup.okio:okio:3.17.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -7,6 +7,7 @@ import org.booklore.model.dto.request.FetchMetadataRequest;
 import org.booklore.model.enums.MetadataProvider;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.util.BookUtils;
+import org.booklore.util.LanguageNormalizer;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Connection;
@@ -301,7 +302,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                 .asin(amazonBookId)
                 .publisher(getPublisher(doc))
                 .publishedDate(getPublicationDate(doc))
-                .language(getLanguage(doc))
+                .language(LanguageNormalizer.normalize(getLanguage(doc)))
                 .pageCount(getPageCount(doc))
                 .thumbnailUrl(getThumbnail(doc))
                 .amazonRating(getRating(doc))

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
@@ -9,6 +9,7 @@ import org.booklore.model.dto.request.FetchMetadataRequest;
 import org.booklore.model.enums.MetadataProvider;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.util.BookUtils;
+import org.booklore.util.LanguageNormalizer;
 import org.jsoup.Connection;
 import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
@@ -363,7 +364,7 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
                 .seriesNumber(seriesNumber)
                 .publisher(publisher)
                 .publishedDate(publishedDate)
-                .language(language)
+                .language(LanguageNormalizer.normalize(language))
                 .thumbnailUrl(imageUrl)
                 .audibleRating(rating)
                 .audibleReviewCount(reviewCount)

--- a/backend/src/main/java/org/booklore/service/metadata/parser/DoubanBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/DoubanBookParser.java
@@ -9,6 +9,7 @@ import org.booklore.model.dto.request.FetchMetadataRequest;
 import org.booklore.model.enums.MetadataProvider;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.util.BookUtils;
+import org.booklore.util.LanguageNormalizer;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -290,7 +291,7 @@ public class DoubanBookParser implements BookParser {
                 .doubanId(doubanBookId)
                 .publisher(getPublisher(doc))
                 .publishedDate(getPublicationDate(doc))
-                .language(getLanguage(doc))
+                .language(LanguageNormalizer.normalize(getLanguage(doc)))
                 .pageCount(getPageCount(doc))
                 .thumbnailUrl(getThumbnail(doc))
                 .doubanRating(getRating(doc))

--- a/backend/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
@@ -11,6 +11,7 @@ import org.booklore.model.dto.request.FetchMetadataRequest;
 import org.booklore.model.enums.MetadataProvider;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.util.BookUtils;
+import org.booklore.util.LanguageNormalizer;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.similarity.FuzzyScore;
@@ -361,7 +362,7 @@ public class GoodReadsParser implements BookParser, DetailedMetadataProvider {
 
             JsonNode languageJson = detailsJson.get("language");
             if (languageJson != null && languageJson.isObject()) {
-                builder.language(normalizeNull(languageJson.path("name").asText(null)));
+                builder.language(LanguageNormalizer.normalize(normalizeNull(languageJson.path("name").asText(null))));
             }
         }
 

--- a/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
@@ -9,6 +9,7 @@ import org.booklore.model.dto.settings.MetadataProviderSettings;
 import org.booklore.model.enums.MetadataProvider;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.util.BookUtils;
+import org.booklore.util.LanguageNormalizer;
 import org.jsoup.Jsoup;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -273,7 +274,7 @@ public class GoogleParser implements BookParser {
                 .isbn10(isbns.get("ISBN_10"))
                 .pageCount(pageCount)
                 .thumbnailUrl(extractBestCoverImage(volumeInfo.getImageLinks()))
-                .language(normalizeLanguage(volumeInfo.getLanguage()))
+                .language(LanguageNormalizer.normalize(volumeInfo.getLanguage()))
                 .externalUrl(externalUrl)
                 .seriesName(seriesData.name)
                 .seriesNumber(seriesData.number)
@@ -431,13 +432,6 @@ public class GoogleParser implements BookParser {
         return cleaned.isEmpty() ? null : cleaned;
     }
 
-    private String normalizeLanguage(String language) {
-        if (language == null || language.isBlank()) {
-            return null;
-        }
-        // Google uses ISO 639-1 codes, just ensure lowercase
-        return language.toLowerCase().trim();
-    }
 
     private String getExternalUrl(GoogleBooksApiResponse.Item.VolumeInfo volumeInfo) {
         // Prefer canonical volume link, then info link

--- a/backend/src/main/java/org/booklore/service/metadata/parser/HardcoverParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/HardcoverParser.java
@@ -9,6 +9,7 @@ import org.booklore.service.metadata.parser.hardcover.HardcoverBookDetails;
 import org.booklore.service.metadata.parser.hardcover.HardcoverBookSearchService;
 import org.booklore.service.metadata.parser.hardcover.HardcoverMoodFilter;
 import org.booklore.util.BookUtils;
+import org.booklore.util.LanguageNormalizer;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -259,7 +260,7 @@ public class HardcoverParser implements BookParser {
 
         // Set the language from the edition
         if (edition.getLanguage() != null && edition.getLanguage().getCode2() != null) {
-            metadata.setLanguage(edition.getLanguage().getCode2());
+            metadata.setLanguage(LanguageNormalizer.normalize(edition.getLanguage().getCode2()));
         }
 
         // Set the Publisher from the edition

--- a/backend/src/main/java/org/booklore/service/metadata/parser/LubimyCzytacParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/LubimyCzytacParser.java
@@ -233,7 +233,7 @@ public class LubimyCzytacParser implements BookParser {
         Elements languageElements = doc.select("dt:contains(Język:) + dd");
         if (!languageElements.isEmpty()) {
             String language = languageElements.first().text().trim().toLowerCase();
-            metadata.setLanguage(LanguageNormalizer.normalize(mapLanguage(language)));
+            metadata.setLanguage(LanguageNormalizer.normalize(language));
         }
 
         Element descElement = doc.selectFirst("#book-description");
@@ -335,18 +335,6 @@ public class LubimyCzytacParser implements BookParser {
         }
 
         return false;
-    }
-
-    private String mapLanguage(String polishLanguage) {
-        return switch (polishLanguage) {
-            case "polski" -> "pl";
-            case "angielski" -> "en";
-            case "niemiecki" -> "de";
-            case "francuski" -> "fr";
-            case "hiszpański" -> "es";
-            case "włoski" -> "it";
-            default -> polishLanguage;
-        };
     }
 
     private void parseSeriesInfo(String seriesText, BookMetadata metadata) {

--- a/backend/src/main/java/org/booklore/service/metadata/parser/LubimyCzytacParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/LubimyCzytacParser.java
@@ -7,6 +7,7 @@ import org.booklore.model.dto.BookMetadata;
 import org.booklore.model.dto.request.FetchMetadataRequest;
 import org.booklore.model.enums.MetadataProvider;
 import org.booklore.service.appsettings.AppSettingService;
+import org.booklore.util.LanguageNormalizer;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -232,7 +233,7 @@ public class LubimyCzytacParser implements BookParser {
         Elements languageElements = doc.select("dt:contains(Język:) + dd");
         if (!languageElements.isEmpty()) {
             String language = languageElements.first().text().trim().toLowerCase();
-            metadata.setLanguage(mapLanguage(language));
+            metadata.setLanguage(LanguageNormalizer.normalize(mapLanguage(language)));
         }
 
         Element descElement = doc.selectFirst("#book-description");

--- a/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
@@ -10,6 +10,7 @@ import org.booklore.model.dto.response.ranobedbapi.RanobedbSearchResponse;
 import org.booklore.model.enums.MetadataProvider;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.util.BookUtils;
+import org.booklore.util.LanguageNormalizer;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 import tools.jackson.databind.ObjectMapper;
@@ -259,7 +260,7 @@ public class RanobeDbParser implements BookParser {
                     .publisher(englishPublisher != null ? englishPublisher.getName() : null)
                     .thumbnailUrl(book.getImage() != null ? RANOBEDB_IMAGE_URL + book.getImage().getFilename() : null)
                     .description(book.getDescription())
-                    .language(englishRelease != null ? englishRelease.getLang() : book.getLang())
+                    .language(LanguageNormalizer.normalize(englishRelease != null ? englishRelease.getLang() : book.getLang()))
                     .seriesName(book.getSeries() != null ? book.getSeries().getTitle() : null)
                     .seriesNumber(seriesIndex != -1 ? seriesIndex + 1.0f : null)
                     .seriesTotal(seriesBooks.isEmpty() ? null : seriesBooks.size())

--- a/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
+++ b/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
@@ -30,7 +30,7 @@ public class LanguageNormalizer {
             result = resolveCode(trimmed);
         }
 
-        return result != null ? result : trimmed.toLowerCase().strip();
+        return result != null ? result : trimmed.toLowerCase(Locale.ROOT).strip();
     }
 
     private static String resolveCode(String input) {

--- a/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
+++ b/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
@@ -1,0 +1,57 @@
+package org.booklore.util;
+
+import com.neovisionaries.i18n.LanguageAlpha3Code;
+import com.neovisionaries.i18n.LanguageCode;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class LanguageNormalizer {
+
+    private LanguageNormalizer() {}
+
+    public static String normalize(String input) {
+        if (input == null || input.isBlank()) {
+            return null;
+        }
+        String trimmed = input.trim();
+
+        // Handle BCP 47 / IETF tags ("fr-FR", "fr_FR") — take the primary subtag
+        String primary = trimmed;
+        if (trimmed.contains("-") || trimmed.contains("_")) {
+            primary = trimmed.split("[-_]")[0];
+        }
+
+        String result = resolveCode(primary);
+        if (result == null && !primary.equals(trimmed)) {
+            result = resolveCode(trimmed);
+        }
+
+        return result != null ? result : trimmed.toLowerCase().strip();
+    }
+
+    private static String resolveCode(String input) {
+        // ISO 639-1 (case-insensitive): "fr", "FR"
+        LanguageCode byCode = LanguageCode.getByCode(input, false);
+        if (byCode != null) {
+            return byCode.name();
+        }
+
+        // ISO 639-2 alpha-3 (case-insensitive): "fre", "fra", "eng"
+        LanguageAlpha3Code byAlpha3 = LanguageAlpha3Code.getByCode(input, false);
+        if (byAlpha3 != null) {
+            LanguageCode alpha2 = byAlpha3.getAlpha2();
+            if (alpha2 != null) {
+                return alpha2.name();
+            }
+        }
+
+        // English name match (case-insensitive): "French", "German", etc.
+        List<LanguageCode> byName = LanguageCode.findByName("(?i)" + Pattern.quote(input));
+        if (!byName.isEmpty()) {
+            return byName.get(0).name();
+        }
+
+        return null;
+    }
+}

--- a/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
+++ b/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
@@ -13,17 +13,15 @@ import java.util.regex.Pattern;
 @UtilityClass
 public class LanguageNormalizer {
 
-    public static String normalize(String input) {
+    private static final Pattern BCP47_SEPARATOR = Pattern.compile("[-_]");
+
+    public String normalize(String input) {
         if (input == null || input.isBlank()) {
             return null;
         }
         String trimmed = input.trim();
 
-        // BCP 47 / IETF tags ("fr-FR", "fr_FR") — take primary subtag first
-        String primary = trimmed;
-        if (trimmed.contains("-") || trimmed.contains("_")) {
-            primary = trimmed.split("[-_]")[0];
-        }
+        String primary = BCP47_SEPARATOR.split(trimmed)[0];
 
         String result = resolveCode(primary);
         if (result == null && !primary.equals(trimmed)) {
@@ -33,7 +31,7 @@ public class LanguageNormalizer {
         return result != null ? result : trimmed.toLowerCase(Locale.ROOT).strip();
     }
 
-    private static String resolveCode(String input) {
+    private String resolveCode(String input) {
         LanguageCode byCode = LanguageCode.getByCode(input, false);
         if (byCode != null) return byCode.name();
 
@@ -44,7 +42,7 @@ public class LanguageNormalizer {
         }
 
         List<LanguageCode> byName = LanguageCode.findByName("(?i)" + Pattern.quote(input));
-        if (!byName.isEmpty()) return byName.get(0).name();
+        if (!byName.isEmpty()) return byName.getFirst().name();
 
         return LocalizedNameMap.MAP.get(input.toLowerCase(Locale.ROOT).trim());
     }
@@ -54,14 +52,14 @@ public class LanguageNormalizer {
 
         private static Map<String, String> build() {
             Locale[] displayLocales = {
-                Locale.FRENCH, Locale.GERMAN, Locale.ITALIAN,
-                new Locale("es"), new Locale("pt"), new Locale("nl"),
-                new Locale("ru"), new Locale("pl"), new Locale("ja")
+                Locale.of("fr"), Locale.of("de"), Locale.of("it"), Locale.of("ja"),
+                Locale.of("es"), Locale.of("pt"), Locale.of("nl"),
+                Locale.of("ru"), Locale.of("pl")
             };
             Map<String, String> map = new HashMap<>();
             for (LanguageCode code : LanguageCode.values()) {
                 if (code == LanguageCode.undefined) continue;
-                Locale locale = new Locale(code.name());
+                Locale locale = Locale.of(code.name());
                 for (Locale displayLocale : displayLocales) {
                     String displayName = locale.getDisplayLanguage(displayLocale).toLowerCase(Locale.ROOT);
                     if (displayName.length() > 2) {

--- a/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
+++ b/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
@@ -2,13 +2,16 @@ package org.booklore.util;
 
 import com.neovisionaries.i18n.LanguageAlpha3Code;
 import com.neovisionaries.i18n.LanguageCode;
+import lombok.experimental.UtilityClass;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
+@UtilityClass
 public class LanguageNormalizer {
-
-    private LanguageNormalizer() {}
 
     public static String normalize(String input) {
         if (input == null || input.isBlank()) {
@@ -16,7 +19,7 @@ public class LanguageNormalizer {
         }
         String trimmed = input.trim();
 
-        // Handle BCP 47 / IETF tags ("fr-FR", "fr_FR") — take the primary subtag
+        // BCP 47 / IETF tags ("fr-FR", "fr_FR") — take primary subtag first
         String primary = trimmed;
         if (trimmed.contains("-") || trimmed.contains("_")) {
             primary = trimmed.split("[-_]")[0];
@@ -31,27 +34,42 @@ public class LanguageNormalizer {
     }
 
     private static String resolveCode(String input) {
-        // ISO 639-1 (case-insensitive): "fr", "FR"
         LanguageCode byCode = LanguageCode.getByCode(input, false);
-        if (byCode != null) {
-            return byCode.name();
-        }
+        if (byCode != null) return byCode.name();
 
-        // ISO 639-2 alpha-3 (case-insensitive): "fre", "fra", "eng"
         LanguageAlpha3Code byAlpha3 = LanguageAlpha3Code.getByCode(input, false);
         if (byAlpha3 != null) {
             LanguageCode alpha2 = byAlpha3.getAlpha2();
-            if (alpha2 != null) {
-                return alpha2.name();
-            }
+            if (alpha2 != null) return alpha2.name();
         }
 
-        // English name match (case-insensitive): "French", "German", etc.
         List<LanguageCode> byName = LanguageCode.findByName("(?i)" + Pattern.quote(input));
-        if (!byName.isEmpty()) {
-            return byName.get(0).name();
-        }
+        if (!byName.isEmpty()) return byName.get(0).name();
 
-        return null;
+        return LocalizedNameMap.MAP.get(input.toLowerCase(Locale.ROOT).trim());
+    }
+
+    private static final class LocalizedNameMap {
+        static final Map<String, String> MAP = build();
+
+        private static Map<String, String> build() {
+            Locale[] displayLocales = {
+                Locale.FRENCH, Locale.GERMAN, Locale.ITALIAN,
+                new Locale("es"), new Locale("pt"), new Locale("nl"),
+                new Locale("ru"), new Locale("pl"), new Locale("ja")
+            };
+            Map<String, String> map = new HashMap<>();
+            for (LanguageCode code : LanguageCode.values()) {
+                if (code == LanguageCode.undefined) continue;
+                Locale locale = new Locale(code.name());
+                for (Locale displayLocale : displayLocales) {
+                    String displayName = locale.getDisplayLanguage(displayLocale).toLowerCase(Locale.ROOT);
+                    if (displayName.length() > 2) {
+                        map.putIfAbsent(displayName, code.name());
+                    }
+                }
+            }
+            return Map.copyOf(map);
+        }
     }
 }

--- a/backend/src/test/java/org/booklore/util/LanguageNormalizerTest.java
+++ b/backend/src/test/java/org/booklore/util/LanguageNormalizerTest.java
@@ -8,92 +8,48 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class LanguageNormalizerTest {
 
-    // --- null / blank ---
-
     @Test
     void null_returnsNull() {
         assertNull(LanguageNormalizer.normalize(null));
     }
 
-    @Test
-    void blank_returnsNull() {
-        assertNull(LanguageNormalizer.normalize("   "));
-    }
-
-    // --- ISO 639-1 passthrough ---
-
     @ParameterizedTest
-    @CsvSource({"fr,fr", "en,en", "de,de", "es,es", "ja,ja", "zh,zh"})
-    void iso6391_passthrough(String input, String expected) {
-        assertEquals(expected, LanguageNormalizer.normalize(input));
+    @CsvSource({"''", "'   '"})
+    void emptyOrBlank_returnsNull(String input) {
+        assertNull(LanguageNormalizer.normalize(input));
     }
 
     @Test
-    void iso6391_uppercased_lowercased() {
-        assertEquals("fr", LanguageNormalizer.normalize("FR"));
+    void numeric_returnsLowercasedAsIs() {
+        assertEquals("123", LanguageNormalizer.normalize("123"));
     }
 
-    // --- ISO 639-2 ---
-
     @ParameterizedTest
-    @CsvSource({"fre,fr", "fra,fr", "eng,en", "ger,de", "deu,de", "spa,es", "ita,it", "por,pt", "jpn,ja", "zho,zh", "chi,zh"})
-    void iso6392_mapsToIso6391(String input, String expected) {
-        assertEquals(expected, LanguageNormalizer.normalize(input));
-    }
-
-    // --- Full English names (Amazon / GoodReads) ---
-
-    @ParameterizedTest
-    @CsvSource({"French,fr", "English,en", "German,de", "Spanish,es", "Italian,it", "Portuguese,pt", "Japanese,ja", "Chinese,zh", "Polish,pl", "Russian,ru", "Arabic,ar", "Korean,ko"})
-    void englishNames_mapsToIso6391(String input, String expected) {
-        assertEquals(expected, LanguageNormalizer.normalize(input));
-    }
-
-    // --- BCP 47 tags ---
-
-    @ParameterizedTest
-    @CsvSource({"fr-FR,fr", "en-US,en", "de-DE,de", "fr_FR,fr", "pt-BR,pt"})
-    void bcp47Tags_mapsToIso6391(String input, String expected) {
-        assertEquals(expected, LanguageNormalizer.normalize(input));
-    }
-
-    // --- Mixed case ---
-
-    @ParameterizedTest
-    @CsvSource({"FRENCH,fr", "french,fr", "FRE,fr", "Fr-FR,fr"})
-    void mixedCase_normalized(String input, String expected) {
-        assertEquals(expected, LanguageNormalizer.normalize(input));
-    }
-
-    // --- Localized names (CLDR fallback) ---
-
-    @ParameterizedTest
-    @CsvSource({"français,fr", "anglais,en", "espagnol,es", "allemand,de", "italien,it", "portugais,pt", "russe,ru", "polonais,pl"})
-    void frenchNames_mapsToIso6391(String input, String expected) {
+    @CsvSource({"fr-FR,fr", "en-US,en", "pt-BR,pt", "fr_FR,fr"})
+    void bcp47Tags_extractsPrimarySubtag(String input, String expected) {
         assertEquals(expected, LanguageNormalizer.normalize(input));
     }
 
     @ParameterizedTest
-    @CsvSource({"Französisch,fr", "Englisch,en", "Spanisch,es", "Italienisch,it"})
-    void germanNames_mapsToIso6391(String input, String expected) {
+    @CsvSource({"français,fr", "anglais,en", "espagnol,es", "allemand,de", "russe,ru", "polonais,pl"})
+    void frenchLocalizedNames_mapsToIso6391(String input, String expected) {
         assertEquals(expected, LanguageNormalizer.normalize(input));
     }
 
     @ParameterizedTest
-    @CsvSource({"inglés,en", "alemán,de", "francés,fr", "italiano,it"})
-    void spanishNames_mapsToIso6391(String input, String expected) {
+    @CsvSource({"Französisch,fr", "Englisch,en", "Spanisch,es"})
+    void germanLocalizedNames_mapsToIso6391(String input, String expected) {
         assertEquals(expected, LanguageNormalizer.normalize(input));
     }
 
-    // --- Unknown fallback ---
+    @ParameterizedTest
+    @CsvSource({"inglés,en", "alemán,de", "francés,fr"})
+    void spanishLocalizedNames_mapsToIso6391(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
 
     @Test
-    void unknown_returnsLowercased() {
+    void unknown_returnsLowercasedAsIs() {
         assertEquals("klingon", LanguageNormalizer.normalize("Klingon"));
-    }
-
-    @Test
-    void unknown_code_returnsLowercased() {
-        assertEquals("xx", LanguageNormalizer.normalize("XX"));
     }
 }

--- a/backend/src/test/java/org/booklore/util/LanguageNormalizerTest.java
+++ b/backend/src/test/java/org/booklore/util/LanguageNormalizerTest.java
@@ -1,0 +1,79 @@
+package org.booklore.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LanguageNormalizerTest {
+
+    // --- null / blank ---
+
+    @Test
+    void null_returnsNull() {
+        assertNull(LanguageNormalizer.normalize(null));
+    }
+
+    @Test
+    void blank_returnsNull() {
+        assertNull(LanguageNormalizer.normalize("   "));
+    }
+
+    // --- ISO 639-1 passthrough ---
+
+    @ParameterizedTest
+    @CsvSource({"fr,fr", "en,en", "de,de", "es,es", "ja,ja", "zh,zh"})
+    void iso6391_passthrough(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    @Test
+    void iso6391_uppercased_lowercased() {
+        assertEquals("fr", LanguageNormalizer.normalize("FR"));
+    }
+
+    // --- ISO 639-2 ---
+
+    @ParameterizedTest
+    @CsvSource({"fre,fr", "fra,fr", "eng,en", "ger,de", "deu,de", "spa,es", "ita,it", "por,pt", "jpn,ja", "zho,zh", "chi,zh"})
+    void iso6392_mapsToIso6391(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    // --- Full English names (Amazon / GoodReads) ---
+
+    @ParameterizedTest
+    @CsvSource({"French,fr", "English,en", "German,de", "Spanish,es", "Italian,it", "Portuguese,pt", "Japanese,ja", "Chinese,zh", "Polish,pl", "Russian,ru", "Arabic,ar", "Korean,ko"})
+    void englishNames_mapsToIso6391(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    // --- BCP 47 tags ---
+
+    @ParameterizedTest
+    @CsvSource({"fr-FR,fr", "en-US,en", "de-DE,de", "fr_FR,fr", "pt-BR,pt"})
+    void bcp47Tags_mapsToIso6391(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    // --- Mixed case ---
+
+    @ParameterizedTest
+    @CsvSource({"FRENCH,fr", "french,fr", "FRE,fr", "Fr-FR,fr"})
+    void mixedCase_normalized(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    // --- Unknown fallback ---
+
+    @Test
+    void unknown_returnsLowercased() {
+        assertEquals("klingon", LanguageNormalizer.normalize("Klingon"));
+    }
+
+    @Test
+    void unknown_code_returnsLowercased() {
+        assertEquals("xx", LanguageNormalizer.normalize("XX"));
+    }
+}

--- a/backend/src/test/java/org/booklore/util/LanguageNormalizerTest.java
+++ b/backend/src/test/java/org/booklore/util/LanguageNormalizerTest.java
@@ -65,6 +65,26 @@ class LanguageNormalizerTest {
         assertEquals(expected, LanguageNormalizer.normalize(input));
     }
 
+    // --- Localized names (CLDR fallback) ---
+
+    @ParameterizedTest
+    @CsvSource({"français,fr", "anglais,en", "espagnol,es", "allemand,de", "italien,it", "portugais,pt", "russe,ru", "polonais,pl"})
+    void frenchNames_mapsToIso6391(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"Französisch,fr", "Englisch,en", "Spanisch,es", "Italienisch,it"})
+    void germanNames_mapsToIso6391(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"inglés,en", "alemán,de", "francés,fr", "italiano,it"})
+    void spanishNames_mapsToIso6391(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
     // --- Unknown fallback ---
 
     @Test


### PR DESCRIPTION
## Description

Normalises book metadata language values to ISO 639-1 two-letter codes. All parsers (Amazon, GoodReads, Google, Audible, Douban, RanobeDb, LubimyCzytac, Hardcover) now go through a shared `LanguageNormalizer` utility that handles ISO 639-1/639-2 codes, full English names, BCP 47 tags, and localized names via JDK CLDR fallback.

## Linked Issue

Fixes #1383

## Changes

**Backend**
 - Added `LanguageNormalizer` (nv-i18n + JDK CLDR): ISO 639-1 passthrough, ISO 639-2 alpha-3, full English names, BCP 47 tags, CLDR fallback for localized names (e.g. "français" → `fr`, "Französisch" → `fr`)
 - Wired `LanguageNormalizer` into all 8 parsers (Amazon, GoodReads, Google, Audible, Douban, RanobeDb, LubimyCzytac, Hardcover)
 - Removed duplicate `mapLanguage()` from `LubimyCzytacParser` (covered by CLDR)
 - CLDR name map is lazily initialized. No startup cost if the normalizer is never hit with a localized name

**Tests**
 - New `LanguageNormalizerTest.java`: null/blank, ISO 639-1 passthrough, ISO 639-2 alpha-3, full English names, BCP 47 tags, French/German/Spanish localized names → ISO codes, unknown fallback
  
## Manual Testing Steps

1. Fetch metadata from a provider that returns a raw language value (e.g. `"French"`, `"français"`, `"fre"`) and verify the value is saved as the normalised ISO 639-1 code (e.g. `fr`).   
 2. Run `just api check`.

## Screenshots (Optional)

N/A — backend-only change.

## Additional Context (Optional)

The CLDR map covers localized names across 9 display locales (French, German, Italian, Spanish, Portuguese, Dutch, Russian, Polish, Japanese). English names are handled by nv-i18n's `LanguageCode.findByName()` and don't require the CLDR fallback.

## AI Disclosure
  
I used Claude Code which helped me design some aspects of `LanguageNormalizer`, generate and fix tests, and draft this PR description. All changes were reviewed, validated and tested.

## Checklist

 - [x] This PR links and implements an accepted issue.
 - [x] This PR is a single focused change.
 - [x] There are new or updated tests validating this change.
 - [x] I ran `just ui check` and `just api check`.
 - [x] I have added screenshots if there were any UI changes.
 - [x] I have disclosed any AI usage as per the organization AI Policy above.
 - [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented standardized language normalization across all book sources (Amazon, Audible, Douban, GoodReads, Google, Hardcover, and others) for consistent language code representation.

* **Chores**
  * Added internationalization library dependency to support language code resolution and normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->