### PR TITLE
chore: drop duplicate goodreads requests

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/GoodReadsParser.java
@@ -73,28 +73,6 @@ public class GoodReadsParser implements BookParser, DetailedMetadataProvider {
             }
         }
 
-        String isbn = ParserUtils.cleanIsbn(fetchMetadataRequest.getIsbn());
-        if (isbn != null && !isbn.isBlank()) {
-            log.info("GoodReads: Trying ISBN lookup: {}", isbn);
-            try {
-                Document doc = fetchDoc(BASE_ISBN_URL + isbn);
-                String goodreadsId = extractGoodreadsIdFromOgUrl(doc);
-                if (goodreadsId != null) {
-                    BookMetadata metadata = parseBookDetails(doc, goodreadsId);
-                    if (metadata != null) {
-                        return metadata;
-                    }
-                }
-                log.info("GoodReads: ISBN lookup returned no results, falling back to title search");
-            } catch (Exception e) {
-                log.warn("GoodReads: ISBN lookup failed: {}, falling back to title search", e.getMessage());
-            }
-        }
-
-        Optional<BookMetadata> preview = fetchMetadataPreviews(book, fetchMetadataRequest).stream().findFirst();
-        if (preview.isEmpty()) {
-            return null;
-        }
         return fetchMetadataStream(book, fetchMetadataRequest).blockFirst();
     }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the ISBN request was duplicative, but the preview request was being executed and then thrown out which means we doubled up the request

dropping these now to make it easier to replace the query in goodreads

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #1335 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* drops duplicate ISBN & "book preview" lookup

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

Technically goodreads isn't working so it's hard to test regressions - but I was able to attach a debugger & determine that we entered the `fetchMetadataStream` method

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined metadata resolution logic by removing direct ISBN lookups from the primary method. The system now proceeds directly to preview-based resolution when existing book identifiers are unavailable, altering the data retrieval path while maintaining functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->