### PR TITLE
fix(opds): add audiobook covers for opds navigation

### DIFF
--- a/backend/src/main/java/org/booklore/controller/OpdsController.java
+++ b/backend/src/main/java/org/booklore/controller/OpdsController.java
@@ -73,6 +73,10 @@ public class OpdsController {
             coverImage = bookService.getAudiobookCover(bookId);
         }
 
+        if (coverImage == null) {
+            return ResponseEntity.notFound().build();
+        }
+
         String contentType = "image/jpeg";
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType(contentType))

--- a/backend/src/main/java/org/booklore/controller/OpdsController.java
+++ b/backend/src/main/java/org/booklore/controller/OpdsController.java
@@ -67,6 +67,12 @@ public class OpdsController {
     public ResponseEntity<Resource> getBookCover(@Parameter(description = "ID of the book") @PathVariable long bookId) {
         opdsBookService.validateBookContentAccess(bookId, getOpdsUserId());
         Resource coverImage = bookService.getBookThumbnail(bookId);
+
+        if (coverImage == null) {
+            // Fall back to audiobook if possible
+            coverImage = bookService.getAudiobookCover(bookId);
+        }
+
         String contentType = "image/jpeg";
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType(contentType))

--- a/backend/src/main/java/org/booklore/service/opds/OpdsFeedService.java
+++ b/backend/src/main/java/org/booklore/service/opds/OpdsFeedService.java
@@ -555,6 +555,20 @@ public class OpdsFeedService {
         }
     }
 
