### PR TITLE
fix(metadata): NPE when updating book without files

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/MetadataManagementService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/MetadataManagementService.java
@@ -59,12 +59,12 @@ public class MetadataManagementService {
         for (BookMetadataEntity metadata : metadataList) {
             if (metadata.getBook() != null) {
                 BookEntity book = metadata.getBook();
-                if (Boolean.TRUE.equals(book.getIsPhysical())) {
+                BookFileEntity primaryFile = book.getPrimaryBookFile();
+                if (Boolean.TRUE.equals(book.getIsPhysical()) || primaryFile == null) {
                     continue;
                 }
                 boolean bookModified = false;
 
-                var primaryFile = book.getPrimaryBookFile();
                 BookFileType bookType = primaryFile.getBookType();
                 if (appProperties.isLocalStorage()) {
                     Optional<MetadataWriter> writerOpt = metadataWriterFactory.getWriter(bookType);

--- a/backend/src/test/java/org/booklore/service/metadata/MetadataManagementServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/MetadataManagementServiceTest.java
@@ -460,6 +460,29 @@ class MetadataManagementServiceTest {
     }
 
     @Test
+    void writeMetadataToFile_skipsWhenBookPrimaryFileIsNull() {
+        LibraryPathEntity libraryPath = new LibraryPathEntity();
+        libraryPath.setPath("/example");
+        BookEntity book = BookEntity.builder()
+                .id(1L)
+                .bookFiles(List.of())
+                .libraryPath(libraryPath)
+                .build();
+        BookMetadataEntity metadata = BookMetadataEntity.builder()
+                .seriesName("Old")
+                .book(book)
+                .build();
+        book.setMetadata(metadata);
+
+        when(bookMetadataRepository.findAllBySeriesNameIgnoreCase("Old")).thenReturn(List.of(metadata));
+
+        service.consolidateMetadata(MergeMetadataType.series, List.of("New"), List.of("Old"));
+
+        verify(metadataWriterFactory, never()).getWriter(any());
+        verify(bookRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
     void writeMetadataToFile_skipsWriterWhenNoneAvailable() throws Exception {
         Path tempDir = Files.createTempDirectory("test-metadata-skip-");
         Path subDir = tempDir.resolve("sub");


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
when updating metadata of a book that lacks any files but is not marked as "physical", an attempt to interact with the "primary file" happens which leads to a null pointer exception.

This PR updates the metadata manager where this NPE occurs to prevent that behavior.

## Linked Issue

<!-- Required. Example: Fixes #123 -->

fixes #1368 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* checks for null book file entity in metadata management service

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. modify an existing non-physical book to remove the files from it
2. attempt to remove a genre from that book
3. observe completed successfully

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed an edge case in metadata consolidation that could cause errors when processing books without a primary file. The system now includes proper validation to check for this condition before writing metadata, automatically skipping such books to ensure reliable and stable operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->