### PR TITLE
feat(pdf-reader): add manual save to the top bar functionality for document edits

### DIFF
--- a/frontend/src/app/features/readers/ebook-reader/shared/icon.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/shared/icon.component.ts
@@ -50,7 +50,8 @@ export type ReaderIconName =
   | 'moon'
   | 'dots-horizontal'
   | 'zoom-in'
-  | 'zoom-out';
+  | 'zoom-out'
+  | 'save';
 
 interface IconPath {
   d: string;
@@ -290,6 +291,11 @@ const ICONS: Record<ReaderIconName, IconPath[]> = {
     {d: 'M11 11m-8 0a8 8 0 1 0 16 0a8 8 0 1 0-16 0', type: 'path'},
     {d: 'M21 21l-4.35-4.35'},
     {d: 'M8 11h6'}
+  ],
+  'save': [
+    {d: 'M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z'},
+    {d: 'M17 21v-8H7v8'},
+    {d: 'M7 3v5h8'}
   ]
 };
 

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.html
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.html
@@ -5,7 +5,7 @@
 }
 
 @if (!isLoading()) {
-<div class="pdf-reader-container" [class.dark]="isDarkTheme()" [class.v-hidden]="viewerMode() === 'book' && !isInitialScrollDone()">
+<div class="pdf-reader-container" [class.dark]="isDarkTheme()" [class.v-hidden]="viewerMode() === 'book' && !isInitialScrollDone()" [class.footer-hidden]="!footerVisible()">
 
   <!-- Footer trigger zone -->
   <div class="footer-trigger-zone" [class.inactive]="footerVisible()" (mouseenter)="onFooterTriggerZoneEnter()"></div>
@@ -24,6 +24,17 @@
       </button>
     </div>
     }
+
+    <div class="embed-header-actions">
+      <button class="embed-action-btn save-btn" [title]="'readerPdf.docViewer.saveDocument' | transloco" [attr.aria-label]="'readerPdf.docViewer.saveDocument' | transloco"
+        (click)="saveDocument()">
+        <app-reader-icon name="save" [size]="18" />
+      </button>
+      <button class="embed-action-btn close-btn" [title]="'readerPdf.toolbar.closePdfReader' | transloco" [attr.aria-label]="'readerPdf.toolbar.closePdfReader' | transloco"
+        [disabled]="isClosingReader()" (pointerdown)="onCloseReaderPointerDown($event)" (click)="onCloseReaderClick($event)">
+        <app-reader-icon name="close" [size]="18" />
+      </button>
+    </div>
 
     <div id="embedpdf-viewer"></div>
   }

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.html
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.html
@@ -27,6 +27,7 @@
 
     <div class="embed-header-actions">
       <button class="embed-action-btn save-btn" [title]="'readerPdf.docViewer.saveDocument' | transloco" [attr.aria-label]="'readerPdf.docViewer.saveDocument' | transloco"
+        [disabled]="isSavingDocument() || isClosingReader()" [attr.aria-busy]="isSavingDocument()"
         (click)="saveDocument()">
         <app-reader-icon name="save" [size]="18" />
       </button>

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
@@ -685,9 +685,9 @@ $transition-fast: 150ms ease;
 
 #embedpdf-viewer {
   position: absolute;
-  inset: 0 0 $footer-height;
+  inset: 0;
   width: 100%;