+    private Instant getCoverUpdatedOn(Book book) {
+        if (book.getMetadata() != null) {
+            if (book.getMetadata().getCoverUpdatedOn() != null) {
+                return book.getMetadata().getCoverUpdatedOn();
+            }
+
+            if (book.getMetadata().getAudiobookCoverUpdatedOn() != null) {
+                return book.getMetadata().getAudiobookCoverUpdatedOn();
+            }
+        }
+
+        return null;
+    }
+
     private void appendLinks(StringBuilder feed, Book book) {
         // Add acquisition link for primary file
         if (book.getPrimaryFile() != null) {
@@ -568,8 +582,9 @@ public class OpdsFeedService {
             }
         }
 
-        if (book.getMetadata() != null && book.getMetadata().getCoverUpdatedOn() != null) {
-            String coverUrl = "/api/v1/opds/" + book.getId() + "/cover?" + book.getMetadata().getCoverUpdatedOn();
+        Instant coverUpdatedOn = getCoverUpdatedOn(book);
+        if (coverUpdatedOn != null) {
+            String coverUrl = "/api/v1/opds/" + book.getId() + "/cover?" + coverUpdatedOn;
             feed.append("    <link rel=\"http://opds-spec.org/image\" href=\"")
                     .append(escapeXml(coverUrl)).append("\" type=\"image/jpeg\"/>\n");
             feed.append("    <link rel=\"http://opds-spec.org/image/thumbnail\" href=\"")

--- a/backend/src/test/java/org/booklore/service/opds/OpdsFeedServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/opds/OpdsFeedServiceTest.java
@@ -168,6 +168,98 @@ class OpdsFeedServiceTest {
     }
 
     @Test
+    void generateCatalogFeed_shouldOmitCoverWhenNotUpdatedOn() {
+        mockAuthenticatedUser();
+
+        when(request.getParameter("libraryId")).thenReturn(null);
+        when(request.getParameter("shelfId")).thenReturn(null);
+        when(request.getParameter("magicShelfId")).thenReturn(null);
+        when(request.getParameter("q")).thenReturn(null);
+        when(request.getParameter("page")).thenReturn(null);
+        when(request.getParameter("size")).thenReturn(null);
+        when(request.getRequestURI()).thenReturn("/api/v1/opds/catalog");
+        when(request.getQueryString()).thenReturn(null);
+
+        Book book = Book.builder()
+                .id(10L)
+                .primaryFile(BookFile.builder().id(1L).bookType(BookFileType.EPUB).build())
+                .addedOn(FIXED_INSTANT)
+                .metadata(BookMetadata.builder()
+                        .build())
+                .build();
+
+        Page<Book> page = new PageImpl<>(List.of(book), PageRequest.of(0, 50), 1);
+        when(opdsBookService.getBooksPage(eq(TEST_USER_ID), any(), any(), any(), eq(0), eq(50))).thenReturn(page);
+        when(opdsBookService.applySortOrder(any(), any())).thenReturn(page);
+
+        String xml = opdsFeedService.generateCatalogFeed(request);
+        assertThat(xml).doesNotContain("link rel=\"http://opds-spec.org/image\" href=\"/api/v1/opds/10/cover");
+        verify(opdsBookService).getBooksPage(TEST_USER_ID, null, null, null, 0, 50);
+    }
+
+    @Test
+    void generateCatalogFeed_shouldShowEbookCover() {
+        mockAuthenticatedUser();
+
+        when(request.getParameter("libraryId")).thenReturn(null);
+        when(request.getParameter("shelfId")).thenReturn(null);
+        when(request.getParameter("magicShelfId")).thenReturn(null);
+        when(request.getParameter("q")).thenReturn(null);
+        when(request.getParameter("page")).thenReturn(null);
+        when(request.getParameter("size")).thenReturn(null);
+        when(request.getRequestURI()).thenReturn("/api/v1/opds/catalog");
+        when(request.getQueryString()).thenReturn(null);
+
+        Book book = Book.builder()
+                .id(10L)
+                .primaryFile(BookFile.builder().id(1L).bookType(BookFileType.EPUB).build())
+                .addedOn(FIXED_INSTANT)
+                .metadata(BookMetadata.builder()
+                        .coverUpdatedOn(FIXED_INSTANT)
+                        .build())
+                .build();
+
+        Page<Book> page = new PageImpl<>(List.of(book), PageRequest.of(0, 50), 1);
+        when(opdsBookService.getBooksPage(eq(TEST_USER_ID), any(), any(), any(), eq(0), eq(50))).thenReturn(page);
+        when(opdsBookService.applySortOrder(any(), any())).thenReturn(page);
+
+        String xml = opdsFeedService.generateCatalogFeed(request);
+        assertThat(xml).contains("link rel=\"http://opds-spec.org/image\" href=\"/api/v1/opds/10/cover");
+        verify(opdsBookService).getBooksPage(TEST_USER_ID, null, null, null, 0, 50);
+    }
+
+    @Test
+    void generateCatalogFeed_shouldShowAudiobookCover() {
+        mockAuthenticatedUser();
+
+        when(request.getParameter("libraryId")).thenReturn(null);
+        when(request.getParameter("shelfId")).thenReturn(null);
+        when(request.getParameter("magicShelfId")).thenReturn(null);
+        when(request.getParameter("q")).thenReturn(null);
+        when(request.getParameter("page")).thenReturn(null);
+        when(request.getParameter("size")).thenReturn(null);
+        when(request.getRequestURI()).thenReturn("/api/v1/opds/catalog");
+        when(request.getQueryString()).thenReturn(null);
+
+        Book book = Book.builder()
+                .id(10L)
+                .primaryFile(BookFile.builder().id(1L).bookType(BookFileType.EPUB).build())
+                .addedOn(FIXED_INSTANT)
+                .metadata(BookMetadata.builder()
+                        .audiobookCoverUpdatedOn(FIXED_INSTANT)
+                        .build())
+                .build();
+
+        Page<Book> page = new PageImpl<>(List.of(book), PageRequest.of(0, 50), 1);
+        when(opdsBookService.getBooksPage(eq(TEST_USER_ID), any(), any(), any(), eq(0), eq(50))).thenReturn(page);
+        when(opdsBookService.applySortOrder(any(), any())).thenReturn(page);
+
+        String xml = opdsFeedService.generateCatalogFeed(request);
+        assertThat(xml).contains("link rel=\"http://opds-spec.org/image\" href=\"/api/v1/opds/10/cover");
+        verify(opdsBookService).getBooksPage(TEST_USER_ID, null, null, null, 0, 50);
+    }
+
+    @Test
     void generateCatalogFeed_shouldHandleEmptyPage() {
         mockAuthenticatedUser();
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
The OPDS API does not support audiobook covers - it ignores them entirely.

This PR updates OPDS so that it will read from both the book cover thumbnail and the audiobook cover thumbnail.  This is in the publication link definition in the OPDS response.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1404

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* adds audiobook cover link in OPDS 
* adds tests to validate behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. add audiobook to library
2. curl'd `/api/v1/opds/catalog`
3. observed now audiobook has an image

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced audiobook cover image handling in OPDS feeds with proper fallback to book covers when unavailable.

* **Bug Fixes**
  * Improved cover metadata timestamp handling to ensure accurate cover information in feed links.

* **Tests**
  * Added coverage for cover link generation behavior in catalog feeds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->