### PR TITLE
refactor(api): avoid using objectmapper on `TaskCreateRequest`

### DIFF
--- a/backend/src/main/java/org/booklore/model/dto/request/TaskCreateRequest.java
+++ b/backend/src/main/java/org/booklore/model/dto/request/TaskCreateRequest.java
@@ -10,7 +10,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.booklore.model.enums.TaskType;
 import org.booklore.task.options.LibraryRescanOptions;
-import tools.jackson.databind.ObjectMapper;
 
 @Data
 @Builder
@@ -31,13 +30,10 @@ public class TaskCreateRequest {
     private Object options;
 
     public <T> T getOptionsAs(Class<T> optionsClass) {
-        if (options == null) {
-            return null;
-        }
         if (optionsClass.isInstance(options)) {
             return optionsClass.cast(options);
         }
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.convertValue(options, optionsClass);
+
+        return null;
     }
 }

--- a/backend/src/main/java/org/booklore/task/tasks/RefreshMetadataTask.java
+++ b/backend/src/main/java/org/booklore/task/tasks/RefreshMetadataTask.java
@@ -18,6 +18,7 @@ import static org.booklore.model.enums.UserPermission.CAN_BULK_AUTO_FETCH_METADA
 @Component
 @Slf4j
 public class RefreshMetadataTask implements Task {
+
     private final MetadataRefreshService metadataRefreshService;
 
     @Override

--- a/backend/src/main/java/org/booklore/task/tasks/RefreshMetadataTask.java
+++ b/backend/src/main/java/org/booklore/task/tasks/RefreshMetadataTask.java
@@ -18,7 +18,6 @@ import static org.booklore.model.enums.UserPermission.CAN_BULK_AUTO_FETCH_METADA
 @Component
 @Slf4j
 public class RefreshMetadataTask implements Task {
-
     private final MetadataRefreshService metadataRefreshService;
 
     @Override

--- a/backend/src/test/java/org/booklore/task/tasks/LibraryRescanTaskTest.java
+++ b/backend/src/test/java/org/booklore/task/tasks/LibraryRescanTaskTest.java
@@ -39,19 +39,17 @@ class LibraryRescanTaskTest {
 
     private BookLoreUser user;
     private TaskCreateRequest request;
-    private LibraryRescanOptions options;
 
     @BeforeEach
     void setUp() {
         user = BookLoreUser.builder()
                 .permissions(new BookLoreUser.UserPermissions())
                 .build();
-        request = mock(TaskCreateRequest.class);
-        
-        // Lenient stubs because not all tests use them
-        lenient().when(request.getTaskId()).thenReturn("task-123");
-        options = LibraryRescanOptions.builder().build();
-        lenient().when(request.getOptionsAs(LibraryRescanOptions.class)).thenReturn(options);
+
+        request = TaskCreateRequest.builder()
+                .taskId("task-123")
+                .options(LibraryRescanOptions.builder().build())
+                .build();
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/task/tasks/RefreshMetadataTaskTest.java
+++ b/backend/src/test/java/org/booklore/task/tasks/RefreshMetadataTaskTest.java
@@ -39,11 +39,12 @@ class RefreshMetadataTaskTest {
     void setUp() {
         BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();
         user = BookLoreUser.builder().permissions(permissions).build();
-        
-        taskCreateRequest = mock(TaskCreateRequest.class);
+
         metadataRefreshRequest = MetadataRefreshRequest.builder().build();
-        
-        when(taskCreateRequest.getOptionsAs(MetadataRefreshRequest.class)).thenReturn(metadataRefreshRequest);
+        taskCreateRequest = TaskCreateRequest.builder()
+                .taskId("task-1")
+                .options(metadataRefreshRequest)
+                .build();
     }
 
     @Test
@@ -111,16 +112,27 @@ class RefreshMetadataTaskTest {
     }
 
     @Test
+    void execute_shouldHandleMissingOptions() {
+        taskCreateRequest.setOptions(null);
+
+        refreshMetadataTask.execute(taskCreateRequest);
+
+        ArgumentCaptor<MetadataRefreshRequest> requestCaptor = ArgumentCaptor.forClass(MetadataRefreshRequest.class);
+
+        verify(metadataRefreshService).refreshMetadata(requestCaptor.capture(), anyString());
+        assertNull(requestCaptor.getValue());
+    }
+
+    @Test
     void execute_shouldCallServiceAndReturnCompleted() {
-        when(taskCreateRequest.getTaskId()).thenReturn("task-1");
         TaskCreateResponse response = refreshMetadataTask.execute(taskCreateRequest);
 
         assertEquals(TaskStatus.COMPLETED, response.getStatus());
         assertEquals("task-1", response.getTaskId());
-        
+
         ArgumentCaptor<MetadataRefreshRequest> requestCaptor = ArgumentCaptor.forClass(MetadataRefreshRequest.class);
         ArgumentCaptor<String> taskIdCaptor = ArgumentCaptor.forClass(String.class);
-        
+
         verify(metadataRefreshService).refreshMetadata(requestCaptor.capture(), taskIdCaptor.capture());
         assertEquals(metadataRefreshRequest, requestCaptor.getValue());
         assertEquals("task-1", taskIdCaptor.getValue());
@@ -128,7 +140,6 @@ class RefreshMetadataTaskTest {
 
     @Test
     void execute_shouldPropagateException_whenServiceThrows() {
-        when(taskCreateRequest.getTaskId()).thenReturn("task-1");
         doThrow(new RuntimeException("Service error")).when(metadataRefreshService).refreshMetadata(metadataRefreshRequest, "task-1");
 
         assertThrows(RuntimeException.class, () -> refreshMetadataTask.execute(taskCreateRequest));
@@ -136,7 +147,6 @@ class RefreshMetadataTaskTest {
 
     @Test
     void execute_shouldHandleCancellation() {
-        when(taskCreateRequest.getTaskId()).thenReturn("task-1");
         doThrow(new CancellationException("Task cancelled")).when(metadataRefreshService).refreshMetadata(metadataRefreshRequest, "task-1");
 
         assertThrows(CancellationException.class, () -> refreshMetadataTask.execute(taskCreateRequest));


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
Jackson has the following message at the top of the Blackbird README:

> Warning The Java implementation of lambdas associates each generated lambda object strongly with the ClassLoader of the target class. This means that each Blackbird instance will add dynamic accessors to your classes that cannot be unloaded until the entire ClassLoader is garbage collected. Therefore, Blackbird is not appropriate if you instantiate many ObjectMappers, since you will eventually run out of class space and OOM.

While I don't think this is the cause of the issues we're seeing with blackbird serialization, it's possible that we are doing something weird with classloaders, so we should avoid making our own `ObjectMapper`s.

This removes the `ObjectMapper` from `TaskCreateRequest` - through testing, I cannot find a case where the code path was being hit and doing anything meaningful.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
Related to #1071

## Changes

* drops `ObjectMapper.convertValue()` call from `TaskCreateRequest`
* updates tests to match new behavior

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Open Grimmory
2. Select library extra actions v-ellipsis & click rescan
3. Inspect logs for errors
4. Go to settings -> Tasks
5. Run "Refresh Metadata" task
6. Run "Sync Library Files" task
7. Inspect logs for errors

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permission checks now safely handle missing or invalid refresh requests and task options, preventing failures when optional refresh parameters are absent.

* **Tests**
  * Tests updated to use realistic request objects and cover missing/invalid task options, improving confidence in task processing and permission-validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->