### PR TITLE
refactor(ui): use signals for library import progress

### DIFF
--- a/frontend/src/app/shared/components/library-import-progress-widget/library-import-progress-widget-component.html
+++ b/frontend/src/app/shared/components/library-import-progress-widget/library-import-progress-widget-component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t">
-  @if (progressService.state$ | async; as progress) {
+  @if (progressService.state(); as progress) {
     @if (progress.active) {
     <div class="rounded-lg border border-[var(--primary-color)] bg-[var(--card-background)] p-4">
       <div class="mb-2 flex items-center justify-between gap-3">

--- a/frontend/src/app/shared/components/library-import-progress-widget/library-import-progress-widget-component.ts
+++ b/frontend/src/app/shared/components/library-import-progress-widget/library-import-progress-widget-component.ts
@@ -1,4 +1,3 @@
-import {AsyncPipe} from '@angular/common';
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {Router} from '@angular/router';
 import {ButtonDirective} from 'primeng/button';
@@ -13,7 +12,7 @@ import {LibraryImportProgressService, LibraryImportProgressState, LibraryImportP
   templateUrl: './library-import-progress-widget-component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [AsyncPipe, ButtonDirective, ProgressBar, Tag, TranslocoDirective]
+  imports: [ButtonDirective, ProgressBar, Tag, TranslocoDirective]
 })
 export class LibraryImportProgressWidgetComponent {
   protected readonly progressService = inject(LibraryImportProgressService);

--- a/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.html
+++ b/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.html
@@ -1,12 +1,12 @@
 <div class="metadata-progress-box">
   <app-live-notification-box/>
-  @if (hasMetadataTasks$ | async) {
+  @if (hasMetadataTasks()) {
     <app-metadata-progress-widget/>
   }
-  @if (hasActiveLibraryImport$ | async) {
+  @if (hasActiveLibraryImport()) {
     <app-library-import-progress-widget/>
   }
-  @if (hasPendingBookdropFiles$ | async) {
+  @if (hasPendingBookdropFiles()) {
     <app-bookdrop-files-widget-component/>
   }
 </div>

--- a/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.spec.ts
+++ b/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.spec.ts
@@ -1,3 +1,4 @@
+import {Signal, signal, WritableSignal} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
@@ -14,12 +15,12 @@ describe('UnifiedNotificationBoxComponent', () => {
   let component: UnifiedNotificationBoxComponent;
   let activeTasks$: BehaviorSubject<Record<string, unknown>>;
   let hasPendingFiles$: BehaviorSubject<boolean>;
-  let hasActiveImport$: BehaviorSubject<boolean>;
+  let hasActiveImport: WritableSignal<boolean>;
 
   beforeEach(async () => {
     activeTasks$ = new BehaviorSubject<Record<string, unknown>>({});
     hasPendingFiles$ = new BehaviorSubject(false);
-    hasActiveImport$ = new BehaviorSubject(false);
+    hasActiveImport = signal(false);
 
     await TestBed.configureTestingModule({
       imports: [UnifiedNotificationBoxComponent, getTranslocoModule()],
@@ -34,7 +35,7 @@ describe('UnifiedNotificationBoxComponent', () => {
         },
         {
           provide: LibraryImportProgressService,
-          useValue: {hasActiveImport$},
+          useValue: {hasActiveImport},
         },
       ],
     }).compileComponents();
@@ -48,12 +49,9 @@ describe('UnifiedNotificationBoxComponent', () => {
   });
 
   it('reports whether there are metadata tasks to show', () => {
-    let hasMetadataTasks: boolean | undefined;
-    component.hasMetadataTasks$.subscribe(value => {
-      hasMetadataTasks = value;
-    });
+    const popover = component as unknown as {hasMetadataTasks: Signal<boolean>};
 
-    expect(hasMetadataTasks).toBe(false);
+    expect(popover.hasMetadataTasks()).toBe(false);
 
     activeTasks$.next({
       'task-1': {
@@ -66,28 +64,22 @@ describe('UnifiedNotificationBoxComponent', () => {
       },
     });
 
-    expect(hasMetadataTasks).toBe(true);
+    expect(popover.hasMetadataTasks()).toBe(true);
   });
 
   it('forwards the bookdrop pending-file signal', () => {
-    let hasPendingFiles: boolean | undefined;
-    component.hasPendingBookdropFiles$.subscribe(value => {
-      hasPendingFiles = value;
-    });
+    const popover = component as unknown as {hasPendingBookdropFiles: Signal<boolean>};
 
-    expect(hasPendingFiles).toBe(false);
+    expect(popover.hasPendingBookdropFiles()).toBe(false);
     hasPendingFiles$.next(true);
-    expect(hasPendingFiles).toBe(true);
+    expect(popover.hasPendingBookdropFiles()).toBe(true);
   });
 
   it('forwards the active library import signal', () => {
-    let hasActiveImport: boolean | undefined;
-    component.hasActiveLibraryImport$.subscribe(value => {
-      hasActiveImport = value;
-    });
+    const popover = component as unknown as {hasActiveLibraryImport: Signal<boolean>};
 
-    expect(hasActiveImport).toBe(false);
-    hasActiveImport$.next(true);
-    expect(hasActiveImport).toBe(true);
+    expect(popover.hasActiveLibraryImport()).toBe(false);
+    hasActiveImport.set(true);
+    expect(popover.hasActiveLibraryImport()).toBe(true);
   });
 });

--- a/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.ts
+++ b/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.ts
@@ -1,7 +1,6 @@
-import {Component, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, inject} from '@angular/core';
 import {LiveNotificationBoxComponent} from '../live-notification-box/live-notification-box.component';
 import {MetadataProgressService} from '../../service/metadata-progress.service';
-import {map} from 'rxjs/operators';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {BookdropFileService} from '../../../features/bookdrop/service/bookdrop-file.service';
 import {BookdropFilesWidgetComponent} from '../../../features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component';
@@ -19,18 +18,16 @@ import {LibraryImportProgressWidgetComponent} from '../library-import-progress-w
   ],
   templateUrl: './unified-notification-popover-component.html',
   standalone: true,
-  styleUrl: './unified-notification-popover-component.scss'
+  styleUrl: './unified-notification-popover-component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UnifiedNotificationBoxComponent {
   private readonly metadataProgressService = inject(MetadataProgressService);
   private readonly bookdropFileService = inject(BookdropFileService);
   private readonly libraryImportProgressService = inject(LibraryImportProgressService);
 
-  protected readonly hasMetadataTasks = toSignal(
-    this.metadataProgressService.activeTasks$.pipe(map(tasks => Object.keys(tasks).length > 0)),
-    {initialValue: false}
-  );
-
+  private readonly activeMetadataTasks = toSignal(this.metadataProgressService.activeTasks$, {initialValue: {}});
+  protected readonly hasMetadataTasks = computed(() => Object.keys(this.activeMetadataTasks()).length > 0);
   protected readonly hasPendingBookdropFiles = toSignal(this.bookdropFileService.hasPendingFiles$, {initialValue: false});
   protected readonly hasActiveLibraryImport = this.libraryImportProgressService.hasActiveImport;
 }

--- a/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.ts
+++ b/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.ts
@@ -2,7 +2,7 @@ import {Component, inject} from '@angular/core';
 import {LiveNotificationBoxComponent} from '../live-notification-box/live-notification-box.component';
 import {MetadataProgressService} from '../../service/metadata-progress.service';
 import {map} from 'rxjs/operators';
-import {AsyncPipe} from '@angular/common';
+import {toSignal} from '@angular/core/rxjs-interop';
 import {BookdropFileService} from '../../../features/bookdrop/service/bookdrop-file.service';
 import {BookdropFilesWidgetComponent} from '../../../features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component';
 import {MetadataProgressWidgetComponent} from '../metadata-progress-widget/metadata-progress-widget-component';
@@ -15,7 +15,6 @@ import {LibraryImportProgressWidgetComponent} from '../library-import-progress-w
     LiveNotificationBoxComponent,
     MetadataProgressWidgetComponent,
     LibraryImportProgressWidgetComponent,
-    AsyncPipe,
     BookdropFilesWidgetComponent
   ],
   templateUrl: './unified-notification-popover-component.html',
@@ -23,14 +22,15 @@ import {LibraryImportProgressWidgetComponent} from '../library-import-progress-w
   styleUrl: './unified-notification-popover-component.scss'
 })
 export class UnifiedNotificationBoxComponent {
-  metadataProgressService = inject(MetadataProgressService);
-  bookdropFileService = inject(BookdropFileService);
-  libraryImportProgressService = inject(LibraryImportProgressService);
+  private readonly metadataProgressService = inject(MetadataProgressService);
+  private readonly bookdropFileService = inject(BookdropFileService);
+  private readonly libraryImportProgressService = inject(LibraryImportProgressService);
 
-  hasMetadataTasks$ = this.metadataProgressService.activeTasks$.pipe(
-    map(tasks => Object.keys(tasks).length > 0)
+  protected readonly hasMetadataTasks = toSignal(
+    this.metadataProgressService.activeTasks$.pipe(map(tasks => Object.keys(tasks).length > 0)),
+    {initialValue: false}
   );
 
-  hasPendingBookdropFiles$ = this.bookdropFileService.hasPendingFiles$;
-  hasActiveLibraryImport$ = this.libraryImportProgressService.hasActiveImport$;
+  protected readonly hasPendingBookdropFiles = toSignal(this.bookdropFileService.hasPendingFiles$, {initialValue: false});
+  protected readonly hasActiveLibraryImport = this.libraryImportProgressService.hasActiveImport;
 }

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.html
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.html
@@ -101,8 +101,8 @@
     >
       <span class="sidebar-notification-button-content">
         <i class="pi pi-bell" aria-hidden="true"></i>
-        @if (shouldShowNotificationBadge) {
-          <span class="sidebar-notification-badge">{{ completedTaskCount }}</span>
+        @if (shouldShowNotificationBadge()) {
+          <span class="sidebar-notification-badge">{{ completedTaskCount() }}</span>
         }
       </span>
     </button>
@@ -202,8 +202,8 @@
       >
         <span class="sidebar-notification-button-content">
           <i class="pi pi-bell" aria-hidden="true"></i>
-          @if (shouldShowNotificationBadge) {
-            <span class="sidebar-notification-badge">{{ completedTaskCount }}</span>
+          @if (shouldShowNotificationBadge()) {
+            <span class="sidebar-notification-badge">{{ completedTaskCount() }}</span>
           }
         </span>
         <span class="sidebar-footer-action-label">{{ t('notifications') }}</span>

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.spec.ts
@@ -1,4 +1,4 @@
-import { computed, signal, WritableSignal } from '@angular/core';
+import { computed, Signal, signal, WritableSignal } from '@angular/core';
 import { CdkOverlayOrigin } from '@angular/cdk/overlay';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
@@ -43,7 +43,7 @@ describe('AppSidebarComponent', () => {
   let activeTasks$: BehaviorSubject<Record<string, MetadataBatchProgressNotification>>;
   let progressUpdates$: BehaviorSubject<MetadataBatchProgressNotification>;
   let hasPendingFiles$: BehaviorSubject<boolean>;
-  let hasActiveImport$: BehaviorSubject<boolean>;
+  let hasActiveImport: WritableSignal<boolean>;
   const sidebarCollapsed = signal(false);
   const isDesktop = signal(true);
   const layoutService = {
@@ -70,7 +70,7 @@ describe('AppSidebarComponent', () => {
       review: false,
     });
     hasPendingFiles$ = new BehaviorSubject(false);
-    hasActiveImport$ = new BehaviorSubject(false);
+    hasActiveImport = signal(false);
 
     TestBed.configureTestingModule({
       imports: [AppSidebarComponent, getTranslocoModule()],
@@ -100,7 +100,7 @@ describe('AppSidebarComponent', () => {
         { provide: AuthService, useValue: { logout: vi.fn() } },
         { provide: MetadataProgressService, useValue: { activeTasks$, progressUpdates$ } },
         { provide: BookdropFileService, useValue: { hasPendingFiles$ } },
-        { provide: LibraryImportProgressService, useValue: { hasActiveImport$ } },
+        { provide: LibraryImportProgressService, useValue: { hasActiveImport } },
         { provide: VersionService, useValue: { getVersion: vi.fn(() => versionInfo) } },
         { provide: LayoutService, useValue: layoutService },
         { provide: UserService, useValue: { currentUser } },
@@ -253,8 +253,8 @@ describe('AppSidebarComponent', () => {
 
   it('aggregates metadata tasks, library imports, and pending bookdrop files into the sidebar badge count', () => {
     const sidebar = component as unknown as {
-      completedTaskCount: number;
-      shouldShowNotificationBadge: boolean;
+      completedTaskCount: Signal<number>;
+      shouldShowNotificationBadge: Signal<boolean>;
     };
 
     activeTasks$.next({
@@ -276,15 +276,15 @@ describe('AppSidebarComponent', () => {
       },
     });
     hasPendingFiles$.next(true);
-    hasActiveImport$.next(true);
+    hasActiveImport.set(true);
 
-    expect(sidebar.completedTaskCount).toBe(4);
-    expect(sidebar.shouldShowNotificationBadge).toBe(true);
+    expect(sidebar.completedTaskCount()).toBe(4);
+    expect(sidebar.shouldShowNotificationBadge()).toBe(true);
   });
 
   it('hides the badge while metadata progress is actively running', () => {
     const sidebar = component as unknown as {
-      shouldShowNotificationBadge: boolean;
+      shouldShowNotificationBadge: Signal<boolean>;
     };
 
     activeTasks$.next({
@@ -306,6 +306,6 @@ describe('AppSidebarComponent', () => {
       review: false,
     });
 
-    expect(sidebar.shouldShowNotificationBadge).toBe(false);
+    expect(sidebar.shouldShowNotificationBadge()).toBe(false);
   });
 });

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { AppSidebarSectionComponent } from './app.sidebar-section.component';
 import { Menu } from 'primeng/menu';
@@ -23,7 +23,8 @@ import { LayoutService } from '../layout.service';
 import { TranslocoDirective, TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { Tooltip } from 'primeng/tooltip';
 import type { MenuItem } from 'primeng/api';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs/operators';
 import { NavItem, SidebarSection } from '../navigation/nav-item.model';
 import { buildCreateActionNavItems } from '../navigation/nav-catalog';
 import {
@@ -36,7 +37,7 @@ import {
 import { VersionService } from '../../service/version.service';
 import { MetadataProgressService } from '../../service/metadata-progress.service';
 import { BookdropFileService } from '../../../features/bookdrop/service/bookdrop-file.service';
-import { MetadataBatchProgressNotification, MetadataBatchStatus } from '../../model/metadata-batch-progress.model';
+import { MetadataBatchStatus } from '../../model/metadata-batch-progress.model';
 import { LibraryImportProgressService } from '../../service/library-import-progress.service';
 
 const DOCUMENTATION_URL = 'https://grimmory.org/docs/getting-started';
@@ -137,7 +138,6 @@ export class AppSidebarComponent {
   private readonly seriesDataService = inject(SeriesDataService);
   private readonly authorService = inject(AuthorService);
   private readonly t = inject(TranslocoService);
-  private readonly destroyRef = inject(DestroyRef);
   private readonly metadataProgressService = inject(MetadataProgressService);
   private readonly bookdropFileService = inject(BookdropFileService);
   private readonly libraryImportProgressService = inject(LibraryImportProgressService);
@@ -230,44 +230,25 @@ export class AppSidebarComponent {
   protected readonly notificationPopoverPositions = computed(() =>
     this.layoutService.isDesktop() ? RIGHT_ALIGN_TOP : this.notificationPopoverMobilePositions()
   );
-  protected progressHighlight = false;
-  protected completedTaskCount = 0;
-  protected hasPendingBookdropFiles = false;
-  protected hasActiveLibraryImport = false;
-
-  private readonly latestTasks: Record<string, MetadataBatchProgressNotification> = {};
-
-  constructor() {
-    this.subscribeToMetadataProgress();
-
-    this.metadataProgressService.activeTasks$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((tasks) => {
-        this.replaceLatestTasks(tasks);
-        this.updateCompletedTaskCount();
-      });
-
-    this.bookdropFileService.hasPendingFiles$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((hasPending) => {
-        this.hasPendingBookdropFiles = hasPending;
-        this.updateCompletedTaskCount();
-      });
-
-    this.libraryImportProgressService.hasActiveImport$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((hasActive) => {
-        this.hasActiveLibraryImport = hasActive;
-        this.updateCompletedTaskCount();
-      });
-  }
+  private readonly activeMetadataTasks = toSignal(this.metadataProgressService.activeTasks$, { initialValue: {} });
+  private readonly progressHighlight = toSignal(
+    this.metadataProgressService.progressUpdates$.pipe(map(progress => progress.status === MetadataBatchStatus.IN_PROGRESS)),
+    { initialValue: false }
+  );
+  private readonly hasPendingBookdropFiles = toSignal(this.bookdropFileService.hasPendingFiles$, { initialValue: false });
+  private readonly hasActiveLibraryImport = this.libraryImportProgressService.hasActiveImport;
+  protected readonly completedTaskCount = computed(() => {
+    const metadataTaskCount = Object.keys(this.activeMetadataTasks()).length;
+    const bookdropFileTaskCount = this.hasPendingBookdropFiles() ? 1 : 0;
+    const libraryImportTaskCount = this.hasActiveLibraryImport() ? 1 : 0;
+    return metadataTaskCount + bookdropFileTaskCount + libraryImportTaskCount;
+  });
+  protected readonly shouldShowNotificationBadge = computed(() =>
+    this.completedTaskCount() > 0 && !this.progressHighlight()
+  );
 
   openSearch(): void {
     this.commandPaletteService.open();
-  }
-
-  protected get shouldShowNotificationBadge(): boolean {
-    return this.completedTaskCount > 0 && !this.progressHighlight;
   }
 
   closeMobileSidebar(): void {
@@ -375,25 +356,4 @@ export class AppSidebarComponent {
     this.notificationPopoverOrigin.set(null);
   }
 
-  private subscribeToMetadataProgress(): void {
-    this.metadataProgressService.progressUpdates$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((progress) => {
-        this.progressHighlight = progress.status === MetadataBatchStatus.IN_PROGRESS;
-      });
-  }
-
-  private replaceLatestTasks(tasks: Record<string, MetadataBatchProgressNotification>): void {
-    for (const key of Object.keys(this.latestTasks)) {
-      delete this.latestTasks[key];
-    }
-    Object.assign(this.latestTasks, tasks);
-  }
-
-  private updateCompletedTaskCount(): void {
-    const metadataTaskCount = Object.keys(this.latestTasks).length;
-    const bookdropFileTaskCount = this.hasPendingBookdropFiles ? 1 : 0;
-    const libraryImportTaskCount = this.hasActiveLibraryImport ? 1 : 0;
-    this.completedTaskCount = metadataTaskCount + bookdropFileTaskCount + libraryImportTaskCount;
-  }
 }

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.ts
@@ -24,7 +24,6 @@ import { TranslocoDirective, TranslocoPipe, TranslocoService } from '@jsverse/tr
 import { Tooltip } from 'primeng/tooltip';
 import type { MenuItem } from 'primeng/api';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs/operators';
 import { NavItem, SidebarSection } from '../navigation/nav-item.model';
 import { buildCreateActionNavItems } from '../navigation/nav-catalog';
 import {
@@ -231,9 +230,9 @@ export class AppSidebarComponent {
     this.layoutService.isDesktop() ? RIGHT_ALIGN_TOP : this.notificationPopoverMobilePositions()
   );
   private readonly activeMetadataTasks = toSignal(this.metadataProgressService.activeTasks$, { initialValue: {} });
-  private readonly progressHighlight = toSignal(
-    this.metadataProgressService.progressUpdates$.pipe(map(progress => progress.status === MetadataBatchStatus.IN_PROGRESS)),
-    { initialValue: false }
+  private readonly latestProgress = toSignal(this.metadataProgressService.progressUpdates$, { initialValue: null });
+  private readonly progressHighlight = computed(() =>
+    this.latestProgress()?.status === MetadataBatchStatus.IN_PROGRESS
   );
   private readonly hasPendingBookdropFiles = toSignal(this.bookdropFileService.hasPendingFiles$, { initialValue: false });
   private readonly hasActiveLibraryImport = this.libraryImportProgressService.hasActiveImport;

--- a/frontend/src/app/shared/service/library-import-progress.service.spec.ts
+++ b/frontend/src/app/shared/service/library-import-progress.service.spec.ts
@@ -1,7 +1,7 @@
 import {TestBed} from '@angular/core/testing';
 import {afterEach, describe, expect, it} from 'vitest';
 
-import {LibraryImportProgressService, LibraryImportProgressState} from './library-import-progress.service';
+import {LibraryImportProgressService} from './library-import-progress.service';
 
 describe('LibraryImportProgressService', () => {
   afterEach(() => {
@@ -11,16 +11,12 @@ describe('LibraryImportProgressService', () => {
   it('tracks progress from start through completion and clear', () => {
     TestBed.configureTestingModule({providers: [LibraryImportProgressService]});
     const service = TestBed.inject(LibraryImportProgressService);
-    let latest: LibraryImportProgressState | undefined;
-    service.state$.subscribe(state => {
-      latest = state;
-    });
 
     service.start('Main Library', 2);
     service.attachLibrary(7);
     service.recordBookAdded('First');
 
-    expect(latest).toEqual({
+    expect(service.state()).toEqual({
       active: true,
       libraryId: 7,
       libraryName: 'Main Library',
@@ -32,16 +28,16 @@ describe('LibraryImportProgressService', () => {
 
     service.fail();
 
-    expect(latest?.status).toBe('ERROR');
+    expect(service.state().status).toBe('ERROR');
 
     service.start('Main Library', 2);
     service.recordBookAdded('First');
     service.recordBookAdded('Second');
 
-    expect(latest?.status).toBe('COMPLETED');
+    expect(service.state().status).toBe('COMPLETED');
 
     service.clear();
 
-    expect(latest?.active).toBe(false);
+    expect(service.hasActiveImport()).toBe(false);
   });
 });

--- a/frontend/src/app/shared/service/library-import-progress.service.ts
+++ b/frontend/src/app/shared/service/library-import-progress.service.ts
@@ -1,6 +1,4 @@
-import {Injectable} from '@angular/core';
-import {BehaviorSubject} from 'rxjs';
-import {map} from 'rxjs/operators';
+import {computed, Injectable, signal} from '@angular/core';
 
 export type LibraryImportProgressStatus = 'IN_PROGRESS' | 'COMPLETED' | 'ERROR';
 
@@ -24,10 +22,10 @@ const EMPTY_STATE: LibraryImportProgressState = {
 
 @Injectable({providedIn: 'root'})
 export class LibraryImportProgressService {
-  private readonly stateSubject = new BehaviorSubject<LibraryImportProgressState>(EMPTY_STATE);
+  private readonly stateSignal = signal<LibraryImportProgressState>(EMPTY_STATE);
 
-  readonly state$ = this.stateSubject.asObservable();
-  readonly hasActiveImport$ = this.state$.pipe(map(state => state.active));
+  readonly state = this.stateSignal.asReadonly();
+  readonly hasActiveImport = computed(() => this.stateSignal().active);
 
   start(libraryName: string, expectedCount: number): void {
     if (expectedCount <= 0) {
@@ -35,7 +33,7 @@ export class LibraryImportProgressService {
       return;
     }
 
-    this.stateSubject.next({
+    this.stateSignal.set({
       active: false,
       libraryName,
       expectedCount,
@@ -45,17 +43,17 @@ export class LibraryImportProgressService {
   }
 
   attachLibrary(libraryId: number): void {
-    const state = this.stateSubject.value;
+    const state = this.stateSignal();
     if (state.expectedCount <= 0) return;
-    this.stateSubject.next({...state, libraryId});
+    this.stateSignal.set({...state, libraryId});
   }
 
   recordBookAdded(bookTitle: string): void {
-    const state = this.stateSubject.value;
+    const state = this.stateSignal();
     if (state.expectedCount <= 0 || state.status !== 'IN_PROGRESS') return;
 
     const processedCount = Math.min(state.processedCount + 1, state.expectedCount);
-    this.stateSubject.next({
+    this.stateSignal.set({
       ...state,
       active: true,
       processedCount,
@@ -67,16 +65,16 @@ export class LibraryImportProgressService {
   }
 
   fail(): void {
-    const state = this.stateSubject.value;
+    const state = this.stateSignal();
     if (state.expectedCount <= 0 || state.status !== 'IN_PROGRESS') return;
     if (!state.active) {
       this.clear();
       return;
     }
-    this.stateSubject.next({...state, status: 'ERROR'});
+    this.stateSignal.set({...state, status: 'ERROR'});
   }
 
   clear(): void {
-    this.stateSubject.next(EMPTY_STATE);
+    this.stateSignal.set(EMPTY_STATE);
   }
 }


### PR DESCRIPTION
## Description

Followup to #1428 which moved library processing UI from full-screen to the notifications popup. This PR converts the process to angular signals. 

## Linked Issue

N/A

## Changes

- LibraryImportProgressService now uses signal / computed instead of BehaviourSubject
- Notification popover and sidebar badge now use signal reads instead of the manual subscription path. 
- Cleanup of manual subscription code no longer needed. 

## Manual Testing Steps

Library processing works as intended in the UI. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modernized internal state management architecture for notification badges, library import progress tracking, and sidebar metadata indicators. These updates improve application performance and maintainability without affecting user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->