### PR TITLE
fix(ui): stats light mode theming

### DIFF
--- a/frontend/src/app/features/stats/component/_chart-shared.scss
+++ b/frontend/src/app/features/stats/component/_chart-shared.scss
@@ -1,5 +1,34 @@
 // Shared chart styles for consistency across all chart components
 
+@mixin accent-surface($radius: 20px) {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--stats-badge-accent) 20%, transparent),
+    color-mix(in srgb, var(--stats-badge-accent) 10%, transparent)
+  );
+  border: 1px solid color-mix(in srgb, var(--stats-badge-accent) 30%, transparent);
+  border-radius: $radius;
+}
+
+@mixin accent-text($accent-weight: 62%) {
+  color: color-mix(in srgb, var(--stats-badge-accent) $accent-weight, var(--color-text));
+}
+
+@mixin accent-badge {
+  @include accent-surface;
+  @include accent-text;
+
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+@mixin neutral-surface($radius: 8px) {
+  background: color-mix(in srgb, var(--color-text) 5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  border-radius: $radius;
+}
+
 .chart-header {
   display: flex;
   justify-content: space-between;
@@ -13,7 +42,7 @@
     min-width: 200px;
 
     h3 {
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       font-size: 1.25rem;
       font-weight: 500;
       margin: 0 0 0.5rem;
@@ -23,7 +52,7 @@
     }
 
     .chart-description {
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       font-size: 0.9rem;
       margin: 0;
       line-height: 1.4;
@@ -31,20 +60,22 @@
   }
 
   .stats-badge {
+    @include neutral-surface;
+
     display: flex;
     flex-direction: column;
     align-items: center;
-    border-radius: 8px;
     padding: 0.5rem 1rem;
 
     .badge-value {
       font-size: 1.5rem;
       font-weight: 600;
+      color: var(--color-text);
     }
 
     .badge-label {
       font-size: 0.75rem;
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }
@@ -58,7 +89,7 @@
   justify-content: center;
   padding: 2rem;
   text-align: center;
-  color: var(--text-secondary-color);
+  color: var(--color-text-secondary);
 
   i {
     font-size: 2rem;
@@ -69,7 +100,7 @@
   p {
     font-size: 0.9rem;
     margin: 0 0 0.5rem;
-    color: var(--text-color, #fff);
+    color: var(--color-text);
   }
 
   small {

--- a/frontend/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared' as chart-shared;
 
 .author-universe-container {
   width: 100%;
@@ -6,17 +6,14 @@
 
 .author-title-icon {
   font-size: 1.5rem;
-  color: #8b5cf6;
+  color: var(--color-violet-500);
 }
 
 .author-count-badge {
-  background: linear-gradient(135deg, rgb(139 92 246 / 20%), rgb(139 92 246 / 10%));
-  border: 1px solid rgb(139 92 246 / 30%);
-  border-radius: 20px;
-  padding: 0.4rem 1rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: #a78bfa;
+  --stats-badge-accent: var(--color-violet-500);
+
+  @include chart-shared.accent-badge;
+
   white-space: nowrap;
 }
 
@@ -28,13 +25,13 @@
     align-items: center;
     gap: 0.5rem;
     font-size: 0.8rem;
-    color: var(--text-secondary-color);
-    background: rgb(255 255 255 / 5%);
-    border-radius: 6px;
     padding: 0.5rem 0.75rem;
+    color: var(--color-text-secondary);
+
+    @include chart-shared.neutral-surface(6px);
 
     i {
-      color: #8b5cf6;
+      color: var(--color-violet-500);
     }
   }
 }
@@ -48,7 +45,7 @@
 .insights-section {
   margin-top: 1.25rem;
   padding-top: 1rem;
-  border-top: 1px solid rgb(255 255 255 / 10%);
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .insights-grid {
@@ -61,27 +58,35 @@
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  background: linear-gradient(135deg, rgb(139 92 246 / 10%), rgb(139 92 246 / 5%));
-  border: 1px solid rgb(139 92 246 / 20%);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-violet-500) 10%, transparent),
+    color-mix(in srgb, var(--color-violet-500) 5%, transparent)
+  );
+  border: 1px solid color-mix(in srgb, var(--color-violet-500) 20%, transparent);
   border-radius: 8px;
   padding: 0.6rem 0.85rem;
   transition: all 0.2s ease;
 
   &:hover {
-    background: linear-gradient(135deg, rgb(139 92 246 / 15%), rgb(139 92 246 / 8%));
-    border-color: rgb(139 92 246 / 35%);
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-violet-500) 15%, transparent),
+      color-mix(in srgb, var(--color-violet-500) 8%, transparent)
+    );
+    border-color: color-mix(in srgb, var(--color-violet-500) 35%, transparent);
     transform: translateY(-1px);
   }
 
   .insight-icon {
-    color: #f59e0b;
+    color: var(--color-amber-500);
     font-size: 0.85rem;
     flex-shrink: 0;
   }
 
   .insight-text {
     font-size: 0.85rem;
-    color: var(--text-color, #fff);
+    color: var(--color-text);
     line-height: 1.3;
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.ts
@@ -7,6 +7,7 @@ import {BookService} from '../../../../../book/service/book.service';
 import {Book, ReadStatus} from '../../../../../book/model/book.model';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {AsyncPipe} from '@angular/common';
+import {StatsChartThemeService} from '../../../shared/stats-chart-theme.service';
 
 interface AuthorStats {
   name: string;
@@ -50,6 +51,7 @@ export class AuthorUniverseChartComponent {
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly chartTheme = inject(StatsChartThemeService);
   private readonly syncChartEffect = effect(() => {
     if (this.bookService.isBooksLoading()) {
       return;
@@ -90,7 +92,6 @@ export class AuthorUniverseChartComponent {
           title: {
             display: true,
             text: this.t.translate('statsLibrary.authorUniverse.axisBooks'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12,
@@ -98,7 +99,6 @@ export class AuthorUniverseChartComponent {
             }
           },
           ticks: {
-            color: 'rgba(255, 255, 255, 0.8)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -107,7 +107,6 @@ export class AuthorUniverseChartComponent {
             stepSize: 1
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.08)'
           },
           border: {display: false},
           min: 0
@@ -116,7 +115,6 @@ export class AuthorUniverseChartComponent {
           title: {
             display: true,
             text: this.t.translate('statsLibrary.authorUniverse.axisRating'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12,
@@ -124,7 +122,6 @@ export class AuthorUniverseChartComponent {
             }
           },
           ticks: {
-            color: 'rgba(255, 255, 255, 0.8)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -132,7 +129,6 @@ export class AuthorUniverseChartComponent {
             callback: (value) => value.toLocaleString()
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.08)'
           },
           border: {display: false},
           min: 0,
@@ -145,7 +141,6 @@ export class AuthorUniverseChartComponent {
           display: true,
           position: 'bottom',
           labels: {
-            color: 'rgba(255, 255, 255, 0.9)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -325,7 +320,6 @@ export class AuthorUniverseChartComponent {
         borderColor: COMPLETION_COLORS.high,
         borderWidth: 2,
         hoverBorderWidth: 3,
-        hoverBorderColor: '#ffffff'
       });
     }
 
@@ -337,7 +331,6 @@ export class AuthorUniverseChartComponent {
         borderColor: COMPLETION_COLORS.medium,
         borderWidth: 2,
         hoverBorderWidth: 3,
-        hoverBorderColor: '#ffffff'
       });
     }
 
@@ -349,7 +342,6 @@ export class AuthorUniverseChartComponent {
         borderColor: COMPLETION_COLORS.low,
         borderWidth: 2,
         hoverBorderWidth: 3,
-        hoverBorderColor: '#ffffff'
       });
     }
 
@@ -361,7 +353,6 @@ export class AuthorUniverseChartComponent {
         borderColor: COMPLETION_COLORS.minimal,
         borderWidth: 2,
         hoverBorderWidth: 3,
-        hoverBorderColor: '#ffffff'
       });
     }
 
@@ -373,7 +364,6 @@ export class AuthorUniverseChartComponent {
         borderColor: COMPLETION_COLORS.unread,
         borderWidth: 2,
         hoverBorderWidth: 3,
-        hoverBorderColor: '#ffffff'
       });
     }
 
@@ -497,6 +487,7 @@ export class AuthorUniverseChartComponent {
 
   private handleExternalTooltip(context: { chart: Chart; tooltip: TooltipModel<'bubble'> }): void {
     const {chart, tooltip} = context;
+    const colors = this.chartTheme.colors();
     let tooltipEl = document.getElementById('author-chart-tooltip');
 
     if (!tooltipEl) {
@@ -505,8 +496,6 @@ export class AuthorUniverseChartComponent {
       Object.assign(tooltipEl.style, {
         position: 'fixed',
         zIndex: '9999',
-        background: 'rgba(0, 0, 0, 0.95)',
-        border: '2px solid #8b5cf6',
         borderRadius: '8px',
         padding: '12px 16px',
         pointerEvents: 'none',
@@ -519,6 +508,9 @@ export class AuthorUniverseChartComponent {
       });
       document.body.appendChild(tooltipEl);
     }
+
+    tooltipEl.style.background = colors.surface;
+    tooltipEl.style.border = `1px solid ${colors.border}`;
 
     if (tooltip.opacity === 0) {
       tooltipEl.style.opacity = '0';
@@ -541,7 +533,7 @@ export class AuthorUniverseChartComponent {
 
     const safeGenres = this.escapeHtml(stats.categories.slice(0, 3).join(', '));
     const categoriesHtml = stats.categories.length > 0
-      ? `<div style="color:rgba(255,255,255,0.9);font-size:12px;line-height:1.6">${this.t.translate('statsLibrary.authorUniverse.tooltipGenres', {genres: safeGenres})}</div>`
+      ? `<div style="color:${colors.textSecondary};font-size:12px;line-height:1.6">${this.t.translate('statsLibrary.authorUniverse.tooltipGenres', {genres: safeGenres})}</div>`
       : '';
 
     const booksLine = this.t.translate('statsLibrary.authorUniverse.tooltipBooks', {count: stats.bookCount});
@@ -551,11 +543,11 @@ export class AuthorUniverseChartComponent {
 
     const safeName = this.escapeHtml(stats.name);
     tooltipEl.innerHTML = `
-      <div style="color:#fff;font-size:14px;font-weight:700;margin-bottom:6px">${safeName}</div>
-      <div style="color:rgba(255,255,255,0.9);font-size:12px;line-height:1.6">${booksLine}</div>
-      <div style="color:rgba(255,255,255,0.9);font-size:12px;line-height:1.6">${pagesLine}</div>
-      <div style="color:rgba(255,255,255,0.9);font-size:12px;line-height:1.6">${ratingLine}</div>
-      <div style="color:rgba(255,255,255,0.9);font-size:12px;line-height:1.6">${readLine}</div>
+      <div style="color:${colors.text};font-size:14px;font-weight:700;margin-bottom:6px">${safeName}</div>
+      <div style="color:${colors.textSecondary};font-size:12px;line-height:1.6">${booksLine}</div>
+      <div style="color:${colors.textSecondary};font-size:12px;line-height:1.6">${pagesLine}</div>
+      <div style="color:${colors.textSecondary};font-size:12px;line-height:1.6">${ratingLine}</div>
+      <div style="color:${colors.textSecondary};font-size:12px;line-height:1.6">${readLine}</div>
       ${categoriesHtml}
     `;
 

--- a/frontend/src/app/features/stats/component/library-stats/charts/book-formats-chart/book-formats-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/book-formats-chart/book-formats-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared';
 
 .book-formats-container {
   width: 100%;

--- a/frontend/src/app/features/stats/component/library-stats/charts/book-formats-chart/book-formats-chart.component.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/book-formats-chart/book-formats-chart.component.spec.ts
@@ -132,10 +132,10 @@ describe('BookFormatsChartComponent', () => {
 
     expect(dataset.data).toEqual([4, 3, 2, 1]);
     expect(dataset.backgroundColor).toEqual(EXPECTED_FORMAT_COLORS);
-    expect(dataset.borderColor).toEqual(EXPECTED_FORMAT_COLORS.map(() => 'rgba(255, 255, 255, 0.2)'));
-    expect(dataset.borderWidth).toBe(2);
-    expect(dataset.hoverBorderColor).toBe('#ffffff');
-    expect(dataset.hoverBorderWidth).toBe(3);
+    expect(dataset.borderColor).toBeUndefined();
+    expect(dataset.borderWidth).toBeUndefined();
+    expect(dataset.hoverBorderColor).toBeUndefined();
+    expect(dataset.hoverBorderWidth).toBeUndefined();
   });
 
   it('formats the tooltip callback from computed chart data without a live Chart.js instance', () => {

--- a/frontend/src/app/features/stats/component/library-stats/charts/book-formats-chart/book-formats-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/book-formats-chart/book-formats-chart.component.ts
@@ -57,7 +57,6 @@ export class BookFormatsChartComponent {
         display: true,
         position: 'right',
         labels: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -69,9 +68,6 @@ export class BookFormatsChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#E11D48',
         borderWidth: 2,
         cornerRadius: 8,
@@ -107,11 +103,7 @@ export class BookFormatsChartComponent {
       labels,
       datasets: [{
         data,
-        backgroundColor: colors,
-        borderColor: colors.map(() => 'rgba(255, 255, 255, 0.2)'),
-        borderWidth: 2,
-        hoverBorderColor: '#ffffff',
-        hoverBorderWidth: 3
+        backgroundColor: colors
       }]
     };
   });

--- a/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared';
 
 .language-chart-container {
   width: 100%;

--- a/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.spec.ts
@@ -178,10 +178,10 @@ describe('LanguageChartComponent', () => {
 
     expect(dataset.data).toEqual([17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3]);
     expect(dataset.backgroundColor).toEqual(EXPECTED_LANGUAGE_COLORS);
-    expect(dataset.borderColor).toEqual(EXPECTED_LANGUAGE_COLORS.map(() => 'rgba(255, 255, 255, 0.2)'));
-    expect(dataset.borderWidth).toBe(2);
-    expect(dataset.hoverBorderColor).toBe('#ffffff');
-    expect(dataset.hoverBorderWidth).toBe(3);
+    expect(dataset.borderColor).toBeUndefined();
+    expect(dataset.borderWidth).toBeUndefined();
+    expect(dataset.hoverBorderColor).toBeUndefined();
+    expect(dataset.hoverBorderWidth).toBeUndefined();
   });
 
   it('formats the tooltip callback from computed chart data without a live Chart.js instance', () => {

--- a/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.ts
@@ -160,7 +160,6 @@ export class LanguageChartComponent {
         display: true,
         position: 'right',
         labels: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -172,9 +171,6 @@ export class LanguageChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#2563EB',
         borderWidth: 2,
         cornerRadius: 8,
@@ -210,11 +206,7 @@ export class LanguageChartComponent {
       labels,
       datasets: [{
         data,
-        backgroundColor: colors,
-        borderColor: colors.map(() => 'rgba(255, 255, 255, 0.2)'),
-        borderWidth: 2,
-        hoverBorderColor: '#ffffff',
-        hoverBorderWidth: 3
+        backgroundColor: colors
       }]
     };
   });

--- a/frontend/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared';
 
 .metadata-score-container {
   width: 100%;

--- a/frontend/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.spec.ts
@@ -161,10 +161,10 @@ describe('MetadataScoreChartComponent', () => {
 
     expect(dataset.data).toEqual([1, 2, 2, 2, 2]);
     expect(dataset.backgroundColor).toEqual(EXPECTED_SCORE_COLORS);
-    expect(dataset.borderColor).toEqual(EXPECTED_SCORE_COLORS.map(() => 'rgba(255, 255, 255, 0.2)'));
-    expect(dataset.borderWidth).toBe(2);
-    expect(dataset.hoverBorderColor).toBe('#ffffff');
-    expect(dataset.hoverBorderWidth).toBe(3);
+    expect(dataset.borderColor).toBeUndefined();
+    expect(dataset.borderWidth).toBeUndefined();
+    expect(dataset.hoverBorderColor).toBeUndefined();
+    expect(dataset.hoverBorderWidth).toBeUndefined();
   });
 
   it('formats the tooltip callback from computed chart data without a live Chart.js instance', () => {

--- a/frontend/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.ts
@@ -61,7 +61,6 @@ export class MetadataScoreChartComponent {
         display: true,
         position: 'right',
         labels: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11
@@ -74,9 +73,6 @@ export class MetadataScoreChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#16A34A',
         borderWidth: 2,
         cornerRadius: 8,
@@ -112,11 +108,7 @@ export class MetadataScoreChartComponent {
       labels,
       datasets: [{
         data,
-        backgroundColor: colors,
-        borderColor: colors.map(() => 'rgba(255, 255, 255, 0.2)'),
-        borderWidth: 2,
-        hoverBorderColor: '#ffffff',
-        hoverBorderWidth: 3
+        backgroundColor: colors
       }]
     };
   });

--- a/frontend/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared';
 
 .page-count-container {
   width: 100%;

--- a/frontend/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.spec.ts
@@ -152,7 +152,7 @@ describe('PageCountChartComponent', () => {
 
     expect(dataset.data).toEqual([2, 2, 2, 2, 2, 2, 1]);
     expect(dataset.backgroundColor).toEqual(EXPECTED_PAGE_RANGE_COLORS);
-    expect(dataset.borderColor).toEqual(EXPECTED_PAGE_RANGE_COLORS.map(() => 'rgba(255, 255, 255, 0.2)'));
+    expect(dataset.borderColor).toBeUndefined();
     expect(dataset.borderWidth).toBe(1);
     expect(dataset.borderRadius).toBe(4);
     expect(dataset.barPercentage).toBe(0.8);

--- a/frontend/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.ts
@@ -64,9 +64,6 @@ export class PageCountChartComponent {
       legend: {display: false},
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#8B5CF6',
         borderWidth: 2,
         cornerRadius: 8,
@@ -90,14 +87,12 @@ export class PageCountChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsLibrary.pageCount.axisPageCount'),
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11
           }
         },
         ticks: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 10
@@ -110,7 +105,6 @@ export class PageCountChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsLibrary.pageCount.axisBooks'),
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11
@@ -118,7 +112,6 @@ export class PageCountChartComponent {
         },
         beginAtZero: true,
         ticks: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 10
@@ -127,7 +120,6 @@ export class PageCountChartComponent {
           maxTicksLimit: 6
         },
         grid: {
-          color: 'rgba(255, 255, 255, 0.1)'
         },
         border: {display: false}
       }
@@ -150,7 +142,6 @@ export class PageCountChartComponent {
       datasets: [{
         data,
         backgroundColor: colors,
-        borderColor: colors.map(() => 'rgba(255, 255, 255, 0.2)'),
         borderWidth: 1,
         borderRadius: 4,
         barPercentage: 0.8,

--- a/frontend/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared' as chart-shared;
 
 .publication-timeline-container {
   width: 100%;
@@ -6,17 +6,14 @@
 
 .timeline-title-icon {
   font-size: 1.5rem;
-  color: #a78bfa;
+  color: var(--color-violet-400);
 }
 
 .books-count-badge {
-  background: linear-gradient(135deg, rgb(167 139 250 / 20%), rgb(167 139 250 / 10%));
-  border: 1px solid rgb(167 139 250 / 30%);
-  border-radius: 20px;
-  padding: 0.4rem 1rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: #c4b5fd;
+  --stats-badge-accent: var(--color-violet-400);
+
+  @include chart-shared.accent-badge;
+
   white-space: nowrap;
 }
 
@@ -29,7 +26,7 @@
 .insights-section {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid rgb(255 255 255 / 10%);
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .insights-row {
@@ -44,27 +41,26 @@
   align-items: center;
   text-align: center;
   padding: 0.75rem;
-  border-radius: 8px;
-  background: rgb(255 255 255 / 3%);
-  border: 1px solid rgb(255 255 255 / 8%);
+
+  @include chart-shared.neutral-surface;
 
   .insight-label {
     font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    color: var(--text-secondary-color);
+    color: var(--color-text-secondary);
     margin-bottom: 0.25rem;
   }
 
   .insight-value {
     font-size: 1.5rem;
     font-weight: 600;
-    color: var(--text-color, #fff);
+    color: var(--color-text);
   }
 
   .insight-detail {
     font-size: 0.75rem;
-    color: var(--text-secondary-color);
+    color: var(--color-text-secondary);
     margin-top: 0.25rem;
     max-width: 150px;
     overflow: hidden;
@@ -74,49 +70,49 @@
 
   &.oldest {
     .insight-value {
-      color: #f59e0b;
+      color: var(--color-amber-500);
     }
   }
 
   &.average {
     .insight-value {
-      color: #a78bfa;
+      color: var(--color-violet-400);
     }
   }
 
   &.newest {
     .insight-value {
-      color: #22d3ee;
+      color: var(--color-cyan-400);
     }
   }
 
   &.timespan {
     .insight-value {
-      color: #f472b6;
+      color: var(--color-pink-400);
     }
   }
 
   &.peak {
     .insight-value {
-      color: #4ade80;
+      color: var(--color-green-400);
     }
   }
 
   &.golden-era {
     .insight-value {
-      color: #fb923c;
+      color: var(--color-orange-400);
     }
   }
 
   &.common-year {
     .insight-value {
-      color: #34d399;
+      color: var(--color-emerald-400);
     }
   }
 
   &.rarity {
     .insight-value {
-      color: #f87171;
+      color: var(--color-red-400);
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.ts
@@ -116,7 +116,6 @@ export class PublicationTimelineChartComponent {
         x: {
           beginAtZero: true,
           ticks: {
-            color: 'rgba(255, 255, 255, 0.8)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -125,13 +124,11 @@ export class PublicationTimelineChartComponent {
             stepSize: 1
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.08)'
           },
           border: {display: false},
           title: {
             display: true,
             text: this.t.translate('statsLibrary.publicationTimeline.axisNumberOfBooks'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12,
@@ -141,7 +138,6 @@ export class PublicationTimelineChartComponent {
         },
         y: {
           ticks: {
-            color: 'rgba(255, 255, 255, 0.9)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -159,9 +155,6 @@ export class PublicationTimelineChartComponent {
         },
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.95)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
           borderColor: '#a78bfa',
           borderWidth: 2,
           cornerRadius: 8,

--- a/frontend/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared' as chart-shared;
 
 .publication-trend-container {
   width: 100%;
@@ -6,17 +6,14 @@
 
 .trend-title-icon {
   font-size: 1.5rem;
-  color: #06b6d4;
+  color: var(--color-cyan-500);
 }
 
 .year-range-badge {
-  background: linear-gradient(135deg, rgb(6 182 212 / 20%), rgb(6 182 212 / 10%));
-  border: 1px solid rgb(6 182 212 / 30%);
-  border-radius: 20px;
-  padding: 0.4rem 1rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: #22d3ee;
+  --stats-badge-accent: var(--color-cyan-500);
+
+  @include chart-shared.accent-badge;
+
   white-space: nowrap;
 }
 
@@ -29,7 +26,7 @@
 .insights-section {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid rgb(255 255 255 / 10%);
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .insights-row {
@@ -47,76 +44,75 @@
   align-items: center;
   text-align: center;
   padding: 0.75rem;
-  border-radius: 8px;
-  background: rgb(255 255 255 / 3%);
-  border: 1px solid rgb(255 255 255 / 8%);
+
+  @include chart-shared.neutral-surface;
 
   .insight-label {
     font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    color: var(--text-secondary-color);
+    color: var(--color-text-secondary);
     margin-bottom: 0.25rem;
   }
 
   .insight-value {
     font-size: 1.5rem;
     font-weight: 600;
-    color: var(--text-color, #fff);
+    color: var(--color-text);
   }
 
   .insight-detail {
     font-size: 0.75rem;
-    color: var(--text-secondary-color);
+    color: var(--color-text-secondary);
     margin-top: 0.25rem;
   }
 
   &.peak {
     .insight-value {
-      color: #f59e0b;
+      color: var(--color-amber-500);
     }
   }
 
   &.recent {
     .insight-value {
-      color: #06b6d4;
+      color: var(--color-cyan-500);
     }
   }
 
   &.average {
     .insight-value {
-      color: #a78bfa;
+      color: var(--color-violet-400);
     }
   }
 
   &.productive {
     .insight-value {
-      color: #4ade80;
+      color: var(--color-green-400);
       font-size: 1.25rem;
     }
   }
 
   &.timespan {
     .insight-value {
-      color: #f472b6;
+      color: var(--color-pink-400);
     }
   }
 
   &.century21 {
     .insight-value {
-      color: #38bdf8;
+      color: var(--color-sky-400);
     }
   }
 
   &.classics {
     .insight-value {
-      color: #fbbf24;
+      color: var(--color-amber-400);
     }
   }
 
   &.unique {
     .insight-value {
-      color: #c084fc;
+      color: var(--color-purple-400);
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.ts
@@ -91,7 +91,6 @@ export class PublicationTrendChartComponent {
         borderColor: '#06b6d4',
         backgroundColor: 'rgba(6, 182, 212, 0.1)',
         pointBackgroundColor: '#06b6d4',
-        pointBorderColor: '#ffffff',
         fill: true
       }]
     };
@@ -111,7 +110,6 @@ export class PublicationTrendChartComponent {
       scales: {
         x: {
           ticks: {
-            color: 'rgba(255, 255, 255, 0.8)',
             font: {
               family: "'Inter', sans-serif",
               size: 10
@@ -122,13 +120,11 @@ export class PublicationTrendChartComponent {
             maxTicksLimit: 20
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.05)'
           },
           border: {display: false},
           title: {
             display: true,
             text: this.t.translate('statsLibrary.publicationTrend.axisPublicationYear'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12,
@@ -139,7 +135,6 @@ export class PublicationTrendChartComponent {
         y: {
           beginAtZero: true,
           ticks: {
-            color: 'rgba(255, 255, 255, 0.8)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -148,13 +143,11 @@ export class PublicationTrendChartComponent {
             stepSize: 1
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.08)'
           },
           border: {display: false},
           title: {
             display: true,
             text: this.t.translate('statsLibrary.publicationTrend.axisBooks'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12,
@@ -169,9 +162,6 @@ export class PublicationTrendChartComponent {
         },
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.95)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
           borderColor: '#06b6d4',
           borderWidth: 2,
           cornerRadius: 8,
@@ -200,8 +190,7 @@ export class PublicationTrendChartComponent {
         point: {
           radius: 4,
           hoverRadius: 7,
-          borderWidth: 2,
-          backgroundColor: '#0e1117'
+          borderWidth: 2
         }
       },
       interaction: {

--- a/frontend/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared' as chart-shared;
 
 .reading-journey-container {
   width: 100%;
@@ -6,17 +6,14 @@
 
 .journey-title-icon {
   font-size: 1.5rem;
-  color: #10b981;
+  color: var(--color-emerald-500);
 }
 
 .date-range-badge {
-  background: linear-gradient(135deg, rgb(16 185 129 / 20%), rgb(16 185 129 / 10%));
-  border: 1px solid rgb(16 185 129 / 30%);
-  border-radius: 20px;
-  padding: 0.4rem 1rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: #34d399;
+  --stats-badge-accent: var(--color-emerald-500);
+
+  @include chart-shared.accent-badge;
+
   white-space: nowrap;
 }
 
@@ -29,7 +26,7 @@
 .insights-section {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid rgb(255 255 255 / 10%);
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .insights-row {
@@ -44,27 +41,26 @@
   align-items: center;
   text-align: center;
   padding: 0.75rem;
-  border-radius: 8px;
-  background: rgb(255 255 255 / 3%);
-  border: 1px solid rgb(255 255 255 / 8%);
+
+  @include chart-shared.neutral-surface;
 
   .insight-label {
     font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    color: var(--text-secondary-color);
+    color: var(--color-text-secondary);
     margin-bottom: 0.25rem;
   }
 
   .insight-value {
     font-size: 1.5rem;
     font-weight: 600;
-    color: var(--text-color, #fff);
+    color: var(--color-text);
   }
 
   .insight-detail {
     font-size: 0.75rem;
-    color: var(--text-secondary-color);
+    color: var(--color-text-secondary);
     margin-top: 0.25rem;
     white-space: nowrap;
     overflow: hidden;
@@ -74,50 +70,50 @@
 
   &.backlog {
     .insight-value {
-      color: #f59e0b;
+      color: var(--color-amber-500);
     }
   }
 
   &.time-to-read {
     .insight-value {
-      color: #8b5cf6;
+      color: var(--color-violet-500);
     }
   }
 
   &.productive {
     .insight-value {
-      color: #10b981;
+      color: var(--color-emerald-500);
     }
   }
 
   &.acquisition {
     .insight-value {
-      color: #3b82f6;
+      color: var(--color-blue-500);
     }
   }
 
   &.finish-rate {
     .insight-value {
-      color: #06b6d4;
+      color: var(--color-cyan-500);
     }
   }
 
   &.streak {
     .insight-value {
-      color: #f472b6;
+      color: var(--color-pink-400);
     }
   }
 
   &.recent {
     .insight-value {
-      color: #a78bfa;
+      color: var(--color-violet-400);
       font-size: 1.1rem;
     }
   }
 
   &.total {
     .insight-value {
-      color: #22d3ee;
+      color: var(--color-cyan-400);
       font-size: 1.1rem;
     }
   }

--- a/frontend/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.ts
@@ -87,7 +87,6 @@ export class ReadingJourneyChartComponent {
           borderColor: '#3b82f6',
           backgroundColor: 'rgba(59, 130, 246, 0.1)',
           pointBackgroundColor: '#3b82f6',
-          pointBorderColor: '#ffffff',
           fill: true,
           order: 2
         },
@@ -97,7 +96,6 @@ export class ReadingJourneyChartComponent {
           borderColor: '#10b981',
           backgroundColor: 'rgba(16, 185, 129, 0.2)',
           pointBackgroundColor: '#10b981',
-          pointBorderColor: '#ffffff',
           fill: true,
           order: 1
         }
@@ -119,7 +117,6 @@ export class ReadingJourneyChartComponent {
       scales: {
         x: {
           ticks: {
-            color: 'rgba(255, 255, 255, 0.8)',
             font: {
               family: "'Inter', sans-serif",
               size: 10
@@ -130,13 +127,11 @@ export class ReadingJourneyChartComponent {
             maxTicksLimit: 24
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.05)'
           },
           border: {display: false},
           title: {
             display: true,
             text: this.t.translate('statsLibrary.readingJourney.axisMonth'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12,
@@ -147,7 +142,6 @@ export class ReadingJourneyChartComponent {
         y: {
           beginAtZero: true,
           ticks: {
-            color: 'rgba(255, 255, 255, 0.8)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -155,13 +149,11 @@ export class ReadingJourneyChartComponent {
             precision: 0
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.08)'
           },
           border: {display: false},
           title: {
             display: true,
             text: this.t.translate('statsLibrary.readingJourney.axisCumulativeBooks'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12,
@@ -175,7 +167,6 @@ export class ReadingJourneyChartComponent {
           display: true,
           position: 'top',
           labels: {
-            color: 'rgba(255, 255, 255, 0.9)',
             font: {
               family: "'Inter', sans-serif",
               size: 12
@@ -187,9 +178,6 @@ export class ReadingJourneyChartComponent {
         },
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.95)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
           borderColor: '#10b981',
           borderWidth: 2,
           cornerRadius: 8,

--- a/frontend/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.scss
@@ -1,4 +1,4 @@
-@use '../../../_chart-shared';
+@use '../../../chart-shared' as chart-shared;
 
 .top-items-container {
   width: 100%;
@@ -17,7 +17,7 @@
     min-width: 200px;
 
     h3 {
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       font-size: 1.25rem;
       font-weight: 500;
       margin: 0 0 0.5rem;
@@ -31,7 +31,7 @@
     }
 
     .chart-description {
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       font-size: 0.9rem;
       margin: 0;
       line-height: 1.4;
@@ -61,20 +61,19 @@
   flex-direction: column;
   align-items: center;
   padding: 0.5rem 0.75rem;
-  background: rgb(255 255 255 / 5%);
-  border-radius: 8px;
-  border: 1px solid rgb(255 255 255 / 10%);
+
+  @include chart-shared.neutral-surface;
 
   .badge-value {
     font-size: 1.25rem;
     font-weight: 600;
-    color: #fff;
+    color: var(--color-text);
     line-height: 1;
   }
 
   .badge-label {
     font-size: 0.7rem;
-    color: rgb(255 255 255 / 60%);
+    color: var(--color-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.5px;
     margin-top: 0.25rem;
@@ -98,9 +97,8 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.75rem 1rem;
-    background: rgb(255 255 255 / 5%);
-    border-radius: 8px;
-    border: 1px solid rgb(255 255 255 / 10%);
+
+    @include chart-shared.neutral-surface;
 
     > i {
       font-size: 1.1rem;
@@ -115,14 +113,14 @@
 
       .insight-label {
         font-size: 0.75rem;
-        color: var(--text-secondary-color);
+        color: var(--color-text-secondary);
         text-transform: uppercase;
         letter-spacing: 0.3px;
       }
 
       .insight-value {
         font-size: 0.9rem;
-        color: var(--text-color, #fff);
+        color: var(--color-text);
         font-weight: 500;
         white-space: nowrap;
         overflow: hidden;

--- a/frontend/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.ts
@@ -152,7 +152,6 @@ export class TopItemsChartComponent implements OnInit {
           stacked: true,
           beginAtZero: true,
           ticks: {
-            color: 'rgba(255, 255, 255, 0.8)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -161,13 +160,11 @@ export class TopItemsChartComponent implements OnInit {
             stepSize: 1
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.08)'
           },
           border: {display: false},
           title: {
             display: true,
             text: this.t.translate('statsLibrary.topItems.axisNumberOfBooks'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12,
@@ -178,7 +175,6 @@ export class TopItemsChartComponent implements OnInit {
         y: {
           stacked: true,
           ticks: {
-            color: 'rgba(255, 255, 255, 0.9)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -196,7 +192,6 @@ export class TopItemsChartComponent implements OnInit {
           display: true,
           position: 'bottom',
           labels: {
-            color: 'rgba(255, 255, 255, 0.9)',
             font: {
               family: "'Inter', sans-serif",
               size: 11
@@ -208,9 +203,6 @@ export class TopItemsChartComponent implements OnInit {
         },
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.95)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
           borderColor: currentColor,
           borderWidth: 2,
           cornerRadius: 8,
@@ -277,7 +269,6 @@ export class TopItemsChartComponent implements OnInit {
             barPercentage: 0.85,
             categoryPercentage: 0.8,
             hoverBorderWidth: 2,
-            hoverBorderColor: '#ffffff'
           };
         });
 

--- a/frontend/src/app/features/stats/component/library-stats/library-stats.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/library-stats.component.ts
@@ -17,6 +17,7 @@ import {LibraryFilterService, LibraryOption} from './service/library-filter.serv
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {BookService} from '../../../book/service/book.service';
 import {LibraryService} from '../../../book/service/library.service';
+import {StatsChartThemeService} from '../shared/stats-chart-theme.service';
 
 interface ChartConfig {
   id: string;
@@ -57,6 +58,7 @@ export class LibraryStatsComponent {
   private readonly bookService = inject(BookService);
   private readonly libraryService = inject(LibraryService);
   private readonly t = inject(TranslocoService);
+  private readonly chartTheme = inject(StatsChartThemeService);
 
   public readonly isLoading = computed(() =>
     this.bookService.isBooksLoading() || this.libraryService.isLibrariesLoading()
@@ -77,6 +79,10 @@ export class LibraryStatsComponent {
   public showConfigPanel = false;
 
   public chartsConfig: ChartConfig[] = this.buildChartsConfig();
+
+  constructor() {
+    this.chartTheme.activate();
+  }
 
   onLibraryChange(selectedLibrary: LibraryOption | null): void {
     if (!selectedLibrary) {

--- a/frontend/src/app/features/stats/component/shared/stats-chart-theme.service.ts
+++ b/frontend/src/app/features/stats/component/shared/stats-chart-theme.service.ts
@@ -1,0 +1,158 @@
+import {DOCUMENT, isPlatformBrowser} from '@angular/common';
+import {DestroyRef, inject, Injectable, PLATFORM_ID, signal} from '@angular/core';
+import {Chart, ChartConfiguration, registerables} from 'chart.js';
+import {ThemeService} from 'ng2-charts';
+
+export interface StatsChartThemeColors {
+  text: string;
+  textSecondary: string;
+  textMuted: string;
+  border: string;
+  grid: string;
+  surface: string;
+}
+
+let cachedSignature = '';
+let cachedColors: StatsChartThemeColors | null = null;
+let chartDefaultsRegistered = false;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StatsChartThemeService {
+  private readonly document = inject(DOCUMENT);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly ngChartsThemeService = inject(ThemeService);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly revision = signal(0);
+  readonly themeRevision = this.revision.asReadonly();
+  private observer: MutationObserver | null = null;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => this.observer?.disconnect());
+  }
+
+  activate(): void {
+    if (!isPlatformBrowser(this.platformId) || this.observer) {
+      return;
+    }
+
+    this.applyTheme();
+    this.observer = new MutationObserver(() => this.applyTheme());
+    this.observer.observe(this.document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-app-theme', 'style'],
+    });
+  }
+
+  colors(): StatsChartThemeColors {
+    this.revision();
+    return readStatsChartThemeColors();
+  }
+
+  private applyTheme(): void {
+    this.ngChartsThemeService.setColorschemesOptions(buildStatsChartThemeOptions());
+    this.revision.update((value) => value + 1);
+  }
+}
+
+function buildStatsChartThemeOptions(): ChartConfiguration['options'] {
+  const colors = readStatsChartThemeColors();
+
+  applyStatsChartDefaults(colors);
+
+  return {
+    color: colors.textSecondary,
+    backgroundColor: colors.surface,
+    borderColor: colors.grid,
+    plugins: {
+      legend: {labels: {color: colors.textSecondary}},
+      tooltip: {
+        backgroundColor: colors.surface,
+        titleColor: colors.text,
+        bodyColor: colors.textSecondary,
+        borderColor: colors.border,
+        borderWidth: 1,
+      },
+      datalabels: {color: colors.text},
+    },
+  };
+}
+
+function applyStatsChartDefaults(colors: StatsChartThemeColors): void {
+  if (!chartDefaultsRegistered) {
+    Chart.register(...registerables);
+    chartDefaultsRegistered = true;
+  }
+
+  Chart.defaults.color = colors.textSecondary;
+  Chart.defaults.backgroundColor = colors.surface;
+  Chart.defaults.borderColor = colors.grid;
+
+  Object.assign(Chart.defaults.elements.arc, {
+    borderColor: 'transparent',
+    borderWidth: 0,
+    hoverBorderColor: colors.textSecondary,
+    hoverBorderWidth: 2,
+  });
+
+  Object.assign(Chart.defaults.elements.point, {
+    backgroundColor: colors.surface,
+    hoverBorderColor: colors.textSecondary,
+  });
+
+  Object.assign(Chart.defaults.scale.ticks, {
+    color: colors.textSecondary,
+    backdropColor: 'transparent',
+  });
+  Object.assign(Chart.defaults.scale.grid, {color: colors.grid});
+  Object.assign(Chart.defaults.scales.radialLinear.angleLines, {color: colors.grid});
+  Object.assign(Chart.defaults.scales.radialLinear.pointLabels, {color: colors.textSecondary});
+  Object.assign(Chart.defaults.scales.radialLinear.ticks, {
+    color: colors.textSecondary,
+    backdropColor: 'transparent',
+  });
+}
+
+export function readStatsChartThemeColors(): StatsChartThemeColors {
+  if (typeof document === 'undefined' || !document.body) {
+    throw new Error('Stats chart theme colors require browser CSS theme tokens.');
+  }
+
+  const root = document.documentElement;
+  const signature = [
+    root.dataset['appTheme'] ?? '',
+    root.className,
+    root.getAttribute('style') ?? '',
+  ].join('|');
+
+  if (signature === cachedSignature && cachedColors) {
+    return cachedColors;
+  }
+
+  const text = resolveCssColor('--color-text');
+  const textSecondary = resolveCssColor('--color-text-secondary');
+  const textMuted = resolveCssColor('--color-text-muted');
+  const border = resolveCssColor('--color-border');
+  const surface = resolveCssColor('--color-card');
+
+  cachedSignature = signature;
+  cachedColors = {text, textSecondary, textMuted, border, grid: border, surface};
+
+  return cachedColors;
+}
+
+function resolveCssColor(variableName: string): string {
+  const probe = document.createElement('span');
+  probe.style.color = `var(${variableName})`;
+  probe.style.display = 'none';
+  document.body.appendChild(probe);
+  const resolved = getComputedStyle(probe).color;
+  probe.remove();
+
+  if (!resolved) {
+    throw new Error(`Stats chart theme token ${variableName} could not be resolved.`);
+  }
+
+  return resolved;
+}

--- a/frontend/src/app/features/stats/component/user-stats/charts/book-flow-chart/book-flow-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/book-flow-chart/book-flow-chart.component.scss
@@ -45,8 +45,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: rgb(255 255 255 / 5%);
-    border: 1px solid rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 0.5rem 1rem;
     flex: 1;

--- a/frontend/src/app/features/stats/component/user-stats/charts/book-flow-chart/book-flow-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/book-flow-chart/book-flow-chart.component.ts
@@ -3,6 +3,7 @@ import {Tooltip} from 'primeng/tooltip';
 import {BookService} from '../../../../../book/service/book.service';
 import {Book, ReadStatus} from '../../../../../book/model/book.model';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
+import {StatsChartThemeService} from '../../../shared/stats-chart-theme.service';
 
 interface SankeyNode {
   id: string;
@@ -33,7 +34,10 @@ export class BookFlowChartComponent implements AfterViewInit {
 
   private readonly bookService = inject(BookService);
   private readonly t = inject(TranslocoService);
+  private readonly chartTheme = inject(StatsChartThemeService);
   private readonly syncChartEffect = effect(() => {
+    this.chartTheme.themeRevision();
+
     if (this.bookService.isBooksLoading()) {
       this.dataReady = false;
       return;
@@ -228,8 +232,9 @@ export class BookFlowChartComponent implements AfterViewInit {
     const leftMargin = 100;
     const rightMargin = 110;
     const colX = [leftMargin, width * 0.45, width - rightMargin];
+    const colors = this.chartTheme.colors();
 
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+    ctx.fillStyle = colors.textMuted;
     ctx.font = '11px Inter, sans-serif';
     ctx.textAlign = 'center';
     ctx.fillText(this.t.translate('statsUser.bookFlow.colAdded'), colX[0] + nodeWidth / 2, 18);
@@ -281,13 +286,13 @@ export class BookFlowChartComponent implements AfterViewInit {
       ctx.fill();
       ctx.globalAlpha = 1;
 
-      ctx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
+      ctx.strokeStyle = colors.grid;
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.roundRect(x, node.y, nodeWidth, node.height, 3);
       ctx.stroke();
 
-      ctx.fillStyle = 'rgba(255, 255, 255, 0.9)';
+      ctx.fillStyle = colors.text;
       ctx.font = '11px Inter, sans-serif';
       const labelX = node.column === 2 ? x + nodeWidth + 8 : x - 8;
       ctx.textAlign = node.column === 2 ? 'left' : 'right';

--- a/frontend/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.scss
@@ -1,3 +1,5 @@
+@use '../../../chart-shared' as chart-shared;
+
 .book-length-container {
   width: 100%;
 }
@@ -15,7 +17,7 @@
     min-width: 200px;
 
     h3 {
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       font-size: 1.25rem;
       font-weight: 500;
       margin: 0 0 0.5rem;
@@ -25,7 +27,7 @@
     }
 
     .chart-description {
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       font-size: 0.9rem;
       margin: 0;
       line-height: 1.4;
@@ -33,23 +35,25 @@
   }
 
   .stats-badge {
+    --stats-badge-accent: var(--color-cyan-500);
+
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: rgb(0 188 212 / 15%);
-    border: 1px solid rgb(0 188 212 / 30%);
-    border-radius: 8px;
     padding: 0.5rem 1rem;
+
+    @include chart-shared.accent-surface(8px);
 
     .badge-value {
       font-size: 1.5rem;
       font-weight: 600;
-      color: #00bcd4;
+
+      @include chart-shared.accent-text;
     }
 
     .badge-label {
       font-size: 0.75rem;
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }
@@ -58,7 +62,7 @@
 
 .book-length-icon {
   font-size: 1.5rem;
-  color: #00bcd4;
+  color: var(--color-cyan-500);
 }
 
 .stats-row {
@@ -71,22 +75,21 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: rgb(255 255 255 / 5%);
-    border: 1px solid rgb(255 255 255 / 10%);
-    border-radius: 8px;
     padding: 0.5rem 1rem;
     flex: 1;
+
+    @include chart-shared.neutral-surface;
 
     .stat-value-sm {
       font-size: 0.9rem;
       font-weight: 500;
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       text-align: center;
     }
 
     .stat-label {
       font-size: 0.75rem;
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
       margin-top: 0.25rem;
@@ -107,7 +110,7 @@
   justify-content: center;
   padding: 3rem;
   text-align: center;
-  color: var(--text-secondary-color);
+  color: var(--color-text-secondary);
 
   i {
     font-size: 2.5rem;
@@ -118,7 +121,7 @@
   p {
     font-size: 1rem;
     margin: 0 0 0.5rem;
-    color: var(--text-color, #fff);
+    color: var(--color-text);
   }
 
   small {

--- a/frontend/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.ts
@@ -70,14 +70,11 @@ export class BookLengthChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.bookLength.axisPageCount'),
-          color: '#ffffff',
           font: {family: "'Inter', sans-serif", size: 12, weight: 'bold'}
         },
         ticks: {
-          color: 'rgba(255, 255, 255, 0.8)',
           font: {family: "'Inter', sans-serif", size: 11}
-        },
-        grid: {color: 'rgba(255, 255, 255, 0.1)'}
+        }
       },
       y: {
         min: 0,
@@ -85,15 +82,12 @@ export class BookLengthChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.bookLength.axisPersonalRating'),
-          color: '#ffffff',
           font: {family: "'Inter', sans-serif", size: 12, weight: 'bold'}
         },
         ticks: {
-          color: 'rgba(255, 255, 255, 0.8)',
           stepSize: 1,
           font: {family: "'Inter', sans-serif", size: 11}
-        },
-        grid: {color: 'rgba(255, 255, 255, 0.1)'}
+        }
       }
     },
     plugins: {
@@ -101,7 +95,6 @@ export class BookLengthChartComponent {
         display: true,
         position: 'top',
         labels: {
-          color: '#ffffff',
           font: {family: "'Inter', sans-serif", size: 11},
           usePointStyle: true,
           pointStyle: 'circle',
@@ -110,9 +103,6 @@ export class BookLengthChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#00bcd4',
         borderWidth: 2,
         cornerRadius: 8,
@@ -196,7 +186,7 @@ export class BookLengthChartComponent {
         label: this.t.translate('statsUser.bookLength.trend'),
         data: trend as BookScatterPoint[],
         backgroundColor: 'transparent',
-        borderColor: 'rgba(255, 255, 255, 0.4)',
+        borderColor: 'transparent',
         pointRadius: 0,
         pointHoverRadius: 0,
         pointBorderWidth: 0

--- a/frontend/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.scss
@@ -43,11 +43,11 @@
   flex-shrink: 0;
 
   .year-nav-btn {
-    background: rgb(255 255 255 / 10%);
-    border: 1px solid rgb(255 255 255 / 20%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
+    border: 1px solid var(--color-border);
     border-radius: 6px;
     padding: 0.6rem;
-    color: #fff;
+    color: var(--color-text);
     cursor: pointer;
     transition: all 0.3s ease;
     display: flex;
@@ -55,8 +55,8 @@
     justify-content: center;
 
     &:hover {
-      background: rgb(255 255 255 / 20%);
-      border-color: rgb(255 255 255 / 30%);
+      background: color-mix(in srgb, var(--color-text) 10%, transparent);
+      border-color: var(--color-border);
       transform: translateY(-1px);
     }
 
@@ -68,7 +68,7 @@
   .current-year {
     font-size: 1.125rem;
     font-weight: 600;
-    color: #fff;
+    color: var(--color-text);
     min-width: 4.5rem;
     text-align: center;
   }
@@ -84,8 +84,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: rgb(255 255 255 / 5%);
-    border: 1px solid rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 0.5rem 1rem;
     min-width: 80px;

--- a/frontend/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.ts
@@ -68,7 +68,6 @@ export class CompletionRaceChartComponent implements OnInit, OnDestroy {
           display: true,
           position: 'top',
           labels: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             boxWidth: 12,
             padding: 8,
@@ -78,10 +77,6 @@ export class CompletionRaceChartComponent implements OnInit, OnDestroy {
         },
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.9)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
-          borderColor: '#ffffff',
           borderWidth: 1,
           cornerRadius: 6,
           padding: 12,
@@ -104,15 +99,12 @@ export class CompletionRaceChartComponent implements OnInit, OnDestroy {
           title: {
             display: true,
             text: this.t.translate('statsUser.completionRace.axisDaysSinceFirstSession'),
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 12, weight: 'bold'}
           },
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             stepSize: 1
           },
-          grid: {color: 'rgba(255, 255, 255, 0.1)'},
           border: {display: false}
         },
         y: {
@@ -121,15 +113,12 @@ export class CompletionRaceChartComponent implements OnInit, OnDestroy {
           title: {
             display: true,
             text: this.t.translate('statsUser.completionRace.axisProgress'),
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 12, weight: 'bold'}
           },
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             callback: (value) => `${value}%`
           },
-          grid: {color: 'rgba(255, 255, 255, 0.1)'},
           border: {display: false}
         }
       },

--- a/frontend/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.scss
@@ -38,11 +38,11 @@
   flex-shrink: 0;
 
   .year-nav-btn {
-    background: rgb(255 255 255 / 10%);
-    border: 1px solid rgb(255 255 255 / 20%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
+    border: 1px solid var(--color-border);
     border-radius: 6px;
     padding: 0.6rem;
-    color: #fff;
+    color: var(--color-text);
     cursor: pointer;
     transition: all 0.3s ease;
     display: flex;
@@ -50,8 +50,8 @@
     justify-content: center;
 
     &:hover {
-      background: rgb(255 255 255 / 20%);
-      border-color: rgb(255 255 255 / 30%);
+      background: color-mix(in srgb, var(--color-text) 10%, transparent);
+      border-color: var(--color-border);
       transform: translateY(-1px);
     }
 
@@ -67,7 +67,7 @@
   .current-year {
     font-size: 1.125rem;
     font-weight: 600;
-    color: #fff;
+    color: var(--color-text);
     min-width: 4.5rem;
     text-align: center;
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.ts
@@ -51,7 +51,6 @@ export class CompletionTimelineChartComponent implements OnInit {
           display: true,
           position: 'top',
           labels: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             boxWidth: 12,
             padding: 10
@@ -59,10 +58,6 @@ export class CompletionTimelineChartComponent implements OnInit {
         },
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.9)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
-          borderColor: '#ffffff',
           borderWidth: 1,
           cornerRadius: 6,
           displayColors: true,
@@ -85,7 +80,6 @@ export class CompletionTimelineChartComponent implements OnInit {
           title: {
             display: true,
             text: this.t.translate('statsUser.completionTimeline.axisMonth'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 13,
@@ -93,7 +87,6 @@ export class CompletionTimelineChartComponent implements OnInit {
             }
           },
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11}
           },
           grid: {display: false},
@@ -103,7 +96,6 @@ export class CompletionTimelineChartComponent implements OnInit {
           title: {
             display: true,
             text: this.t.translate('statsUser.completionTimeline.axisNumberOfBooks'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 13,
@@ -112,12 +104,10 @@ export class CompletionTimelineChartComponent implements OnInit {
           },
           beginAtZero: true,
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             stepSize: 1
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.1)'
           },
           border: {display: false}
         }

--- a/frontend/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.ts
@@ -55,7 +55,6 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
           display: true,
           position: 'top',
           labels: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             boxWidth: 12,
             padding: 10
@@ -63,10 +62,6 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
         },
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.9)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
-          borderColor: '#ffffff',
           borderWidth: 1,
           cornerRadius: 6,
           displayColors: true,
@@ -96,7 +91,6 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
           title: {
             display: true,
             text: this.t.translate('statsUser.favoriteDays.axisDayOfWeek'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 13,
@@ -104,7 +98,6 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
             }
           },
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11}
           },
           grid: {display: false},
@@ -126,12 +119,10 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
           },
           beginAtZero: true,
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             stepSize: 1
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.1)'
           },
           border: {display: false}
         },
@@ -151,7 +142,6 @@ export class FavoriteDaysChartComponent implements OnInit, OnDestroy {
           },
           beginAtZero: true,
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             callback: function (value) {
               return (typeof value === 'number' ? value.toFixed(1) : '0.0') + 'h';

--- a/frontend/src/app/features/stats/component/user-stats/charts/genre-stats-chart/genre-stats-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/genre-stats-chart/genre-stats-chart.component.ts
@@ -48,10 +48,6 @@ export class GenreStatsChartComponent implements OnInit {
         legend: {display: false},
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.9)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
-          borderColor: '#ffffff',
           borderWidth: 1,
           cornerRadius: 6,
           displayColors: true,
@@ -82,14 +78,12 @@ export class GenreStatsChartComponent implements OnInit {
           title: {
             display: true,
             text: this.t.translate('statsUser.genreStats.axisGenres'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12
             }
           },
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             maxRotation: 90,
             minRotation: 90,
@@ -109,7 +103,6 @@ export class GenreStatsChartComponent implements OnInit {
           title: {
             display: true,
             text: this.t.translate('statsUser.genreStats.axisTimeRead'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 12
@@ -117,7 +110,6 @@ export class GenreStatsChartComponent implements OnInit {
           },
           beginAtZero: true,
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             callback: (value) => {
               const seconds = value as number;
@@ -151,7 +143,6 @@ export class GenreStatsChartComponent implements OnInit {
             maxTicksLimit: 8
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.1)'
           },
           border: {display: false}
         }

--- a/frontend/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.scss
@@ -45,14 +45,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.15rem;
-    background: rgb(255 255 255 / 5%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border-radius: 8px;
     padding: 0.5rem 0.75rem;
     flex: 1;
     min-width: 100px;
 
     .stat-value {
-      color: #fff;
+      color: var(--color-text);
       font-size: 0.95rem;
       font-weight: 600;
       white-space: nowrap;
@@ -77,8 +77,8 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    background: rgb(255 255 255 / 5%);
-    border: 1px solid rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 0.5rem 0.75rem;
     flex: 1;
@@ -95,7 +95,7 @@
       overflow: hidden;
 
       .book-name {
-        color: #fff;
+        color: var(--color-text);
         font-size: 0.85rem;
         font-weight: 500;
         display: block;

--- a/frontend/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.ts
@@ -46,9 +46,6 @@ export class PageTurnerChartComponent implements OnInit {
         legend: {display: false},
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.95)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
           borderColor: 'rgba(251, 146, 60, 0.8)',
           borderWidth: 2,
           cornerRadius: 8,
@@ -67,21 +64,17 @@ export class PageTurnerChartComponent implements OnInit {
           title: {
             display: true,
             text: this.t.translate('statsUser.pageTurner.axisGripScore'),
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 13, weight: 'bold'}
           },
           min: 0,
           max: 100,
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11}
           },
-          grid: {color: 'rgba(255, 255, 255, 0.1)'},
           border: {display: false}
         },
         y: {
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11}
           },
           grid: {display: false},

--- a/frontend/src/app/features/stats/component/user-stats/charts/peak-hours-chart/peak-hours-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/peak-hours-chart/peak-hours-chart.component.ts
@@ -54,7 +54,6 @@ export class PeakHoursChartComponent implements OnInit {
           display: true,
           position: 'top',
           labels: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             boxWidth: 12,
             padding: 10
@@ -62,10 +61,6 @@ export class PeakHoursChartComponent implements OnInit {
         },
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.9)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
-          borderColor: '#ffffff',
           borderWidth: 1,
           cornerRadius: 6,
           displayColors: true,
@@ -93,7 +88,6 @@ export class PeakHoursChartComponent implements OnInit {
           title: {
             display: true,
             text: this.t.translate('statsUser.peakHours.axisHourOfDay'),
-            color: '#ffffff',
             font: {
               family: "'Inter', sans-serif",
               size: 13,
@@ -101,11 +95,9 @@ export class PeakHoursChartComponent implements OnInit {
             }
           },
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11}
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.1)'
           },
           border: {display: false}
         },
@@ -125,12 +117,10 @@ export class PeakHoursChartComponent implements OnInit {
           },
           beginAtZero: true,
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             stepSize: 1
           },
           grid: {
-            color: 'rgba(255, 255, 255, 0.1)'
           },
           border: {display: false}
         },
@@ -150,7 +140,6 @@ export class PeakHoursChartComponent implements OnInit {
           },
           beginAtZero: true,
           ticks: {
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11},
             callback: function (value) {
               return (typeof value === 'number' ? Math.round(value) : '0') + 'm';
@@ -241,7 +230,6 @@ export class PeakHoursChartComponent implements OnInit {
           pointRadius: 4,
           pointHoverRadius: 6,
           pointBackgroundColor: 'rgba(34, 197, 94, 0.9)',
-          pointBorderColor: '#ffffff',
           pointBorderWidth: 2,
           yAxisID: 'y'
         },
@@ -256,7 +244,6 @@ export class PeakHoursChartComponent implements OnInit {
           pointRadius: 4,
           pointHoverRadius: 6,
           pointBackgroundColor: 'rgba(251, 191, 36, 0.9)',
-          pointBorderColor: '#ffffff',
           pointBorderWidth: 2,
           yAxisID: 'y1'
         }

--- a/frontend/src/app/features/stats/component/user-stats/charts/personal-rating-chart/personal-rating-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/personal-rating-chart/personal-rating-chart.component.ts
@@ -26,10 +26,8 @@ const CHART_COLORS = [
 ] as const;
 
 const CHART_DEFAULTS = {
-  borderColor: '#ffffff',
   borderWidth: 1,
   hoverBorderWidth: 2,
-  hoverBorderColor: '#ffffff'
 } as const;
 
 const RATING_RANGES = [
@@ -77,10 +75,6 @@ export class PersonalRatingChartComponent {
       legend: {display: false},
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
-        borderColor: '#ffffff',
         borderWidth: 1,
         cornerRadius: 6,
         displayColors: true,
@@ -103,14 +97,12 @@ export class PersonalRatingChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.personalRating.axisPersonalRating'),
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12
           }
         },
         ticks: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11
@@ -123,7 +115,6 @@ export class PersonalRatingChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.personalRating.axisNumberOfBooks'),
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -131,7 +122,6 @@ export class PersonalRatingChartComponent {
         },
         beginAtZero: true,
         ticks: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11
@@ -140,7 +130,6 @@ export class PersonalRatingChartComponent {
           maxTicksLimit: 8
         },
         grid: {
-          color: 'rgba(255, 255, 255, 0.1)'
         },
         border: {display: false}
       }

--- a/frontend/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.scss
@@ -48,9 +48,9 @@
     align-items: center;
     min-width: 80px;
     padding: 0.5rem 1rem;
-    border: 1px solid rgb(255 255 255 / 10%);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
-    background: rgb(255 255 255 / 5%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
 
     .stat-value {
       color: var(--text-color, #fff);

--- a/frontend/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.ts
@@ -46,12 +46,10 @@ export class PublicationEraChartComponent {
     plugins: {
       legend: {
         display: true, position: 'bottom',
-        labels: {color: 'rgba(255, 255, 255, 0.8)', font: {family: "'Inter', sans-serif", size: 11}, boxWidth: 12, padding: 12}
+        labels: {font: {family: "'Inter', sans-serif", size: 11}, boxWidth: 12, padding: 12}
       },
       tooltip: {
-        enabled: true, backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        titleColor: '#ffffff', bodyColor: '#ffffff',
-        borderColor: '#ffffff', borderWidth: 1, cornerRadius: 6, padding: 10,
+        enabled: true, borderWidth: 1, cornerRadius: 6, padding: 10,
         callbacks: {
           label: (ctx) => {
             return `${ctx.dataset.label}: ${ctx.parsed.y} books`;
@@ -62,15 +60,13 @@ export class PublicationEraChartComponent {
     },
     scales: {
       x: {
-        grid: {color: 'rgba(255, 255, 255, 0.08)'},
-        ticks: {color: 'rgba(255, 255, 255, 0.6)', font: {size: 11}},
-        title: {display: true, text: 'Rating Range', color: 'rgba(255, 255, 255, 0.5)', font: {size: 11}}
+        ticks: {font: {size: 11}},
+        title: {display: true, text: 'Rating Range', font: {size: 11}}
       },
       y: {
         beginAtZero: true,
-        grid: {color: 'rgba(255, 255, 255, 0.08)'},
-        ticks: {color: 'rgba(255, 255, 255, 0.6)', font: {size: 11}, stepSize: 1},
-        title: {display: true, text: 'Books', color: 'rgba(255, 255, 255, 0.5)', font: {size: 11}}
+        ticks: {font: {size: 11}, stepSize: 1},
+        title: {display: true, text: 'Books', font: {size: 11}}
       }
     },
     interaction: {mode: 'index', intersect: false}
@@ -134,7 +130,6 @@ export class PublicationEraChartComponent {
         borderWidth: 2.5,
         pointRadius: 5,
         pointBackgroundColor: this.DECADE_COLORS[i % this.DECADE_COLORS.length],
-        pointBorderColor: '#ffffff',
         pointBorderWidth: 1.5,
         tension: 0.3,
         fill: false

--- a/frontend/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.scss
@@ -1,3 +1,5 @@
+@use '../../../chart-shared' as chart-shared;
+
 .rating-taste-container {
   width: 100%;
 }
@@ -15,7 +17,7 @@
     min-width: 200px;
 
     h3 {
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       font-size: 1.25rem;
       font-weight: 500;
       margin: 0 0 0.5rem;
@@ -25,7 +27,7 @@
     }
 
     .chart-description {
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       font-size: 0.9rem;
       margin: 0;
       line-height: 1.4;
@@ -33,23 +35,25 @@
   }
 
   .stats-badge {
+    --stats-badge-accent: var(--color-violet-600);
+
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: rgb(156 39 176 / 15%);
-    border: 1px solid rgb(156 39 176 / 30%);
-    border-radius: 8px;
     padding: 0.5rem 1rem;
+
+    @include chart-shared.accent-surface(8px);
 
     .badge-value {
       font-size: 1.5rem;
       font-weight: 600;
-      color: #9c27b0;
+
+      @include chart-shared.accent-text;
     }
 
     .badge-label {
       font-size: 0.75rem;
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }
@@ -58,7 +62,7 @@
 
 .rating-taste-icon {
   font-size: 1.5rem;
-  color: rgb(156 39 176 / 100%);
+  color: var(--color-violet-600);
 }
 
 .chart-wrapper {
@@ -75,11 +79,11 @@
     .quadrant-label {
       position: absolute;
       font-size: 0.7rem;
-      color: rgb(255 255 255 / 40%);
+      color: var(--color-text-secondary);
       font-weight: 500;
       padding: 0.25rem 0.5rem;
-      border-radius: 4px;
-      background: rgb(0 0 0 / 30%);
+
+      @include chart-shared.neutral-surface(4px);
 
       &.top-left {
         top: 60px;
@@ -116,7 +120,7 @@
     gap: 0.75rem;
 
     h4 {
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       font-size: 1.1rem;
       font-weight: 500;
       margin: 0;
@@ -127,39 +131,41 @@
       align-items: center;
       gap: 0.5rem;
       padding: 0.4rem 0.75rem;
-      border-radius: 20px;
-      background: rgb(255 255 255 / 10%);
       font-size: 0.85rem;
 
+      @include chart-shared.neutral-surface(20px);
+
       .deviation-label {
-        color: var(--text-secondary-color);
+        color: var(--color-text-secondary);
       }
 
       .deviation-value {
-        color: var(--text-color, #fff);
+        color: var(--color-text);
         font-weight: 600;
       }
 
       .deviation-desc {
-        color: var(--text-secondary-color);
+        color: var(--color-text-secondary);
         font-size: 0.8rem;
       }
 
       &.unique {
-        background: rgb(156 39 176 / 20%);
-        border: 1px solid rgb(156 39 176 / 30%);
+        --stats-badge-accent: var(--color-violet-600);
+
+        @include chart-shared.accent-surface(20px);
 
         .deviation-value {
-          color: #9c27b0;
+          @include chart-shared.accent-text;
         }
       }
 
       &.mainstream {
-        background: rgb(76 175 80 / 20%);
-        border: 1px solid rgb(76 175 80 / 30%);
+        --stats-badge-accent: var(--color-green-500);
+
+        @include chart-shared.accent-surface(20px);
 
         .deviation-value {
-          color: #4caf50;
+          @include chart-shared.accent-text;
         }
       }
     }
@@ -172,12 +178,12 @@
   }
 
   .quadrant-card {
-    background: rgb(255 255 255 / 5%);
-    border-radius: 8px;
     padding: 1rem;
-    border: 1px solid rgb(255 255 255 / 10%);
-    border-left: 4px solid;
     position: relative;
+
+    @include chart-shared.neutral-surface;
+
+    border-left: 4px solid;
 
     .quadrant-header {
       display: flex;
@@ -190,7 +196,7 @@
       }
 
       .quadrant-name {
-        color: var(--text-color, #fff);
+        color: var(--color-text);
         font-weight: 500;
         font-size: 0.95rem;
         flex: 1;
@@ -199,7 +205,7 @@
       .quadrant-count {
         font-weight: 600;
         font-size: 0.85rem;
-        color: #fff;
+        color: var(--color-surface-0);
         padding: 0.15rem 0.5rem;
         border-radius: 12px;
         min-width: 24px;
@@ -208,7 +214,7 @@
     }
 
     .quadrant-description {
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       font-size: 0.8rem;
       margin: 0 0 0.75rem;
       line-height: 1.4;
@@ -216,7 +222,7 @@
 
     .quadrant-bar {
       height: 4px;
-      background: rgb(255 255 255 / 10%);
+      background: color-mix(in srgb, var(--color-text) 8%, transparent);
       border-radius: 2px;
       overflow: hidden;
       margin-bottom: 0.25rem;
@@ -230,7 +236,7 @@
 
     .quadrant-percentage {
       font-size: 0.75rem;
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
     }
   }
 }
@@ -242,7 +248,7 @@
   justify-content: center;
   padding: 3rem;
   text-align: center;
-  color: var(--text-secondary-color);
+  color: var(--color-text-secondary);
 
   i {
     font-size: 2.5rem;
@@ -253,7 +259,7 @@
   p {
     font-size: 1rem;
     margin: 0 0 0.5rem;
-    color: var(--text-color, #fff);
+    color: var(--color-text);
   }
 
   small {

--- a/frontend/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.ts
@@ -69,7 +69,6 @@ export class RatingTasteChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.ratingTaste.axisExternalRating'),
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12,
@@ -77,7 +76,6 @@ export class RatingTasteChartComponent {
           }
         },
         ticks: {
-          color: 'rgba(255, 255, 255, 0.8)',
           stepSize: 1,
           font: {
             family: "'Inter', sans-serif",
@@ -85,7 +83,6 @@ export class RatingTasteChartComponent {
           }
         },
         grid: {
-          color: 'rgba(255, 255, 255, 0.1)',
           drawTicks: true
         }
       },
@@ -95,7 +92,6 @@ export class RatingTasteChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.ratingTaste.axisPersonalRating'),
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12,
@@ -103,7 +99,6 @@ export class RatingTasteChartComponent {
           }
         },
         ticks: {
-          color: 'rgba(255, 255, 255, 0.8)',
           stepSize: 1,
           font: {
             family: "'Inter', sans-serif",
@@ -111,7 +106,6 @@ export class RatingTasteChartComponent {
           }
         },
         grid: {
-          color: 'rgba(255, 255, 255, 0.1)',
           drawTicks: true
         }
       }
@@ -121,7 +115,6 @@ export class RatingTasteChartComponent {
         display: true,
         position: 'top',
         labels: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11
@@ -133,9 +126,6 @@ export class RatingTasteChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#9c27b0',
         borderWidth: 2,
         cornerRadius: 8,

--- a/frontend/src/app/features/stats/component/user-stats/charts/read-status-chart/read-status-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/read-status-chart/read-status-chart.component.ts
@@ -29,13 +29,6 @@ const STATUS_COLOR_MAP: Record<string, string> = {
   [ReadStatus.UNSET]: '#343a40'
 } as const;
 
-const CHART_DEFAULTS = {
-  borderColor: '#ffffff',
-  borderWidth: 2,
-  hoverBorderWidth: 3,
-  hoverBorderColor: '#ffffff'
-} as const;
-
 type StatusChartData = ChartData<'doughnut', number[], string>;
 
 @Component({
@@ -71,7 +64,6 @@ export class ReadStatusChartComponent {
         labels: {
           padding: 15,
           usePointStyle: true,
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -81,10 +73,6 @@ export class ReadStatusChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
-        borderColor: '#ffffff',
         borderWidth: 1,
         cornerRadius: 6,
         displayColors: true,
@@ -122,8 +110,7 @@ export class ReadStatusChartComponent {
         labels,
         datasets: [{
           data: dataValues,
-          backgroundColor: colors.length > 0 ? colors : [...Object.values(STATUS_COLOR_MAP)],
-          ...CHART_DEFAULTS
+          backgroundColor: colors.length > 0 ? colors : [...Object.values(STATUS_COLOR_MAP)]
         }]
       };
     } catch (error) {
@@ -132,8 +119,7 @@ export class ReadStatusChartComponent {
         labels: [],
         datasets: [{
           data: [],
-          backgroundColor: [...Object.values(STATUS_COLOR_MAP)],
-          ...CHART_DEFAULTS
+          backgroundColor: [...Object.values(STATUS_COLOR_MAP)]
         }]
       };
     }
@@ -217,11 +203,9 @@ export class ReadStatusChartComponent {
       return {
         text: `${String(label)} (${dataValues[index]})`,
         fillStyle: (dataset.backgroundColor as string[])[index],
-        strokeStyle: '#ffffff',
         lineWidth: 1,
         hidden: !isVisible,
         index,
-        fontColor: '#ffffff'
       };
     });
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.scss
@@ -45,8 +45,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: rgb(255 255 255 / 5%);
-    border: 1px solid rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 0.5rem 1rem;
     flex: 1;

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.ts
@@ -46,10 +46,6 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
       legend: {display: false},
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
-        borderColor: '#ffffff',
         borderWidth: 1,
         cornerRadius: 6,
         padding: 12,
@@ -73,10 +69,8 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
     scales: {
       r: {
         ticks: {display: false},
-        grid: {color: 'rgba(255, 255, 255, 0.1)'},
         pointLabels: {
           display: true,
-          color: 'rgba(255, 255, 255, 0.7)',
           font: {family: "'Inter', sans-serif", size: 10}
         }
       }
@@ -162,9 +156,7 @@ export class ReadingClockChartComponent implements OnInit, OnDestroy {
       labels: HOUR_LABELS,
       datasets: [{
         data: hourMinutes,
-        backgroundColor: colors,
-        borderColor: colors.map(c => c.replace(/[\d.]+\)$/, '1)')),
-        borderWidth: 1
+        backgroundColor: colors
       }]
     });
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.scss
@@ -48,9 +48,9 @@
     align-items: center;
     min-width: 80px;
     padding: 0.5rem 1rem;
-    border: 1px solid rgb(255 255 255 / 10%);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
-    background: rgb(255 255 255 / 5%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
 
     .stat-value {
       color: var(--text-color, #fff);

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.ts
@@ -38,23 +38,19 @@ export class ReadingDebtChartComponent {
     plugins: {
       legend: {
         display: true, position: 'bottom',
-        labels: {color: 'rgba(255, 255, 255, 0.8)', font: {family: "'Inter', sans-serif", size: 11}, boxWidth: 12, padding: 15}
+        labels: {font: {family: "'Inter', sans-serif", size: 11}, boxWidth: 12, padding: 15}
       },
       tooltip: {
-        enabled: true, backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        titleColor: '#ffffff', bodyColor: '#ffffff', borderColor: '#ffffff',
-        borderWidth: 1, cornerRadius: 6, padding: 10
+        enabled: true, borderWidth: 1, cornerRadius: 6, padding: 10
       },
       datalabels: {display: false}
     },
     scales: {
       x: {
-        grid: {color: 'rgba(255, 255, 255, 0.08)'},
-        ticks: {color: 'rgba(255, 255, 255, 0.6)', font: {size: 10}}
+        ticks: {font: {size: 10}}
       },
       y: {
-        grid: {color: 'rgba(255, 255, 255, 0.08)'},
-        ticks: {color: 'rgba(255, 255, 255, 0.6)', font: {size: 11}}
+        ticks: {font: {size: 11}}
       },
       y1: {
         position: 'right',

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.scss
@@ -59,10 +59,10 @@
   }
 
   .insight-card {
-    background: rgb(255 255 255 / 5%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border-radius: 8px;
     padding: 1rem;
-    border: 1px solid rgb(255 255 255 / 10%);
+    border: 1px solid var(--color-border);
 
     .insight-header {
       display: flex;
@@ -84,7 +84,7 @@
 
     .insight-progress {
       height: 6px;
-      background: rgb(255 255 255 / 10%);
+      background: color-mix(in srgb, var(--color-text) 10%, transparent);
       border-radius: 3px;
       overflow: hidden;
       margin-bottom: 0.5rem;
@@ -134,4 +134,3 @@
     height: 300px;
   }
 }
-

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.ts
@@ -59,7 +59,6 @@ export class ReadingDNAChartComponent {
         max: 100,
         ticks: {
           stepSize: 20,
-          color: 'rgba(255, 255, 255, 0.6)',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -68,14 +67,11 @@ export class ReadingDNAChartComponent {
           showLabelBackdrop: false
         },
         grid: {
-          color: 'rgba(255, 255, 255, 0.2)',
           circular: true
         },
         angleLines: {
-          color: 'rgba(255, 255, 255, 0.3)'
         },
         pointLabels: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -97,9 +93,6 @@ export class ReadingDNAChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#e91e63',
         borderWidth: 2,
         cornerRadius: 8,
@@ -136,8 +129,7 @@ export class ReadingDNAChartComponent {
       point: {
         radius: 5,
         hoverRadius: 8,
-        borderWidth: 3,
-        backgroundColor: 'rgba(255, 255, 255, 0.8)'
+        borderWidth: 3
       }
     }
   };
@@ -176,7 +168,6 @@ export class ReadingDNAChartComponent {
         borderColor: '#e91e63',
         borderWidth: 3,
         pointBackgroundColor: gradientColors,
-        pointBorderColor: '#ffffff',
         pointBorderWidth: 3,
         pointRadius: 5,
         pointHoverRadius: 8,

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.scss
@@ -59,10 +59,10 @@
   }
 
   .insight-card {
-    background: rgb(255 255 255 / 5%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border-radius: 8px;
     padding: 1rem;
-    border: 1px solid rgb(255 255 255 / 10%);
+    border: 1px solid var(--color-border);
 
     .insight-header {
       display: flex;
@@ -84,7 +84,7 @@
 
     .insight-progress {
       height: 6px;
-      background: rgb(255 255 255 / 10%);
+      background: color-mix(in srgb, var(--color-text) 10%, transparent);
       border-radius: 3px;
       overflow: hidden;
       margin-bottom: 0.5rem;
@@ -134,4 +134,3 @@
     height: 300px;
   }
 }
-

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.ts
@@ -61,7 +61,6 @@ export class ReadingHabitsChartComponent {
         max: 100,
         ticks: {
           stepSize: 20,
-          color: 'rgba(255, 255, 255, 0.6)',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -70,14 +69,11 @@ export class ReadingHabitsChartComponent {
           showLabelBackdrop: false
         },
         grid: {
-          color: 'rgba(255, 255, 255, 0.2)',
           circular: true
         },
         angleLines: {
-          color: 'rgba(255, 255, 255, 0.3)'
         },
         pointLabels: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -98,9 +94,6 @@ export class ReadingHabitsChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#9c27b0',
         borderWidth: 2,
         cornerRadius: 8,
@@ -137,8 +130,7 @@ export class ReadingHabitsChartComponent {
       point: {
         radius: 5,
         hoverRadius: 8,
-        borderWidth: 3,
-        backgroundColor: 'rgba(255, 255, 255, 0.8)'
+        borderWidth: 3
       }
     }
   };
@@ -175,7 +167,6 @@ export class ReadingHabitsChartComponent {
         borderColor: '#9c27b0',
         borderWidth: 3,
         pointBackgroundColor: habitColors,
-        pointBorderColor: '#ffffff',
         pointBorderWidth: 3,
         pointRadius: 5,
         pointHoverRadius: 8,

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-heatmap-chart/reading-heatmap-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-heatmap-chart/reading-heatmap-chart.component.ts
@@ -7,6 +7,7 @@ import {BookService} from '../../../../../book/service/book.service';
 import {Book} from '../../../../../book/model/book.model';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {AsyncPipe} from '@angular/common';
+import {readStatsChartThemeColors} from '../../../shared/stats-chart-theme.service';
 
 interface MatrixDataPoint {
   x: number; // month (0-11)
@@ -65,9 +66,6 @@ export class ReadingHeatmapChartComponent {
       legend: {display: false},
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#ef476f',
         borderWidth: 2,
         cornerRadius: 8,
@@ -91,7 +89,6 @@ export class ReadingHeatmapChartComponent {
       },
       datalabels: {
         display: true,
-        color: '#ffffff',
         font: {
           family: "'Inter', sans-serif",
           size: 10,
@@ -107,7 +104,6 @@ export class ReadingHeatmapChartComponent {
         ticks: {
           stepSize: 1,
           callback: (value) => MONTH_NAMES[value as number] || '',
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11
@@ -121,7 +117,6 @@ export class ReadingHeatmapChartComponent {
         ticks: {
           stepSize: 1,
           callback: (value) => this.yearLabels[value as number] || '',
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11
@@ -173,13 +168,12 @@ export class ReadingHeatmapChartComponent {
         data: heatmapData,
         backgroundColor: (context) => {
           const point = context.raw as MatrixDataPoint;
-          if (!point?.v) return 'rgba(255, 255, 255, 0.05)';
+          if (!point?.v) return readStatsChartThemeColors().grid;
 
           const intensity = point.v / this.maxBookCount;
           const alpha = Math.max(0.2, Math.min(1.0, intensity * 0.8 + 0.2));
           return `rgba(239, 71, 111, ${alpha})`;
         },
-        borderColor: 'rgba(255, 255, 255, 0.2)',
         borderWidth: 1,
         width: ({chart}) => (chart.chartArea?.width || 0) / 12 - 1,
         height: ({chart}) => (chart.chartArea?.height || 0) / years.length - 1

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-progress-chart/reading-progress-chart.component.spec.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-progress-chart/reading-progress-chart.component.spec.ts
@@ -57,11 +57,9 @@ describe('ReadingProgressChartComponent', () => {
       }) => {
         text: string;
         fillStyle: string;
-        strokeStyle: string;
         lineWidth: number;
         hidden: boolean;
         index: number;
-        fontColor: string;
       }[])
       | undefined;
   }
@@ -96,8 +94,8 @@ describe('ReadingProgressChartComponent', () => {
     expect(chartData.datasets[0]?.data).toEqual([1, 2, 2, 2, 2, 1]);
     expect(chartData.datasets[0]?.label).toBe('statsUser.readingProgress.booksByProgress');
     expect(chartData.datasets[0]?.backgroundColor).toEqual(chartColors);
-    expect(chartData.datasets[0]?.borderColor).toBe('#ffffff');
-    expect(chartData.datasets[0]?.hoverBorderWidth).toBe(3);
+    expect(chartData.datasets[0]?.borderColor).toBeUndefined();
+    expect(chartData.datasets[0]?.hoverBorderWidth).toBeUndefined();
   });
 
   it('retains zero-count buckets in a fixed order when only one progress range has books', () => {
@@ -128,8 +126,8 @@ describe('ReadingProgressChartComponent', () => {
     expect(chartData.datasets[0]?.data).toEqual([]);
     expect(chartData.datasets[0]?.label).toBe('statsUser.readingProgress.booksByProgress');
     expect(chartData.datasets[0]?.backgroundColor).toEqual(chartColors);
-    expect(chartData.datasets[0]?.borderWidth).toBe(1);
-    expect(chartData.datasets[0]?.hoverBorderWidth).toBe(2);
+    expect(chartData.datasets[0]?.borderWidth).toBeUndefined();
+    expect(chartData.datasets[0]?.hoverBorderWidth).toBeUndefined();
   });
 
   it('builds deterministic legend labels from the current doughnut dataset without rendering a chart', () => {
@@ -155,12 +153,12 @@ describe('ReadingProgressChartComponent', () => {
     });
 
     expect(legendItems).toEqual([
-      {text: '0%: 1', fillStyle: '#6c757d', strokeStyle: '#ffffff', lineWidth: 1, hidden: false, index: 0, fontColor: '#ffffff'},
-      {text: '1-25%: 1', fillStyle: '#ffc107', strokeStyle: '#ffffff', lineWidth: 1, hidden: true, index: 1, fontColor: '#ffffff'},
-      {text: '26-50%: 1', fillStyle: '#fd7e14', strokeStyle: '#ffffff', lineWidth: 1, hidden: false, index: 2, fontColor: '#ffffff'},
-      {text: '51-75%: 0', fillStyle: '#17a2b8', strokeStyle: '#ffffff', lineWidth: 1, hidden: false, index: 3, fontColor: '#ffffff'},
-      {text: '76-99%: 1', fillStyle: '#6f42c1', strokeStyle: '#ffffff', lineWidth: 1, hidden: false, index: 4, fontColor: '#ffffff'},
-      {text: '100%: 1', fillStyle: '#28a745', strokeStyle: '#ffffff', lineWidth: 1, hidden: false, index: 5, fontColor: '#ffffff'},
+      {text: '0%: 1', fillStyle: '#6c757d', lineWidth: 1, hidden: false, index: 0},
+      {text: '1-25%: 1', fillStyle: '#ffc107', lineWidth: 1, hidden: true, index: 1},
+      {text: '26-50%: 1', fillStyle: '#fd7e14', lineWidth: 1, hidden: false, index: 2},
+      {text: '51-75%: 0', fillStyle: '#17a2b8', lineWidth: 1, hidden: false, index: 3},
+      {text: '76-99%: 1', fillStyle: '#6f42c1', lineWidth: 1, hidden: false, index: 4},
+      {text: '100%: 1', fillStyle: '#28a745', lineWidth: 1, hidden: false, index: 5},
     ]);
   });
 

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-progress-chart/reading-progress-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-progress-chart/reading-progress-chart.component.ts
@@ -21,13 +21,6 @@ const CHART_COLORS = [
   '#28a745'  // Green - Completed (100%)
 ] as const;
 
-const CHART_DEFAULTS = {
-  borderColor: '#ffffff',
-  borderWidth: 1,
-  hoverBorderWidth: 2,
-  hoverBorderColor: '#ffffff'
-} as const;
-
 const PROGRESS_RANGES = [
   {range: '0%', min: 0, max: 0, desc: 'Not Started'},
   {range: '1-25%', min: 0.1, max: 25, desc: 'Just Started'},
@@ -70,7 +63,6 @@ export class ReadingProgressChartComponent {
         display: true,
         position: 'bottom',
         labels: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 12
@@ -90,11 +82,9 @@ export class ReadingProgressChartComponent {
                 return {
                   text: `${label}: ${value}`,
                   fillStyle: (data.datasets[0].backgroundColor as string[])[i],
-                  strokeStyle: '#ffffff',
                   lineWidth: 1,
                   hidden: !isVisible,
                   index: i,
-                  fontColor: '#ffffff'
                 };
               });
             }
@@ -104,10 +94,6 @@ export class ReadingProgressChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
-        borderColor: '#ffffff',
         borderWidth: 1,
         cornerRadius: 6,
         displayColors: true,
@@ -153,10 +139,6 @@ export class ReadingProgressChartComponent {
           label: this.t.translate('statsUser.readingProgress.booksByProgress'),
           data: dataValues,
           backgroundColor: [...CHART_COLORS],
-          borderColor: '#ffffff',
-          borderWidth: 2,
-          hoverBorderWidth: 3,
-          hoverBorderColor: '#ffffff'
         }]
       };
     } catch (error) {
@@ -166,8 +148,7 @@ export class ReadingProgressChartComponent {
         datasets: [{
           label: this.t.translate('statsUser.readingProgress.booksByProgress'),
           data: [],
-          backgroundColor: [...CHART_COLORS],
-          ...CHART_DEFAULTS
+          backgroundColor: [...CHART_COLORS]
         }]
       };
     }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.scss
@@ -1,3 +1,5 @@
+@use '../../../chart-shared' as chart-shared;
+
 .reading-session-heatmap-container {
   width: 100%;
 }
@@ -11,7 +13,7 @@
 
   .chart-title {
     h3 {
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       font-size: 1.25rem;
       font-weight: 500;
       margin: 0 0 0.5rem;
@@ -21,7 +23,7 @@
     }
 
     .chart-description {
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       font-size: 0.9rem;
       margin: 0;
       line-height: 1.4;
@@ -35,20 +37,19 @@
     justify-self: center;
 
     .year-nav-btn {
-      background: rgb(255 255 255 / 10%);
-      border: 1px solid rgb(255 255 255 / 20%);
-      border-radius: 6px;
       padding: 0.6rem;
-      color: #fff;
+      color: var(--color-text);
       cursor: pointer;
       transition: all 0.3s ease;
       display: flex;
       align-items: center;
       justify-content: center;
 
+      @include chart-shared.neutral-surface(6px);
+
       &:hover {
-        background: rgb(255 255 255 / 20%);
-        border-color: rgb(255 255 255 / 30%);
+        background: color-mix(in srgb, var(--color-text) 8%, transparent);
+        border-color: color-mix(in srgb, var(--color-border) 90%, transparent);
         transform: translateY(-1px);
       }
 
@@ -64,7 +65,7 @@
     .current-year {
       font-size: 1.125rem;
       font-weight: 600;
-      color: #fff;
+      color: var(--color-text);
       min-width: 4.5rem;
       text-align: center;
     }
@@ -89,7 +90,7 @@
 
 .heatmap-title-icon {
   font-size: 1.5rem;
-  color: rgb(59 130 246 / 100%);
+  color: var(--color-blue-500);
   vertical-align: middle;
   margin-right: 0.25em;
 }
@@ -102,7 +103,7 @@
   gap: 0.75rem;
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid rgb(255 255 255 / 8%);
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .footer-pills {
@@ -121,26 +122,35 @@
   align-items: center;
   gap: 0.35rem;
   padding: 0.35rem 0.65rem;
-  border-radius: 6px;
-  border: 1px solid rgb(255 255 255 / 10%);
-  background: rgb(255 255 255 / 5%);
   font-size: 0.85rem;
-  color: var(--text-color, #fff);
+  color: var(--color-text);
   font-weight: 500;
   white-space: nowrap;
+
+  @include chart-shared.neutral-surface(6px);
 
   .pill-value {
     font-weight: 700;
   }
 
-  &.current .pill-value { color: #ff9800; }
-  &.longest .pill-value { color: #4caf50; }
-  &.total .pill-value { color: #2196f3; }
-  &.consistency .pill-value { color: #9c27b0; }
+  &.current { --stats-badge-accent: var(--color-orange-500); }
+  &.longest { --stats-badge-accent: var(--color-green-500); }
+  &.total { --stats-badge-accent: var(--color-blue-500); }
+  &.consistency { --stats-badge-accent: var(--color-violet-600); }
+
+  &.current,
+  &.longest,
+  &.total,
+  &.consistency {
+    .pill-value {
+      @include chart-shared.accent-text;
+    }
+  }
 
   &.milestone.unlocked {
-    border-color: rgb(76 175 80 / 30%);
-    background: rgb(76 175 80 / 10%);
+    --stats-badge-accent: var(--color-green-500);
+
+    @include chart-shared.accent-surface(6px);
   }
 
   &.milestone.locked {

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.ts
@@ -8,6 +8,7 @@ import {catchError, takeUntil} from 'rxjs/operators';
 import {ReadingSessionHeatmapResponse, UserStatsService} from '../../../../../settings/user-management/user-stats.service';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {AsyncPipe} from '@angular/common';
+import {readStatsChartThemeColors} from '../../../shared/stats-chart-theme.service';
 
 const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -75,10 +76,6 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
         legend: {display: false},
         tooltip: {
           enabled: true,
-          backgroundColor: 'rgba(0, 0, 0, 0.9)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
-          borderColor: '#ffffff',
           borderWidth: 1,
           cornerRadius: 6,
           displayColors: false,
@@ -122,7 +119,6 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
               }
               return '';
             },
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11}
           },
           grid: {display: false},
@@ -138,7 +134,6 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
               const dayIndex = value as number;
               return dayIndex >= 0 && dayIndex <= 6 ? DAY_NAMES[dayIndex] : '';
             },
-            color: '#ffffff',
             font: {family: "'Inter', sans-serif", size: 11}
           },
           border: {display: false}
@@ -233,13 +228,12 @@ export class ReadingSessionHeatmapComponent implements OnInit, OnDestroy {
         data: heatmapData,
         backgroundColor: (context) => {
           const point = context.raw as MatrixDataPoint;
-          if (!point?.v) return 'rgba(255, 255, 255, 0.05)';
+          if (!point?.v) return readStatsChartThemeColors().grid;
 
           const intensity = point.v / this.maxSessionCount;
           const alpha = Math.max(0.3, Math.min(0.9, intensity * 0.6 + 0.3));
           return `rgba(59, 130, 246, ${alpha})`;
         },
-        borderColor: 'rgba(255, 255, 255, 0.1)',
         borderWidth: 1
       }]
     });

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.scss
@@ -32,11 +32,11 @@
     justify-self: center;
 
     .week-nav-btn {
-      background: rgb(255 255 255 / 10%);
-      border: 1px solid rgb(255 255 255 / 20%);
+      background: color-mix(in srgb, var(--color-text) 5%, transparent);
+      border: 1px solid var(--color-border);
       border-radius: 6px;
       padding: 0.6rem;
-      color: #fff;
+      color: var(--color-text);
       cursor: pointer;
       transition: all 0.3s ease;
       display: flex;
@@ -44,8 +44,8 @@
       justify-content: center;
 
       &:hover {
-        background: rgb(255 255 255 / 20%);
-        border-color: rgb(255 255 255 / 30%);
+        background: color-mix(in srgb, var(--color-text) 10%, transparent);
+        border-color: var(--color-border);
         transform: translateY(-1px);
       }
 
@@ -67,7 +67,7 @@
       .week-label {
         font-size: 1rem;
         font-weight: 600;
-        color: #fff;
+        color: var(--color-text);
         white-space: nowrap;
         line-height: 1.2;
       }
@@ -97,16 +97,16 @@
   gap: 1rem;
   margin-bottom: 1rem;
   padding: 0.75rem;
-  background: rgb(255 255 255 / 5%);
+  background: color-mix(in srgb, var(--color-text) 5%, transparent);
   border-radius: 8px;
-  border: 1px solid rgb(255 255 255 / 10%);
+  border: 1px solid var(--color-border);
 
   .week-nav-btn {
-    background: rgb(255 255 255 / 10%);
-    border: 1px solid rgb(255 255 255 / 20%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
+    border: 1px solid var(--color-border);
     border-radius: 6px;
     padding: 0.6rem 6rem;
-    color: #fff;
+    color: var(--color-text);
     cursor: pointer;
     transition: all 0.3s ease;
     display: flex;
@@ -114,8 +114,8 @@
     justify-content: center;
 
     &:hover {
-      background: rgb(255 255 255 / 20%);
-      border-color: rgb(255 255 255 / 30%);
+      background: color-mix(in srgb, var(--color-text) 10%, transparent);
+      border-color: var(--color-border);
       transform: translateY(-1px);
     }
 
@@ -137,7 +137,7 @@
     .week-label {
       font-size: 1.125rem;
       font-weight: 600;
-      color: #fff;
+      color: var(--color-text);
       white-space: nowrap;
     }
 
@@ -187,7 +187,7 @@
   .hour-label {
     display: none;
     font-size: 0.75rem;
-    color: rgb(255 255 255 / 60%);
+    color: var(--color-text-secondary);
     position: absolute;
     left: 0;
     transform: translateX(-50%);
@@ -214,16 +214,16 @@
     align-items: center;
     font-size: 0.875rem;
     font-weight: 500;
-    color: rgb(255 255 255 / 90%);
+    color: var(--color-text);
     padding-right: 1rem;
   }
 
   .timeline-track {
     flex: 1;
     position: relative;
-    background: rgb(255 255 255 / 2%);
+    background: color-mix(in srgb, var(--color-text) 2%, transparent);
     border-radius: 4px;
-    border: 1px solid rgb(255 255 255 / 10%);
+    border: 1px solid var(--color-border);
     min-height: 35px;
     overflow: visible;
   }
@@ -237,7 +237,7 @@
   pointer-events: none;
 
   .grid-line {
-    border-right: 1px solid rgb(255 255 255 / 5%);
+    border-right: 1px solid color-mix(in srgb, var(--color-text) 5%, transparent);
 
     &:last-child {
       border-right: none;

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.scss
@@ -45,8 +45,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: rgb(255 255 255 / 5%);
-    border: 1px solid rgb(255 255 255 / 10%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 0.5rem 1rem;
     flex: 1;

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.ts
@@ -54,9 +54,6 @@ export class ReadingSurvivalChartComponent {
       legend: {display: false},
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#e91e63',
         borderWidth: 1,
         cornerRadius: 6,
@@ -75,14 +72,11 @@ export class ReadingSurvivalChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.readingSurvival.axisProgressThreshold'),
-          color: '#ffffff',
           font: {family: "'Inter', sans-serif", size: 12, weight: 'bold'}
         },
         ticks: {
-          color: '#ffffff',
           font: {family: "'Inter', sans-serif", size: 11}
         },
-        grid: {color: 'rgba(255, 255, 255, 0.1)'},
         border: {display: false}
       },
       y: {
@@ -91,15 +85,12 @@ export class ReadingSurvivalChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.readingSurvival.axisBooksSurviving'),
-          color: '#ffffff',
           font: {family: "'Inter', sans-serif", size: 12, weight: 'bold'}
         },
         ticks: {
-          color: '#ffffff',
           font: {family: "'Inter', sans-serif", size: 11},
           callback: (value) => `${value}%`
         },
-        grid: {color: 'rgba(255, 255, 255, 0.1)'},
         border: {display: false}
       }
     }
@@ -165,7 +156,6 @@ export class ReadingSurvivalChartComponent {
           pointRadius: 5,
           pointHoverRadius: 7,
           pointBackgroundColor: '#e91e63',
-          pointBorderColor: '#ffffff',
           pointBorderWidth: 2,
           borderWidth: 2
         }]

--- a/frontend/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.scss
@@ -1,3 +1,5 @@
+@use '../../../chart-shared' as chart-shared;
+
 .series-progress-container {
   width: 100%;
 }
@@ -15,7 +17,7 @@
     min-width: 200px;
 
     h3 {
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       font-size: 1.25rem;
       font-weight: 500;
       margin: 0 0 0.5rem;
@@ -25,7 +27,7 @@
     }
 
     .chart-description {
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       font-size: 0.9rem;
       margin: 0;
       line-height: 1.4;
@@ -50,18 +52,23 @@
       }
 
       &.completed {
-        background: rgb(76 175 80 / 20%);
-        color: #4caf50;
+        --stats-badge-accent: var(--color-green-500);
+
+        @include chart-shared.accent-surface(16px);
+        @include chart-shared.accent-text;
       }
 
       &.in-progress {
-        background: rgb(255 193 7 / 20%);
-        color: #ffc107;
+        --stats-badge-accent: var(--color-amber-500);
+
+        @include chart-shared.accent-surface(16px);
+        @include chart-shared.accent-text;
       }
 
       &.not-started {
-        background: rgb(158 158 158 / 20%);
-        color: #9e9e9e;
+        @include chart-shared.neutral-surface(16px);
+
+        color: var(--color-text-secondary);
       }
     }
   }
@@ -69,7 +76,7 @@
 
 .series-icon {
   font-size: 1.5rem;
-  color: #673ab7;
+  color: var(--color-violet-700);
 }
 
 .stats-row {
@@ -83,27 +90,27 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0.85rem;
-    background: rgb(255 255 255 / 5%);
-    border-radius: 20px;
-    border: 1px solid rgb(255 255 255 / 10%);
+
+    @include chart-shared.neutral-surface(20px);
 
     .pill-value {
       font-size: 1rem;
       font-weight: 600;
-      color: var(--text-color, #fff);
+      color: var(--color-text);
     }
 
     .pill-label {
       font-size: 0.75rem;
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
     }
 
     &.highlight {
-      background: rgb(103 58 183 / 15%);
-      border-color: rgb(103 58 183 / 30%);
+      --stats-badge-accent: var(--color-violet-700);
+
+      @include chart-shared.accent-surface(20px);
 
       .pill-value {
-        color: #673ab7;
+        @include chart-shared.accent-text;
       }
     }
   }
@@ -123,7 +130,7 @@
     margin-bottom: 0.75rem;
 
     h4 {
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       font-size: 0.95rem;
       font-weight: 500;
       margin: 0;
@@ -131,10 +138,10 @@
 
     .series-count {
       font-size: 0.75rem;
-      color: var(--text-secondary-color);
-      background: rgb(255 255 255 / 8%);
+      color: var(--color-text-secondary);
       padding: 0.25rem 0.5rem;
-      border-radius: 4px;
+
+      @include chart-shared.neutral-surface(4px);
     }
   }
 
@@ -152,12 +159,11 @@
       align-items: center;
       gap: 0.5rem;
       padding: 0.4rem 0.65rem;
-      background: rgb(255 255 255 / 5%);
-      border: 1px solid rgb(255 255 255 / 12%);
-      border-radius: 6px;
+
+      @include chart-shared.neutral-surface(6px);
 
       i {
-        color: var(--text-secondary-color);
+        color: var(--color-text-secondary);
         font-size: 0.8rem;
       }
 
@@ -166,12 +172,12 @@
         background: transparent;
         border: none;
         outline: none;
-        color: var(--text-color, #fff);
+        color: var(--color-text);
         font-size: 0.8rem;
         font-family: inherit;
 
         &::placeholder {
-          color: var(--text-secondary-color);
+          color: var(--color-text-secondary);
         }
       }
     }
@@ -183,26 +189,25 @@
       .filter-select,
       .sort-select {
         padding: 0.4rem 0.5rem;
-        background: rgb(255 255 255 / 5%);
-        border: 1px solid rgb(255 255 255 / 12%);
-        border-radius: 6px;
-        color: var(--text-color, #fff);
+        color: var(--color-text);
         font-size: 0.75rem;
         font-family: inherit;
         cursor: pointer;
         outline: none;
 
+        @include chart-shared.neutral-surface(6px);
+
         option {
-          background: #1e1e1e;
-          color: #fff;
+          background: var(--color-card);
+          color: var(--color-text);
         }
 
         &:hover {
-          border-color: rgb(255 255 255 / 25%);
+          border-color: color-mix(in srgb, var(--color-border) 90%, transparent);
         }
 
         &:focus {
-          border-color: #673ab7;
+          border-color: var(--color-violet-700);
         }
       }
     }
@@ -221,7 +226,7 @@
       justify-content: center;
       gap: 0.5rem;
       padding: 1.5rem;
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       font-size: 0.85rem;
 
       i {
@@ -237,7 +242,7 @@
     gap: 0.75rem;
     margin-top: 0.75rem;
     padding-top: 0.75rem;
-    border-top: 1px solid rgb(255 255 255 / 8%);
+    border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 
     .page-btn {
       display: flex;
@@ -245,20 +250,19 @@
       justify-content: center;
       width: 28px;
       height: 28px;
-      background: rgb(255 255 255 / 8%);
-      border: 1px solid rgb(255 255 255 / 12%);
-      border-radius: 6px;
-      color: var(--text-color, #fff);
+      color: var(--color-text);
       cursor: pointer;
       transition: all 0.2s ease;
+
+      @include chart-shared.neutral-surface(6px);
 
       i {
         font-size: 0.7rem;
       }
 
       &:hover:not(:disabled) {
-        background: rgb(103 58 183 / 30%);
-        border-color: #673ab7;
+        background: color-mix(in srgb, var(--color-violet-700) 18%, transparent);
+        border-color: color-mix(in srgb, var(--color-violet-700) 45%, transparent);
       }
 
       &:disabled {
@@ -269,7 +273,7 @@
 
     .page-info {
       font-size: 0.75rem;
-      color: var(--text-secondary-color);
+      color: var(--color-text-secondary);
       min-width: 80px;
       text-align: center;
     }
@@ -277,25 +281,25 @@
 
   .series-card {
     padding: 0.5rem 0.75rem;
-    background: rgb(255 255 255 / 3%);
-    border-radius: 8px;
-    border: 1px solid rgb(255 255 255 / 8%);
+
+    @include chart-shared.neutral-surface;
+
     border-left: 3px solid;
 
     &.completed {
-      border-left-color: #4caf50;
+      border-left-color: var(--color-green-500);
     }
 
     &.in-progress {
-      border-left-color: #ffc107;
+      border-left-color: var(--color-amber-500);
     }
 
     &.not-started {
-      border-left-color: #9e9e9e;
+      border-left-color: var(--color-text-muted);
     }
 
     &.abandoned {
-      border-left-color: #ef5350;
+      border-left-color: var(--color-red-500);
     }
 
     .series-main {
@@ -317,7 +321,7 @@
           display: block;
           font-size: 0.9rem;
           font-weight: 500;
-          color: var(--text-color, #fff);
+          color: var(--color-text);
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
@@ -331,7 +335,7 @@
 
           .books-count {
             font-size: 0.75rem;
-            color: var(--text-secondary-color);
+            color: var(--color-text-secondary);
 
             .total-hint {
               opacity: 0.7;
@@ -343,7 +347,7 @@
             align-items: center;
             gap: 0.2rem;
             font-size: 0.75rem;
-            color: #ffc107;
+            color: var(--color-amber-500);
 
             i {
               font-size: 0.65rem;
@@ -361,7 +365,7 @@
       .progress-bar-container {
         flex: 1;
         height: 6px;
-        background: rgb(255 255 255 / 10%);
+        background: color-mix(in srgb, var(--color-text) 8%, transparent);
         border-radius: 3px;
         overflow: hidden;
         position: relative;
@@ -375,11 +379,11 @@
 
           &.read {
             left: 0;
-            background: linear-gradient(90deg, #4caf50, #66bb6a);
+            background: linear-gradient(90deg, var(--color-green-500), var(--color-green-400));
           }
 
           &.reading {
-            background: #ffc107;
+            background: var(--color-amber-500);
           }
         }
       }
@@ -387,7 +391,7 @@
       .progress-text {
         font-size: 0.75rem;
         font-weight: 600;
-        color: var(--text-color, #fff);
+        color: var(--color-text);
         min-width: 32px;
         text-align: right;
       }
@@ -396,16 +400,16 @@
     .next-up {
       margin-top: 0.35rem;
       padding-top: 0.3rem;
-      border-top: 1px dashed rgb(255 255 255 / 10%);
+      border-top: 1px dashed color-mix(in srgb, var(--color-border) 70%, transparent);
       font-size: 0.7rem;
 
       .next-label {
-        color: var(--text-secondary-color);
+        color: var(--color-text-secondary);
         margin-right: 0.35rem;
       }
 
       .next-title {
-        color: #673ab7;
+        color: var(--color-violet-700);
         font-weight: 500;
       }
     }
@@ -419,7 +423,7 @@
   justify-content: center;
   padding: 2.5rem;
   text-align: center;
-  color: var(--text-secondary-color);
+  color: var(--color-text-secondary);
 
   i {
     font-size: 2rem;
@@ -430,7 +434,7 @@
   p {
     font-size: 0.95rem;
     margin: 0 0 0.35rem;
-    color: var(--text-color, #fff);
+    color: var(--color-text);
   }
 
   small {

--- a/frontend/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.ts
@@ -88,7 +88,6 @@ export class SeriesProgressChartComponent {
         title: {
           display: true,
           text: this.t.translate('statsUser.seriesProgress.axisCompletion'),
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 11,
@@ -96,7 +95,6 @@ export class SeriesProgressChartComponent {
           }
         },
         ticks: {
-          color: 'rgba(255, 255, 255, 0.8)',
           font: {
             family: "'Inter', sans-serif",
             size: 10
@@ -104,13 +102,11 @@ export class SeriesProgressChartComponent {
           callback: (value) => `${value}%`
         },
         grid: {
-          color: 'rgba(255, 255, 255, 0.1)'
         }
       },
       y: {
         stacked: true,
         ticks: {
-          color: 'rgba(255, 255, 255, 0.8)',
           font: {
             family: "'Inter', sans-serif",
             size: 10
@@ -126,7 +122,6 @@ export class SeriesProgressChartComponent {
         display: true,
         position: 'top',
         labels: {
-          color: '#ffffff',
           font: {
             family: "'Inter', sans-serif",
             size: 10
@@ -138,9 +133,6 @@ export class SeriesProgressChartComponent {
       },
       tooltip: {
         enabled: true,
-        backgroundColor: 'rgba(0, 0, 0, 0.95)',
-        titleColor: '#ffffff',
-        bodyColor: '#ffffff',
         borderColor: '#673ab7',
         borderWidth: 2,
         cornerRadius: 8,

--- a/frontend/src/app/features/stats/component/user-stats/charts/session-archetypes-chart/session-archetypes-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/session-archetypes-chart/session-archetypes-chart.component.scss
@@ -36,15 +36,15 @@
 
     .nav-btn {
       padding: 0.3rem 0.5rem;
-      border: 1px solid rgb(255 255 255 / 20%);
+      border: 1px solid var(--color-border);
       border-radius: 6px;
-      background: rgb(255 255 255 / 10%);
+      background: color-mix(in srgb, var(--color-text) 5%, transparent);
       color: var(--text-color, #fff);
       cursor: pointer;
       transition: background 0.2s;
 
       &:hover {
-        background: rgb(255 255 255 / 20%);
+        background: color-mix(in srgb, var(--color-text) 10%, transparent);
       }
     }
 
@@ -76,9 +76,9 @@
     align-items: center;
     min-width: 80px;
     padding: 0.5rem 1rem;
-    border: 1px solid rgb(255 255 255 / 10%);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
-    background: rgb(255 255 255 / 5%);
+    background: color-mix(in srgb, var(--color-text) 5%, transparent);
 
     .stat-value {
       color: var(--text-color, #fff);

--- a/frontend/src/app/features/stats/component/user-stats/charts/session-archetypes-chart/session-archetypes-chart.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/charts/session-archetypes-chart/session-archetypes-chart.component.ts
@@ -42,12 +42,10 @@ export class SessionArchetypesChartComponent implements OnInit, OnDestroy {
     plugins: {
       legend: {
         display: true, position: 'bottom',
-        labels: {color: 'rgba(255, 255, 255, 0.8)', font: {family: "'Inter', sans-serif", size: 11}, boxWidth: 10, padding: 12}
+        labels: {font: {family: "'Inter', sans-serif", size: 11}, boxWidth: 10, padding: 12}
       },
       tooltip: {
-        enabled: true, backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        titleColor: '#ffffff', bodyColor: '#ffffff',
-        cornerRadius: 6, padding: 10,
+        enabled: true, cornerRadius: 6, padding: 10,
         callbacks: {
           label: (ctx) => {
             const hour = ctx.parsed.x ?? 0;
@@ -63,9 +61,8 @@ export class SessionArchetypesChartComponent implements OnInit, OnDestroy {
     scales: {
       x: {
         min: 0, max: 24,
-        grid: {color: 'rgba(255, 255, 255, 0.08)'},
         ticks: {
-          color: 'rgba(255, 255, 255, 0.6)', font: {size: 10}, stepSize: 3,
+          font: {size: 10}, stepSize: 3,
           callback: (val) => {
             const h = Number(val);
             if (h === 0) return '12am';
@@ -73,13 +70,12 @@ export class SessionArchetypesChartComponent implements OnInit, OnDestroy {
             return h < 12 ? `${h}am` : `${h - 12}pm`;
           }
         },
-        title: {display: true, text: 'Time of Day', color: 'rgba(255, 255, 255, 0.5)', font: {size: 11}}
+        title: {display: true, text: 'Time of Day', font: {size: 11}}
       },
       y: {
         min: 0,
-        grid: {color: 'rgba(255, 255, 255, 0.08)'},
-        ticks: {color: 'rgba(255, 255, 255, 0.6)', font: {size: 11}},
-        title: {display: true, text: 'Duration (min)', color: 'rgba(255, 255, 255, 0.5)', font: {size: 11}}
+        ticks: {font: {size: 11}},
+        title: {display: true, text: 'Duration (min)', font: {size: 11}}
       }
     }
   };

--- a/frontend/src/app/features/stats/component/user-stats/user-stats.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/user-stats.component.ts
@@ -28,6 +28,7 @@ import {ReadingDebtChartComponent} from './charts/reading-debt-chart/reading-deb
 import {PublicationEraChartComponent} from './charts/publication-era-chart/publication-era-chart.component';
 import {SessionArchetypesChartComponent} from './charts/session-archetypes-chart/session-archetypes-chart.component';
 import {UserChartConfig, UserChartConfigService} from './service/user-chart-config.service';
+import {StatsChartThemeService} from '../shared/stats-chart-theme.service';
 
 import {provideCharts, withDefaultRegisterables} from 'ng2-charts';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
@@ -71,6 +72,7 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
 export class UserStatsComponent {
   private userService = inject(UserService);
   private chartConfigService = inject(UserChartConfigService);
+  private readonly chartTheme = inject(StatsChartThemeService);
 
   public currentYear = new Date().getFullYear();
   public readonly userName = computed(() => {
@@ -80,6 +82,10 @@ export class UserStatsComponent {
   public readonly showConfigPanel = signal(false);
   public readonly charts = this.chartConfigService.charts;
   public readonly visibleCharts = this.chartConfigService.visibleCharts;
+
+  constructor() {
+    this.chartTheme.activate();
+  }
 
   toggleChart(chartId: string): void {
     this.chartConfigService.toggleChart(chartId);

--- a/frontend/src/assets/styles/utilities.scss
+++ b/frontend/src/assets/styles/utilities.scss
@@ -41,13 +41,13 @@
 }
 
 .chart-info-icon {
-  color: rgb(255 255 255 / 35%);
+  color: var(--color-text-muted);
   font-size: 0.9rem;
   cursor: help;
   transition: color var(--transition-base);
 
   &:hover {
-    color: rgb(255 255 255 / 80%);
+    color: var(--color-text-secondary);
   }
 }
 


### PR DESCRIPTION
## Description

Fixes regressions with the two statistics pages in light mode. 

## Linked Issue

N/A

## Changes

New stats_chart_theme_service.ts to manage chart.js/ng2-charts theming. This pushes the dark or light mode theming to all chart components upon switch. 
Various CSS switches to correct colour tokens, as well as replacing hardcoded dark mode colours with better alternatives for both themes. 

## Manual Testing Steps

Open the stats pages in both light and dark modes, confirm no visual regression when switching to light mode, no missing text or labels vs dark mode. 

## Screenshots (Optional)
<img width="1624" height="977" alt="Screenshot 2026-05-27 at 17 49 41" src="https://github.com/user-attachments/assets/caf603f0-9608-4e74-bc2d-4bb57d97759f" />

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated chart styling infrastructure with unified theming system across all data visualization components.
  * Migrated chart colors from hardcoded values to CSS design tokens for improved theme consistency.
  * Simplified Chart.js configurations by removing redundant color overrides.

* **Chores**
  * Updated shared styling modules and SCSS imports for chart components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->