### PR TITLE
fix(ui): backfill legacy appearance theme to system

### DIFF
--- a/frontend/src/app/shared/service/app-config.service.spec.ts
+++ b/frontend/src/app/shared/service/app-config.service.spec.ts
@@ -123,7 +123,7 @@ describe('AppConfigService', () => {
     );
   });
 
-  it('resets legacy saved palette state to the default theme and dark appearance', () => {
+  it('resets legacy saved palette state to the default theme and system appearance', () => {
     localStorageMock.setItem('appConfigState', JSON.stringify({
       preset: 'Aura',
       primary: 'blue',
@@ -143,14 +143,14 @@ describe('AppConfigService', () => {
 
     expect(service.appState()).toEqual({
       themePreference: 'grimmory',
-      appearancePreference: 'dark',
+      appearancePreference: 'system',
       customPrimary: 'orange',
     });
     expect(root.dataset['appTheme']).toBe('grimmory');
-    expect(root.classList.contains('dark')).toBe(true);
+    expect(root.classList.contains('dark')).toBe(false);
     expect(localStorageMock.getItem('appConfigState')).toBe(JSON.stringify({
       themePreference: 'grimmory',
-      appearancePreference: 'dark',
+      appearancePreference: 'system',
       customPrimary: 'orange',
     }));
   });

--- a/frontend/src/app/shared/service/app-config.service.ts
+++ b/frontend/src/app/shared/service/app-config.service.ts
@@ -15,7 +15,6 @@ import {
 
 const PRIMARY_COLOR_STOPS = ['50', '100', '200', '300', '400', '500', '600', '700', '800', '900', '950'];
 const DEFAULT_APPEARANCE_PREFERENCE: AppearancePreference = 'system';
-const LEGACY_APPEARANCE_PREFERENCE: AppearancePreference = 'dark';
 
 type StoredAppState = Partial<AppState> & {
   preset?: unknown;
@@ -95,7 +94,7 @@ export class AppConfigService {
     if (this.isLegacyPaletteState(state)) {
       return this.withDefaults({
         themePreference: DEFAULT_APP_THEME,
-        appearancePreference: LEGACY_APPEARANCE_PREFERENCE,
+        appearancePreference: DEFAULT_APPEARANCE_PREFERENCE,
         customPrimary: DEFAULT_CUSTOM_PRIMARY,
       });
     }


### PR DESCRIPTION
## Description

Follow up to https://github.com/grimmory-tools/grimmory/pull/1468 to keep the backfill for app theme to system. Will help drive feedback more easily from nightly testers.

## Linked Issue

N/A

## Changes

- Kill `LEGACY_APPEARANCE_PREFERENCE`, replace w/ existing default value

## Manual Testing Steps

1. Verify light theme on backfilled clients

## Screenshots (Optional)

N/A

## Additional Context (Optional)

As per a convo w/ James

## AI Disclosure

N/A

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default appearance preference to follow system settings instead of dark mode.
  * Improved handling of legacy appearance preference settings to ensure proper normalization when migrating stored preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->