### PR TITLE
fix(kobo): limit kobo shelf additions to permissible books

### DIFF
--- a/backend/src/main/java/org/booklore/service/kobo/KoboAutoShelfService.java
+++ b/backend/src/main/java/org/booklore/service/kobo/KoboAutoShelfService.java
@@ -3,12 +3,15 @@ package org.booklore.service.kobo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookLoreUserEntity;
 import org.booklore.model.entity.KoboUserSettingsEntity;
 import org.booklore.model.entity.ShelfEntity;
+import org.booklore.model.entity.UserPermissionsEntity;
 import org.booklore.model.enums.ShelfType;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.KoboUserSettingsRepository;
 import org.booklore.repository.ShelfRepository;
+import org.booklore.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +28,7 @@ public class KoboAutoShelfService {
 
     private final KoboUserSettingsRepository koboUserSettingsRepository;
     private final ShelfRepository shelfRepository;
+    private final UserRepository userRepository;
     private final BookRepository bookRepository;
     private final KoboCompatibilityService koboCompatibilityService;
 
@@ -36,7 +40,13 @@ public class KoboAutoShelfService {
         }
 
         BookEntity book = bookRepository.findByIdWithBookFiles(bookId).orElse(null);
+        if (book == null) {
+            log.warn("Book {} not found for Kobo auto-add", bookId);
+            return;
+        }
+
         if (!isBookEligible(book)) {
+            log.debug("Book {} is not eligible for Kobo auto-add", bookId);
             return;
         }
 
@@ -51,6 +61,10 @@ public class KoboAutoShelfService {
                 .map(KoboUserSettingsEntity::getUserId)
                 .toList();
 
+        Map<Long, BookLoreUserEntity> users = userRepository.findAllById(userIds)
+                .stream()
+                .collect(Collectors.toMap(BookLoreUserEntity::getId, u -> u));
+
         List<ShelfEntity> shelves = shelfRepository.findByUserIdInAndName(userIds, ShelfType.KOBO.getName());
 
         Map<Long, ShelfEntity> shelfByUser = shelves
@@ -64,6 +78,11 @@ public class KoboAutoShelfService {
 
             if (shelf == null) {
                 log.debug("User {} has auto-add enabled but no Kobo shelf exists", setting.getUserId());
+                continue;
+            }
+
+            if (!hasBookLibraryAccess(users.get(setting.getUserId()), book)) {
+                log.debug("Book {} is not available for user {}", book.getId(), setting.getUserId());
                 continue;
             }
 
@@ -86,17 +105,22 @@ public class KoboAutoShelfService {
         }
     }
 
+    private boolean hasBookLibraryAccess(BookLoreUserEntity user, BookEntity bookEntity) {
+        if (user == null) {
+            return false;
+        }
+
+        UserPermissionsEntity permissions = user.getPermissions();
+        if (permissions != null && permissions.isPermissionAdmin()) {
+            return true;
+        }
+
+        return user.getLibraries()
+                .stream()
+                .anyMatch(library -> library.equals(bookEntity.getLibrary()));
+    }
+
     private boolean isBookEligible(BookEntity book) {
-        if (book == null) {
-            log.warn("Book not found for Kobo auto-add");
-            return false;
-        }
-
-        if (!koboCompatibilityService.isBookSupportedForKobo(book)) {
-            log.debug("Book {} is not Kobo-compatible, skipping", book.getId());
-            return false;
-        }
-
-        return true;
+        return koboCompatibilityService.isBookSupportedForKobo(book);
     }
 }

--- a/backend/src/test/java/org/booklore/service/kobo/KoboAutoShelfServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/kobo/KoboAutoShelfServiceTest.java
@@ -315,4 +315,26 @@ class KoboAutoShelfServiceTest {
         assert testBook.getShelves() != null;
         assert testBook.getShelves().isEmpty();
     }
+
+    @Test
+    void autoAddBookToKoboShelves_shouldHandleMissingUsers() {
+        testBook = BookEntity.builder()
+                .id(1L)
+                .library(library1)
+                .build();
+
+        when(userRepository.findAllById(List.of(100L))).thenReturn(List.of());
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(testBook));
+        when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
+        when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())
+                .thenReturn(List.of(settings1));
+        when(shelfRepository.findByUserIdInAndName(List.of(100L), ShelfType.KOBO.getName()))
+                .thenReturn(List.of(koboShelf1));
+
+        koboAutoShelfService.autoAddBookToKoboShelves(1L);
+
+        verify(bookRepository, never()).save(testBook);
+        assert testBook.getShelves() != null;
+        assert testBook.getShelves().isEmpty();
+    }
 }

