### PR TITLE
feat(ui): move settings button to sidebar footer row

### DIFF
--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.html
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.html
@@ -107,6 +107,19 @@
       </span>
     </button>
 
+    <a
+      class="sidebar-icon-button sidebar-mobile-landscape-action"
+      [class.active-route]="isSettingsActive()"
+      [attr.aria-current]="isSettingsActive() ? 'page' : null"
+      [routerLink]="['/settings']"
+      [attr.aria-label]="t('settings')"
+      [pTooltip]="t('settings')"
+      [tooltipDisabled]="!layoutService.isDesktop()"
+      tooltipPosition="bottom"
+    >
+      <i class="pi pi-cog" aria-hidden="true"></i>
+    </a>
+
     @if (currentUser(); as user) {
       <button
         type="button"
@@ -208,6 +221,20 @@
         </span>
         <span class="sidebar-footer-action-label">{{ t('notifications') }}</span>
       </button>
+
+      <a
+        class="sidebar-action-link sidebar-footer-action"
+        [class.active-route]="isSettingsActive()"
+        [attr.aria-current]="isSettingsActive() ? 'page' : null"
+        [routerLink]="['/settings']"
+        [attr.aria-label]="t('settings')"
+        [pTooltip]="t('settings')"
+        [tooltipDisabled]="!layoutService.isDesktop()"
+        tooltipPosition="top"
+      >
+        <i class="pi pi-cog" aria-hidden="true"></i>
+        <span class="sidebar-footer-action-label">{{ t('settings') }}</span>
+      </a>
 
     </div>
     @if (currentUser(); as user) {
@@ -344,17 +371,8 @@
               </button>
             </div>
 
-            <div class="user-account-popover-header-actions">
-              <button
-                appButton
-                type="button"
-                (click)="openSettings()"
-              >
-                <i class="pi pi-cog" aria-hidden="true"></i>
-                <span>{{ t('settings') }}</span>
-              </button>
-
-              @if (updateAvailable()) {
+            @if (updateAvailable()) {
+              <div class="user-account-popover-header-actions">
                 <button
                   appButton
                   variant="primary"
@@ -364,8 +382,8 @@
                   <i class="pi pi-arrow-up-right" aria-hidden="true"></i>
                   <span>{{ t('updateAvailable') }}</span>
                 </button>
-              }
-            </div>
+              </div>
+            }
           </header>
 
           <div class="user-account-popover-body">

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.scss
@@ -129,6 +129,7 @@
   border-radius: var(--sidebar-row-radius);
   color: var(--text-color-secondary);
   cursor: pointer;
+  text-decoration: none;
   transition: background-color var(--transition-fast), color var(--transition-fast);
 
   &:hover {
@@ -199,7 +200,7 @@
 .sidebar-footer {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: var(--space-2);
   padding-top: var(--space-2);
   margin-top: var(--space-2);
   border-top: 1px solid var(--border-color);
@@ -222,6 +223,7 @@
   font: inherit;
   font-size: var(--text-base);
   text-align: left;
+  text-decoration: none;
   cursor: pointer;
   transition: background-color var(--transition-fast), padding var(--transition-base);
 
@@ -238,6 +240,10 @@
   &.active-route {
     color: var(--primary-color);
     background-color: color-mix(in srgb, var(--primary-color) 8%, transparent);
+
+    .sidebar-footer-action-label {
+      color: inherit;
+    }
   }
 
   i {
@@ -269,6 +275,8 @@
   flex: 1 1 0;
   width: auto;
   min-width: 0;
+  height: calc(var(--sidebar-row-min-height) + 0.25rem);
+  min-height: calc(var(--sidebar-row-min-height) + 0.25rem);
   justify-content: center;
   padding-left: 0;
   padding-right: 0;
@@ -598,6 +606,11 @@
 
       &:hover {
         background-color: var(--surface-hover);
+      }
+
+      &.active-route {
+        background-color: color-mix(in srgb, var(--primary-color) 8%, transparent);
+        color: var(--primary-color);
       }
     }
 

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.spec.ts
@@ -46,9 +46,11 @@ describe('AppSidebarComponent', () => {
   let hasActiveImport: WritableSignal<boolean>;
   const sidebarCollapsed = signal(false);
   const isDesktop = signal(true);
+  const currentPath = signal('/dashboard');
   const layoutService = {
     sidebarCollapsed,
     isDesktop,
+    currentPath,
     desktopSidebarCollapsed: computed(() => isDesktop() && sidebarCollapsed()),
     librarySort: signal({ field: 'name', order: 'desc' }),
     shelfSort: signal({ field: 'name', order: 'asc' }),
@@ -116,6 +118,7 @@ describe('AppSidebarComponent', () => {
     fixture = TestBed.createComponent(AppSidebarComponent);
     component = fixture.componentInstance;
     layoutService.isDesktop.set(true);
+    layoutService.currentPath.set('/dashboard');
     layoutService.closeMobileSidebar.mockReset();
   });
 
@@ -181,6 +184,16 @@ describe('AppSidebarComponent', () => {
     currentUser.set({ name: '', username: 'alex', permissions: {} });
 
     expect(component.userInitials()).toBe('A');
+  });
+
+  it('marks settings active from the current layout path', () => {
+    const sidebar = component as unknown as { isSettingsActive: () => boolean };
+
+    expect(sidebar.isSettingsActive()).toBe(false);
+
+    layoutService.currentPath.set('/settings');
+
+    expect(sidebar.isSettingsActive()).toBe(true);
   });
 
   it('returns an empty string when no user is signed in', () => {

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.ts
@@ -163,6 +163,7 @@ export class AppSidebarComponent {
     const user = this.currentUser();
     return !!user && (user.permissions.admin || user.permissions.canUpload);
   });
+  protected readonly isSettingsActive = computed(() => this.layoutService.currentPath() === '/settings');
 
   readonly searchShortcutLabel = detectSearchShortcut(
     typeof navigator !== 'undefined' ? navigator.userAgent : ''
@@ -275,11 +276,6 @@ export class AppSidebarComponent {
 
   protected openAccountSettings(): void {
     void this.dialogLauncherService.openUserProfileDialog().catch(() => undefined);
-    this.closeUserPopover();
-  }
-
-  protected openSettings(): void {
-    this.router.navigate(['/settings']);
     this.closeUserPopover();
   }
 


### PR DESCRIPTION
## Description

Moves the settings button from the user popover to a main button in the sidebar footer. 

## Linked Issue

Fixes #1459 

## Changes

- Removed settings button from the user popover, adds a fourth footer action button to replace it. 
- Increased sizing / spacing of the action buttons to better display four options. 

## Manual Testing Steps

N/A

## Screenshots (Optional)

New button on desktop, active, and on mobile
<img width="263" height="196" alt="Screenshot 2026-05-24 at 08 18 32" src="https://github.com/user-attachments/assets/398318cb-893b-47c1-bc07-544bfc918a8c" />

<img width="268" height="140" alt="Screenshot 2026-05-24 at 08 18 26" src="https://github.com/user-attachments/assets/a16a3e96-eabc-481d-bfb9-a395bc588ff7" />  

<img width="268" alt="Screenshot 2026-05-24 at 08 18 45" src="https://github.com/user-attachments/assets/c76c9e3a-c9b0-4cb2-8863-f1043fdffe9f" />

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Settings link to the sidebar navigation with improved active state styling

* **Style**
  * Enhanced sidebar link styling and spacing for mobile layouts
  * Improved active route visual indicators

* **Tests**
  * Added test coverage for settings navigation functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->