### PR TITLE
fix(api): flush/clear EntityManager after deleting books

### DIFF
--- a/backend/src/main/java/org/booklore/service/book/BookService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookService.java
@@ -1,5 +1,6 @@
 package org.booklore.service.book;
 
+import jakarta.persistence.EntityManager;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +53,7 @@ public class BookService {
 
     private final BookRepository bookRepository;
     private final BookFileRepository bookFileRepository;
+    private final EntityManager entityManager;
     private final PdfViewerPreferencesRepository pdfViewerPreferencesRepository;
     private final CbxViewerPreferencesRepository cbxViewerPreferencesRepository;
     private final NewPdfViewerPreferencesRepository newPdfViewerPreferencesRepository;
@@ -461,6 +463,12 @@ public class BookService {
         }
 
         bookRepository.deleteAllInBatch(books);
+
+        // Because this is `InBatch` we need to clear and flush the entity manager to
+        // prevent unexpected updates of records when the transaction commits.
+        entityManager.clear();
+        entityManager.flush();
+
         auditService.log(AuditAction.BOOK_DELETED, "Deleted " + ids.size() + " book(s)");
         BookDeletionResponse response = new BookDeletionResponse(ids, failedFileDeletions);
         return failedFileDeletions.isEmpty()

--- a/backend/src/main/java/org/booklore/service/book/BookService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookService.java
@@ -466,8 +466,8 @@ public class BookService {
 
         // Because this is `InBatch` we need to clear and flush the entity manager to
         // prevent unexpected updates of records when the transaction commits.
-        entityManager.clear();
         entityManager.flush();
+        entityManager.clear();
 
         auditService.log(AuditAction.BOOK_DELETED, "Deleted " + ids.size() + " book(s)");
         BookDeletionResponse response = new BookDeletionResponse(ids, failedFileDeletions);

--- a/backend/src/test/java/org/booklore/BookServiceDeleteTests.java
+++ b/backend/src/test/java/org/booklore/BookServiceDeleteTests.java
@@ -1,5 +1,6 @@
 package org.booklore;
 
+import jakarta.persistence.EntityManager;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.mapper.BookMapper;
 import org.booklore.repository.*;
@@ -57,10 +58,12 @@ class BookServiceDeleteTests {
         SidecarMetadataWriter sidecarMetadataWriter = Mockito.mock(SidecarMetadataWriter.class);
         FileStreamingService fileStreamingService = Mockito.mock(FileStreamingService.class);
         AuditService auditService = Mockito.mock(AuditService.class);
+        EntityManager entityManager = Mockito.mock(EntityManager.class);
 
         bookService = new BookService(
                 bookRepository,
                 bookFileRepository,
+                entityManager,
                 pdfViewerPreferencesRepository,
                 cbxViewerPreferencesRepository,
                 newPdfViewerPreferencesRepository,

--- a/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -1,5 +1,6 @@
 package org.booklore.service.book;
 
+import jakarta.persistence.EntityManager;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.booklore.config.security.service.AuthenticationService;
@@ -75,6 +76,8 @@ class BookServiceTest {
     private BookUpdateService bookUpdateService;
     @Mock
     private AuditService auditService;
+    @Mock
+    private EntityManager entityManager;
 
     @InjectMocks
     private BookService bookService;
@@ -359,6 +362,37 @@ class BookServiceTest {
             fileUtilsMock.when(() -> FileUtils.getBookFullPath(entity)).thenReturn(Path.of("/tmp/nonexistentfile.txt"));
             assertThrows(APIException.class, () -> bookService.getBookContent(12L));
         }
+    }
+
+    @Test
+    void deleteBooks_flushesEntityManager() throws Exception {
+        BookEntity entity = new BookEntity();
+        entity.setId(11L);
+        LibraryEntity library = new LibraryEntity();
+        library.setId(42L);
+        LibraryPathEntity libPath = new LibraryPathEntity();
+        libPath.setPath("/tmp");
+        library.setLibraryPaths(List.of(libPath));
+        entity.setLibrary(library);
+        entity.setLibraryPath(libPath);
+        BookFileEntity primaryFile = new BookFileEntity();
+        primaryFile.setBook(entity);
+        primaryFile.setFileSubPath("");
+        primaryFile.setFileName("bookfile.txt");
+        entity.setBookFiles(List.of(primaryFile));
+
+        Path filePath = Paths.get("/tmp/bookfile.txt");
+        Files.createDirectories(filePath.getParent());
+        Files.write(filePath, "abc".getBytes());
+
+        doNothing().when(bookRepository).deleteAllInBatch(anyList());
+        when(bookQueryService.findAllWithMetadataByIds(Set.of(11L))).thenReturn(List.of(entity));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
+
+        bookService.deleteBooks(Set.of(11L)).getBody();
+
+        verify(entityManager).flush();
+        verify(entityManager).clear();
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -365,7 +365,7 @@ class BookServiceTest {
     }
 
     @Test
-    void deleteBooks_flushesEntityManager() throws Exception {
+    void deleteBooks_clearsEntityManager() throws Exception {
         BookEntity entity = new BookEntity();
         entity.setId(11L);
         LibraryEntity library = new LibraryEntity();
@@ -391,7 +391,6 @@ class BookServiceTest {
 
         bookService.deleteBooks(Set.of(11L)).getBody();
 
-        verify(entityManager).flush();
         verify(entityManager).clear();
     }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
`BookService` uses `deleteAllInBatch` for deleting books from the database, which activates cascades to delete things like the `BookFileEntity`.  This is a bit of a problem because then hibernate doesn't know these have actually been deleted & tries to modify them when the transaction completes.

To work around that behavior, this PR flushes and clears the entity manager.  This means that the `BookService.deleteBooks` method may have unintended side effects now.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1442 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* Adds an `EntityManager` flush & clear after deleting books

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Upload an audiobook to file
2. Rescan library to see audiobook file.
3. Delete audiobook.

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
N/A

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of batch book deletions by ensuring the persistence state is synchronized and cleared after bulk removals, reducing chances of stale data or inconsistent audit records.

* **Tests**
  * Added tests verifying the persistence state is properly synchronized and cleared during bulk deletion to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->