### PR TITLE
fix: library stats showing 0KB due to incorrect fileSizeKb field path

### DIFF
--- a/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.spec.ts
@@ -41,6 +41,56 @@ describe('LibrariesSummaryService', () => {
     expect(service.formattedSize()).toBe('0 KB');
   });
 
+  it('aggregates totals for the selected library and formats megabytes', () => {
+    books.set([
+      {
+        id: 1,
+        libraryId: 1,
+        libraryName: 'Alpha',
+        fileSizeKb: 1024,
+        metadata: {
+          bookId: 1,
+          authors: ['Alice', 'Bob'],
+          seriesName: 'Series A',
+          publisher: 'Publisher X',
+        },
+      } as Book,
+      {
+        id: 2,
+        libraryId: 1,
+        libraryName: 'Alpha',
+        fileSizeKb: 1024,
+        metadata: {
+          bookId: 2,
+          authors: ['Alice', 'Carol'],
+          publisher: 'Publisher X',
+        },
+      } as Book,
+      {
+        id: 3,
+        libraryId: 2,
+        libraryName: 'Beta',
+        fileSizeKb: 10240,
+        metadata: {
+          bookId: 3,
+          authors: ['Dave'],
+        },
+      } as Book,
+    ]);
+    selectedLibrary.set(1);
+
+    const service = TestBed.inject(LibrariesSummaryService);
+
+    expect(service.booksSummary()).toEqual({
+      totalBooks: 2,
+      totalSizeKb: 2048,
+      totalAuthors: 3,
+      totalSeries: 1,
+      totalPublishers: 1,
+    });
+    expect(service.formattedSize()).toBe('2.00 MB');
+  });
+
   it('uses primary file size when the book does not expose a top-level file size', () => {
     books.set([
       {

--- a/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.spec.ts
@@ -41,57 +41,33 @@ describe('LibrariesSummaryService', () => {
     expect(service.formattedSize()).toBe('0 KB');
   });
 
-  it('aggregates totals for the selected library and formats megabytes', () => {
+  it('uses primary file size when the book does not expose a top-level file size', () => {
     books.set([
       {
         id: 1,
         libraryId: 1,
         libraryName: 'Alpha',
-        fileSizeKb: 1024,
+        primaryFile: {
+          bookId: 1,
+          fileSizeKb: 2048,
+        },
         metadata: {
           bookId: 1,
-          authors: ['Alice', 'Alice ', 'Bob'],
-          seriesName: 'Series A',
-          publisher: 'Publisher A',
-        },
-      } as Book,
-      {
-        id: 2,
-        libraryId: 2,
-        libraryName: 'Beta',
-        fileSizeKb: 4096,
-        metadata: {
-          bookId: 2,
-          authors: ['Zed'],
-          seriesName: 'Series B',
-          publisher: 'Publisher B',
-        },
-      } as Book,
-      {
-        id: 3,
-        libraryId: 1,
-        libraryName: 'Alpha',
-        fileSizeKb: 1024 * 1024,
-        metadata: {
-          bookId: 3,
-          authors: ['Carol'],
-          seriesName: 'Series A',
-          publisher: 'Publisher A',
+          authors: ['Alice'],
         },
       } as Book,
     ]);
-    selectedLibrary.set(1);
 
     const service = TestBed.inject(LibrariesSummaryService);
-    const summary = service.booksSummary();
 
-    expect(summary).toEqual({
-      totalBooks: 2,
-      totalSizeKb: 1024 + 1024 * 1024,
-      totalAuthors: 3,
-      totalSeries: 1,
-      totalPublishers: 1,
+    expect(service.booksSummary()).toEqual({
+      totalBooks: 1,
+      totalSizeKb: 2048,
+      totalAuthors: 1,
+      totalSeries: 0,
+      totalPublishers: 0,
     });
-    expect(service.formattedSize()).toBe('1.00 GB');
+    expect(service.formattedSize()).toBe('2.00 MB');
   });
+
 });

--- a/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.spec.ts
@@ -124,4 +124,35 @@ describe('LibrariesSummaryService', () => {
     expect(service.formattedSize()).toBe('2.00 MB');
   });
 
+  it('prioritizes top-level file size when the book has a primary file size', () => {
+    books.set([
+      {
+        id: 1,
+        libraryId: 1,
+        libraryName: 'Alpha',
+        primaryFile: {
+          bookId: 1,
+          fileSizeKb: 2048,
+        },
+        fileSizeKb: 4096,
+        metadata: {
+          bookId: 1,
+          authors: ['Alice'],
+        },
+      } as Book,
+    ]);
+
+    const service = TestBed.inject(LibrariesSummaryService);
+
+    expect(service.booksSummary()).toEqual({
+      totalBooks: 1,
+      totalSizeKb: 4096,
+      totalAuthors: 1,
+      totalSeries: 0,
+      totalPublishers: 0,
+    });
+    expect(service.formattedSize()).toBe('4.00 MB');
+  });
+
+
 });

--- a/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.spec.ts
@@ -50,45 +50,49 @@ describe('LibrariesSummaryService', () => {
         fileSizeKb: 1024,
         metadata: {
           bookId: 1,
-          authors: ['Alice', 'Bob'],
+          authors: ['Alice', 'Alice ', 'Bob'],
           seriesName: 'Series A',
-          publisher: 'Publisher X',
+          publisher: 'Publisher A',
         },
       } as Book,
       {
         id: 2,
-        libraryId: 1,
-        libraryName: 'Alpha',
-        fileSizeKb: 1024,
+        libraryId: 2,
+        libraryName: 'Beta',
+        fileSizeKb: 4096,
         metadata: {
           bookId: 2,
-          authors: ['Alice', 'Carol'],
-          publisher: 'Publisher X',
+          authors: ['Zed'],
+          seriesName: 'Series B',
+          publisher: 'Publisher B',
         },
       } as Book,
       {
         id: 3,
-        libraryId: 2,
-        libraryName: 'Beta',
-        fileSizeKb: 10240,
+        libraryId: 1,
+        libraryName: 'Alpha',
+        fileSizeKb: 1024 * 1024,
         metadata: {
           bookId: 3,
-          authors: ['Dave'],
+          authors: ['Carol'],
+          seriesName: 'Series A',
+          publisher: 'Publisher A',
         },
       } as Book,
     ]);
     selectedLibrary.set(1);
 
     const service = TestBed.inject(LibrariesSummaryService);
+    const summary = service.booksSummary();
 
-    expect(service.booksSummary()).toEqual({
+    expect(summary).toEqual({
       totalBooks: 2,
-      totalSizeKb: 2048,
+      totalSizeKb: 1024 + 1024 * 1024,
       totalAuthors: 3,
       totalSeries: 1,
       totalPublishers: 1,
     });
-    expect(service.formattedSize()).toBe('2.00 MB');
+    expect(service.formattedSize()).toBe('1.00 GB');
   });
 
   it('uses primary file size when the book does not expose a top-level file size', () => {

--- a/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.ts
+++ b/frontend/src/app/features/stats/component/library-stats/service/libraries-summary.service.ts
@@ -29,7 +29,7 @@ export class LibrariesSummaryService {
       : books;
 
     const totalBooks = filteredBooks.length;
-    const totalSizeKb = filteredBooks.reduce((sum, book) => sum + (book.fileSizeKb || 0), 0);
+    const totalSizeKb = filteredBooks.reduce((sum, book) => sum + (book.fileSizeKb ?? book.primaryFile?.fileSizeKb ?? 0), 0);
 
     const authorSet = new Set<string>();
     const seriesSet = new Set<string>();


### PR DESCRIPTION
## Description
The Library Stats page always displays 0KB because the code reads book.fileSizeKb at the top level, but the /api/v1/books endpoint returns file size nested under book.primaryFile.fileSizeKb.

## Linked Issue
Closes #1406

## Changes
- libraries-summary.service.ts line 32: book.fileSizeKb to book.fileSizeKb ?? book.primaryFile?.fileSizeKb ?? 0
- libraries-summary.service.spec.ts: mock data updated to match API response

## Manual Testing Steps
1. Open Library Stats page with books in library
2. Verify size displays non-zero value
3. Verify empty library still shows 0 KB
4. Run npm test -- --testPathPattern=libraries-summary

## AI Disclosure
This PR was drafted with AI assistance. All code changes were reviewed and understood before submission.

## Checklist
- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced library statistics calculation to more reliably determine file sizes using a fallback mechanism, ensuring accurate total size display even when file size data is stored in different locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->