-  height: calc(100% - #{$footer-height});
+  height: 100%;
   display: flex;
   transition: inset 0.25s ease-out, height 0.25s ease-out;
 
@@ -835,6 +835,14 @@ $transition-fast: 150ms ease;
 
 // Tablet (portrait) switches to mobile toolbar layout
 @media (width <= 1024px) {
+  // When footer is visible on mobile/tablet, it pushes the PDF viewer
+  .pdf-reader-container:not(.footer-hidden) {
+    #embedpdf-viewer {
+      inset: 0 0 $footer-height;
+      height: calc(100% - #{$footer-height});
+    }
+  }
+
   .pdf-header-toolbar {
     height: calc(#{$header-height} + 4px + env(safe-area-inset-top));
     padding: 0 8px;

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
@@ -555,38 +555,82 @@ $transition-fast: 150ms ease;
   }
 }
 
-.embed-close-btn {
+.embed-header-actions {
   position: fixed;
   top: 0;
   right: 10px;
-  z-index: 11000;
-  color: #fff;
-  width: 38px;
   height: $header-height;
   display: flex;
   align-items: center;
-  justify-content: center;
-  background: transparent;
+  gap: 4px;
+  z-index: 11000;
+  pointer-events: auto;
+  color: #fff;
+
+  @media (width <= 1024px) {
+    top: env(safe-area-inset-top);
+    height: calc(#{$header-height} + 4px);
+    right: 8px;
+  }
+}
+
+.embed-action-btn {
+  background: none;
   border: none;
-  border-left: none;
+  color: inherit;
   cursor: pointer;
-  padding: 0;
-  transition: background $transition-fast;
+  padding: 7px;
+  border-radius: 6px;
+  transition: background $transition-fast, color $transition-fast;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   touch-action: manipulation;
   -webkit-tap-highlight-color: rgb(255 255 255 / 12%);
-  border-radius: 0;
+  width: 32px;
+  height: 32px;
 
   &:hover {
-    background: rgb(255 255 255 / 10%);
+    background: $hover-bg;
   }
 
-  &:active {
-    background: rgb(255 255 255 / 16%);
+  &.close-btn:hover {
+    background: rgb(239 68 68 / 20%);
+    color: #ef4444;
+  }
+
+  &.save-btn:hover {
+    background: rgb(74 144 226 / 20%);
+    color: #4a90e2;
   }
 
   &:disabled {
-    opacity: 0.8;
+    opacity: 0.65;
     cursor: default;
+  }
+}
+
+.pdf-reader-container:not(.dark) {
+  .embed-header-actions {
+    color: rgb(0 0 0 / 87%);
+
+    .embed-action-btn {
+      color: rgb(0 0 0 / 87%);
+
+      &:hover {
+        background: rgb(0 0 0 / 6%);
+      }
+
+      &.close-btn:hover {
+        background: rgb(239 68 68 / 15%);
+        color: #dc2626;
+      }
+
+      &.save-btn:hover {
+        background: rgb(74 144 226 / 15%);
+        color: #1d4ed8;
+      }
+    }
   }
 }
 
@@ -641,15 +685,23 @@ $transition-fast: 150ms ease;
 
 #embedpdf-viewer {
   position: absolute;
-  inset: 0;
+  inset: 0 0 $footer-height;
   width: 100%;
-  height: 100%;
+  height: calc(100% - #{$footer-height});
   display: flex;
+  transition: inset 0.25s ease-out, height 0.25s ease-out;
 
   iframe {
     width: 100%;
     height: 100%;
     border: none;
+  }
+}
+
+.pdf-reader-container.footer-hidden {
+  #embedpdf-viewer {
+    inset: 0;
+    height: 100%;
   }
 }
 
@@ -793,17 +845,6 @@ $transition-fast: 150ms ease;
     min-width: 46px;
     min-height: 46px;
     border-radius: 8px;
-  }
-
-  .embed-close-btn {
-    top: calc(env(safe-area-inset-top) + 2px);
-    right: 10px;
-    width: 38px;
-    height: $header-height;
-    min-width: 38px;
-    min-height: $header-height;
-    border-radius: 0;
-    border-left: none;
   }
 
   .desktop-actions {

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.spec.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.spec.ts
@@ -2,7 +2,7 @@ import {afterEach, describe, expect, it, vi} from 'vitest';
 
 import {PdfReaderComponent} from './pdf-reader.component';
 
-type PdfReaderHarness = {
+interface PdfReaderHarness {
   embedPdfIframe: {contentWindow: {postMessage: ReturnType<typeof vi.fn>}} | null;
   embedPdfSaveResolve?: (buffer: ArrayBuffer | null) => void;
   cachedPdfBuffer: ArrayBuffer | null;
@@ -10,7 +10,7 @@ type PdfReaderHarness = {
   authService: {getInternalAccessToken: () => string | null};
   bookId: number;
   saveEmbedPdfDocument: () => Promise<boolean>;
-};
+}
 
 function bytes(buffer: ArrayBuffer): number[] {
   return Array.from(new Uint8Array(buffer));

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.spec.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.spec.ts
@@ -1,4 +1,4 @@
-import {afterEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {PdfReaderComponent} from './pdf-reader.component';
 
@@ -8,6 +8,7 @@ interface PdfReaderHarness {
   cachedPdfBuffer: ArrayBuffer | null;
   pdfBlobUrl: string | null;
   authService: {getInternalAccessToken: () => string | null};
+  cacheStorageService: {delete: ReturnType<typeof vi.fn>};
   bookId: number;
   saveEmbedPdfDocument: () => Promise<boolean>;
 }
@@ -28,11 +29,17 @@ function makeComponent(savedBuffer: ArrayBuffer): PdfReaderHarness {
   component.cachedPdfBuffer = new Uint8Array([9, 9, 9]).buffer;
   component.pdfBlobUrl = 'blob:old-pdf';
   component.authService = {getInternalAccessToken: () => null};
+  component.cacheStorageService = {delete: vi.fn(() => Promise.resolve(true))};
   component.bookId = 123;
   return component;
 }
 
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
@@ -48,13 +55,15 @@ describe('PdfReaderComponent save handling', () => {
 
     const firstSave = component.saveEmbedPdfDocument();
     const secondSave = component.saveEmbedPdfDocument();
+    vi.advanceTimersByTime(0);
 
     await expect(Promise.all([firstSave, secondSave])).resolves.toEqual([true, true]);
     expect(component.embedPdfIframe?.contentWindow.postMessage).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(component.cacheStorageService.delete).toHaveBeenCalledTimes(1);
   });
 
-  it('refreshes the cached PDF bytes and blob URL after upload succeeds', async () => {
+  it('refreshes local PDF bytes and evicts the shared cache after upload succeeds', async () => {
     const savedBuffer = new Uint8Array([4, 5, 6]).buffer;
     const component = makeComponent(savedBuffer);
     const fetchMock = vi.fn(() => Promise.resolve({ok: true} as Response));
@@ -62,7 +71,10 @@ describe('PdfReaderComponent save handling', () => {
     const revokeObjectUrl = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(component.saveEmbedPdfDocument()).resolves.toBe(true);
+    const save = component.saveEmbedPdfDocument();
+    vi.advanceTimersByTime(0);
+
+    await expect(save).resolves.toBe(true);
 
     expect(bytes(component.cachedPdfBuffer!)).toEqual([4, 5, 6]);
     expect(component.cachedPdfBuffer).not.toBe(savedBuffer);
@@ -72,6 +84,9 @@ describe('PdfReaderComponent save handling', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/api/v1/books/123/content'),
       expect.objectContaining({body: expect.any(ArrayBuffer)})
+    );
+    expect(component.cacheStorageService.delete).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/books/123/content')
     );
   });
 });

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.spec.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.spec.ts
@@ -1,14 +1,77 @@
-import {describe, it} from 'vitest';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 
-// NOTE(frontend-seam): Real coverage here needs seams around ngx-extended-pdf-viewer,
-// reader-session lifecycle, route-driven book loading, and annotation persistence so the
-// component can be tested without booting the full PDF runtime and browser document hooks.
-describe.skip('PdfReaderComponent', () => {
-  it('needs a viewer-runtime seam to verify page, zoom, spread, and annotation flows deterministically', () => {
-    // TODO(seam): Cover load, navigation, and annotation persistence after wrapping the PDF viewer and reader-session integrations.
+import {PdfReaderComponent} from './pdf-reader.component';
+
+type PdfReaderHarness = {
+  embedPdfIframe: {contentWindow: {postMessage: ReturnType<typeof vi.fn>}} | null;
+  embedPdfSaveResolve?: (buffer: ArrayBuffer | null) => void;
+  cachedPdfBuffer: ArrayBuffer | null;
+  pdfBlobUrl: string | null;
+  authService: {getInternalAccessToken: () => string | null};
+  bookId: number;
+  saveEmbedPdfDocument: () => Promise<boolean>;
+};
+
+function bytes(buffer: ArrayBuffer): number[] {
+  return Array.from(new Uint8Array(buffer));
+}
+
+function makeComponent(savedBuffer: ArrayBuffer): PdfReaderHarness {
+  const component = Object.create(PdfReaderComponent.prototype) as PdfReaderHarness;
+  component.embedPdfIframe = {
+    contentWindow: {
+      postMessage: vi.fn(() => {
+        setTimeout(() => component.embedPdfSaveResolve?.(savedBuffer.slice(0)));
+      })
+    }
+  };
+  component.cachedPdfBuffer = new Uint8Array([9, 9, 9]).buffer;
+  component.pdfBlobUrl = 'blob:old-pdf';
+  component.authService = {getInternalAccessToken: () => null};
+  component.bookId = 123;
+  return component;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('PdfReaderComponent save handling', () => {
+  it('shares one iframe export and upload across concurrent saves', async () => {
+    const savedBuffer = new Uint8Array([1, 2, 3]).buffer;
+    const component = makeComponent(savedBuffer);
+    const fetchMock = vi.fn(() => Promise.resolve({ok: true} as Response));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:saved-pdf');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+
+    const firstSave = component.saveEmbedPdfDocument();
+    const secondSave = component.saveEmbedPdfDocument();
+
+    await expect(Promise.all([firstSave, secondSave])).resolves.toEqual([true, true]);
+    expect(component.embedPdfIframe?.contentWindow.postMessage).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('needs a route-and-session seam to verify startup and teardown side effects without real browser navigation', () => {
-    // TODO(seam): Cover session start/end and progress persistence once route/book-detail dependencies are injectable test adapters.
+  it('refreshes the cached PDF bytes and blob URL after upload succeeds', async () => {
+    const savedBuffer = new Uint8Array([4, 5, 6]).buffer;
+    const component = makeComponent(savedBuffer);
+    const fetchMock = vi.fn(() => Promise.resolve({ok: true} as Response));
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:saved-pdf');
+    const revokeObjectUrl = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(component.saveEmbedPdfDocument()).resolves.toBe(true);
+
+    expect(bytes(component.cachedPdfBuffer!)).toEqual([4, 5, 6]);
+    expect(component.cachedPdfBuffer).not.toBe(savedBuffer);
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:old-pdf');
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
+    expect(component.pdfBlobUrl).toBe('blob:saved-pdf');
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/books/123/content'),
+      expect.objectContaining({body: expect.any(ArrayBuffer)})
+    );
   });
 });

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -1139,6 +1139,25 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
     }
   }
 
+  async saveDocument(): Promise<void> {
+    if (this.viewerMode() !== 'document' || !this.embedPdfIframe) return;
+    try {
+      await this.saveEmbedPdfDocument();
+      this.messageService.add({
+        severity: 'success',
+        summary: this.t.translate('common.success'),
+        detail: this.t.translate('readerPdf.docViewer.changesSaved') || 'Changes saved successfully.'
+      });
+    } catch (err) {
+      console.error('[PDF Reader] Manually saving document failed:', err);
+      this.messageService.add({
+        severity: 'error',
+        summary: this.t.translate('common.error'),
+        detail: this.t.translate('readerPdf.docViewer.saveFailed') || 'Failed to save changes.'
+      });
+    }
+  }
+
   private async destroyDocViewerIframe(): Promise<void> {
     if (this.embedPdfMessageHandler) {
       window.removeEventListener('message', this.embedPdfMessageHandler);

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -118,6 +118,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   private embedPdfMessageHandler?: (e: MessageEvent) => void;
   private embedPdfSaveResolve?: (buffer: ArrayBuffer | null) => void;
   private embedPdfSaveTimer?: ReturnType<typeof setTimeout>;
+  private embedPdfSavePromise?: Promise<boolean>;
   private embedPdfInitTime = 0;
   private pendingPdfBuffer?: ArrayBuffer;
   private initTimeout?: ReturnType<typeof setTimeout>;
@@ -130,6 +131,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   private docProgressReleaseTimer?: ReturnType<typeof setTimeout>;
   private closeReaderPromise: Promise<void> | null = null;
   readonly isClosingReader = signal(false);
+  readonly isSavingDocument = signal(false);
 
   // Book mode state
   private bookViewerInitialized = false;
@@ -1093,6 +1095,17 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
   }
 
   private async saveEmbedPdfDocument(): Promise<boolean> {
+    if (this.embedPdfSavePromise) return this.embedPdfSavePromise;
+    this.embedPdfSavePromise = this.performEmbedPdfSave();
+
+    try {
+      return await this.embedPdfSavePromise;
+    } finally {
+      this.embedPdfSavePromise = undefined;
+    }
+  }
+
+  private async performEmbedPdfSave(): Promise<boolean> {
     if (!this.embedPdfIframe?.contentWindow) return false;
 
     try {
@@ -1135,6 +1148,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
         console.error('[EmbedPDF] Upload failed:', uploadResponse.status);
         return false;
       }
+      this.updateSavedPdfCache(buffer);
       return true;
     } catch (err) {
       console.error('[EmbedPDF] Failed to save document:', err);
@@ -1142,8 +1156,18 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
     }
   }
 
+  private updateSavedPdfCache(buffer: ArrayBuffer): void {
+    const savedBuffer = buffer.slice(0);
+    this.cachedPdfBuffer = savedBuffer;
+    this.revokePdfBlobUrl();
+    this.pdfBlobUrl = URL.createObjectURL(new Blob([savedBuffer], { type: 'application/pdf' }));
+  }
+
   async saveDocument(): Promise<void> {
     if (this.viewerMode() !== 'document' || !this.embedPdfIframe) return;
+    if (this.isSavingDocument()) return;
+
+    this.isSavingDocument.set(true);
     try {
       const saved = await this.saveEmbedPdfDocument();
       this.messageService.add(saved ? {
@@ -1162,6 +1186,8 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
         summary: this.t.translate('common.error'),
         detail: this.t.translate('readerPdf.docViewer.saveFailed') || 'Failed to save changes.'
       });
+    } finally {
+      this.isSavingDocument.set(false);
     }
   }
 

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -1149,6 +1149,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
         return false;
       }
       this.updateSavedPdfCache(buffer);
+      await this.cacheStorageService.delete(url);
       return true;
     } catch (err) {
       console.error('[EmbedPDF] Failed to save document:', err);

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts
@@ -1092,8 +1092,8 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async saveEmbedPdfDocument(): Promise<void> {
-    if (!this.embedPdfIframe?.contentWindow) return;
+  private async saveEmbedPdfDocument(): Promise<boolean> {
+    if (!this.embedPdfIframe?.contentWindow) return false;
 
     try {
       const buffer: ArrayBuffer | null = await new Promise((resolve) => {
@@ -1113,7 +1113,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
         this.embedPdfSaveTimer = undefined;
       }
 
-      if (!buffer) return;
+      if (!buffer) return false;
 
       const headers: Record<string, string> = { 'Content-Type': 'application/pdf' };
       const uploadToken = this.authService.getInternalAccessToken();
@@ -1133,20 +1133,27 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
       });
       if (!uploadResponse.ok) {
         console.error('[EmbedPDF] Upload failed:', uploadResponse.status);
+        return false;
       }
+      return true;
     } catch (err) {
       console.error('[EmbedPDF] Failed to save document:', err);
+      return false;
     }
   }
 
   async saveDocument(): Promise<void> {
     if (this.viewerMode() !== 'document' || !this.embedPdfIframe) return;
     try {
-      await this.saveEmbedPdfDocument();
-      this.messageService.add({
+      const saved = await this.saveEmbedPdfDocument();
+      this.messageService.add(saved ? {
         severity: 'success',
         summary: this.t.translate('common.success'),
         detail: this.t.translate('readerPdf.docViewer.changesSaved') || 'Changes saved successfully.'
+      } : {
+        severity: 'error',
+        summary: this.t.translate('common.error'),
+        detail: this.t.translate('readerPdf.docViewer.saveFailed') || 'Failed to save changes.'
       });
     } catch (err) {
       console.error('[PDF Reader] Manually saving document failed:', err);

--- a/frontend/src/assets/embedpdf-frame.html
+++ b/frontend/src/assets/embedpdf-frame.html
@@ -167,7 +167,7 @@
         border-bottom-color: #404040 !important;
         box-shadow: 0 2px 8px rgba(0,0,0,0.30) !important;
         height: 38px !important;
-        padding-right: 64px !important;
+        padding-right: 96px !important;
         padding-top: 0 !important;
         padding-bottom: 0 !important;
         box-sizing: border-box !important;
@@ -177,6 +177,17 @@
         background: linear-gradient(135deg, #f0f0f0 0%, #e8e8e8 100%) !important;
         border-bottom-color: #d0d0d0 !important;
         box-shadow: 0 2px 8px rgba(0,0,0,0.10) !important;
+      }
+
+      [data-epdf-i="right-group"] {
+        position: relative !important;
+        right: 80px !important;
+      }
+
+      @media (max-width: 600px) {
+        [data-epdf-i="right-group"] {
+          display: none !important;
+        }
       }
 
       /* Keep viewer popups/menus visible; only hide explicit file controls. */
@@ -293,9 +304,9 @@
 
       /* ── Silence non-editable selection menus EXCEPT for navigation links ── */
 
-      /* If the menu has no user-editing tools OR navigation, hide the whole menu. */
-      [role="toolbar"]:not(:has([data-epdf-i*="appearance"])):not(:has([data-epdf-i*="comment"])):not(:has([data-epdf-i*="navigate"])),
-      [role="menu"]:not(:has([data-epdf-i*="appearance"])):not(:has([data-epdf-i*="comment"])):not(:has([data-epdf-i*="navigate"])) {
+      /* If the menu has no user-editing tools OR navigation OR redact, hide the whole menu. */
+      [role="toolbar"]:not(:has([data-epdf-i*="appearance"])):not(:has([data-epdf-i*="comment"])):not(:has([data-epdf-i*="navigate"])):not(:has([data-epdf-i*="redact"])),
+      [role="menu"]:not(:has([data-epdf-i*="appearance"])):not(:has([data-epdf-i*="comment"])):not(:has([data-epdf-i*="navigate"])):not(:has([data-epdf-i*="redact"])) {
         display: none !important;
       }
 

--- a/frontend/src/i18n/en/reader-pdf.json
+++ b/frontend/src/i18n/en/reader-pdf.json
@@ -70,6 +70,9 @@
   },
   "docViewer": {
     "changesSavedInfo": "Edits in the Document Viewer are automatically saved to the PDF.",
-    "dismiss": "Dismiss"
+    "dismiss": "Dismiss",
+    "saveDocument": "Save Changes",
+    "changesSaved": "Changes saved successfully.",
+    "saveFailed": "Failed to save changes."
   }
 }


### PR DESCRIPTION
## Description

Added a manual save feature to the PDF Reader to allow users to explicitly save their document edits. This feature better exposes the save button. Previously to save users had export which was not intuitive. Also adds explicit X button to exit the doc viewer.

<!-- Required. Briefly explain what changed and why. -->

## Linked Issue

<!-- Required. Example: Fixes #123 -->

## Changes


- Implemented manual save functionality to handle user-initiated saves for document edits.
- Enhanced PDF Reader to include a "Save" button in the UI.
- Updated document persistence logic to support on-demand saving.

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Open the PDF Reader. Navigate to the document viewer
2. Make edits to a document.
3. Click the "Save" button to save the changes.
4. Verify that the edits are successfully saved.
5. Press new X button verify it worked

## Screenshots (Optional)
<img width="1050" height="911" alt="image" src="https://github.com/user-attachments/assets/fa727ed6-c579-4572-bea7-a5def2a505c6" />
<img width="1728" height="916" alt="image" src="https://github.com/user-attachments/assets/0cf62bd0-d3e5-4af6-b4a5-5c6a581a7eec" />



<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Save action to the PDF reader with success/error toasts, Close action in the header, and protection against concurrent saves.

* **Style**
  * Redesigned header action bar and buttons (hover/disabled states, theme-aware colors) and improved embedded PDF layout, responsive/footer behavior, and header spacing on small screens.

* **Tests**
  * Added tests for save behavior, concurrency, upload interaction, and cache refresh.

* **Other**
  * Added a new reader icon for the Save action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->