### PR TITLE
fix(settings): hide opds, email, and device settings tabs when users lacks relevant perms

### DIFF
--- a/frontend/src/app/features/settings/device-settings/device-settings-component.html
+++ b/frontend/src/app/features/settings/device-settings/device-settings-component.html
@@ -1,13 +1,21 @@
 <div class="device-settings-container">
-  <div class="settings-content">
-    <div class="preferences-section">
-      <app-koreader-settings-component></app-koreader-settings-component>
+  @if (userService.currentUser(); as currentUser) {
+    <div class="settings-content">
+      @if (currentUser.permissions.admin || currentUser.permissions.canSyncKoReader) {
+        <div class="preferences-section">
+          <app-koreader-settings-component></app-koreader-settings-component>
+        </div>
+      }
+      @if (currentUser.permissions.admin || currentUser.permissions.canSyncKoReader || currentUser.permissions.canSyncKobo) {
+        <div class="preferences-section">
+          <app-hardcover-settings-component></app-hardcover-settings-component>
+        </div>
+      }
+      @if (currentUser.permissions.admin || currentUser.permissions.canSyncKobo) {
+        <div class="preferences-section">
+          <app-kobo-sync-setting-component></app-kobo-sync-setting-component>
+        </div>
+      }
     </div>
-    <div class="preferences-section">
-      <app-hardcover-settings-component></app-hardcover-settings-component>
-    </div>
-    <div class="preferences-section">
-      <app-kobo-sync-setting-component></app-kobo-sync-setting-component>
-    </div>
-  </div>
+  }
 </div>

--- a/frontend/src/app/features/settings/device-settings/device-settings-component.ts
+++ b/frontend/src/app/features/settings/device-settings/device-settings-component.ts
@@ -1,7 +1,8 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {KoreaderSettingsComponent} from './component/koreader-settings/koreader-settings-component';
 import {KoboSyncSettingsComponent} from './component/kobo-sync-settings/kobo-sync-settings-component';
 import {HardcoverSettingsComponent} from './component/hardcover-settings/hardcover-settings-component';
+import {UserService} from '../user-management/user.service';
 
 @Component({
   selector: 'app-device-settings-component',
@@ -14,5 +15,6 @@ import {HardcoverSettingsComponent} from './component/hardcover-settings/hardcov
   styleUrl: './device-settings-component.scss'
 })
 export class DeviceSettingsComponent {
+  protected readonly userService = inject(UserService);
 
 }

--- a/frontend/src/app/features/settings/settings.component.html
+++ b/frontend/src/app/features/settings/settings.component.html
@@ -10,7 +10,7 @@
             <p-tab [value]="SettingsTab.ReaderSettings">
               <i class="pi pi-book"></i> {{ t('reader') }}
             </p-tab>
