### PR TITLE
fix(readers): create reader-specific chrome colours

### DIFF
--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -738,7 +738,7 @@
       font-weight: 600;
       color: #fff;
       cursor: pointer;
-      transition: all 0.3s ease;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
       box-shadow: 0 4px 20px rgb(74 144 226 / 30%);
       min-width: 280px;
 

--- a/frontend/src/app/features/readers/cbx-reader/dialogs/cbx-note-dialog.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/dialogs/cbx-note-dialog.component.scss
@@ -1,14 +1,4 @@
-// Variables matching reader styling
-$dialog-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #4a90e2;
-$active-bg: rgb(74 144 226 / 15%);
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../shared/styles/reader-chrome' as *;
 
 .dialog-overlay {
   position: fixed;
@@ -19,7 +9,7 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 }
 
 @keyframes fade-in {
@@ -28,8 +18,9 @@ $transition-normal: 200ms ease;
 }
 
 .dialog {
-  background: $dialog-bg;
-  border: 1px solid $border-color;
+  @include surface;
+
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   width: 90%;
   max-width: 500px;
@@ -55,17 +46,16 @@ $transition-normal: 200ms ease;
 
 .dialog-header {
   padding: 16px 20px;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: linear-gradient(180deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 
   h2 {
     margin: 0;
     font-size: 16px;
     font-weight: 600;
-    color: $text-primary;
     letter-spacing: -0.3px;
   }
 }
@@ -73,11 +63,11 @@ $transition-normal: 200ms ease;
 .close-btn {
   background: none;
   border: none;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   cursor: pointer;
   padding: 6px;
   border-radius: 6px;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   line-height: 1;
   width: 32px;
   height: 32px;
@@ -86,8 +76,8 @@ $transition-normal: 200ms ease;
   justify-content: center;
 
   &:hover {
-    background: $hover-bg;
-    color: $text-primary;
+    background: var(--reader-chrome-hover);
+    color: var(--color-white);
   }
 }
 
@@ -102,7 +92,7 @@ $transition-normal: 200ms ease;
 
 .section-label {
   display: block;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
@@ -114,10 +104,10 @@ $transition-normal: 200ms ease;
   .page-info {
     margin: 0;
     padding: 12px 16px;
-    background: rgb(255 255 255 / 3%);
-    border-left: 3px solid $active-color;
+    background: color-mix(in srgb, var(--color-white) 3%, transparent);
+    border-left: 3px solid var(--reader-chrome-accent);
     border-radius: 0 8px 8px 0;
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
     font-size: 13px;
     line-height: 1.6;
   }
@@ -133,24 +123,24 @@ $transition-normal: 200ms ease;
   flex: 1;
   min-height: 120px;
   padding: 12px 16px;
-  background: rgb(255 255 255 / 3%);
-  border: 1px solid $border-color;
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 8px;
-  color: $text-primary;
+  color: var(--color-white);
   font-size: 14px;
   line-height: 1.6;
   resize: vertical;
   font-family: inherit;
-  transition: border-color $transition-fast, box-shadow $transition-fast;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 
   &::placeholder {
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
   }
 
   &:focus {
     outline: none;
-    border-color: $active-color;
-    box-shadow: 0 0 0 3px rgb(74 144 226 / 15%);
+    border-color: var(--reader-chrome-accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
   }
 }
 
@@ -168,7 +158,7 @@ $transition-normal: 200ms ease;
   border: 2px solid transparent;
   background: var(--color);
   cursor: pointer;
-  transition: transform $transition-fast, border-color $transition-fast, box-shadow $transition-fast;
+  transition: transform var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
   position: relative;
 
   &:hover {
@@ -176,8 +166,8 @@ $transition-normal: 200ms ease;
   }
 
   &.selected {
-    border-color: $text-primary;
-    box-shadow: 0 0 0 3px rgb(255 255 255 / 20%);
+    border-color: var(--color-white);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-white) 20%, transparent);
 
     &::after {
       content: '\2713';
@@ -196,11 +186,11 @@ $transition-normal: 200ms ease;
 
 .dialog-footer {
   padding: 16px 20px;
-  border-top: 1px solid $border-color;
+  border-top: 1px solid var(--reader-chrome-border);
   display: flex;
   justify-content: flex-end;
   gap: 12px;
-  background: linear-gradient(0deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(0deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 }
 
 .btn {
@@ -209,7 +199,7 @@ $transition-normal: 200ms ease;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
-  transition: background $transition-fast, transform $transition-fast, opacity $transition-fast;
+  transition: background var(--transition-fast), transform var(--transition-fast), opacity var(--transition-fast);
   border: none;
 
   &:active {
@@ -224,19 +214,19 @@ $transition-normal: 200ms ease;
 }
 
 .btn-secondary {
-  background: $hover-bg;
-  color: $text-primary;
+  background: var(--reader-chrome-hover);
+  color: var(--color-white);
 
   &:hover:not(:disabled) {
-    background: rgb(255 255 255 / 12%);
+    background: color-mix(in srgb, var(--color-white) 12%, transparent);
   }
 }
 
 .btn-primary {
-  background: $active-color;
+  background: var(--reader-chrome-accent);
   color: white;
 
   &:hover:not(:disabled) {
-    background: #5a9ee6;
+    background: var(--reader-chrome-accent-hover);
   }
 }

--- a/frontend/src/app/features/readers/cbx-reader/dialogs/cbx-shortcuts-help.component.html
+++ b/frontend/src/app/features/readers/cbx-reader/dialogs/cbx-shortcuts-help.component.html
@@ -12,7 +12,7 @@
         <div class="shortcut-group">
           <h3 class="group-title">{{ group.title }}</h3>
           <div class="shortcuts-list">
-            @for (shortcut of group.shortcuts; track shortcut.description) {
+            @for (shortcut of group.shortcuts; track $index) {
               <div class="shortcut-item">
                 <div class="shortcut-keys">
                   @for (key of shortcut.keys; track key; let last = $last) {

--- a/frontend/src/app/features/readers/cbx-reader/dialogs/cbx-shortcuts-help.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/dialogs/cbx-shortcuts-help.component.scss
@@ -1,12 +1,4 @@
-$dialog-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #4a90e2;
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../shared/styles/reader-chrome' as *;
 
 .dialog-overlay {
   position: fixed;
@@ -17,7 +9,7 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 }
 
 @keyframes fade-in {
@@ -26,8 +18,9 @@ $transition-normal: 200ms ease;
 }
 
 .dialog {
-  background: $dialog-bg;
-  border: 1px solid $border-color;
+  @include surface;
+
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   width: 90%;
   max-width: 480px;
@@ -53,17 +46,16 @@ $transition-normal: 200ms ease;
 
 .dialog-header {
   padding: 16px 20px;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: linear-gradient(180deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 
   h2 {
     margin: 0;
     font-size: 16px;
     font-weight: 600;
-    color: $text-primary;
     letter-spacing: -0.3px;
   }
 }
@@ -71,11 +63,11 @@ $transition-normal: 200ms ease;
 .close-btn {
   background: none;
   border: none;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   cursor: pointer;
   padding: 6px;
   border-radius: 6px;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   line-height: 1;
   width: 32px;
   height: 32px;
@@ -84,8 +76,8 @@ $transition-normal: 200ms ease;
   justify-content: center;
 
   &:hover {
-    background: $hover-bg;
-    color: $text-primary;
+    background: var(--reader-chrome-hover);
+    color: var(--color-white);
   }
 }
 
@@ -105,7 +97,7 @@ $transition-normal: 200ms ease;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
   }
 }
 
@@ -121,12 +113,12 @@ $transition-normal: 200ms ease;
   justify-content: space-between;
   gap: 16px;
   padding: 8px 12px;
-  background: rgb(255 255 255 / 3%);
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
   border-radius: 8px;
-  transition: background $transition-fast;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: rgb(255 255 255 / 5%);
+    background: color-mix(in srgb, var(--color-white) 5%, transparent);
   }
 }
 
@@ -144,18 +136,18 @@ $transition-normal: 200ms ease;
   min-width: 28px;
   height: 26px;
   padding: 0 8px;
-  background: rgb(255 255 255 / 10%);
-  border: 1px solid rgb(255 255 255 / 15%);
+  background: color-mix(in srgb, var(--color-white) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-white) 15%, transparent);
   border-radius: 5px;
   font-family: inherit;
   font-size: 12px;
   font-weight: 500;
-  color: $text-primary;
+  color: var(--color-white);
   box-shadow: 0 2px 0 rgb(0 0 0 / 20%);
 }
 
 .key-separator {
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   font-size: 12px;
   margin: 0 2px;
 }
@@ -170,21 +162,21 @@ $transition-normal: 200ms ease;
 
 .shortcut-description {
   font-size: 13px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
 }
 
 .mobile-gesture {
   font-size: 11px;
-  color: $active-color;
+  color: var(--reader-chrome-accent);
   font-style: italic;
 }
 
 .dialog-footer {
   padding: 16px 20px;
-  border-top: 1px solid $border-color;
+  border-top: 1px solid var(--reader-chrome-border);
   display: flex;
   justify-content: flex-end;
-  background: linear-gradient(0deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(0deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 }
 
 .btn {
@@ -193,7 +185,7 @@ $transition-normal: 200ms ease;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
-  transition: background $transition-fast, transform $transition-fast;
+  transition: background var(--transition-fast), transform var(--transition-fast);
   border: none;
 
   &:active {
@@ -202,11 +194,11 @@ $transition-normal: 200ms ease;
 }
 
 .btn-primary {
-  background: $active-color;
+  background: var(--reader-chrome-accent);
   color: white;
 
   &:hover {
-    background: #5a9ee6;
+    background: var(--reader-chrome-accent-hover);
   }
 }
 

--- a/frontend/src/app/features/readers/cbx-reader/layout/footer/cbx-footer.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/layout/footer/cbx-footer.component.scss
@@ -1,16 +1,8 @@
-@use 'sass:color';
-
-// Variables
-$footer-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #4a90e2;
-$transition-fast: 150ms ease;
+@use '../../../shared/styles/reader-chrome' as *;
 
 .cbx-footer {
+  @include surface;
+
   position: absolute;
   bottom: 0;
   left: 0;
@@ -22,10 +14,8 @@ $transition-fast: 150ms ease;
   justify-content: space-between;
   gap: 12px;
   z-index: 1000;
-  background: linear-gradient(135deg, #2d2d2d 0%, #1f1f1f 100%);
-  border-top: 1px solid #404040;
+  border-top: 1px solid var(--reader-chrome-border);
   box-shadow: 0 -2px 8px rgb(0 0 0 / 30%);
-  color: $text-primary;
   transform: translateY(100%);
   opacity: 0;
   transition: transform 0.3s ease, opacity 0.3s ease;
@@ -59,13 +49,16 @@ $transition-fast: 150ms ease;
 }
 
 .nav-btn {
-  background: rgb(51 51 51 / 90%);
-  border: 1px solid #555;
-  color: $text-primary;
+  background: var(--reader-chrome-control-bg);
+  border: 1px solid var(--reader-chrome-strong-border);
+  color: var(--reader-chrome-fg);
   padding: 6px 10px;
   border-radius: 4px;
   cursor: pointer;
-  transition: all $transition-fast;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    opacity var(--transition-fast);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -74,22 +67,22 @@ $transition-fast: 150ms ease;
   font-weight: bold;
 
   &:hover:not(:disabled) {
-    background: #4a4a4a;
-    border-color: #666;
+    background: var(--reader-chrome-hover);
+    border-color: color-mix(in srgb, var(--reader-chrome-fg) 25%, transparent);
   }
 
   &:disabled {
-    background: #2a2a2a;
-    color: #666;
+    background: color-mix(in srgb, var(--reader-chrome-fg) 4%, transparent);
+    color: var(--reader-chrome-fg-muted);
     cursor: not-allowed;
-    border-color: #333;
+    border-color: var(--reader-chrome-border);
   }
 
   &.series-btn {
     gap: 6px;
     padding: 6px 12px;
-    background: $active-color;
-    border-color: $active-color;
+    background: var(--reader-chrome-accent);
+    border-color: var(--reader-chrome-accent);
 
     .label {
       font-size: 12px;
@@ -97,12 +90,12 @@ $transition-fast: 150ms ease;
     }
 
     &:hover:not(:disabled) {
-      background: color.adjust($active-color, $lightness: -10%);
+      background: var(--reader-chrome-accent-active);
     }
 
     &:disabled {
-      background: #555;
-      border-color: #555;
+      background: var(--reader-chrome-control-bg);
+      border-color: var(--reader-chrome-strong-border);
       opacity: 0.5;
     }
   }
@@ -110,7 +103,7 @@ $transition-fast: 150ms ease;
 
 .page-info {
   padding: 4px 12px;
-  background: rgb(255 255 255 / 10%);
+  background: var(--reader-chrome-control-bg);
   border-radius: 4px;
   font-size: 13px;
   font-weight: 500;
@@ -118,17 +111,17 @@ $transition-fast: 150ms ease;
   text-align: center;
 
   .current {
-    color: $active-color;
+    color: var(--reader-chrome-accent);
     font-weight: 600;
   }
 
   .separator {
-    color: $active-color;
+    color: var(--reader-chrome-accent);
     font-weight: 600;
   }
 
   .total {
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
   }
 }
 
@@ -159,7 +152,7 @@ $transition-fast: 150ms ease;
     &::-webkit-slider-runnable-track {
       width: 100%;
       height: 6px;
-      background: rgb(255 255 255 / 12%);
+      background: color-mix(in srgb, var(--color-white) 12%, transparent);
       border-radius: 3px;
       cursor: pointer;
     }
@@ -167,14 +160,14 @@ $transition-fast: 150ms ease;
     &::-moz-range-track {
       width: 100%;
       height: 6px;
-      background: rgb(255 255 255 / 12%);
+      background: color-mix(in srgb, var(--color-white) 12%, transparent);
       border-radius: 3px;
       cursor: pointer;
     }
 
     &::-ms-fill-lower,
     &::-ms-fill-upper {
-      background: rgb(255 255 255 / 12%);
+      background: color-mix(in srgb, var(--color-white) 12%, transparent);
       border-radius: 3px;
     }
 
@@ -184,10 +177,10 @@ $transition-fast: 150ms ease;
       width: 18px;
       height: 18px;
       border-radius: 50%;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       cursor: pointer;
       box-shadow: 0 2px 6px rgb(0 0 0 / 30%);
-      transition: transform $transition-fast, box-shadow $transition-fast;
+      transition: transform var(--transition-fast), box-shadow var(--transition-fast);
       margin-top: calc((6px - 18px) / 2); /* center thumb on track */
     }
 
@@ -195,11 +188,11 @@ $transition-fast: 150ms ease;
       width: 18px;
       height: 18px;
       border-radius: 50%;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       cursor: pointer;
       border: none;
       box-shadow: 0 2px 6px rgb(0 0 0 / 30%);
-      transition: transform $transition-fast, box-shadow $transition-fast;
+      transition: transform var(--transition-fast), box-shadow var(--transition-fast);
       margin-top: calc((6px - 18px) / 2);
     }
 
@@ -207,7 +200,7 @@ $transition-fast: 150ms ease;
       width: 18px;
       height: 18px;
       border-radius: 50%;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       cursor: pointer;
       border: none;
       box-shadow: 0 2px 6px rgb(0 0 0 / 30%);
@@ -239,7 +232,7 @@ $transition-fast: 150ms ease;
         transform: translateX(-50%);
         width: 2px;
         height: 10px;
-        background: rgb(255 255 255 / 50%);
+        background: color-mix(in srgb, var(--reader-chrome-fg) 50%, transparent);
         top: 0;
       }
     }
@@ -250,26 +243,26 @@ $transition-fast: 150ms ease;
   display: flex;
   align-items: center;
   gap: 4px;
-  background: rgb(51 51 51 / 90%);
+  background: var(--reader-chrome-control-bg);
   border-radius: 4px;
   padding: 2px;
-  border: 1px solid #555;
+  border: 1px solid var(--reader-chrome-strong-border);
 
   .page-input {
     width: 55px;
     padding: 4px 6px;
     border: none;
     border-radius: 3px;
-    background: #404040;
-    color: $text-primary;
+    background: var(--reader-chrome-control-bg);
+    color: var(--reader-chrome-fg);
     font-size: 12px;
     text-align: center;
-    transition: all 0.2s ease;
+    transition: background 0.2s ease, box-shadow 0.2s ease;
 
     &:focus {
       outline: none;
-      background: #4a4a4a;
-      box-shadow: 0 0 0 1px rgb(74 144 226 / 50%);
+      background: var(--reader-chrome-hover);
+      box-shadow: 0 0 0 1px color-mix(in srgb, var(--reader-chrome-accent) 50%, transparent);
     }
 
     &::placeholder {
@@ -279,21 +272,21 @@ $transition-fast: 150ms ease;
 
   .go-btn {
     padding: 4px 10px;
-    background: $active-color;
+    background: var(--reader-chrome-accent);
     color: white;
     border: none;
     border-radius: 3px;
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: background 0.2s ease, opacity 0.2s ease;
 
     &:hover:not(:disabled) {
-      background: color.adjust($active-color, $lightness: -10%);
+      background: var(--reader-chrome-accent-active);
     }
 
     &:disabled {
-      background: #666;
+      background: var(--reader-chrome-control-bg);
       cursor: not-allowed;
       opacity: 0.6;
     }

--- a/frontend/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.scss
@@ -1,4 +1,8 @@
+@use '../../../shared/styles/reader-chrome' as *;
+
 .cbx-header {
+  @include surface;
+
   position: absolute;
   top: 0;
   left: 0;
@@ -10,10 +14,8 @@
   justify-content: space-between;
   font-size: 14px;
   z-index: 1000;
-  background: linear-gradient(135deg, #2d2d2d 0%, #1f1f1f 100%);
-  border-bottom: 1px solid #404040;
+  border-bottom: 1px solid var(--reader-chrome-border);
   box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
-  color: #fff;
   opacity: 1;
   pointer-events: auto;
   transform: translateY(0);
@@ -51,7 +53,7 @@
     }
 
     &:hover {
-      background: rgb(255 255 255 / 12%);
+      background: var(--reader-chrome-hover);
     }
 
     &:last-child {
@@ -65,17 +67,17 @@
       }
 
       &:hover {
-        background: rgb(239 68 68 / 20%);
+        background: color-mix(in srgb, var(--color-red-500) 20%, transparent);
       }
     }
 
     &.active {
-      color: #ef4444;
-      background: rgb(239 68 68 / 15%);
+      color: var(--color-red-500);
+      background: color-mix(in srgb, var(--color-red-500) 15%, transparent);
     }
 
     &.has-notes {
-      color: #ffc107;
+      color: var(--color-amber-400);
       position: relative;
     }
 
@@ -85,9 +87,9 @@
       right: 4px;
       width: 8px;
       height: 8px;
-      background: #ffc107;
+      background: var(--color-amber-400);
       border-radius: 50%;
-      border: 1px solid #1f1f1f;
+      border: 1px solid var(--reader-chrome-bg);
     }
   }
 
@@ -121,12 +123,13 @@
   }
 
   .overflow-dropdown {
+    @include surface;
+
     position: absolute;
     top: 100%;
     right: 0;
     margin-top: 4px;
-    background: #2d2d2d;
-    border: 1px solid #404040;
+    border: 1px solid var(--reader-chrome-border);
     border-radius: 8px;
     box-shadow: 0 4px 12px rgb(0 0 0 / 40%);
     z-index: 1000;
@@ -142,19 +145,19 @@
     padding: 8px 12px;
     background: none;
     border: none;
-    color: #fff;
+    color: inherit;
     font-size: 13px;
     cursor: pointer;
     border-radius: 6px;
     white-space: nowrap;
 
     &:hover {
-      background: rgb(255 255 255 / 12%);
+      background: var(--reader-chrome-hover);
     }
 
     &.active {
-      color: #ef4444;
-      background: rgb(239 68 68 / 15%);
+      color: var(--color-red-500);
+      background: color-mix(in srgb, var(--color-red-500) 15%, transparent);
     }
   }
 }

--- a/frontend/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/layout/quick-settings/cbx-quick-settings.component.scss
@@ -1,23 +1,11 @@
-@use 'sass:color';
-
-// Variables
-$panel-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #4a90e2;
-$active-bg: rgb(74 144 226 / 15%);
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../../shared/styles/reader-chrome' as *;
 
 .quick-settings-overlay {
   position: fixed;
   inset: 0;
   z-index: 12000;
   background: rgb(0 0 0 / 30%);
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
   cursor: pointer;
 }
 
@@ -27,12 +15,13 @@ $transition-normal: 200ms ease;
 }
 
 .quick-settings-panel {
+  @include surface;
+
   position: absolute;
   top: 52px;
   right: 60px;
   width: 340px;
-  background: $panel-bg;
-  border: 1px solid $border-color;
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   box-shadow: 0 12px 40px rgb(0 0 0 / 50%);
   animation: slide-down 200ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -59,9 +48,9 @@ $transition-normal: 200ms ease;
   right: 18px;
   width: 16px;
   height: 16px;
-  background: $panel-bg;
-  border-left: 1px solid $border-color;
-  border-top: 1px solid $border-color;
+  background: var(--reader-chrome-bg);
+  border-left: 1px solid var(--reader-chrome-border);
+  border-top: 1px solid var(--reader-chrome-border);
   transform: rotate(45deg);
   border-radius: 3px 0 0;
 }
@@ -77,11 +66,10 @@ $transition-normal: 200ms ease;
   padding: 12px 0;
 
   &:not(:last-child) {
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid var(--reader-chrome-border);
   }
 
   > label {
-    color: $text-primary;
     font-size: 13px;
     font-weight: 500;
     flex-shrink: 0;
@@ -102,7 +90,7 @@ $transition-normal: 200ms ease;
 
 .mode-label {
   font-size: 12px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   min-width: 60px;
   text-align: right;
 }
@@ -112,7 +100,7 @@ $transition-normal: 200ms ease;
   position: relative;
   width: 40px;
   height: 22px;
-  background: rgb(255 255 255 / 15%);
+  background: color-mix(in srgb, var(--color-white) 15%, transparent);
   border: none;
   border-radius: 11px;
   cursor: pointer;
@@ -120,7 +108,7 @@ $transition-normal: 200ms ease;
   padding: 0;
 
   &.active {
-    background: $active-color;
+    background: var(--reader-chrome-accent);
 
     .slider {
       transform: translateX(18px);
@@ -133,17 +121,17 @@ $transition-normal: 200ms ease;
     left: 2px;
     width: 18px;
     height: 18px;
-    background: #fff;
+    background: var(--color-white);
     border-radius: 50%;
     transition: transform 300ms ease;
     box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   }
 
   &:hover {
-    background: rgb(255 255 255 / 20%);
+    background: color-mix(in srgb, var(--color-white) 20%, transparent);
 
     &.active {
-      background: color.adjust($active-color, $lightness: 5%);
+      background: var(--reader-chrome-accent-hover);
     }
   }
 }
@@ -152,17 +140,17 @@ $transition-normal: 200ms ease;
 .button-group {
   display: flex;
   gap: 4px;
-  background: rgb(255 255 255 / 3%);
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
   padding: 3px;
   border-radius: 6px;
-  border: 1px solid $border-color;
+  border: 1px solid var(--reader-chrome-border);
 }
 
 .option-btn {
   width: 32px;
   height: 28px;
   background: transparent;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -170,15 +158,17 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all $transition-fast;
+  transition: background var(--transition-fast),
+    box-shadow var(--transition-fast),
+    color var(--transition-fast);
 
   &:hover {
-    background: $hover-bg;
-    color: $text-primary;
+    background: var(--reader-chrome-hover);
+    color: var(--color-white);
   }
 
   &.active {
-    background: $active-color;
+    background: var(--reader-chrome-accent);
     color: white;
   }
 
@@ -199,7 +189,7 @@ $transition-normal: 200ms ease;
 
     &.active {
       background: transparent;
-      box-shadow: 0 0 0 2px $active-color;
+      box-shadow: 0 0 0 2px var(--reader-chrome-accent);
     }
   }
 
@@ -207,7 +197,7 @@ $transition-normal: 200ms ease;
     width: 20px;
     height: 20px;
     border-radius: 50%;
-    border: 1px solid rgb(255 255 255 / 30%);
+    border: 1px solid color-mix(in srgb, var(--color-white) 30%, transparent);
   }
 }
 

--- a/frontend/src/app/features/readers/cbx-reader/layout/sidebar/cbx-sidebar.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/layout/sidebar/cbx-sidebar.component.scss
@@ -1,15 +1,6 @@
-// Variables
+@use '../../../shared/styles/reader-chrome' as *;
+
 $sidebar-width: 300px;
-$sidebar-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 6%);
-$active-bg: rgb(74 144 226 / 15%);
-$active-color: #4a90e2;
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
 
 // Overlay
 .sidebar-overlay {
@@ -18,24 +9,24 @@ $transition-normal: 200ms ease;
   background: rgb(0 0 0 / 40%);
   backdrop-filter: blur(2px);
   z-index: 12000;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 
   &.closing {
-    animation: fade-out $transition-normal forwards;
+    animation: fade-out var(--transition-base) forwards;
   }
 }
 
 // Sidebar container
 .sidebar {
+  @include surface;
+
   position: fixed;
   top: 0;
   left: 0;
   bottom: 0;
   width: $sidebar-width;
-  background: $sidebar-bg;
   display: flex;
   flex-direction: column;
-  color: $text-primary;
   box-shadow: 4px 0 24px rgb(0 0 0 / 30%);
   animation: slide-in 250ms cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 12001;
@@ -50,8 +41,8 @@ $transition-normal: 200ms ease;
   display: flex;
   gap: 14px;
   padding: 20px 16px;
-  border-bottom: 1px solid $border-color;
-  background: linear-gradient(180deg, rgb(255 255 255 / 3%) 0%, transparent 100%);
+  border-bottom: 1px solid var(--reader-chrome-border);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-white) 3%, transparent) 0%, transparent 100%);
 }
 
 .book-cover {
@@ -84,7 +75,7 @@ $transition-normal: 200ms ease;
 
 .book-authors {
   font-size: 12px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   margin: 0;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -95,7 +86,7 @@ $transition-normal: 200ms ease;
 // Tabs
 .tabs {
   display: flex;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   background: rgb(0 0 0 / 20%);
 }
 
@@ -108,20 +99,20 @@ $transition-normal: 200ms ease;
   padding: 12px 8px;
   background: none;
   border: none;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
-  transition: color $transition-fast, background $transition-fast;
+  transition: color var(--transition-fast), background var(--transition-fast);
   position: relative;
 
   &:hover {
-    color: $text-primary;
-    background: $hover-bg;
+    color: var(--color-white);
+    background: var(--reader-chrome-hover);
   }
 
   &.active {
-    color: $active-color;
+    color: var(--reader-chrome-accent);
 
     &::after {
       content: '';
@@ -130,7 +121,7 @@ $transition-normal: 200ms ease;
       left: 16px;
       right: 16px;
       height: 2px;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       border-radius: 1px 1px 0 0;
     }
   }
@@ -148,7 +139,7 @@ $transition-normal: 200ms ease;
   min-width: 16px;
   height: 16px;
   padding: 0 4px;
-  background: $active-color;
+  background: var(--reader-chrome-accent);
   color: white;
   font-size: 10px;
   font-weight: 600;
@@ -179,20 +170,20 @@ $transition-normal: 200ms ease;
   padding: 12px 16px;
   background: none;
   border: none;
-  color: $text-primary;
+  color: var(--color-white);
   font-size: 13px;
   text-align: left;
   cursor: pointer;
-  transition: background $transition-fast;
+  transition: background var(--transition-fast);
   gap: 12px;
 
   &:hover {
-    background: $hover-bg;
+    background: var(--reader-chrome-hover);
   }
 
   &.active {
-    background: $active-bg;
-    color: $active-color;
+    background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+    color: var(--reader-chrome-accent);
     font-weight: 500;
   }
 }
@@ -237,20 +228,20 @@ $transition-normal: 200ms ease;
   padding-right: 12px;
   background: none;
   border: none;
-  color: $text-primary;
+  color: var(--color-white);
   font-size: 13px;
   text-align: left;
   cursor: pointer;
-  transition: background $transition-fast;
+  transition: background var(--transition-fast);
   gap: 8px;
 
   &:hover {
-    background: $hover-bg;
+    background: var(--reader-chrome-hover);
   }
 
   &.active {
-    background: $active-bg;
-    color: $active-color;
+    background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+    color: var(--reader-chrome-accent);
     font-weight: 500;
   }
 
@@ -266,13 +257,13 @@ $transition-normal: 200ms ease;
   width: 20px;
   height: 20px;
   flex-shrink: 0;
-  color: $text-muted;
-  transition: transform $transition-fast;
+  color: var(--reader-chrome-fg-muted);
+  transition: transform var(--transition-fast);
   border-radius: 4px;
 
   &:hover {
-    background: rgb(255 255 255 / 10%);
-    color: $text-primary;
+    background: color-mix(in srgb, var(--color-white) 10%, transparent);
+    color: var(--color-white);
   }
 
   &.expanded {
@@ -289,7 +280,7 @@ $transition-normal: 200ms ease;
 
 .outline-page {
   font-size: 11px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   flex-shrink: 0;
   min-width: 28px;
   text-align: right;
@@ -308,10 +299,10 @@ $transition-normal: 200ms ease;
   gap: 12px;
   padding: 12px 16px;
   cursor: pointer;
-  transition: background $transition-fast;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: $hover-bg;
+    background: var(--reader-chrome-hover);
 
     .delete-btn,
     .action-buttons {
@@ -342,7 +333,7 @@ $transition-normal: 200ms ease;
 .item-title {
   font-size: 13px;
   font-weight: 500;
-  color: $text-primary;
+  color: var(--color-white);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -350,7 +341,7 @@ $transition-normal: 200ms ease;
 
 .note-text {
   font-size: 13px;
-  color: $text-primary;
+  color: var(--color-white);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -360,7 +351,7 @@ $transition-normal: 200ms ease;
 
 .item-chapter {
   font-size: 11px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -368,7 +359,7 @@ $transition-normal: 200ms ease;
 
 .item-meta {
   font-size: 11px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
 }
 
 .action-buttons {
@@ -376,7 +367,7 @@ $transition-normal: 200ms ease;
   flex-direction: column;
   gap: 4px;
   opacity: 0;
-  transition: opacity $transition-fast;
+  transition: opacity var(--transition-fast);
   flex-shrink: 0;
 }
 
@@ -391,9 +382,9 @@ $transition-normal: 200ms ease;
   background: none;
   border: none;
   border-radius: 6px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   cursor: pointer;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   flex-shrink: 0;
   opacity: 0;
 
@@ -409,13 +400,13 @@ $transition-normal: 200ms ease;
 }
 
 .edit-btn:hover {
-  background: rgb(74 144 226 / 15%);
-  color: $active-color;
+  background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+  color: var(--reader-chrome-accent);
 }
 
 .delete-btn:hover {
-  background: rgb(239 68 68 / 15%);
-  color: #ef4444;
+  background: color-mix(in srgb, var(--color-red-500) 15%, transparent);
+  color: var(--color-red-500);
 }
 
 // Notes container
@@ -431,10 +422,10 @@ $transition-normal: 200ms ease;
   gap: 10px;
   padding: 12px 16px;
   background: rgb(0 0 0 / 20%);
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
 
   .search-icon {
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
     flex-shrink: 0;
   }
 
@@ -442,12 +433,12 @@ $transition-normal: 200ms ease;
     flex: 1;
     background: none;
     border: none;
-    color: $text-primary;
+    color: var(--color-white);
     font-size: 14px;
     outline: none;
 
     &::placeholder {
-      color: $text-muted;
+      color: var(--reader-chrome-fg-muted);
     }
   }
 
@@ -458,17 +449,17 @@ $transition-normal: 200ms ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-white) 10%, transparent);
     border: none;
     border-radius: 50%;
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
     cursor: pointer;
-    transition: background $transition-fast, color $transition-fast;
+    transition: background var(--transition-fast), color var(--transition-fast);
     flex-shrink: 0;
 
     &:hover {
-      background: rgb(255 255 255 / 15%);
-      color: $text-primary;
+      background: color-mix(in srgb, var(--color-white) 15%, transparent);
+      color: var(--color-white);
     }
   }
 }
@@ -481,7 +472,7 @@ $transition-normal: 200ms ease;
   justify-content: center;
   padding: 48px 24px;
   text-align: center;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
 
   .empty-icon {
     width: 48px;
@@ -499,7 +490,7 @@ $transition-normal: 200ms ease;
 
 .empty-hint {
   font-size: 12px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
 }
 
 // Animations

--- a/frontend/src/app/features/readers/ebook-reader/dialogs/metadata-dialog.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/dialogs/metadata-dialog.component.scss
@@ -1,14 +1,4 @@
-// Variables matching sidebar styling
-$dialog-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #818cf8;
-$active-bg: rgb(129 140 248 / 15%);
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../shared/styles/reader-chrome' as *;
 
 .dialog-overlay {
   position: fixed;
@@ -19,7 +9,7 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 }
 
 @keyframes fade-in {
@@ -28,8 +18,9 @@ $transition-normal: 200ms ease;
 }
 
 .dialog {
-  background: $dialog-bg;
-  border: 1px solid $border-color;
+  @include surface;
+
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   width: 90%;
   max-width: 800px;
@@ -61,17 +52,16 @@ $transition-normal: 200ms ease;
 
 .dialog-header {
   padding: 16px 20px;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: linear-gradient(180deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 
   h2 {
     margin: 0;
     font-size: 16px;
     font-weight: 600;
-    color: $text-primary;
     letter-spacing: -0.3px;
   }
 }
@@ -79,12 +69,12 @@ $transition-normal: 200ms ease;
 .close-btn {
   background: none;
   border: none;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   font-size: 18px;
   cursor: pointer;
   padding: 6px;
   border-radius: 6px;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   line-height: 1;
   width: 32px;
   height: 32px;
@@ -93,12 +83,12 @@ $transition-normal: 200ms ease;
   justify-content: center;
 
   &:hover {
-    background: $hover-bg;
-    color: $text-primary;
+    background: var(--reader-chrome-hover);
+    color: var(--color-white);
   }
 
   &:focus-visible {
-    outline: 2px solid $active-color;
+    outline: 2px solid var(--reader-chrome-accent);
     outline-offset: 2px;
   }
 }
@@ -151,8 +141,8 @@ $transition-normal: 200ms ease;
 .cover-placeholder {
   width: 100%;
   aspect-ratio: 2/3;
-  background: linear-gradient(135deg, rgb(255 255 255 / 4%) 0%, rgb(255 255 255 / 1%) 100%);
-  border: 2px dashed rgb(255 255 255 / 12%);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--color-white) 4%, transparent) 0%, color-mix(in srgb, var(--color-white) 1%, transparent) 100%);
+  border: 2px dashed color-mix(in srgb, var(--color-white) 12%, transparent);
   border-radius: 8px;
   display: flex;
   align-items: center;
@@ -173,16 +163,16 @@ $transition-normal: 200ms ease;
 }
 
 .metadata-group {
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 
   &:not(:last-child) {
     padding-bottom: 16px;
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid var(--reader-chrome-border);
   }
 }
 
 .section-title {
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
@@ -208,13 +198,13 @@ $transition-normal: 200ms ease;
 }
 
 .label {
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   font-size: 13px;
   font-weight: 500;
 }
 
 .value {
-  color: $text-primary;
+  color: var(--color-white);
   font-size: 13px;
   overflow-wrap: anywhere;
   line-height: 1.5;
@@ -222,15 +212,15 @@ $transition-normal: 200ms ease;
   &.file-name {
     font-family: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', monospace;
     font-size: 12px;
-    color: $text-secondary;
-    background: rgb(255 255 255 / 3%);
+    color: var(--reader-chrome-fg-secondary);
+    background: color-mix(in srgb, var(--color-white) 3%, transparent);
     padding: 4px 8px;
     border-radius: 4px;
   }
 }
 
 .review-count {
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   font-size: 12px;
   margin-left: 4px;
 }
@@ -242,22 +232,22 @@ $transition-normal: 200ms ease;
 }
 
 .tag {
-  background: $active-bg;
-  color: $text-primary;
+  background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+  color: var(--color-white);
   padding: 4px 12px;
   border-radius: 12px;
   font-size: 12px;
   font-weight: 500;
-  border: 1px solid rgb(129 140 248 / 20%);
-  transition: background $transition-fast;
+  border: 1px solid color-mix(in srgb, var(--reader-chrome-accent) 20%, transparent);
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: rgb(129 140 248 / 25%);
+    background: color-mix(in srgb, var(--reader-chrome-accent) 25%, transparent);
   }
 }
 
 .description {
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   font-size: 13px;
   line-height: 1.7;
   margin: 0;

--- a/frontend/src/app/features/readers/ebook-reader/dialogs/note-dialog.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/dialogs/note-dialog.component.scss
@@ -1,14 +1,4 @@
-// Variables matching reader styling
-$dialog-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #818cf8;
-$active-bg: rgb(129 140 248 / 15%);
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../shared/styles/reader-chrome' as *;
 
 .dialog-overlay {
   position: fixed;
@@ -19,7 +9,7 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 }
 
 @keyframes fade-in {
@@ -28,8 +18,9 @@ $transition-normal: 200ms ease;
 }
 
 .dialog {
-  background: $dialog-bg;
-  border: 1px solid $border-color;
+  @include surface;
+
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   width: 90%;
   max-width: 500px;
@@ -55,17 +46,16 @@ $transition-normal: 200ms ease;
 
 .dialog-header {
   padding: 16px 20px;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: linear-gradient(180deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 
   h2 {
     margin: 0;
     font-size: 16px;
     font-weight: 600;
-    color: $text-primary;
     letter-spacing: -0.3px;
   }
 }
@@ -73,11 +63,11 @@ $transition-normal: 200ms ease;
 .close-btn {
   background: none;
   border: none;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   cursor: pointer;
   padding: 6px;
   border-radius: 6px;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   line-height: 1;
   width: 32px;
   height: 32px;
@@ -86,8 +76,8 @@ $transition-normal: 200ms ease;
   justify-content: center;
 
   &:hover {
-    background: $hover-bg;
-    color: $text-primary;
+    background: var(--reader-chrome-hover);
+    color: var(--color-white);
   }
 }
 
@@ -102,7 +92,7 @@ $transition-normal: 200ms ease;
 
 .section-label {
   display: block;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
@@ -114,10 +104,10 @@ $transition-normal: 200ms ease;
   .selected-text {
     margin: 0;
     padding: 12px 16px;
-    background: rgb(255 255 255 / 3%);
-    border-left: 3px solid $active-color;
+    background: color-mix(in srgb, var(--color-white) 3%, transparent);
+    border-left: 3px solid var(--reader-chrome-accent);
     border-radius: 0 8px 8px 0;
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
     font-size: 13px;
     font-style: italic;
     line-height: 1.6;
@@ -136,24 +126,24 @@ $transition-normal: 200ms ease;
   flex: 1;
   min-height: 120px;
   padding: 12px 16px;
-  background: rgb(255 255 255 / 3%);
-  border: 1px solid $border-color;
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 8px;
-  color: $text-primary;
+  color: var(--color-white);
   font-size: 14px;
   line-height: 1.6;
   resize: vertical;
   font-family: inherit;
-  transition: border-color $transition-fast, box-shadow $transition-fast;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 
   &::placeholder {
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
   }
 
   &:focus {
     outline: none;
-    border-color: $active-color;
-    box-shadow: 0 0 0 3px rgb(129 140 248 / 15%);
+    border-color: var(--reader-chrome-accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
   }
 }
 
@@ -171,7 +161,7 @@ $transition-normal: 200ms ease;
   border: 2px solid transparent;
   background: var(--color);
   cursor: pointer;
-  transition: transform $transition-fast, border-color $transition-fast, box-shadow $transition-fast;
+  transition: transform var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
   position: relative;
 
   &:hover {
@@ -179,8 +169,8 @@ $transition-normal: 200ms ease;
   }
 
   &.selected {
-    border-color: $text-primary;
-    box-shadow: 0 0 0 3px rgb(255 255 255 / 20%);
+    border-color: var(--color-white);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-white) 20%, transparent);
 
     &::after {
       content: '✓';
@@ -199,11 +189,11 @@ $transition-normal: 200ms ease;
 
 .dialog-footer {
   padding: 16px 20px;
-  border-top: 1px solid $border-color;
+  border-top: 1px solid var(--reader-chrome-border);
   display: flex;
   justify-content: flex-end;
   gap: 12px;
-  background: linear-gradient(0deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(0deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 }
 
 .btn {
@@ -212,7 +202,7 @@ $transition-normal: 200ms ease;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
-  transition: background $transition-fast, transform $transition-fast, opacity $transition-fast;
+  transition: background var(--transition-fast), transform var(--transition-fast), opacity var(--transition-fast);
   border: none;
 
   &:active {
@@ -227,19 +217,19 @@ $transition-normal: 200ms ease;
 }
 
 .btn-secondary {
-  background: $hover-bg;
-  color: $text-primary;
+  background: var(--reader-chrome-hover);
+  color: var(--color-white);
 
   &:hover:not(:disabled) {
-    background: rgb(255 255 255 / 12%);
+    background: color-mix(in srgb, var(--color-white) 12%, transparent);
   }
 }
 
 .btn-primary {
-  background: $active-color;
+  background: var(--reader-chrome-accent);
   color: white;
 
   &:hover:not(:disabled) {
-    background: #9ba3fa;
+    background: var(--reader-chrome-accent-hover);
   }
 }

--- a/frontend/src/app/features/readers/ebook-reader/dialogs/settings-dialog.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/dialogs/settings-dialog.component.scss
@@ -1,14 +1,4 @@
-// Variables matching sidebar styling
-$dialog-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #818cf8;
-$active-bg: rgb(129 140 248 / 15%);
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../shared/styles/reader-chrome' as *;
 
 .dialog-overlay {
   position: fixed;
@@ -18,7 +8,7 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 }
 
 @keyframes fade-in {
@@ -27,8 +17,9 @@ $transition-normal: 200ms ease;
 }
 
 .dialog {
-  background: $dialog-bg;
-  border: 1px solid $border-color;
+  @include surface;
+
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   width: 90%;
   max-width: 520px;
@@ -56,7 +47,7 @@ $transition-normal: 200ms ease;
 .tabs-row {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   background: rgb(0 0 0 / 20%);
   padding: 0 20px;
   justify-content: center;
@@ -73,13 +64,13 @@ $transition-normal: 200ms ease;
 .tab {
   background: none;
   border: none;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   padding: 14px 20px;
   cursor: pointer;
   font-size: 13px;
   font-weight: 500;
   position: relative;
-  transition: color $transition-fast;
+  transition: color var(--transition-fast);
   text-align: center;
   min-width: 90px;
   display: flex;
@@ -87,11 +78,11 @@ $transition-normal: 200ms ease;
   justify-content: center;
 
   &:hover {
-    color: $text-primary;
+    color: var(--color-white);
   }
 
   &.active {
-    color: $active-color;
+    color: var(--reader-chrome-accent);
 
     &::after {
       content: '';
@@ -100,7 +91,7 @@ $transition-normal: 200ms ease;
       right: 16px;
       bottom: 0;
       height: 2px;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       border-radius: 1px 1px 0 0;
     }
   }
@@ -113,12 +104,12 @@ $transition-normal: 200ms ease;
   transform: translateY(-50%);
   background: none;
   border: none;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   font-size: 18px;
   cursor: pointer;
   padding: 6px;
   border-radius: 6px;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   line-height: 1;
   width: 32px;
   height: 32px;
@@ -127,8 +118,8 @@ $transition-normal: 200ms ease;
   justify-content: center;
 
   &:hover {
-    background: $hover-bg;
-    color: $text-primary;
+    background: var(--reader-chrome-hover);
+    color: var(--color-white);
   }
 }
 
@@ -141,11 +132,11 @@ $transition-normal: 200ms ease;
 }
 
 .tab-content {
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 }
 
 .section-header {
-  color: $text-muted;
+  color: var(--reader-chrome-fg-secondary);
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
@@ -153,7 +144,7 @@ $transition-normal: 200ms ease;
   margin-top: 24px;
   margin-bottom: 12px;
   padding-bottom: 8px;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
 
   &:first-child {
     margin-top: 0;
@@ -167,7 +158,7 @@ $transition-normal: 200ms ease;
     gap: 30px;
     padding-bottom: 8px;
     margin-bottom: 24px;
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid var(--reader-chrome-border);
   }
 }
 
@@ -180,7 +171,7 @@ $transition-normal: 200ms ease;
 .mode-icon {
   font-size: 18px;
   opacity: 0.3;
-  transition: all 300ms ease;
+  transition: filter 300ms ease, opacity 300ms ease, transform 300ms ease;
   user-select: none;
 
   &.active {
@@ -213,7 +204,7 @@ $transition-normal: 200ms ease;
   margin-bottom: 2px;
 
   span {
-    color: $text-primary;
+    color: var(--color-white);
     font-size: 14px;
     font-weight: 500;
   }
@@ -223,7 +214,7 @@ $transition-normal: 200ms ease;
   position: relative;
   width: 44px;
   height: 24px;
-  background: rgb(255 255 255 / 15%);
+  background: color-mix(in srgb, var(--color-white) 15%, transparent);
   border: none;
   border-radius: 12px;
   cursor: pointer;
@@ -231,7 +222,7 @@ $transition-normal: 200ms ease;
   padding: 0;
 
   &.active {
-    background: $active-color;
+    background: var(--reader-chrome-accent);
 
     .slider {
       transform: translateX(20px);
@@ -244,22 +235,22 @@ $transition-normal: 200ms ease;
     left: 2px;
     width: 20px;
     height: 20px;
-    background: #fff;
+    background: var(--color-white);
     border-radius: 50%;
     transition: transform 300ms ease;
     box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   }
 
   &:hover {
-    background: rgb(255 255 255 / 20%);
+    background: color-mix(in srgb, var(--color-white) 20%, transparent);
 
     &.active {
-      background: #9aa3fa;
+      background: var(--reader-chrome-accent-hover);
     }
   }
 
   &:focus-visible {
-    outline: 2px solid $active-color;
+    outline: 2px solid var(--reader-chrome-accent);
     outline-offset: 2px;
   }
 }
@@ -285,24 +276,24 @@ $transition-normal: 200ms ease;
   }
 
   .theme-card {
-    background: rgb(255 255 255 / 3%);
-    border: 2px solid $border-color;
+    background: color-mix(in srgb, var(--color-white) 3%, transparent);
+    border: 2px solid var(--reader-chrome-border);
     border-radius: 8px;
     padding: 10px;
-    transition: all $transition-fast;
+    transition: background var(--transition-fast), border-color var(--transition-fast);
     display: flex;
     flex-direction: column;
     gap: 8px;
 
     &:hover {
-      background: $hover-bg;
-      border-color: rgb(255 255 255 / 15%);
+      background: var(--reader-chrome-hover);
+      border-color: color-mix(in srgb, var(--color-white) 15%, transparent);
     }
   }
 
   input:checked + .theme-card {
-    border-color: $active-color;
-    background: $active-bg;
+    border-color: var(--reader-chrome-accent);
+    background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
   }
 
   .theme-colors {
@@ -318,7 +309,7 @@ $transition-normal: 200ms ease;
   }
 
   .theme-name {
-    color: $text-primary;
+    color: var(--color-white);
     font-size: 11px;
     font-weight: 500;
     text-align: center;
@@ -333,35 +324,35 @@ $transition-normal: 200ms ease;
 }
 
 .font-option {
-  background: rgb(255 255 255 / 3%);
-  border: 2px solid $border-color;
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
+  border: 2px solid var(--reader-chrome-border);
   border-radius: 8px;
   padding: 12px;
   cursor: pointer;
-  transition: all $transition-fast;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 8px;
 
   &:hover {
-    background: $hover-bg;
-    border-color: rgb(255 255 255 / 15%);
+    background: var(--reader-chrome-hover);
+    border-color: color-mix(in srgb, var(--color-white) 15%, transparent);
   }
 
   &.active {
-    border-color: $active-color;
-    background: $active-bg;
+    border-color: var(--reader-chrome-accent);
+    background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
   }
 
   .font-preview {
     font-size: 24px;
-    color: $text-primary;
+    color: var(--color-white);
     line-height: 1;
   }
 
   .font-name {
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
     font-size: 11px;
     font-weight: 500;
     text-align: center;
@@ -380,7 +371,6 @@ $transition-normal: 200ms ease;
   }
 
   > label {
-    color: $text-primary;
     font-size: 14px;
     font-weight: 500;
     flex-shrink: 0;
@@ -390,7 +380,7 @@ $transition-normal: 200ms ease;
     flex: 1;
     margin: 0 10px;
     height: 5px;
-    background: rgb(255 255 255 / 12%);
+    background: color-mix(in srgb, var(--color-white) 12%, transparent);
     border-radius: 3px;
     outline: none;
     cursor: pointer;
@@ -401,14 +391,14 @@ $transition-normal: 200ms ease;
       width: 14px;
       height: 14px;
       border-radius: 50%;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       cursor: pointer;
       box-shadow: 0 2px 4px rgb(0 0 0 / 30%);
-      transition: all $transition-fast;
+      transition: box-shadow var(--transition-fast), transform var(--transition-fast);
 
       &:hover {
         transform: scale(1.1);
-        box-shadow: 0 2px 8px rgb(129 140 248 / 50%);
+        box-shadow: 0 2px 8px color-mix(in srgb, var(--reader-chrome-accent) 50%, transparent);
       }
     }
 
@@ -416,7 +406,7 @@ $transition-normal: 200ms ease;
       width: 14px;
       height: 14px;
       border-radius: 50%;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       border: none;
       cursor: pointer;
       box-shadow: 0 2px 4px rgb(0 0 0 / 30%);
@@ -424,7 +414,7 @@ $transition-normal: 200ms ease;
   }
 
   .value {
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
     font-size: 12px;
     min-width: 42px;
     text-align: right;
@@ -457,16 +447,16 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   gap: 4px;
-  background: rgb(255 255 255 / 3%);
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
   padding: 3px;
   border-radius: 6px;
-  border: 1px solid $border-color;
+  border: 1px solid var(--reader-chrome-border);
 
   button {
     width: 28px;
     height: 28px;
-    background: rgb(255 255 255 / 5%);
-    color: $text-secondary;
+    background: color-mix(in srgb, var(--color-white) 5%, transparent);
+    color: var(--reader-chrome-fg-secondary);
     border: none;
     border-radius: 4px;
     cursor: pointer;
@@ -474,12 +464,14 @@ $transition-normal: 200ms ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: all $transition-fast;
+    transition: background var(--transition-fast),
+      color var(--transition-fast),
+      transform var(--transition-fast);
     font-weight: 300;
 
     &:hover {
-      background: $hover-bg;
-      color: $text-primary;
+      background: var(--reader-chrome-hover);
+      color: var(--color-white);
     }
 
     &:active {
@@ -490,7 +482,7 @@ $transition-normal: 200ms ease;
   span {
     min-width: 48px;
     text-align: center;
-    color: $text-primary;
+    color: var(--color-white);
     font-size: 13px;
     font-weight: 500;
     font-variant-numeric: tabular-nums;
@@ -507,7 +499,7 @@ $transition-normal: 200ms ease;
     gap: 7px;
     cursor: pointer;
     font-size: 14px;
-    color: $text-primary;
+    color: var(--color-white);
     font-weight: 500;
     position: relative;
     user-select: none;
@@ -516,21 +508,21 @@ $transition-normal: 200ms ease;
       appearance: none;
       width: 18px;
       height: 18px;
-      border: 2px solid $active-color;
+      border: 2px solid var(--reader-chrome-accent);
       border-radius: 50%;
-      background: rgb(255 255 255 / 5%);
+      background: color-mix(in srgb, var(--color-white) 5%, transparent);
       margin: 0 6px 0 0;
       outline: none;
-      transition: border-color $transition-fast, box-shadow $transition-fast;
+      transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 
       &:checked {
-        background: $active-color;
-        box-shadow: 0 0 0 2px rgb(129 140 248 / 15%);
-        border-color: $active-color;
+        background: var(--reader-chrome-accent);
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+        border-color: var(--reader-chrome-accent);
       }
 
       &:focus-visible {
-        box-shadow: 0 0 0 2px $active-color;
+        box-shadow: 0 0 0 2px var(--reader-chrome-accent);
       }
     }
   }
@@ -548,9 +540,11 @@ $transition-normal: 200ms ease;
   width: 44px;
   height: 44px;
   border-radius: 50%;
-  border: 3px solid rgb(255 255 255 / 15%);
+  border: 3px solid color-mix(in srgb, var(--color-white) 15%, transparent);
   cursor: pointer;
-  transition: all $transition-fast;
+  transition: border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
   position: relative;
   display: flex;
   align-items: center;
@@ -559,7 +553,7 @@ $transition-normal: 200ms ease;
 
   &:hover {
     transform: scale(1.08);
-    border-color: rgb(255 255 255 / 30%);
+    border-color: color-mix(in srgb, var(--color-white) 30%, transparent);
     box-shadow: 0 4px 12px rgb(0 0 0 / 30%);
   }
 
@@ -568,20 +562,20 @@ $transition-normal: 200ms ease;
   }
 
   &.active {
-    border-color: $active-color;
+    border-color: var(--reader-chrome-accent);
     border-width: 3px;
-    box-shadow: 0 0 0 3px rgb(129 140 248 / 25%), 0 4px 12px rgb(0 0 0 / 30%);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--reader-chrome-accent) 25%, transparent), 0 4px 12px rgb(0 0 0 / 30%);
 
     .check-icon {
       color: rgb(0 0 0 / 70%);
       font-size: 18px;
       font-weight: bold;
-      text-shadow: 0 1px 2px rgb(255 255 255 / 50%);
+      text-shadow: 0 1px 2px color-mix(in srgb, var(--color-white) 50%, transparent);
     }
   }
 
   &:focus-visible {
-    outline: 2px solid $active-color;
+    outline: 2px solid var(--reader-chrome-accent);
     outline-offset: 2px;
   }
 }

--- a/frontend/src/app/features/readers/ebook-reader/dialogs/shortcuts-help.component.html
+++ b/frontend/src/app/features/readers/ebook-reader/dialogs/shortcuts-help.component.html
@@ -12,7 +12,7 @@
         <div class="shortcut-group">
           <h3 class="group-title">{{ group.title }}</h3>
           <div class="shortcuts-list">
-            @for (shortcut of group.shortcuts; track shortcut.description) {
+            @for (shortcut of group.shortcuts; track $index) {
               <div class="shortcut-item">
                 <div class="shortcut-keys">
                   @for (key of shortcut.keys; track key; let last = $last) {

--- a/frontend/src/app/features/readers/ebook-reader/dialogs/shortcuts-help.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/dialogs/shortcuts-help.component.scss
@@ -1,12 +1,4 @@
-$dialog-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #818cf8;
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../shared/styles/reader-chrome' as *;
 
 .dialog-overlay {
   position: fixed;
@@ -17,7 +9,7 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 }
 
 @keyframes fade-in {
@@ -26,8 +18,9 @@ $transition-normal: 200ms ease;
 }
 
 .dialog {
-  background: $dialog-bg;
-  border: 1px solid $border-color;
+  @include surface;
+
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   width: 90%;
   max-width: 480px;
@@ -53,17 +46,16 @@ $transition-normal: 200ms ease;
 
 .dialog-header {
   padding: 16px 20px;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: linear-gradient(180deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 
   h2 {
     margin: 0;
     font-size: 16px;
     font-weight: 600;
-    color: $text-primary;
     letter-spacing: -0.3px;
   }
 }
@@ -71,11 +63,11 @@ $transition-normal: 200ms ease;
 .close-btn {
   background: none;
   border: none;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   cursor: pointer;
   padding: 6px;
   border-radius: 6px;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   line-height: 1;
   width: 32px;
   height: 32px;
@@ -84,8 +76,8 @@ $transition-normal: 200ms ease;
   justify-content: center;
 
   &:hover {
-    background: $hover-bg;
-    color: $text-primary;
+    background: var(--reader-chrome-hover);
+    color: var(--color-white);
   }
 }
 
@@ -105,7 +97,7 @@ $transition-normal: 200ms ease;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
   }
 }
 
@@ -121,12 +113,12 @@ $transition-normal: 200ms ease;
   justify-content: space-between;
   gap: 16px;
   padding: 8px 12px;
-  background: rgb(255 255 255 / 3%);
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
   border-radius: 8px;
-  transition: background $transition-fast;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: rgb(255 255 255 / 5%);
+    background: color-mix(in srgb, var(--color-white) 5%, transparent);
   }
 }
 
@@ -144,18 +136,18 @@ $transition-normal: 200ms ease;
   min-width: 28px;
   height: 26px;
   padding: 0 8px;
-  background: rgb(255 255 255 / 10%);
-  border: 1px solid rgb(255 255 255 / 15%);
+  background: color-mix(in srgb, var(--color-white) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-white) 15%, transparent);
   border-radius: 5px;
   font-family: inherit;
   font-size: 12px;
   font-weight: 500;
-  color: $text-primary;
+  color: var(--color-white);
   box-shadow: 0 2px 0 rgb(0 0 0 / 20%);
 }
 
 .key-separator {
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   font-size: 12px;
   margin: 0 2px;
 }
@@ -170,21 +162,21 @@ $transition-normal: 200ms ease;
 
 .shortcut-description {
   font-size: 13px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
 }
 
 .mobile-gesture {
   font-size: 11px;
-  color: $active-color;
+  color: var(--reader-chrome-accent);
   font-style: italic;
 }
 
 .dialog-footer {
   padding: 16px 20px;
-  border-top: 1px solid $border-color;
+  border-top: 1px solid var(--reader-chrome-border);
   display: flex;
   justify-content: flex-end;
-  background: linear-gradient(0deg, rgb(255 255 255 / 2%) 0%, transparent 100%);
+  background: linear-gradient(0deg, color-mix(in srgb, var(--color-white) 2%, transparent) 0%, transparent 100%);
 }
 
 .btn {
@@ -193,7 +185,7 @@ $transition-normal: 200ms ease;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
-  transition: background $transition-fast, transform $transition-fast;
+  transition: background var(--transition-fast), transform var(--transition-fast);
   border: none;
 
   &:active {
@@ -202,11 +194,11 @@ $transition-normal: 200ms ease;
 }
 
 .btn-primary {
-  background: $active-color;
+  background: var(--reader-chrome-accent);
   color: white;
 
   &:hover {
-    background: #9ba3fb;
+    background: var(--reader-chrome-accent-hover);
   }
 }
 

--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.scss
@@ -129,8 +129,8 @@ foliate-view::part(head) {
   align-items: center;
   padding: 8px 16px;
   font-size: 0.875rem;
-  color: var(--text-secondary, #666);
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  color: var(--reader-text-secondary, #666);
+  border-bottom: 1px solid var(--reader-border-color, #e0e0e0);
   font-family: inherit;
   min-height: 32px;
   box-sizing: border-box;
@@ -142,8 +142,8 @@ foliate-view::part(foot) {
   align-items: center;
   padding: 8px 16px;
   font-size: 0.875rem;
-  color: var(--text-secondary, #666);
-  border-top: 1px solid var(--border-color, #e0e0e0);
+  color: var(--reader-text-secondary, #666);
+  border-top: 1px solid var(--reader-border-color, #e0e0e0);
   font-family: inherit;
   min-height: 32px;
   box-sizing: border-box;

--- a/frontend/src/app/features/readers/ebook-reader/layout/footer/footer.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/layout/footer/footer.component.scss
@@ -1,15 +1,8 @@
-// Variables matching sidebar styling
-$navbar-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #818cf8;
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../../shared/styles/reader-chrome' as *;
 
 .reader-navbar {
+  @include text;
+
   position: absolute;
   bottom: 0;
   left: 0;
@@ -20,11 +13,10 @@ $transition-normal: 200ms ease;
   align-items: center;
   gap: 8px;
   z-index: 1000;
-  background: $navbar-bg;
+  background: var(--reader-chrome-bg);
   backdrop-filter: blur(8px);
-  border-top: 1px solid $border-color;
+  border-top: 1px solid var(--reader-chrome-border);
   box-shadow: 0 -2px 12px rgb(0 0 0 / 30%);
-  color: $text-primary;
   opacity: 0;
   pointer-events: none;
   transform: translateY(100%);
@@ -41,11 +33,11 @@ $transition-normal: 200ms ease;
 .icon-btn {
   background: none;
   border: none;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   cursor: pointer;
   padding: 8px;
   border-radius: 8px;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -56,8 +48,8 @@ $transition-normal: 200ms ease;
   }
 
   &:hover:not(:disabled) {
-    background: $hover-bg;
-    color: $text-primary;
+    background: var(--reader-chrome-hover);
+    color: var(--reader-chrome-fg);
   }
 
   &:disabled {
@@ -66,7 +58,7 @@ $transition-normal: 200ms ease;
   }
 
   &:focus-visible {
-    outline: 2px solid $active-color;
+    outline: 2px solid var(--reader-chrome-accent);
     outline-offset: 2px;
   }
 }
@@ -78,24 +70,24 @@ $transition-normal: 200ms ease;
   gap: 12px;
 
   .location-btn {
-    background: rgb(255 255 255 / 5%);
-    border: 1px solid $border-color;
-    color: $text-primary;
+    background: color-mix(in srgb, var(--color-white) 5%, transparent);
+    border: 1px solid var(--reader-chrome-border);
+    color: var(--color-white);
     padding: 6px 14px;
     border-radius: 6px;
     cursor: pointer;
     font-size: 13px;
     font-weight: 500;
-    transition: background $transition-fast, border-color $transition-fast;
+    transition: background var(--transition-fast), border-color var(--transition-fast);
     font-variant-numeric: tabular-nums;
 
     &:hover {
-      background: $hover-bg;
-      border-color: rgb(255 255 255 / 15%);
+      background: var(--reader-chrome-hover);
+      border-color: color-mix(in srgb, var(--color-white) 15%, transparent);
     }
 
     &:focus-visible {
-      outline: 2px solid $active-color;
+      outline: 2px solid var(--reader-chrome-accent);
       outline-offset: 2px;
     }
   }
@@ -112,7 +104,7 @@ $transition-normal: 200ms ease;
       border-radius: 3px;
       outline: none;
       appearance: none;
-      background: rgb(255 255 255 / 12%);
+      background: color-mix(in srgb, var(--color-white) 12%, transparent);
       position: relative;
       z-index: 1;
       cursor: pointer;
@@ -122,14 +114,14 @@ $transition-normal: 200ms ease;
         width: 16px;
         height: 16px;
         border-radius: 50%;
-        background: $active-color;
+        background: var(--reader-chrome-accent);
         cursor: pointer;
         box-shadow: 0 2px 6px rgb(0 0 0 / 30%);
-        transition: transform $transition-fast, box-shadow $transition-fast;
+        transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 
         &:hover {
           transform: scale(1.1);
-          box-shadow: 0 2px 8px rgb(129 140 248 / 40%);
+          box-shadow: 0 2px 8px color-mix(in srgb, var(--reader-chrome-accent) 40%, transparent);
         }
       }
 
@@ -137,14 +129,14 @@ $transition-normal: 200ms ease;
         width: 16px;
         height: 16px;
         border-radius: 50%;
-        background: $active-color;
+        background: var(--reader-chrome-accent);
         cursor: pointer;
         border: none;
         box-shadow: 0 2px 6px rgb(0 0 0 / 30%);
       }
 
       &:focus-visible {
-        outline: 2px solid $active-color;
+        outline: 2px solid var(--reader-chrome-accent);
         outline-offset: 4px;
       }
     }
@@ -165,26 +157,27 @@ $transition-normal: 200ms ease;
       top: 0;
       width: 1.5px;
       height: 10px;
-      background: rgb(255 255 255 / 40%);
+      background: var(--reader-chrome-fg-muted);
       border-radius: 2px;
     }
   }
 }
 
 .location-popover {
+  @include text;
+
   position: absolute;
   bottom: 60px;
   left: 50%;
   transform: translateX(-50%);
-  background: $navbar-bg;
+  background: var(--reader-chrome-bg);
   backdrop-filter: blur(8px);
-  border: 1px solid $border-color;
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   box-shadow: 0 8px 32px rgb(0 0 0 / 50%);
   z-index: 1001;
   min-width: 380px;
   animation: popover-slide-in 200ms cubic-bezier(0.4, 0, 0.2, 1);
-  color: $text-primary;
 
   .popover-content {
     padding: 16px 20px;
@@ -206,7 +199,7 @@ $transition-normal: 200ms ease;
 
       .label {
         font-size: 11px;
-        color: $text-muted;
+        color: var(--reader-chrome-fg-muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
         font-weight: 600;
@@ -216,20 +209,20 @@ $transition-normal: 200ms ease;
         font-size: 20px;
         font-weight: 600;
         letter-spacing: -0.3px;
-        color: $text-primary;
+        color: var(--reader-chrome-fg);
       }
     }
 
     .separator {
       width: 1px;
       height: 44px;
-      background: $border-color;
+      background: var(--reader-chrome-hover);
     }
   }
 
   .divider {
     height: 1px;
-    background: $border-color;
+    background: var(--reader-chrome-hover);
     margin: 12px 0;
   }
 
@@ -247,7 +240,7 @@ $transition-normal: 200ms ease;
 
       .label {
         font-size: 11px;
-        color: $text-muted;
+        color: var(--reader-chrome-fg-muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
         font-weight: 600;
@@ -256,7 +249,7 @@ $transition-normal: 200ms ease;
       .chapter-name {
         font-size: 14px;
         font-weight: 500;
-        color: $text-primary;
+        color: var(--reader-chrome-fg);
         line-height: 1.3;
         max-width: 100%;
         overflow: hidden;
@@ -281,7 +274,7 @@ $transition-normal: 200ms ease;
 
         .label {
           font-size: 11px;
-          color: $text-muted;
+          color: var(--reader-chrome-fg-muted);
           text-transform: uppercase;
           letter-spacing: 0.5px;
           font-weight: 600;
@@ -291,14 +284,14 @@ $transition-normal: 200ms ease;
           font-size: 18px;
           font-weight: 600;
           letter-spacing: -0.3px;
-          color: $text-primary;
+          color: var(--color-white);
         }
       }
 
       .info-separator {
         width: 1px;
         height: 36px;
-        background: $border-color;
+        background: var(--reader-chrome-hover);
       }
     }
   }
@@ -318,47 +311,47 @@ $transition-normal: 200ms ease;
     label {
       font-size: 13px;
       font-weight: 500;
-      color: $text-secondary;
+      color: var(--reader-chrome-fg-secondary);
     }
 
     input {
       width: 65px;
       padding: 6px 10px;
-      background: rgb(255 255 255 / 5%);
-      border: 1px solid $border-color;
+      background: color-mix(in srgb, var(--color-white) 5%, transparent);
+      border: 1px solid var(--reader-chrome-border);
       border-radius: 6px;
-      color: $text-primary;
+      color: var(--color-white);
       font-size: 13px;
       text-align: right;
-      transition: background $transition-fast, border-color $transition-fast;
+      transition: background var(--transition-fast), border-color var(--transition-fast);
       font-variant-numeric: tabular-nums;
 
       &:focus {
         outline: none;
-        background: $hover-bg;
-        border-color: $active-color;
+        background: var(--reader-chrome-hover);
+        border-color: var(--reader-chrome-accent);
       }
     }
 
     span {
       font-size: 13px;
-      color: $text-secondary;
+      color: var(--reader-chrome-fg-secondary);
     }
 
     .go-btn {
       padding: 7px 18px;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       border: none;
       border-radius: 6px;
       color: white;
       font-size: 13px;
       font-weight: 500;
       cursor: pointer;
-      transition: background $transition-fast;
+      transition: background var(--transition-fast);
       flex-shrink: 0;
 
       &:hover {
-        background: #9ba3fb;
+        background: var(--reader-chrome-accent-hover);
       }
     }
   }
@@ -372,12 +365,12 @@ $transition-normal: 200ms ease;
     .nav-btn {
       background: none;
       border: none;
-      color: $text-secondary;
+      color: var(--reader-chrome-fg-secondary);
       padding: 0;
       margin: 0;
       border-radius: 8px;
       cursor: pointer;
-      transition: background $transition-fast, color $transition-fast, transform $transition-fast;
+      transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
       width: 44px;
       height: 44px;
       display: flex;
@@ -390,8 +383,8 @@ $transition-normal: 200ms ease;
       }
 
       &:hover {
-        background: $hover-bg;
-        color: $text-primary;
+        background: var(--reader-chrome-hover);
+        color: var(--color-white);
       }
 
       &:active {
@@ -399,7 +392,7 @@ $transition-normal: 200ms ease;
       }
 
       &:focus-visible {
-        outline: 2px solid $active-color;
+        outline: 2px solid var(--reader-chrome-accent);
         outline-offset: 2px;
       }
     }

--- a/frontend/src/app/features/readers/ebook-reader/layout/header/quick-settings.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/layout/header/quick-settings.component.scss
@@ -1,21 +1,11 @@
-// Variables matching sidebar/dialog styling
-$panel-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 8%);
-$active-color: #818cf8;
-$active-bg: rgb(129 140 248 / 15%);
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
+@use '../../../shared/styles/reader-chrome' as *;
 
 .quick-settings-overlay {
   position: fixed;
   inset: 0;
   z-index: 12000;
   background: rgb(0 0 0 / 30%);
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
   cursor: pointer;
 }
 
@@ -25,12 +15,13 @@ $transition-normal: 200ms ease;
 }
 
 .quick-settings-panel {
+  @include surface;
+
   position: absolute;
   top: 52px;
   right: 60px;
   width: 280px;
-  background: $panel-bg;
-  border: 1px solid $border-color;
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 12px;
   box-shadow: 0 12px 40px rgb(0 0 0 / 50%);
   animation: slide-down 200ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -57,9 +48,9 @@ $transition-normal: 200ms ease;
   right: 18px;
   width: 16px;
   height: 16px;
-  background: $panel-bg;
-  border-left: 1px solid $border-color;
-  border-top: 1px solid $border-color;
+  background: var(--reader-chrome-bg);
+  border-left: 1px solid var(--reader-chrome-border);
+  border-top: 1px solid var(--reader-chrome-border);
   transform: rotate(45deg);
   border-radius: 3px 0 0;
 }
@@ -75,11 +66,10 @@ $transition-normal: 200ms ease;
   padding: 10px 0;
 
   &:not(:last-child) {
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid var(--reader-chrome-border);
   }
 
   > label {
-    color: $text-primary;
     font-size: 13px;
     font-weight: 500;
     flex-shrink: 0;
@@ -96,7 +86,7 @@ $transition-normal: 200ms ease;
 .mode-icon {
   font-size: 14px;
   opacity: 0.3;
-  transition: all 300ms ease;
+  transition: filter 300ms ease, opacity 300ms ease, transform 300ms ease;
   user-select: none;
 
   &.active {
@@ -126,7 +116,7 @@ $transition-normal: 200ms ease;
   position: relative;
   width: 40px;
   height: 22px;
-  background: rgb(255 255 255 / 15%);
+  background: color-mix(in srgb, var(--color-white) 15%, transparent);
   border: none;
   border-radius: 11px;
   cursor: pointer;
@@ -134,7 +124,7 @@ $transition-normal: 200ms ease;
   padding: 0;
 
   &.active {
-    background: $active-color;
+    background: var(--reader-chrome-accent);
 
     .slider {
       transform: translateX(18px);
@@ -147,17 +137,17 @@ $transition-normal: 200ms ease;
     left: 2px;
     width: 18px;
     height: 18px;
-    background: #fff;
+    background: var(--color-white);
     border-radius: 50%;
     transition: transform 300ms ease;
     box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   }
 
   &:hover {
-    background: rgb(255 255 255 / 20%);
+    background: color-mix(in srgb, var(--color-white) 20%, transparent);
 
     &.active {
-      background: #9aa3fa;
+      background: var(--reader-chrome-accent-hover);
     }
   }
 }
@@ -167,16 +157,16 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   gap: 2px;
-  background: rgb(255 255 255 / 3%);
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
   padding: 2px;
   border-radius: 6px;
-  border: 1px solid $border-color;
+  border: 1px solid var(--reader-chrome-border);
 
   button {
     width: 26px;
     height: 26px;
-    background: rgb(255 255 255 / 5%);
-    color: $text-secondary;
+    background: color-mix(in srgb, var(--color-white) 5%, transparent);
+    color: var(--reader-chrome-fg-secondary);
     border: none;
     border-radius: 4px;
     cursor: pointer;
@@ -184,12 +174,14 @@ $transition-normal: 200ms ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: all $transition-fast;
+    transition: background var(--transition-fast),
+      color var(--transition-fast),
+      transform var(--transition-fast);
     font-weight: 300;
 
     &:hover {
-      background: $hover-bg;
-      color: $text-primary;
+      background: var(--reader-chrome-hover);
+      color: var(--color-white);
     }
 
     &:active {
@@ -200,7 +192,6 @@ $transition-normal: 200ms ease;
   span {
     min-width: 50px;
     text-align: center;
-    color: $text-primary;
     font-size: 12px;
     font-weight: 500;
     font-variant-numeric: tabular-nums;
@@ -209,7 +200,7 @@ $transition-normal: 200ms ease;
 
 .panel-footer {
   padding: 12px 16px;
-  border-top: 1px solid $border-color;
+  border-top: 1px solid var(--reader-chrome-border);
   background: rgb(0 0 0 / 15%);
   border-radius: 0 0 12px 12px;
 }
@@ -221,18 +212,19 @@ $transition-normal: 200ms ease;
   gap: 8px;
   width: 100%;
   padding: 10px 16px;
-  background: rgb(255 255 255 / 5%);
-  border: 1px solid $border-color;
+  background: color-mix(in srgb, var(--color-white) 5%, transparent);
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 8px;
-  color: $text-primary;
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: all $transition-fast;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
 
   &:hover {
-    background: $hover-bg;
-    border-color: rgb(255 255 255 / 15%);
+    background: var(--reader-chrome-hover);
+    border-color: color-mix(in srgb, var(--color-white) 15%, transparent);
   }
 
   &:active {

--- a/frontend/src/app/features/readers/ebook-reader/layout/panel/panel.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/layout/panel/panel.component.scss
@@ -1,15 +1,6 @@
-// Variables
+@use '../../../shared/styles/reader-chrome' as *;
+
 $sidebar-width: 320px;
-$sidebar-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 6%);
-$active-bg: rgb(99 102 241 / 15%);
-$active-color: #818cf8;
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
 
 // Overlay
 .sidebar-overlay {
@@ -18,24 +9,24 @@ $transition-normal: 200ms ease;
   background: rgb(0 0 0 / 40%);
   backdrop-filter: blur(1px);
   z-index: 12000;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 
   &.closing {
-    animation: fade-out $transition-normal forwards;
+    animation: fade-out var(--transition-base) forwards;
   }
 }
 
 // Sidebar container - positioned on the RIGHT
 .sidebar {
+  @include surface;
+
   position: fixed;
   top: 0;
   right: 0;
   bottom: 0;
   width: $sidebar-width;
-  background: $sidebar-bg;
   display: flex;
   flex-direction: column;
-  color: $text-primary;
   box-shadow: -4px 0 24px rgb(0 0 0 / 30%);
   animation: slide-in-right 250ms cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 12001;
@@ -50,21 +41,20 @@ $transition-normal: 200ms ease;
   display: flex;
   align-items: center;
   padding: 20px 16px;
-  border-bottom: 1px solid $border-color;
-  background: linear-gradient(180deg, rgb(255 255 255 / 3%) 0%, transparent 100%);
+  border-bottom: 1px solid var(--reader-chrome-border);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-white) 3%, transparent) 0%, transparent 100%);
 }
 
 .sidebar-title {
   font-size: 16px;
   font-weight: 600;
   margin: 0;
-  color: $text-primary;
 }
 
 // Tabs
 .tabs {
   display: flex;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   background: rgb(0 0 0 / 20%);
 }
 
@@ -77,20 +67,20 @@ $transition-normal: 200ms ease;
   padding: 12px 8px;
   background: none;
   border: none;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
-  transition: color $transition-fast, background $transition-fast;
+  transition: color var(--transition-fast), background var(--transition-fast);
   position: relative;
 
   &:hover {
-    color: $text-primary;
-    background: $hover-bg;
+    color: var(--color-white);
+    background: var(--reader-chrome-hover);
   }
 
   &.active {
-    color: $active-color;
+    color: var(--reader-chrome-accent);
 
     &::after {
       content: '';
@@ -99,7 +89,7 @@ $transition-normal: 200ms ease;
       left: 16px;
       right: 16px;
       height: 2px;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       border-radius: 1px 1px 0 0;
     }
   }
@@ -117,7 +107,7 @@ $transition-normal: 200ms ease;
   min-width: 16px;
   height: 16px;
   padding: 0 4px;
-  background: $active-color;
+  background: var(--reader-chrome-accent);
   color: white;
   font-size: 10px;
   font-weight: 600;
@@ -147,10 +137,10 @@ $transition-normal: 200ms ease;
   gap: 12px;
   padding: 12px 16px;
   cursor: pointer;
-  transition: background $transition-fast;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: $hover-bg;
+    background: var(--reader-chrome-hover);
 
     .delete-btn {
       opacity: 1;
@@ -179,10 +169,10 @@ $transition-normal: 200ms ease;
   gap: 10px;
   padding: 12px 16px;
   background: rgb(0 0 0 / 20%);
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
 
   .search-icon {
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
     flex-shrink: 0;
   }
 
@@ -190,12 +180,12 @@ $transition-normal: 200ms ease;
     flex: 1;
     background: none;
     border: none;
-    color: $text-primary;
+    color: var(--color-white);
     font-size: 14px;
     outline: none;
 
     &::placeholder {
-      color: $text-muted;
+      color: var(--reader-chrome-fg-muted);
     }
   }
 
@@ -206,17 +196,17 @@ $transition-normal: 200ms ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-white) 10%, transparent);
     border: none;
     border-radius: 50%;
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
     cursor: pointer;
-    transition: background $transition-fast, color $transition-fast;
+    transition: background var(--transition-fast), color var(--transition-fast);
     flex-shrink: 0;
 
     &:hover {
-      background: rgb(255 255 255 / 15%);
-      color: $text-primary;
+      background: color-mix(in srgb, var(--color-white) 15%, transparent);
+      color: var(--color-white);
     }
   }
 }
@@ -238,7 +228,7 @@ $transition-normal: 200ms ease;
 
 .note-text {
   font-size: 13px;
-  color: $text-primary;
+  color: var(--color-white);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -249,7 +239,7 @@ $transition-normal: 200ms ease;
 .note-selected-text {
   font-size: 12px;
   font-style: italic;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -262,7 +252,7 @@ $transition-normal: 200ms ease;
   flex-direction: column;
   gap: 4px;
   opacity: 0;
-  transition: opacity $transition-fast;
+  transition: opacity var(--transition-fast);
 }
 
 .edit-btn {
@@ -275,9 +265,9 @@ $transition-normal: 200ms ease;
   background: none;
   border: none;
   border-radius: 6px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   cursor: pointer;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   flex-shrink: 0;
 
   svg {
@@ -286,14 +276,14 @@ $transition-normal: 200ms ease;
   }
 
   &:hover {
-    background: rgb(99 102 241 / 15%);
-    color: $active-color;
+    background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+    color: var(--reader-chrome-accent);
   }
 }
 
 .item-chapter {
   font-size: 11px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -301,7 +291,7 @@ $transition-normal: 200ms ease;
 
 .item-meta {
   font-size: 11px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
 }
 
 .delete-btn {
@@ -314,10 +304,10 @@ $transition-normal: 200ms ease;
   background: none;
   border: none;
   border-radius: 6px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   cursor: pointer;
   opacity: 0;
-  transition: opacity $transition-fast, background $transition-fast, color $transition-fast;
+  transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
   flex-shrink: 0;
 
   svg {
@@ -326,8 +316,8 @@ $transition-normal: 200ms ease;
   }
 
   &:hover {
-    background: rgb(239 68 68 / 15%);
-    color: #ef4444;
+    background: color-mix(in srgb, var(--color-red-500) 15%, transparent);
+    color: var(--color-red-500);
   }
 }
 
@@ -339,7 +329,7 @@ $transition-normal: 200ms ease;
   justify-content: center;
   padding: 48px 24px;
   text-align: center;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
 }
 
 .empty-icon {
@@ -357,7 +347,7 @@ $transition-normal: 200ms ease;
 
 .empty-hint {
   font-size: 12px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
 }
 
 // Search
@@ -373,10 +363,10 @@ $transition-normal: 200ms ease;
   gap: 10px;
   padding: 12px 16px;
   background: rgb(0 0 0 / 20%);
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
 
   .search-icon {
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
     flex-shrink: 0;
   }
 
@@ -384,12 +374,12 @@ $transition-normal: 200ms ease;
     flex: 1;
     background: none;
     border: none;
-    color: $text-primary;
+    color: var(--color-white);
     font-size: 14px;
     outline: none;
 
     &::placeholder {
-      color: $text-muted;
+      color: var(--reader-chrome-fg-muted);
     }
   }
 
@@ -400,17 +390,17 @@ $transition-normal: 200ms ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-white) 10%, transparent);
     border: none;
     border-radius: 50%;
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
     cursor: pointer;
-    transition: background $transition-fast, color $transition-fast;
+    transition: background var(--transition-fast), color var(--transition-fast);
     flex-shrink: 0;
 
     &:hover {
-      background: rgb(255 255 255 / 15%);
-      color: $text-primary;
+      background: color-mix(in srgb, var(--color-white) 15%, transparent);
+      color: var(--color-white);
     }
   }
 }
@@ -423,13 +413,13 @@ $transition-normal: 200ms ease;
 
   .progress-bar {
     height: 3px;
-    background: rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-white) 10%, transparent);
     border-radius: 2px;
     overflow: hidden;
 
     .progress-fill {
       height: 100%;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       border-radius: 2px;
       transition: width 200ms ease-out;
     }
@@ -443,7 +433,7 @@ $transition-normal: 200ms ease;
 
   .progress-text {
     font-size: 11px;
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
   }
 
   .cancel-search-btn {
@@ -453,17 +443,17 @@ $transition-normal: 200ms ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgb(255 255 255 / 8%);
+    background: var(--reader-chrome-hover);
     border: none;
     border-radius: 50%;
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
     cursor: pointer;
-    transition: background $transition-fast, color $transition-fast;
+    transition: background var(--transition-fast), color var(--transition-fast);
     flex-shrink: 0;
 
     &:hover {
-      background: rgb(239 68 68 / 15%);
-      color: #ef4444;
+      background: color-mix(in srgb, var(--color-red-500) 15%, transparent);
+      color: var(--color-red-500);
     }
   }
 }
@@ -472,10 +462,10 @@ $transition-normal: 200ms ease;
   padding: 10px 16px;
   font-size: 11px;
   font-weight: 600;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
 }
 
 .search-results {
@@ -491,7 +481,7 @@ $transition-normal: 200ms ease;
 
 .search-excerpt {
   font-size: 13px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   line-height: 1.5;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -499,12 +489,12 @@ $transition-normal: 200ms ease;
   overflow: hidden;
 
   .excerpt-context {
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
   }
 
   .excerpt-match {
     background: rgb(255 255 0 / 25%);
-    color: $text-primary;
+    color: var(--color-white);
     font-weight: 500;
     padding: 1px 2px;
     border-radius: 2px;

--- a/frontend/src/app/features/readers/ebook-reader/layout/sidebar/sidebar.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/layout/sidebar/sidebar.component.scss
@@ -1,15 +1,6 @@
-// Variables
+@use '../../../shared/styles/reader-chrome' as *;
+
 $sidebar-width: 300px;
-$sidebar-bg: #1a1a1a;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$text-muted: rgb(255 255 255 / 40%);
-$border-color: rgb(255 255 255 / 8%);
-$hover-bg: rgb(255 255 255 / 6%);
-$active-bg: rgb(99 102 241 / 15%);
-$active-color: #818cf8;
-$transition-fast: 150ms ease;
-$transition-normal: 200ms ease;
 
 // Overlay
 .sidebar-overlay {
@@ -18,24 +9,24 @@ $transition-normal: 200ms ease;
   background: rgb(0 0 0 / 40%);
   backdrop-filter: blur(2px);
   z-index: 12000;
-  animation: fade-in $transition-normal;
+  animation: fade-in var(--transition-base);
 
   &.closing {
-    animation: fade-out $transition-normal forwards;
+    animation: fade-out var(--transition-base) forwards;
   }
 }
 
 // Sidebar container
 .sidebar {
+  @include surface;
+
   position: fixed;
   top: 0;
   left: 0;
   bottom: 0;
   width: $sidebar-width;
-  background: $sidebar-bg;
   display: flex;
   flex-direction: column;
-  color: $text-primary;
   box-shadow: 4px 0 24px rgb(0 0 0 / 30%);
   animation: slide-in 250ms cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 12001;
@@ -50,8 +41,8 @@ $transition-normal: 200ms ease;
   display: flex;
   gap: 14px;
   padding: 20px 16px;
-  border-bottom: 1px solid $border-color;
-  background: linear-gradient(180deg, rgb(255 255 255 / 3%) 0%, transparent 100%);
+  border-bottom: 1px solid var(--reader-chrome-border);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-white) 3%, transparent) 0%, transparent 100%);
 }
 
 .book-cover {
@@ -62,7 +53,7 @@ $transition-normal: 200ms ease;
   box-shadow: 0 4px 12px rgb(0 0 0 / 30%);
   flex-shrink: 0;
   cursor: pointer;
-  transition: transform $transition-fast, box-shadow $transition-fast;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 
   &:hover {
     transform: scale(1.03);
@@ -70,7 +61,7 @@ $transition-normal: 200ms ease;
   }
 
   &:focus-visible {
-    outline: 2px solid $active-color;
+    outline: 2px solid var(--reader-chrome-accent);
     outline-offset: 2px;
   }
 }
@@ -96,7 +87,7 @@ $transition-normal: 200ms ease;
 
 .book-authors {
   font-size: 12px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   margin: 0;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -107,7 +98,7 @@ $transition-normal: 200ms ease;
 // Tabs
 .tabs {
   display: flex;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
   background: rgb(0 0 0 / 20%);
 }
 
@@ -120,20 +111,20 @@ $transition-normal: 200ms ease;
   padding: 12px 8px;
   background: none;
   border: none;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
-  transition: color $transition-fast, background $transition-fast;
+  transition: color var(--transition-fast), background var(--transition-fast);
   position: relative;
 
   &:hover {
-    color: $text-primary;
-    background: $hover-bg;
+    color: var(--color-white);
+    background: var(--reader-chrome-hover);
   }
 
   &.active {
-    color: $active-color;
+    color: var(--reader-chrome-accent);
 
     &::after {
       content: '';
@@ -142,7 +133,7 @@ $transition-normal: 200ms ease;
       left: 16px;
       right: 16px;
       height: 2px;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       border-radius: 1px 1px 0 0;
     }
   }
@@ -160,7 +151,7 @@ $transition-normal: 200ms ease;
   min-width: 16px;
   height: 16px;
   padding: 0 4px;
-  background: $active-color;
+  background: var(--reader-chrome-accent);
   color: white;
   font-size: 10px;
   font-weight: 600;
@@ -197,19 +188,19 @@ $transition-normal: 200ms ease;
   padding-left: calc(16px + var(--depth, 0) * 16px);
   background: none;
   border: none;
-  color: $text-primary;
+  color: var(--color-white);
   font-size: 13px;
   text-align: left;
   cursor: pointer;
-  transition: background $transition-fast;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: $hover-bg;
+    background: var(--reader-chrome-hover);
   }
 
   &.active {
-    background: $active-bg;
-    color: $active-color;
+    background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+    color: var(--reader-chrome-accent);
     font-weight: 500;
   }
 
@@ -230,8 +221,8 @@ $transition-normal: 200ms ease;
   height: 16px;
   flex-shrink: 0;
   margin-left: 8px;
-  color: $text-muted;
-  transition: transform $transition-fast;
+  color: var(--reader-chrome-fg-muted);
+  transition: transform var(--transition-fast);
 
   &.expanded {
     transform: rotate(90deg);
@@ -251,10 +242,10 @@ $transition-normal: 200ms ease;
   gap: 12px;
   padding: 12px 16px;
   cursor: pointer;
-  transition: background $transition-fast;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: $hover-bg;
+    background: var(--reader-chrome-hover);
 
     .delete-btn {
       opacity: 1;
@@ -284,7 +275,7 @@ $transition-normal: 200ms ease;
 .item-title {
   font-size: 13px;
   font-weight: 500;
-  color: $text-primary;
+  color: var(--color-white);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -293,7 +284,7 @@ $transition-normal: 200ms ease;
 .highlight-text {
   font-size: 13px;
   font-style: italic;
-  color: $text-primary;
+  color: var(--color-white);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -303,7 +294,7 @@ $transition-normal: 200ms ease;
 
 .item-chapter {
   font-size: 11px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -311,7 +302,7 @@ $transition-normal: 200ms ease;
 
 .item-meta {
   font-size: 11px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
 }
 
 .action-buttons {
@@ -319,7 +310,7 @@ $transition-normal: 200ms ease;
   flex-direction: column;
   gap: 4px;
   opacity: 0;
-  transition: opacity $transition-fast;
+  transition: opacity var(--transition-fast);
   flex-shrink: 0;
 }
 
@@ -338,9 +329,9 @@ $transition-normal: 200ms ease;
   background: none;
   border: none;
   border-radius: 6px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
   cursor: pointer;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background var(--transition-fast), color var(--transition-fast);
   flex-shrink: 0;
 
   svg {
@@ -350,13 +341,13 @@ $transition-normal: 200ms ease;
 }
 
 .edit-btn:hover {
-  background: rgb(99 102 241 / 15%);
-  color: $active-color;
+  background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+  color: var(--reader-chrome-accent);
 }
 
 .delete-btn:hover {
-  background: rgb(239 68 68 / 15%);
-  color: #ef4444;
+  background: color-mix(in srgb, var(--color-red-500) 15%, transparent);
+  color: var(--color-red-500);
 }
 
 // Empty state
@@ -367,7 +358,7 @@ $transition-normal: 200ms ease;
   justify-content: center;
   padding: 48px 24px;
   text-align: center;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
 }
 
 .empty-icon {
@@ -385,7 +376,7 @@ $transition-normal: 200ms ease;
 
 .empty-hint {
   font-size: 12px;
-  color: $text-muted;
+  color: var(--reader-chrome-fg-muted);
 }
 
 // Search
@@ -401,10 +392,10 @@ $transition-normal: 200ms ease;
   gap: 10px;
   padding: 12px 16px;
   background: rgb(0 0 0 / 20%);
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
 
   .search-icon {
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
     flex-shrink: 0;
   }
 
@@ -412,12 +403,12 @@ $transition-normal: 200ms ease;
     flex: 1;
     background: none;
     border: none;
-    color: $text-primary;
+    color: var(--color-white);
     font-size: 14px;
     outline: none;
 
     &::placeholder {
-      color: $text-muted;
+      color: var(--reader-chrome-fg-muted);
     }
   }
 
@@ -428,17 +419,17 @@ $transition-normal: 200ms ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-white) 10%, transparent);
     border: none;
     border-radius: 50%;
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
     cursor: pointer;
-    transition: background $transition-fast, color $transition-fast;
+    transition: background var(--transition-fast), color var(--transition-fast);
     flex-shrink: 0;
 
     &:hover {
-      background: rgb(255 255 255 / 15%);
-      color: $text-primary;
+      background: color-mix(in srgb, var(--color-white) 15%, transparent);
+      color: var(--color-white);
     }
   }
 }
@@ -451,13 +442,13 @@ $transition-normal: 200ms ease;
 
   .progress-bar {
     height: 3px;
-    background: rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-white) 10%, transparent);
     border-radius: 2px;
     overflow: hidden;
 
     .progress-fill {
       height: 100%;
-      background: $active-color;
+      background: var(--reader-chrome-accent);
       border-radius: 2px;
       transition: width 200ms ease-out;
     }