--- a/backend/src/test/java/org/booklore/service/kobo/KoboAutoShelfServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/kobo/KoboAutoShelfServiceTest.java
@@ -278,7 +278,7 @@ class KoboAutoShelfServiceTest {
                 .shelves(null)
                 .build();
 
-        when(userRepository.findAllById(List.of(100L))).thenReturn(List.of(testUser1, testUser2));
+        when(userRepository.findAllById(List.of(100L))).thenReturn(List.of(testUser1));
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(testBook));
         when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
         when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())

--- a/backend/src/test/java/org/booklore/service/kobo/KoboAutoShelfServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/kobo/KoboAutoShelfServiceTest.java
@@ -1,13 +1,11 @@
 package org.booklore.service.kobo;
 
-import org.booklore.model.entity.BookEntity;
-import org.booklore.model.entity.BookLoreUserEntity;
-import org.booklore.model.entity.KoboUserSettingsEntity;
-import org.booklore.model.entity.ShelfEntity;
+import org.booklore.model.entity.*;
 import org.booklore.model.enums.ShelfType;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.KoboUserSettingsRepository;
 import org.booklore.repository.ShelfRepository;
+import org.booklore.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Optional;
 
 import static org.mockito.Mockito.*;
@@ -35,6 +34,9 @@ class KoboAutoShelfServiceTest {
     private BookRepository bookRepository;
 
     @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private KoboCompatibilityService koboCompatibilityService;
 
     @InjectMocks
@@ -43,6 +45,8 @@ class KoboAutoShelfServiceTest {
     private BookEntity testBook;
     private BookLoreUserEntity testUser1;
     private BookLoreUserEntity testUser2;
+    private LibraryEntity library1;
+    private LibraryEntity library2;
     private ShelfEntity koboShelf1;
     private ShelfEntity koboShelf2;
     private KoboUserSettingsEntity settings1;
@@ -50,17 +54,30 @@ class KoboAutoShelfServiceTest {
 
     @BeforeEach
     void setUp() {
+        library1 = LibraryEntity.builder()
+                .id(1L)
+                .build();
+
+        library2 = LibraryEntity.builder()
+                .id(2L)
+                .build();
+
         testBook = BookEntity.builder()
                 .id(1L)
+                .library(library1)
                 .shelves(new HashSet<>())
                 .build();
 
         testUser1 = BookLoreUserEntity.builder()
                 .id(100L)
+                .libraries(Set.of(library1))
+                .permissions(UserPermissionsEntity.builder().build())
                 .isDefaultPassword(false).build();
 
         testUser2 = BookLoreUserEntity.builder()
                 .id(200L)
+                .libraries(Set.of(library1, library2))
+                .permissions(UserPermissionsEntity.builder().build())
                 .isDefaultPassword(false).build();
 
         koboShelf1 = ShelfEntity.builder()
@@ -142,6 +159,7 @@ class KoboAutoShelfServiceTest {
 
     @Test
     void autoAddBookToKoboShelves_successfully_shouldAddBookToShelves() {
+        when(userRepository.findAllById(List.of(100L, 200L))).thenReturn(List.of(testUser1, testUser2));
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(testBook));
         when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
         when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())
@@ -164,6 +182,7 @@ class KoboAutoShelfServiceTest {
 
     @Test
     void autoAddBookToKoboShelves_withOneUserMissingShelf_shouldAddOnlyToExistingShelves() {
+        when(userRepository.findAllById(List.of(100L, 200L))).thenReturn(List.of(testUser1, testUser2));
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(testBook));
         when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
         when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())
@@ -183,6 +202,7 @@ class KoboAutoShelfServiceTest {
     void autoAddBookToKoboShelves_withBookAlreadyOnShelf_shouldNotDuplicate() {
         testBook.getShelves().add(koboShelf1);
 
+        when(userRepository.findAllById(List.of(100L, 200L))).thenReturn(List.of(testUser1, testUser2));
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(testBook));
         when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
         when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())
@@ -207,6 +227,7 @@ class KoboAutoShelfServiceTest {
         when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
         when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())
                 .thenReturn(List.of(settings1, settings2));
+        when(userRepository.findAllById(List.of(100L, 200L))).thenReturn(List.of(testUser1, testUser2));
         when(shelfRepository.findByUserIdInAndName(List.of(100L, 200L), ShelfType.KOBO.getName()))
                 .thenReturn(List.of(koboShelf1, koboShelf2));
 
@@ -234,6 +255,7 @@ class KoboAutoShelfServiceTest {
 
     @Test
     void autoAddBookToKoboShelves_withSingleUser_shouldAddToSingleShelf() {
+        when(userRepository.findAllById(List.of(100L))).thenReturn(List.of(testUser1));
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(testBook));
         when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
         when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())
@@ -252,9 +274,11 @@ class KoboAutoShelfServiceTest {
     void autoAddBookToKoboShelves_withNullShelves_shouldInitializeAndAdd() {
         testBook = BookEntity.builder()
                 .id(1L)
+                .library(library1)
                 .shelves(null)
                 .build();
 
+        when(userRepository.findAllById(List.of(100L))).thenReturn(List.of(testUser1, testUser2));
         when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(testBook));
         when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
         when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())
@@ -268,5 +292,27 @@ class KoboAutoShelfServiceTest {
         assert testBook.getShelves() != null;
         assert testBook.getShelves().contains(koboShelf1);
         assert testBook.getShelves().size() == 1;
+    }
+
+    @Test
+    void autoAddBookToKoboShelves_shouldRespectLibraryAssignment() {
+        testBook = BookEntity.builder()
+                .id(1L)
+                .library(library2)
+                .build();
+
+        when(userRepository.findAllById(List.of(100L))).thenReturn(List.of(testUser1, testUser2));
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(testBook));
+        when(koboCompatibilityService.isBookSupportedForKobo(testBook)).thenReturn(true);
+        when(koboUserSettingsRepository.findByAutoAddToShelfTrueAndSyncEnabledTrue())
+                .thenReturn(List.of(settings1));
+        when(shelfRepository.findByUserIdInAndName(List.of(100L), ShelfType.KOBO.getName()))
+                .thenReturn(List.of(koboShelf1));
+
+        koboAutoShelfService.autoAddBookToKoboShelves(1L);
+
+        verify(bookRepository, never()).save(testBook);
+        assert testBook.getShelves() != null;
+        assert testBook.getShelves().isEmpty();
     }
 }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
The kobo book shelf automation did not take into account whether or not a user could see the book when adding them to the kobo shelf.  This PR resolves the issue by adding a filter to prevent books that users cannot read from being added to their shelves.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1418 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* add a filter so automatic kobo shelf additions are limited to books shelf owners can see

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. create second user without access to a library
2. add books to library user does not have access
3. try sync with kobo device attached to new user

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kobo auto-add now only places books on shelves for users who have access to the book's library.
  * Auto-add aborts gracefully when the referenced book is missing and uses a streamlined per-book eligibility check.
  * Per-user access is verified before attempting shelf additions; users without access are skipped.

* **Tests**
  * Added tests verifying library-based access control and that users without access do not receive Kobo shelf placements.
  * Added tests ensuring no shelves are added when eligible users cannot be resolved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->