-            @if (currentUser.permissions.admin || currentUser.permissions.canManageMetadataConfig) {
+            @if (canOpenTab(SettingsTab.MetadataSettings)) {
               <p-tab [value]="SettingsTab.MetadataSettings">
                 <i class="pi pi-sliders-h"></i> {{ t('metadata1') }}
               </p-tab>
@@ -18,47 +18,47 @@
                 <i class="pi pi-database"></i> {{ t('metadata2') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin || currentUser.permissions.canManageGlobalPreferences) {
+            @if (canOpenTab(SettingsTab.ApplicationSettings)) {
               <p-tab [value]="SettingsTab.ApplicationSettings">
                 <i class="pi pi-cog"></i> {{ t('application') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin) {
+            @if (canOpenTab(SettingsTab.UserManagement)) {
               <p-tab [value]="SettingsTab.UserManagement">
                 <i class="pi pi-users"></i> {{ t('users') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin || currentUser.permissions.canEmailBook) {
+            @if (canOpenTab(SettingsTab.EmailSettingsV2)) {
               <p-tab [value]="SettingsTab.EmailSettingsV2">
                 <i class="pi pi-envelope"></i> {{ t('email') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin || currentUser.permissions.canManageMetadataConfig) {
+            @if (canOpenTab(SettingsTab.NamingPattern)) {
               <p-tab [value]="SettingsTab.NamingPattern">
                 <i class="pi pi-sitemap"></i> {{ t('patterns') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin) {
+            @if (canOpenTab(SettingsTab.AuthenticationSettings)) {
               <p-tab [value]="SettingsTab.AuthenticationSettings">
                 <i class="pi pi-lock"></i> {{ t('authentication') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin || currentUser.permissions.canAccessTaskManager) {
+            @if (canOpenTab(SettingsTab.Tasks)) {
               <p-tab [value]="SettingsTab.Tasks">
                 <i class="pi pi-list-check"></i> {{ t('tasks') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin) {
+            @if (canOpenTab(SettingsTab.AuditLogs)) {
               <p-tab [value]="SettingsTab.AuditLogs">
                 <i class="pi pi-history"></i> {{ t('auditLogs') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin || currentUser.permissions.canAccessOpds) {
+            @if (canOpenTab(SettingsTab.OpdsV2)) {
               <p-tab [value]="SettingsTab.OpdsV2">
                 <i class="pi pi-globe"></i> {{ t('opds') }}
               </p-tab>
             }
-            @if (currentUser.permissions.admin || currentUser.permissions.canSyncKoReader || currentUser.permissions.canSyncKobo) {
+            @if (canOpenTab(SettingsTab.DeviceSettings)) {
               <p-tab [value]="SettingsTab.DeviceSettings">
                 <i class="pi pi-mobile"></i> {{ t('devices') }}
               </p-tab>
@@ -77,7 +77,7 @@
               }
             </p-tabpanel>
 
-            @if (currentUser.permissions.admin || currentUser.permissions.canManageMetadataConfig) {
+            @if (canOpenTab(SettingsTab.MetadataSettings)) {
               <p-tabpanel [value]="SettingsTab.MetadataSettings">
                 @if (visitedTabs().has(SettingsTab.MetadataSettings)) {
                   <app-metadata-settings-component></app-metadata-settings-component>
@@ -90,7 +90,7 @@
               </p-tabpanel>
             }
 
-            @if (currentUser.permissions.admin || currentUser.permissions.canManageGlobalPreferences) {
+            @if (canOpenTab(SettingsTab.ApplicationSettings)) {
               <p-tabpanel [value]="SettingsTab.ApplicationSettings">
                 @if (visitedTabs().has(SettingsTab.ApplicationSettings)) {
                   <app-global-preferences></app-global-preferences>
@@ -99,20 +99,20 @@
             }
 
             <!-- [GROUP: Eager Tabs (Always Rendered to ensure initialization)] -->
-            @if (currentUser.permissions.admin) {
+            @if (canOpenTab(SettingsTab.UserManagement)) {
               <p-tabpanel [value]="SettingsTab.UserManagement">
                 <app-user-management></app-user-management>
               </p-tabpanel>
             }
 
-            @if (currentUser.permissions.admin || currentUser.permissions.canEmailBook) {
+            @if (canOpenTab(SettingsTab.EmailSettingsV2)) {
               <p-tabpanel [value]="SettingsTab.EmailSettingsV2">
                 <app-email-v2></app-email-v2>
               </p-tabpanel>
             }
 
             <!-- [GROUP: Lazy Tabs Continued] -->
-            @if (currentUser.permissions.admin || currentUser.permissions.canManageMetadataConfig) {
+            @if (canOpenTab(SettingsTab.NamingPattern)) {
               <p-tabpanel [value]="SettingsTab.NamingPattern">
                 @if (visitedTabs().has(SettingsTab.NamingPattern)) {
                   <app-file-naming-pattern></app-file-naming-pattern>
@@ -120,7 +120,7 @@
               </p-tabpanel>
             }
 
-            @if (currentUser.permissions.admin) {
+            @if (canOpenTab(SettingsTab.AuthenticationSettings)) {
               <p-tabpanel [value]="SettingsTab.AuthenticationSettings">
                 @if (visitedTabs().has(SettingsTab.AuthenticationSettings)) {
                   <app-authentication-settings></app-authentication-settings>
@@ -128,7 +128,7 @@
               </p-tabpanel>
             }
 
-            @if (currentUser.permissions.admin || currentUser.permissions.canAccessTaskManager) {
+            @if (canOpenTab(SettingsTab.Tasks)) {
               <p-tabpanel [value]="SettingsTab.Tasks">
                 @if (visitedTabs().has(SettingsTab.Tasks)) {
                   <app-task-management></app-task-management>
@@ -136,7 +136,7 @@
               </p-tabpanel>
             }
 
-            @if (currentUser.permissions.admin) {
+            @if (canOpenTab(SettingsTab.AuditLogs)) {
               <p-tabpanel [value]="SettingsTab.AuditLogs">
                 @if (visitedTabs().has(SettingsTab.AuditLogs)) {
                   <app-audit-logs></app-audit-logs>
@@ -144,7 +144,7 @@
               </p-tabpanel>
             }
 
-            @if (currentUser.permissions.admin || currentUser.permissions.canAccessOpds) {
+            @if (canOpenTab(SettingsTab.OpdsV2)) {
               <p-tabpanel [value]="SettingsTab.OpdsV2">
                 @if (visitedTabs().has(SettingsTab.OpdsV2)) {
                   <app-opds-settings></app-opds-settings>
@@ -152,7 +152,7 @@
               </p-tabpanel>
             }
 
-            @if (currentUser.permissions.admin || currentUser.permissions.canSyncKoReader || currentUser.permissions.canSyncKobo) {
+            @if (canOpenTab(SettingsTab.DeviceSettings)) {
               <p-tabpanel [value]="SettingsTab.DeviceSettings">
                 @if (visitedTabs().has(SettingsTab.DeviceSettings)) {
                   <app-device-settings-component></app-device-settings-component>

--- a/frontend/src/app/features/settings/settings.component.html
+++ b/frontend/src/app/features/settings/settings.component.html
@@ -28,9 +28,11 @@
                 <i class="pi pi-users"></i> {{ t('users') }}
               </p-tab>
             }
-            <p-tab [value]="SettingsTab.EmailSettingsV2">
-              <i class="pi pi-envelope"></i> {{ t('email') }}
-            </p-tab>
+            @if (currentUser.permissions.admin || currentUser.permissions.canEmailBook) {
+              <p-tab [value]="SettingsTab.EmailSettingsV2">
+                <i class="pi pi-envelope"></i> {{ t('email') }}
+              </p-tab>
+            }
             @if (currentUser.permissions.admin || currentUser.permissions.canManageMetadataConfig) {
               <p-tab [value]="SettingsTab.NamingPattern">
                 <i class="pi pi-sitemap"></i> {{ t('patterns') }}
@@ -99,9 +101,11 @@
               </p-tabpanel>
             }
 
-            <p-tabpanel [value]="SettingsTab.EmailSettingsV2">
-              <app-email-v2></app-email-v2>
-            </p-tabpanel>
+            @if (currentUser.permissions.admin || currentUser.permissions.canEmailBook) {
+              <p-tabpanel [value]="SettingsTab.EmailSettingsV2">
+                <app-email-v2></app-email-v2>
+              </p-tabpanel>
+            }
 
             <!-- [GROUP: Lazy Tabs Continued] -->
             @if (currentUser.permissions.admin || currentUser.permissions.canManageMetadataConfig) {

--- a/frontend/src/app/features/settings/settings.component.html
+++ b/frontend/src/app/features/settings/settings.component.html
@@ -53,12 +53,16 @@
                 <i class="pi pi-history"></i> {{ t('auditLogs') }}
               </p-tab>
             }
-            <p-tab [value]="SettingsTab.OpdsV2">
-              <i class="pi pi-globe"></i> {{ t('opds') }}
-            </p-tab>
-            <p-tab [value]="SettingsTab.DeviceSettings">
-              <i class="pi pi-mobile"></i> {{ t('devices') }}
-            </p-tab>
+            @if (currentUser.permissions.admin || currentUser.permissions.canAccessOpds) {
+              <p-tab [value]="SettingsTab.OpdsV2">
+                <i class="pi pi-globe"></i> {{ t('opds') }}
+              </p-tab>
+            }
+            @if (currentUser.permissions.admin || currentUser.permissions.canSyncKoReader || currentUser.permissions.canSyncKobo) {
+              <p-tab [value]="SettingsTab.DeviceSettings">
+                <i class="pi pi-mobile"></i> {{ t('devices') }}
+              </p-tab>
+            }
           </p-tablist>
           <p-tabpanels>
             <!-- [GROUP: Lazy Tabs] -->
@@ -140,17 +144,21 @@
               </p-tabpanel>
             }
 
-            <p-tabpanel [value]="SettingsTab.OpdsV2">
-              @if (visitedTabs().has(SettingsTab.OpdsV2)) {
-                <app-opds-settings></app-opds-settings>
-              }
-            </p-tabpanel>
+            @if (currentUser.permissions.admin || currentUser.permissions.canAccessOpds) {
+              <p-tabpanel [value]="SettingsTab.OpdsV2">
+                @if (visitedTabs().has(SettingsTab.OpdsV2)) {
+                  <app-opds-settings></app-opds-settings>
+                }
+              </p-tabpanel>
+            }
 
-            <p-tabpanel [value]="SettingsTab.DeviceSettings">
-              @if (visitedTabs().has(SettingsTab.DeviceSettings)) {
-                <app-device-settings-component></app-device-settings-component>
-              }
-            </p-tabpanel>
+            @if (currentUser.permissions.admin || currentUser.permissions.canSyncKoReader || currentUser.permissions.canSyncKobo) {
+              <p-tabpanel [value]="SettingsTab.DeviceSettings">
+                @if (visitedTabs().has(SettingsTab.DeviceSettings)) {
+                  <app-device-settings-component></app-device-settings-component>
+                }
+              </p-tabpanel>
+            }
           </p-tabpanels>
         </p-tabs>
       </div>

--- a/frontend/src/app/features/settings/settings.component.ts
+++ b/frontend/src/app/features/settings/settings.component.ts
@@ -111,13 +111,13 @@ export class SettingsComponent implements OnInit {
 
     // Initialize from snapshot synchronously to ensure p-tabs (lazy) picks up the correct value on first render
     const initialTab = this.route.snapshot.queryParams['tab'];
-    if (this.validTabs.includes(initialTab)) {
+    if (this.validTabs.includes(initialTab) && this.canOpenTab(initialTab as SettingsTab)) {
       this._activeTab.set(initialTab as SettingsTab);
     }
 
     this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
       const tabParam = params['tab'];
-      if (this.validTabs.includes(tabParam)) {
+      if (this.validTabs.includes(tabParam) && this.canOpenTab(tabParam as SettingsTab)) {
         this._activeTab.set(tabParam as SettingsTab);
       } else {
         const defaultTab = SettingsTab.ViewPreferences;
@@ -130,6 +130,33 @@ export class SettingsComponent implements OnInit {
         });
       }
     });
+  }
+
+  protected canOpenTab(tab: SettingsTab): boolean {
+    const permissions = this.userService.currentUser()?.permissions;
+
+    switch (tab) {
+      case SettingsTab.MetadataSettings:
+      case SettingsTab.LibraryMetadataSettings:
+      case SettingsTab.NamingPattern:
+        return !!(permissions?.admin || permissions?.canManageMetadataConfig);
+      case SettingsTab.ApplicationSettings:
+        return !!(permissions?.admin || permissions?.canManageGlobalPreferences);
+      case SettingsTab.UserManagement:
+      case SettingsTab.AuthenticationSettings:
+      case SettingsTab.AuditLogs:
+        return !!permissions?.admin;
+      case SettingsTab.EmailSettingsV2:
+        return !!(permissions?.admin || permissions?.canEmailBook);
+      case SettingsTab.Tasks:
+        return !!(permissions?.admin || permissions?.canAccessTaskManager);
+      case SettingsTab.OpdsV2:
+        return !!(permissions?.admin || permissions?.canAccessOpds);
+      case SettingsTab.DeviceSettings:
+        return !!(permissions?.admin || permissions?.canSyncKoReader || permissions?.canSyncKobo);
+      default:
+        return true;
+    }
   }
 
 }

--- a/frontend/src/app/features/settings/settings.component.ts
+++ b/frontend/src/app/features/settings/settings.component.ts
@@ -136,6 +136,9 @@ export class SettingsComponent implements OnInit {
     const permissions = this.userService.currentUser()?.permissions;
 
     switch (tab) {
+      case SettingsTab.ViewPreferences:
+      case SettingsTab.ReaderSettings:
+        return true;
       case SettingsTab.MetadataSettings:
       case SettingsTab.LibraryMetadataSettings:
       case SettingsTab.NamingPattern:
@@ -155,7 +158,7 @@ export class SettingsComponent implements OnInit {
       case SettingsTab.DeviceSettings:
         return !!(permissions?.admin || permissions?.canSyncKoReader || permissions?.canSyncKobo);
       default:
-        return true;
+        return false;
     }
   }
 


### PR DESCRIPTION
## Description

In settings, the OPDS, Email, and Devices tabs show up for users, regardless of whether or not they have permission to access the content within these tabs. The tabs show an empty state, with a CTA for the user to reach out to their admin if they need permissions, but this just seems broken. The rest of settings properly hides tabs based on user perms, these tabs should as well.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/1424

## Changes

- Gates the OPDS, Email, and Device settings tabs behind relevant settings
- Gates the Kobo, and KOReader components behind permission checks as well, to avoid similar warnings.

## Manual Testing Steps

1. Create a demo user w/ no device, OPDS, or email perms.
2. Verify the tabs show up

## Screenshots (Optional)

### Before
<img width="1269" height="671" alt="Screenshot 2026-05-24 at 11 16 25 PM" src="https://github.com/user-attachments/assets/fe144de2-5c4e-44d7-8cdc-d3ca33c1080b" />
<img width="1273" height="884" alt="Screenshot 2026-05-24 at 11 16 19 PM" src="https://github.com/user-attachments/assets/8a2c650e-15e8-453b-8f92-3748dad67ea5" />

### After

**No permissions:**
<img width="1264" height="1475" alt="Screenshot 2026-05-24 at 11 17 48 PM" src="https://github.com/user-attachments/assets/31fc6cda-d5c6-47dd-a39b-40a73f6f1265" />

**Admin permissions:**
<img width="1262" height="1482" alt="Screenshot 2026-05-24 at 11 22 25 PM" src="https://github.com/user-attachments/assets/172aafc2-e080-4a4b-953c-9825cab0882e" />

**No admin, just Kobo/KOReader:**
<img width="1267" height="1484" alt="Screenshot 2026-05-24 at 11 22 16 PM" src="https://github.com/user-attachments/assets/aab5fe31-eb2d-49fc-90e4-812e05040405" />

**No admin, just KOReader**
<img width="1269" height="1081" alt="Screenshot 2026-05-24 at 11 22 04 PM" src="https://github.com/user-attachments/assets/cd23603e-f2dd-444d-b7a6-fe6fc0031992" />

**No admin, just Kobo**
<img width="1273" height="695" alt="Screenshot 2026-05-24 at 11 21 54 PM" src="https://github.com/user-attachments/assets/7dc27dae-986a-47e1-a298-421951ab7b7e" />

## Additional Context (Optional)

N/A

## AI Disclosure

None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Settings tabs (Email, OPDS, Device Sync, etc.) are now shown only when the user has permission.
  * Device sync preferences (Koreader, Hardcover, Kobo) are rendered only for authorized users and only when a user is present.
  * Active tab from the URL is validated against permissions and falls back to a safe default when not allowed; tabs remain lazy-rendered until visited.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->