@@ -465,7 +456,7 @@ $transition-normal: 200ms ease;
 
   .progress-text {
     font-size: 11px;
-    color: $text-muted;
+    color: var(--reader-chrome-fg-muted);
     text-align: center;
   }
 }
@@ -474,10 +465,10 @@ $transition-normal: 200ms ease;
   padding: 10px 16px;
   font-size: 11px;
   font-weight: 600;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid var(--reader-chrome-border);
 }
 
 .search-results {
@@ -493,7 +484,7 @@ $transition-normal: 200ms ease;
 
 .search-excerpt {
   font-size: 13px;
-  color: $text-secondary;
+  color: var(--reader-chrome-fg-secondary);
   line-height: 1.5;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -501,12 +492,12 @@ $transition-normal: 200ms ease;
   overflow: hidden;
 
   .excerpt-context {
-    color: $text-secondary;
+    color: var(--reader-chrome-fg-secondary);
   }
 
   .excerpt-match {
     background: rgb(255 255 0 / 25%);
-    color: $text-primary;
+    color: var(--color-white);
     font-weight: 500;
     padding: 1px 2px;
     border-radius: 2px;

--- a/frontend/src/app/features/readers/ebook-reader/shared/selection-popup.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/shared/selection-popup.component.scss
@@ -1,3 +1,5 @@
+@use '../../shared/styles/reader-chrome' as *;
+
 .popup-backdrop {
   position: fixed;
   inset: 0;
@@ -6,13 +8,13 @@
 }
 
 .text-selection-popup {
+  @include surface;
+
   position: fixed;
   display: flex;
   align-items: center;
   gap: 4px;
   padding: 6px 8px;
-  background: linear-gradient(180deg, #2d3139 0%, #252830 100%);
-  border: 1px solid rgb(255 255 255 / 8%);
   border-radius: 8px;
   box-shadow: 0 4px 16px rgb(0 0 0 / 30%), 0 0 1px rgb(0 0 0 / 20%);
   z-index: 99999;
@@ -59,18 +61,18 @@
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: rgb(255 255 255 / 80%);
+  color: color-mix(in srgb, var(--color-white) 80%, transparent);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background 0.15s ease, color 0.15s ease;
 
   &:hover {
-    background: rgb(255 255 255 / 10%);
-    color: #fff;
+    background: color-mix(in srgb, var(--color-white) 10%, transparent);
+    color: var(--color-white);
   }
 
   &.active {
-    background: rgb(255 255 255 / 12%);
-    color: #fff;
+    background: color-mix(in srgb, var(--color-white) 12%, transparent);
+    color: var(--color-white);
   }
 
   svg {
@@ -89,15 +91,15 @@
 
 .delete-btn {
   &:hover {
-    background: rgb(239 68 68 / 15%);
-    color: #ef4444;
+    background: color-mix(in srgb, var(--color-red-500) 15%, transparent);
+    color: var(--color-red-500);
   }
 }
 
 .divider {
   width: 1px;
   height: 20px;
-  background: rgb(255 255 255 / 10%);
+  background: color-mix(in srgb, var(--color-white) 10%, transparent);
   margin: 0 2px;
 }
 
@@ -106,12 +108,13 @@
 }
 
 .annotation-options {
+  @include surface;
+
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
   padding: 8px;
-  background: linear-gradient(180deg, #2d3139 0%, #252830 100%);
-  border: 1px solid rgb(255 255 255 / 8%);
+  border: 1px solid var(--reader-chrome-border);
   border-radius: 8px;
   box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
   z-index: 100000;
@@ -163,14 +166,16 @@
   width: 32px;
   height: 28px;
   padding: 0;
-  border: 1px solid rgb(255 255 255 / 10%);
+  border: 1px solid color-mix(in srgb, var(--color-white) 10%, transparent);
   border-radius: 4px;
-  background: rgb(255 255 255 / 3%);
-  color: rgb(255 255 255 / 70%);
+  background: color-mix(in srgb, var(--color-white) 3%, transparent);
+  color: color-mix(in srgb, var(--color-white) 70%, transparent);
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
 
   .style-text {
     display: block;
@@ -194,15 +199,15 @@
   }
 
   &:hover {
-    border-color: rgb(255 255 255 / 20%);
-    background: rgb(255 255 255 / 8%);
-    color: #fff;
+    border-color: color-mix(in srgb, var(--color-white) 20%, transparent);
+    background: var(--reader-chrome-hover);
+    color: var(--color-white);
   }
 
   &.selected {
-    border-color: #3b82f6;
-    background: rgb(59 130 246 / 15%);
-    color: #fff;
+    border-color: var(--reader-chrome-accent);
+    background: color-mix(in srgb, var(--reader-chrome-accent) 15%, transparent);
+    color: var(--color-white);
   }
 }
 
@@ -220,15 +225,16 @@
   border-radius: 50%;
   background: var(--color);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
 
   &:hover {
     transform: scale(1.1);
   }
 
   &.selected {
-    border-color: #fff;
-    box-shadow: 0 0 0 2px rgb(59 130 246 / 50%);
+    border-color: var(--color-white);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--reader-chrome-accent) 50%, transparent);
   }
 }
-

--- a/frontend/src/app/features/readers/pdf-reader/components/pdf-sidebar.component.scss
+++ b/frontend/src/app/features/readers/pdf-reader/components/pdf-sidebar.component.scss
@@ -1,18 +1,12 @@
+@use '../../shared/styles/reader-chrome' as *;
+
 $sidebar-width: 320px;
-$sidebar-bg: #141414;
-$sidebar-bg-light: #fff;
-$text-primary: #fff;
-$text-primary-light: #1a1a1a;
-$text-secondary: rgb(255 255 255 / 70%);
-$text-secondary-light: rgb(0 0 0 / 60%);
-$text-muted: rgb(255 255 255 / 45%);
-$text-muted-light: rgb(0 0 0 / 40%);
-$border-color: rgb(255 255 255 / 10%);
-$border-color-light: rgb(0 0 0 / 8%);
-$hover-bg: rgb(255 255 255 / 6%);
-$hover-bg-light: rgb(0 0 0 / 4%);
-$active-bg: #3b82f6;
-$active-color: #3b82f6;
+$text-primary: var(--reader-chrome-fg);
+$text-secondary: var(--reader-chrome-fg-secondary);
+$text-muted: var(--reader-chrome-fg-muted);
+$border-color: var(--reader-chrome-border);
+$hover-bg: var(--reader-chrome-hover);
+$active-color: var(--reader-chrome-accent);
 $transition-base: 250ms cubic-bezier(0.4, 0, 0.2, 1);
 $transition-fast: 150ms ease;
 
@@ -33,13 +27,13 @@ $transition-fast: 150ms ease;
 }
 
 .sidebar {
+  @include surface;
+
   position: fixed;
   top: 0;
   left: 0;
   bottom: 0;
   width: $sidebar-width;
-  background: $sidebar-bg;
-  color: $text-primary;
   display: flex;
   flex-direction: column;
   box-shadow: 12px 0 32px rgb(0 0 0 / 40%);
@@ -79,7 +73,7 @@ $transition-fast: 150ms ease;
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: all $transition-fast;
+      transition: background $transition-fast, color $transition-fast;
 
       &:hover {
         color: $text-primary;
@@ -111,7 +105,7 @@ $transition-fast: 150ms ease;
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  transition: all $transition-fast;
+  transition: background $transition-fast, color $transition-fast;
   min-width: 0;
 
   span {
@@ -129,7 +123,7 @@ $transition-fast: 150ms ease;
     height: 3px;
     background: transparent;
     border-radius: 3px 3px 0 0;
-    transition: all $transition-fast;
+    transition: background $transition-fast, box-shadow $transition-fast;
   }
 
   &:hover {
@@ -192,7 +186,7 @@ $transition-fast: 150ms ease;
   font-size: 13.5px;
   font-weight: 500;
   cursor: pointer;
-  transition: all $transition-fast;
+  transition: background $transition-fast, color $transition-fast;
   text-align: left;
   line-height: 1.4;
 
@@ -238,7 +232,9 @@ $transition-fast: 150ms ease;
   cursor: pointer;
   background: rgb(255 255 255 / 1%);
   border: 1px solid transparent;
-  transition: all $transition-fast;
+  transition: background $transition-fast,
+    border-color $transition-fast,
+    transform $transition-fast;
 
   &:hover {
     background: $hover-bg;
@@ -315,7 +311,11 @@ $transition-fast: 150ms ease;
   cursor: pointer;
   opacity: 0;
   transform: translateX(8px);
-  transition: all $transition-fast;
+  transition: background $transition-fast,
+    box-shadow $transition-fast,
+    color $transition-fast,
+    opacity $transition-fast,
+    transform $transition-fast;
   flex-shrink: 0;
 
   &:hover {
@@ -376,78 +376,4 @@ $transition-fast: 150ms ease;
 @keyframes slide-out {
   from { transform: translateX(0); }
   to { transform: translateX(-100%); }
-}
-
-// --- Light Theme Support ---
-
-:host-context([data-color-scheme="light"]) {
-  .sidebar-overlay {
-    background: rgb(0 0 0 / 20%);
-  }
-  
-  .sidebar {
-    background: $sidebar-bg-light;
-    color: $text-primary-light;
-    border-right-color: $border-color-light;
-    box-shadow: 12px 0 32px rgb(0 0 0 / 10%);
-
-    .sidebar-header {
-      background: rgb(0 0 0 / 1%);
-      border-bottom-color: $border-color-light;
-      
-      .sidebar-title {
-        color: $text-muted-light;
-      }
-    }
-  }
-
-  .tabs {
-    border-bottom-color: $border-color-light;
-  }
-
-  .tab {
-    color: $text-secondary-light;
-
-    &:hover {
-      background: $hover-bg-light;
-      color: $text-primary-light;
-    }
-  }
-
-  .tab-item:hover, .chapter-row:hover {
-    background: $hover-bg-light;
-  }
-
-  .chapter-row {
-    color: $text-secondary-light;
-
-    &:hover {
-      color: $text-primary-light;
-    }
-
-    .chapter-page {
-      color: $text-muted-light;
-    }
-  }
-
-  .reader-list-item {
-    background: rgb(0 0 0 / 2%);
-
-    &:hover {
-      background: $hover-bg-light;
-      border-color: $border-color-light;
-    }
-  }
-
-  .item-title {
-    color: $text-primary-light;
-  }
-  
-  .item-meta {
-    color: $text-muted-light;
-  }
-
-  .highlight-text {
-    color: $text-secondary-light;
-  }
 }

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
@@ -1,16 +1,20 @@
-@use 'sass:color';
+@use '../shared/styles/reader-chrome' as *;
 
 /* stylelint-disable selector-id-pattern, selector-class-pattern */
 
 // Design tokens matching CBX/E-Book readers
 $header-height: 38px;
 $footer-height: 52px;
-$gradient-bg: linear-gradient(135deg, #2d2d2d 0%, #1f1f1f 100%);
-$border-color: #404040;
-$text-primary: rgb(255 255 255 / 95%);
-$text-secondary: rgb(255 255 255 / 60%);
-$active-color: #4a90e2;
-$hover-bg: rgb(255 255 255 / 12%);
+$chrome-bg: var(--reader-chrome-bg);
+$chrome-bg-raised: var(--reader-chrome-bg-raised);
+$chrome-control-bg: var(--reader-chrome-control-bg);
+$border-color: var(--reader-chrome-border);
+$strong-border-color: var(--reader-chrome-strong-border);
+$text-primary: var(--reader-chrome-fg);
+$text-secondary: var(--reader-chrome-fg-secondary);
+$active-color: var(--reader-chrome-accent);
+$active-hover-color: var(--reader-chrome-accent-hover);
+$hover-bg: var(--reader-chrome-hover);
 $transition-fast: 150ms ease;
 
 .v-hidden {
@@ -20,23 +24,27 @@ $transition-fast: 150ms ease;
 // --- Loading ---
 
 .loading-container {
+  @include tokens;
+
   position: fixed;
   inset: 0;
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100dvh;
-  background: #1a1a1a;
+  background: $chrome-bg;
   z-index: 1000;
 }
 
 // --- Reader container ---
 
 .pdf-reader-container {
+  @include tokens;
+
   position: fixed;
   inset: 0;
   height: 100dvh;
-  background: #1a1a1a;
+  background: $chrome-bg;
   z-index: 900;
   overflow: hidden;
   box-sizing: border-box;
@@ -88,10 +96,10 @@ $transition-fast: 150ms ease;
   align-items: center;
   justify-content: space-between;
   z-index: 1001;
-  background: $gradient-bg;
+  background: $chrome-bg;
   border-bottom: 1px solid $border-color;
   box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
-  color: #fff;
+  color: $text-primary;
   opacity: 1;
   pointer-events: auto;
   transform: translateY(0);
@@ -194,7 +202,7 @@ $transition-fast: 150ms ease;
   right: 0;
   height: 36px;
   z-index: 1002;
-  background: color.adjust(#2d2d2d, $lightness: -3%);
+  background: $chrome-bg-raised;
   border-bottom: 1px solid $border-color;
   display: flex;
   align-items: center;
@@ -216,7 +224,7 @@ $transition-fast: 150ms ease;
     gap: 6px;
     flex: 1;
     max-width: 360px;
-    background: #404040;
+    background: $chrome-control-bg;
     border-radius: 4px;
     padding: 0 8px;
     color: $text-secondary;
@@ -264,7 +272,7 @@ $transition-fast: 150ms ease;
   left: 50%;
   transform: translateX(-50%);
   margin-top: 4px;
-  background: #333;
+  background: $chrome-bg-raised;
   border: 1px solid $border-color;
   border-radius: 6px;
   padding: 4px 0;
@@ -330,7 +338,7 @@ $transition-fast: 150ms ease;
   justify-content: space-between;
   gap: 12px;
   z-index: 1002;
-  background: $gradient-bg;
+  background: $chrome-bg;
   border-top: 1px solid $border-color;
   box-shadow: 0 -2px 8px rgb(0 0 0 / 30%);
   color: $text-primary;
@@ -354,33 +362,36 @@ $transition-fast: 150ms ease;
 }
 
 .nav-btn {
-  background: rgb(51 51 51 / 90%);
-  border: 1px solid #555;
+  background: $chrome-control-bg;
+  border: 1px solid $strong-border-color;
   color: $text-primary;
   padding: 6px 10px;
   border-radius: 4px;
   cursor: pointer;
-  transition: all $transition-fast;
+  transition: background $transition-fast,
+    border-color $transition-fast,
+    color $transition-fast,
+    opacity $transition-fast;
   display: flex;
   align-items: center;
   justify-content: center;
 
   &:hover:not(:disabled) {
-    background: #4a4a4a;
-    border-color: #666;
+    background: $hover-bg;
+    border-color: color-mix(in srgb, var(--reader-chrome-fg) 25%, transparent);
   }
 
   &:disabled {
-    background: #2a2a2a;
-    color: #666;
+    background: color-mix(in srgb, var(--reader-chrome-fg) 4%, transparent);
+    color: var(--reader-chrome-fg-muted);
     cursor: not-allowed;
-    border-color: #333;
+    border-color: $border-color;
   }
 }
 
 .page-info {
   padding: 4px 12px;
-  background: rgb(255 255 255 / 10%);
+  background: $chrome-control-bg;
   border-radius: 4px;
   font-size: 13px;
   font-weight: 500;
@@ -427,7 +438,7 @@ $transition-fast: 150ms ease;
     &::-webkit-slider-runnable-track {
       width: 100%;
       height: 6px;
-      background: rgb(255 255 255 / 12%);
+      background: color-mix(in srgb, var(--reader-chrome-fg) 12%, transparent);
       border-radius: 3px;
       cursor: pointer;
     }
@@ -435,7 +446,7 @@ $transition-fast: 150ms ease;
     &::-moz-range-track {
       width: 100%;
       height: 6px;
-      background: rgb(255 255 255 / 12%);
+      background: color-mix(in srgb, var(--reader-chrome-fg) 12%, transparent);
       border-radius: 3px;
       cursor: pointer;
     }
@@ -487,7 +498,7 @@ $transition-fast: 150ms ease;
         transform: translateX(-50%);
         width: 2px;
         height: 10px;
-        background: rgb(255 255 255 / 50%);
+        background: color-mix(in srgb, var(--reader-chrome-fg) 50%, transparent);
         top: 0;
       }
     }
@@ -505,24 +516,24 @@ $transition-fast: 150ms ease;
     white-space: nowrap;
     gap: 6px;
     padding: 0 12px;
-    border: 1px solid var(--surface-border);
-    background: var(--surface-card);
-    color: var(--text-color-secondary);
+    border: 1px solid $strong-border-color;
+    background: $chrome-control-bg;
+    color: $text-secondary;
     cursor: pointer;
     font-size: 0.85rem;
     font-weight: 500;
-    transition: all 0.2s;
+    transition: background 0.2s, border-color 0.2s, color 0.2s;
     height: 30px;
 
     &:hover {
-      color: var(--text-color);
-      background: var(--surface-hover);
+      color: $text-primary;
+      background: $hover-bg;
     }
 
     &.active {
-      background: var(--primary-color);
-      color: var(--primary-color-text);
-      border-color: var(--primary-color);
+      background: $active-color;
+      color: $text-primary;
+      border-color: $active-color;
       z-index: 1;
     }
 
@@ -544,9 +555,9 @@ $transition-fast: 150ms ease;
   bottom: 80px;
   left: 24px;
   z-index: 1001;
-  background-color: var(--surface-card);
-  color: var(--text-color-secondary);
-  border: 1px solid var(--surface-border);
+  background-color: $chrome-bg-raised;
+  color: $text-secondary;
+  border: 1px solid $border-color;
   padding: 8px 16px;
   border-radius: 20px;
   display: flex;
@@ -559,7 +570,7 @@ $transition-fast: 150ms ease;
 
   i {
     font-size: 1rem;
-    color: var(--primary-color);
+    color: $active-color;
   }
 }
 
@@ -647,7 +658,7 @@ $transition-fast: 150ms ease;
   top: 48px;
   right: 12px;
   z-index: 1010;
-  background: rgb(45 45 45 / 90%);
+  background: color-mix(in srgb, var(--reader-chrome-bg-raised) 90%, transparent);
   color: $text-primary;
   padding: 6px 12px;
   border-radius: 20px;
@@ -670,11 +681,11 @@ $transition-fast: 150ms ease;
     align-items: center;
     padding: 2px;
     border-radius: 50%;
-    transition: all 0.2s;
+    transition: background 0.2s, color 0.2s;
 
     &:hover {
-      color: #fff;
-      background: rgb(255 255 255 / 10%);
+      color: $text-primary;
+      background: $hover-bg;
     }
   }
 }
@@ -718,24 +729,24 @@ $transition-fast: 150ms ease;
   display: flex;
   align-items: center;
   gap: 4px;
-  background: rgb(51 51 51 / 90%);
+  background: $chrome-control-bg;
   border-radius: 4px;
   padding: 2px;
-  border: 1px solid #555;
+  border: 1px solid $strong-border-color;
 
   .page-input {
     width: 55px;
     padding: 4px 6px;
     border: none;
     border-radius: 3px;
-    background: #404040;
+    background: $chrome-control-bg;
     color: $text-primary;
     font-size: 12px;
     text-align: center;
 
     &:focus {
       outline: none;
-      background: #4a4a4a;
+      background: $hover-bg;
     }
 
     &::placeholder {
@@ -756,7 +767,7 @@ $transition-fast: 150ms ease;
     transition: background $transition-fast;
 
     &:hover:not(:disabled) {
-      background: color.adjust($active-color, $lightness: -10%);
+      background: $active-hover-color;
     }
 
     &:disabled {
@@ -796,7 +807,7 @@ $transition-fast: 150ms ease;
   top: $header-height;
   right: 8px;
   z-index: 1010;
-  background: #2d2d2d;
+  background: $chrome-bg-raised;
   border: 1px solid $border-color;
   border-radius: 8px;
   padding: 4px 0;

--- a/frontend/src/app/features/readers/shared/styles/_reader-chrome.scss
+++ b/frontend/src/app/features/readers/shared/styles/_reader-chrome.scss
@@ -1,0 +1,37 @@
+@mixin tokens {
+  color-scheme: dark;
+
+  --reader-chrome-fg: var(--color-white);
+  --reader-chrome-fg-secondary: color-mix(in srgb, var(--reader-chrome-fg) 60%, transparent);
+  --reader-chrome-fg-muted: color-mix(in srgb, var(--reader-chrome-fg) 40%, transparent);
+  --reader-chrome-bg: var(--color-surface-900);
+  --reader-chrome-bg-raised: color-mix(in srgb, var(--reader-chrome-fg) 5%, var(--reader-chrome-bg));
+  --reader-chrome-control-bg: color-mix(in srgb, var(--reader-chrome-fg) 10%, transparent);
+  --reader-chrome-border: color-mix(in srgb, var(--reader-chrome-fg) 8%, transparent);
+  --reader-chrome-strong-border: color-mix(in srgb, var(--reader-chrome-fg) 18%, transparent);
+  --reader-chrome-hover: color-mix(in srgb, var(--reader-chrome-fg) 8%, transparent);
+  --reader-chrome-accent: var(--color-primary-400);
+  --reader-chrome-accent-hover: var(--color-primary-300);
+  --reader-chrome-accent-active: var(--color-primary-200);
+}
+
+@mixin surface {
+  @include tokens;
+
+  background: var(--reader-chrome-bg);
+  color: var(--reader-chrome-fg);
+
+  :is(h1, h2, h3, h4, h5, h6, p) {
+    color: inherit;
+  }
+}
+
+@mixin text {
+  @include tokens;
+
+  color: var(--reader-chrome-fg);
+
+  :is(h1, h2, h3, h4, h5, h6, p) {
+    color: inherit;
+  }
+}


### PR DESCRIPTION
## Description

Requires #1468, I'll rebase once that's in. 

With the introduction of light mode, some basic text colour tokens that the reader interfaces use suddenly have the wrong text colour, usually black text on black reader UI. 

This adds a single set of reader-chrome CSS, reducing duplicate hardcoded colour values across all the readers and fixing visual regressions with the new light mode. 

## Linked Issue

N/A

## Changes

- New reader_chrome.scss with consistent colours regardless of dark/light theme. 
- Removed duplicate colours used in every reader SCSS file, switched to the reader-chrome tokens. 

## Manual Testing Steps

Open each of the readers (PDF, epub, CBX, audiobook), verify that the control interfaces look consistent when the Grimmory UI is set to both light and dark mode. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

This does not affect the actual reading UI, the pages etc - they continue to have their own theme options, light/dark mode etc. This concerns the control chrome around them only. 

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Unified design system across all reader applications for improved visual consistency.
  * Optimized animations and transitions throughout the interface for smoother interactive performance.
  * Enhanced interactive element styling, including refined hover and focus states for clearer user feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->