### PR TITLE
fix(api): clear EntityManager before deleting books

### DIFF
--- a/backend/src/main/java/org/booklore/service/book/BookService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookService.java
@@ -462,12 +462,12 @@ public class BookService {
             }
         }
 
-        bookRepository.deleteAllInBatch(books);
-
         // Because this is `InBatch` we need to clear and flush the entity manager to
         // prevent unexpected updates of records when the transaction commits.
         entityManager.flush();
         entityManager.clear();
+
+        bookRepository.deleteAllInBatch(books);
 
         auditService.log(AuditAction.BOOK_DELETED, "Deleted " + ids.size() + " book(s)");
         BookDeletionResponse response = new BookDeletionResponse(ids, failedFileDeletions);

--- a/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -21,6 +21,7 @@ import org.booklore.util.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -391,7 +392,15 @@ class BookServiceTest {
 
         bookService.deleteBooks(Set.of(11L)).getBody();
 
-        verify(entityManager).clear();
+        InOrder order = inOrder(entityManager, bookRepository);
+
+        // The order of the calls is important - we MUST flush, then clear, and
+        // only then can we delete.  If we change the order then we end up with errors.
+        order.verify(entityManager).flush();
+        order.verify(entityManager).clear();
+        order.verify(bookRepository).deleteAllInBatch(anyList());
+
+        order.verifyNoMoreInteractions();
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
in #1453 we flushed and cleared after books but after further testing it seems that we need to do this before deleting the books to avoid the bug we saw

## Linked Issue

<!-- Required. Example: Fixes #123 -->
Fixes #1442 
Amends #1453

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* moves the flush / clear above the delete-in-batch
* updates tests to enforce behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Upload mp3 to library
2. Scan library to get audiobook to show
3. Delete audiobook and wait for success / failure

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved book deletion reliability by optimizing the order of internal database operations.

* **Tests**
  * Enhanced test coverage for book deletion to verify correct operation sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->