### PR TITLE
feat(kobo): add subtitle to KoboBookMetadata

### DIFF
--- a/backend/src/main/java/org/booklore/model/dto/kobo/KoboBookMetadata.java
+++ b/backend/src/main/java/org/booklore/model/dto/kobo/KoboBookMetadata.java
@@ -57,6 +57,9 @@ public class KoboBookMetadata {
     private String title;
     private String description;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String subtitle;
+
     @Builder.Default
     private List<String> categories = List.of("00000000-0000-0000-0000-000000000001");
 

--- a/backend/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
+++ b/backend/src/main/java/org/booklore/service/kobo/KoboEntitlementService.java
@@ -406,6 +406,7 @@ public class KoboEntitlementService {
                 .contributorRoles(Collections.emptyList())
                 .entitlementId(String.valueOf(book.getId()))
                 .title(metadata.getTitle())
+                .subtitle(metadata.getSubtitle())
                 .description(metadata.getDescription())
                 .contributors(authors)
                 .series(series)

--- a/backend/src/test/java/org/booklore/model/dto/kobo/KoboBookMetadataTest.java
+++ b/backend/src/test/java/org/booklore/model/dto/kobo/KoboBookMetadataTest.java
@@ -1,0 +1,50 @@
+package org.booklore.model.dto.kobo;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KoboBookMetadataTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldIncludeSubtitleWhenNotNull() {
+        // Given: Book has a subtitle
+        KoboBookMetadata metadata = KoboBookMetadata.builder()
+                .title("Test Book")
+                .subtitle("A Subtitle")
+                .build();
+
+        // When: Serializing to JSON
+        String json = objectMapper.writeValueAsString(metadata);
+        Map<String, Object> result = objectMapper.readValue(json, Map.class);
+
+        // Then: Subtitle should be included
+        assertThat(result)
+                .containsKey("Title")
+                .containsKey("Subtitle");
+    }
+
+    @Test
+    void shouldExcludeSubtitleWhenNull() {
+        // Given: Book does not have a subtitle
+        KoboBookMetadata metadata = KoboBookMetadata.builder()
+                .title("Test Book")
+                .subtitle(null)
+                .build();
+
+        // When: Serializing to JSON
+        String json = objectMapper.writeValueAsString(metadata);
+        Map<String, Object> result = objectMapper.readValue(json, Map.class);
+
+        // Then: Subtitle should be excluded
+        assertThat(result)
+                .containsKey("Title")
+                .doesNotContainKey("Subtitle");
+    }
+
+}

--- a/backend/src/test/java/org/booklore/service/KoboEntitlementServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoboEntitlementServiceTest.java
@@ -1,7 +1,6 @@
 package org.booklore.service;
 
 import org.booklore.config.security.service.AuthenticationService;
-import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.kobo.KoboBookMetadata;
@@ -217,6 +216,51 @@ class KoboEntitlementServiceTest {
         assertNotNull(result);
         assertEquals(1, result.getDownloadUrls().size());
         assertEquals(KoboBookFormat.KEPUB.toString(), result.getDownloadUrls().getFirst().getFormat());
+    }
+
+    @Test
+    void mapToKoboMetadata_subtitleNull() {
+        long bookId = 1L;
+        BookEntity epubBook = createEpubBookEntity(bookId);
+        epubBook.getMetadata().setSubtitle(null);
+        String token = "test-token";
+
+        when(bookQueryService.findAllWithMetadataByIds(Set.of(bookId)))
+                .thenReturn(List.of(epubBook));
+        when(koboCompatibilityService.isBookSupportedForKobo(epubBook))
+                .thenReturn(true);
+        when(koboUrlBuilder.downloadUrl(token, epubBook.getId()))
+                .thenReturn("http://test.com/download/" + epubBook.getId());
+        when(appSettingService.getAppSettings())
+                .thenReturn(createAppSettingsWithKoboSettings());
+
+        KoboBookMetadata result = koboEntitlementService.getMetadataForBook(bookId, token);
+
+        assertNotNull(result);
+        assertNull(result.getSubtitle());
+    }
+
+    @Test
+    void mapToKoboMetadata_shouldIncludeSubtitleWhenNotNull() {
+        long bookId = 1L;
+        String subtitle = "A test subtitle";
+        BookEntity epubBook = createEpubBookEntity(bookId);
+        epubBook.getMetadata().setSubtitle(subtitle);
+        String token = "test-token";
+
+        when(bookQueryService.findAllWithMetadataByIds(Set.of(bookId)))
+                .thenReturn(List.of(epubBook));
+        when(koboCompatibilityService.isBookSupportedForKobo(epubBook))
+                .thenReturn(true);
+        when(koboUrlBuilder.downloadUrl(token, epubBook.getId()))
+                .thenReturn("http://test.com/download/" + epubBook.getId());
+        when(appSettingService.getAppSettings())
+                .thenReturn(createAppSettingsWithKoboSettings());
+
+        KoboBookMetadata result = koboEntitlementService.getMetadataForBook(bookId, token);
+
+        assertNotNull(result);
+        assertEquals(subtitle, result.getSubtitle());
     }
 
     private BookEntity createCbxBookEntity(Long id) {


### PR DESCRIPTION
## Description

This PR adds the subtitle field to Kobo books.

Something to note; due to the way Kobo syncing works, subtitles in existing books are not synced if there are no changes in the book in Grimmory. To sync the subtitle, one needs to a) de-shelf and re-shelf the book to the Kobo shelf or b) make an edit to the metadata of the book in Grimmory, triggering a change in the Kobo sync API. This threw me for a loop when testing.

## Linked Issue

Fixes #681

## Changes

- Add subtitle to KoboBookMetadata
- Map it in KoboEntitlementService.mapToKoboMetadata()
- Add new test methods to KoboEntitlementServiceTest
- Create new test class for the KoboBookMetadata DTO, verifies the subtitle field is not included in the JSON representation if it is null

## Manual Testing Steps

1. Built the application
2. Deployed to my server
3. Verified that subtitles are present in books synced from Grimmory

## AI Disclosure

None

## Checklist

- [ ] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Book metadata now includes a subtitle field so listings can show and carry more detailed book information; subtitle is omitted from output when empty.

* **Tests**
  * Added tests verifying subtitle is serialized when present and omitted when null, and that subtitle mapping from source metadata is preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->