### PR TITLE
fix(file-imports): Properly group multi-file audiobooks imported via the folder watcher

### DIFF
--- a/backend/src/main/java/org/booklore/service/watcher/LibraryFileEventProcessor.java
+++ b/backend/src/main/java/org/booklore/service/watcher/LibraryFileEventProcessor.java
@@ -251,6 +251,12 @@ public class LibraryFileEventProcessor implements SmartLifecycle {
         var mode = library.getOrganizationMode() != null
                 ? library.getOrganizationMode() : LibraryOrganizationMode.AUTO_DETECT;
 
+        FolderAnalysis analysis = analyzeFolderForAudiobook(folderPath);
+        if (analysis.isFolderBasedAudiobook()) {
+            processFolderAudiobook(library, folderPath, analysis);
+            return;
+        }
+
         if (mode == LibraryOrganizationMode.BOOK_PER_FILE) {
             processFilesInFolderIndividually(library, folderPath);
             return;
@@ -261,30 +267,27 @@ public class LibraryFileEventProcessor implements SmartLifecycle {
             return;
         }
 
-        // AUTO_DETECT: existing audiobook folder detection logic
-        FolderAnalysis analysis = analyzeFolderForAudiobook(folderPath);
+        processTrackedAndWalkedFiles(library, folderPath);
+    }
 
-        if (analysis.isFolderBasedAudiobook()) {
-            log.info("[FOLDER_AUDIOBOOK] Detected folder-based audiobook: {} ({} audio files)",
-                    folderPath.getFileName(), analysis.audioFileCount());
-            try {
-                bookFileTransactionalHandler.handleNewFolderAudiobook(library.getId(), folderPath);
-                int cleared = 0;
-                var iterator = filesFromPendingFolder.iterator();
-                while (iterator.hasNext()) {
-                    if (iterator.next().startsWith(folderPath)) {
-                        iterator.remove();
-                        cleared++;
-                    }
+    private void processFolderAudiobook(LibraryEntity library, Path folderPath, FolderAnalysis analysis) {
+        log.info("[FOLDER_AUDIOBOOK] Detected folder-based audiobook: {} ({} audio files)",
+                folderPath.getFileName(), analysis.audioFileCount());
+        try {
+            bookFileTransactionalHandler.handleNewFolderAudiobook(library.getId(), folderPath);
+            int cleared = 0;
+            var iterator = filesFromPendingFolder.iterator();
+            while (iterator.hasNext()) {
+                if (iterator.next().startsWith(folderPath)) {
+                    iterator.remove();
+                    cleared++;
                 }
-                if (cleared > 0) {
-                    log.debug("[FOLDER_AUDIOBOOK] Cleared {} tracked files that are now part of folder audiobook", cleared);
-                }
-            } catch (Exception e) {
-                log.warn("[ERROR] Processing folder audiobook '{}': {}", folderPath, e.getMessage());
             }
-        } else {
-            processTrackedAndWalkedFiles(library, folderPath);
+            if (cleared > 0) {
+                log.debug("[FOLDER_AUDIOBOOK] Cleared {} tracked files that are now part of folder audiobook", cleared);
+            }
+        } catch (Exception e) {
+            log.warn("[ERROR] Processing folder audiobook '{}': {}", folderPath, e.getMessage());
         }
     }
 

--- a/backend/src/test/java/org/booklore/service/library/LibraryFileHelperTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryFileHelperTest.java
@@ -375,6 +375,34 @@ class LibraryFileHelperTest {
     }
 
     @Test
+    void bookPerFile_collapsesMultiFileAudiobookSubfolder() throws IOException {
+        Path audioDir = Files.createDirectories(tempDir.resolve("Chaptered Audiobook"));
+        Files.write(audioDir.resolve("Chaptered Audiobook - 1 - Chapter One.mp3"), new byte[]{1});
+        Files.write(audioDir.resolve("Chaptered Audiobook - 2 - Chapter Two.mp3"), new byte[]{1});
+
+        List<LibraryFile> files = libraryFileHelper.getLibraryFiles(createLibraryWithMode(tempDir, LibraryOrganizationMode.BOOK_PER_FILE));
+
+        assertThat(files).hasSize(1);
+        assertThat(files.getFirst().isFolderBased()).isTrue();
+        assertThat(files.getFirst().getFileName()).isEqualTo("Chaptered Audiobook");
+        assertThat(files.getFirst().getBookFileType()).isEqualTo(BookFileType.AUDIOBOOK);
+    }
+
+    @Test
+    void bookPerFolder_collapsesMultiFileAudiobookSubfolder() throws IOException {
+        Path audioDir = Files.createDirectories(tempDir.resolve("Chaptered Audiobook"));
+        Files.write(audioDir.resolve("Chaptered Audiobook - 1 - Chapter One.mp3"), new byte[]{1});
+        Files.write(audioDir.resolve("Chaptered Audiobook - 2 - Chapter Two.mp3"), new byte[]{1});
+
+        List<LibraryFile> files = libraryFileHelper.getLibraryFiles(createLibraryWithMode(tempDir, LibraryOrganizationMode.BOOK_PER_FOLDER));
+
+        assertThat(files).hasSize(1);
+        assertThat(files.getFirst().isFolderBased()).isTrue();
+        assertThat(files.getFirst().getFileName()).isEqualTo("Chaptered Audiobook");
+        assertThat(files.getFirst().getBookFileType()).isEqualTo(BookFileType.AUDIOBOOK);
+    }
+
+    @Test
     void autoDetect_singleAudioFileStaysIndividual() throws IOException {
         Path dir = Files.createDirectories(tempDir.resolve("Book"));
         Files.write(dir.resolve("book.m4b"), new byte[]{1});

--- a/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
@@ -185,6 +185,42 @@ class LibraryFileEventProcessorTest {
         }
 
         @Test
+        void bookPerFileMode_processesMultiFileAudiobookFolderAsOneBook() throws Exception {
+            library.setOrganizationMode(LibraryOrganizationMode.BOOK_PER_FILE);
+
+            Path folder = tempDir.resolve("Chaptered Audiobook");
+            Files.createDirectory(folder);
+            Files.writeString(folder.resolve("Chaptered Audiobook - 1 - Chapter One.mp3"), "audio content 1");
+            Files.writeString(folder.resolve("Chaptered Audiobook - 2 - Chapter Two.mp3"), "audio content 2");
+
+            processor.processEvent(StandardWatchEventKinds.ENTRY_CREATE, 1L, folder, true);
+
+            Thread.sleep(8000);
+
+            verify(bookFileTransactionalHandler).handleNewFolderAudiobook(eq(1L), eq(folder));
+            verify(bookFileTransactionalHandler, never()).handleNewBookFile(anyLong(), any());
+            verify(libraryProcessingService, never()).processLibraryFiles(any(), any());
+        }
+
+        @Test
+        void bookPerFolderMode_processesMultiFileAudiobookFolderAsOneBook() throws Exception {
+            library.setOrganizationMode(LibraryOrganizationMode.BOOK_PER_FOLDER);
+
+            Path folder = tempDir.resolve("Chaptered Audiobook");
+            Files.createDirectory(folder);
+            Files.writeString(folder.resolve("Chaptered Audiobook - 1 - Chapter One.mp3"), "audio content 1");
+            Files.writeString(folder.resolve("Chaptered Audiobook - 2 - Chapter Two.mp3"), "audio content 2");
+
+            processor.processEvent(StandardWatchEventKinds.ENTRY_CREATE, 1L, folder, true);
+
+            Thread.sleep(8000);
+
+            verify(bookFileTransactionalHandler).handleNewFolderAudiobook(eq(1L), eq(folder));
+            verify(bookFileTransactionalHandler, never()).handleNewBookFile(anyLong(), any());
+            verify(libraryProcessingService, never()).processLibraryFiles(any(), any());
+        }
+
+        @Test
         void bookPerFileMode_ignoresFolderWithIgnoreFile() throws Exception {
             library.setOrganizationMode(LibraryOrganizationMode.BOOK_PER_FILE);
 


### PR DESCRIPTION
## Description

`Organization Mode: Book Per File` and `Watch folders` is enabled, adding a chapter-based audiobook folder causes Grimmory to import each `.mp3` track as its own separate book entry.

This PR fixes this behaviour by moving the audiobook handling before the behaviour for `BOOK_PER_FILE` libraries is executed.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/1007

## Changes

- Move audiobook handling before `BOOK_PER_FILE` handling
- Move audiobook handling into a cleaner helper function
- Improved test coverage for red/green tests for these cases

## Manual Testing Steps

As per the issue;

1. Create or use a library with these settings:
   - `Watch folders`: enabled
   - `Metadata source`: `Embedded only`
   - `Organization mode`: `Book Per File`
   - all formats allowed
2. Use a library path that contains a chapter-based audiobook folder with multiple `.mp3` files inside a single book folder, for example:
```text
Sample Author/
└── Sample Audiobook/
    ├── Sample Audiobook - 1 - Opening Credits.mp3
    ├── Sample Audiobook - 2 - Dedication.mp3
    ├── ...
    └── Sample Audiobook - 21 - End Credits.mp3
```

3. Let Grimmory detect the folder via the watch-folder flow, or copy/move that folder into the watched library location while Grimmory is running.
4. Open the library after the import finishes.
5. Observe that each `.mp3` file is imported as its own separate book entry instead of a single audiobook.


## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

Codex was used to generate improved spec coverage

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved folder-based audiobook handling to better detect and process folders containing multiple audio files as single audiobooks

* **Tests**
  * Added test coverage for audiobook subfolder detection and collapsing behavior
  * Verified folder-based audiobook processing across multiple library organization modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->