### PR TITLE
fix(ui): use signals for OPDS users to improve reactivity

### DIFF
--- a/frontend/src/app/features/settings/opds-settings/opds-settings.html
+++ b/frontend/src/app/features/settings/opds-settings/opds-settings.html
@@ -44,7 +44,7 @@
             </div>
             <p-toggleswitch
               [(ngModel)]="opdsEnabled"
-              [disabled]="loading"
+              [disabled]="loading()"
               (onChange)="toggleOpdsServer()">
             </p-toggleswitch>
           </div>
@@ -68,7 +68,7 @@
             </div>
             <p-toggleswitch
               [(ngModel)]="komgaApiEnabled"
-              [disabled]="loading"
+              [disabled]="loading()"
               (onChange)="toggleKomgaApi()">
             </p-toggleswitch>
           </div>
@@ -93,7 +93,7 @@
               </div>
               <p-toggleswitch
                 [(ngModel)]="komgaGroupUnknown"
-                [disabled]="loading"
+                [disabled]="loading()"
                 (onChange)="toggleKomgaGroupUnknown()">
               </p-toggleswitch>
             </div>
@@ -207,7 +207,7 @@
         </div>
 
         <div class="section-body">
-          @if (users.length === 0) {
+          @if (users().length === 0) {
             <div class="empty-state">
               <i class="pi pi-users"></i>
               <p class="empty-title">{{ t('users.emptyTitle') }}</p>
@@ -215,7 +215,7 @@
             </div>
           } @else {
             <div class="users-list">
-              @for (user of users; track user.id) {
+              @for (user of users(); track user.id) {
                 <div class="user-item">
                   <div class="user-info">
                     <div class="user-avatar">

--- a/frontend/src/app/features/settings/opds-settings/opds-settings.spec.ts
+++ b/frontend/src/app/features/settings/opds-settings/opds-settings.spec.ts
@@ -71,13 +71,13 @@ describe('OpdsSettings', () => {
     component.ngOnInit();
 
     TestBed.flushEffects();
-    expect(component.loading).toBe(true);
+    expect(component.loading()).toBe(true);
 
     appSettingsState.set(buildAppSettings());
     TestBed.flushEffects();
 
     expect(getUser).not.toHaveBeenCalled();
-    expect(component.loading).toBe(false);
+    expect(component.loading()).toBe(false);
 
     fixture.destroy();
   });
@@ -100,8 +100,8 @@ describe('OpdsSettings', () => {
     TestBed.flushEffects();
 
     expect(getUser).toHaveBeenCalledOnce();
-    expect(component.loading).toBe(false);
-    expect(component.users).toHaveLength(1);
+    expect(component.loading()).toBe(false);
+    expect(component.users()).toHaveLength(1);
 
     fixture.destroy();
   });

--- a/frontend/src/app/features/settings/opds-settings/opds-settings.ts
+++ b/frontend/src/app/features/settings/opds-settings/opds-settings.ts
@@ -1,4 +1,4 @@
-import {Component, DestroyRef, effect, inject, OnInit} from '@angular/core';
+import {Component, DestroyRef, WritableSignal, effect, inject, signal, OnInit} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import {Button} from 'primeng/button';
@@ -56,8 +56,8 @@ export class OpdsSettings implements OnInit {
   private appSettingsService = inject(AppSettingsService);
   private t = inject(TranslocoService);
 
-  users: OpdsUserV2[] = [];
-  loading = false;
+  users: WritableSignal<OpdsUserV2[]> = signal([]);
+  loading = signal(false);
   showCreateUserDialog = false;
   newUser: OpdsUserV2CreateRequest = {username: '', password: '', sortOrder: 'RECENT'};
   passwordVisibility: boolean[] = [];
@@ -87,8 +87,8 @@ export class OpdsSettings implements OnInit {
     const user = this.userService.currentUser();
     this.hasPermission = !!(user?.permissions.canAccessOpds || user?.permissions.admin);
     if (!this.hasPermission) {
-      this.loading = false;
-      this.users = [];
+      this.loading.set(false);
+      this.users.set([]);
       this.hasLoadedUsers = false;
     }
   });
@@ -103,7 +103,7 @@ export class OpdsSettings implements OnInit {
     }
 
     if (!settings) {
-      this.loading = true;
+      this.loading.set(true);
       return;
     }
 
@@ -111,7 +111,7 @@ export class OpdsSettings implements OnInit {
   });
 
   ngOnInit(): void {
-    this.loading = true;
+    this.loading.set(true);
   }
 
   private applyAppSettings(settings: AppSettings): void {
@@ -124,14 +124,14 @@ export class OpdsSettings implements OnInit {
         this.loadUsers();
       }
     } else {
-      this.users = [];
-      this.loading = false;
+      this.users.set([]);
+      this.loading.set(false);
       this.hasLoadedUsers = false;
     }
   }
 
   private loadUsers(): void {
-    this.loading = true;
+    this.loading.set(true);
     this.hasLoadedUsers = true;
     this.opdsService.getUser().pipe(
       takeUntilDestroyed(this.destroyRef),
@@ -141,9 +141,9 @@ export class OpdsSettings implements OnInit {
         return of([]);
       })
     ).subscribe(users => {
-      this.users = users;
+      this.users.set([...users]);
       this.passwordVisibility = new Array(users.length).fill(false);
-      this.loading = false;
+      this.loading.set(false);
     });
   }
 
@@ -154,7 +154,7 @@ export class OpdsSettings implements OnInit {
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
       next: user => {
-        this.users.push(user);
+        this.users.update(users => [...users, user]);
         this.resetCreateUserDialog();
         this.showMessage('success', this.t.translate('common.success'), this.t.translate('settingsOpds.createSuccess'));
       },
@@ -187,7 +187,7 @@ export class OpdsSettings implements OnInit {
         return of(null);
       })
     ).subscribe(() => {
-      this.users = this.users.filter(u => u.id !== user.id);
+      this.users.update(users => users.filter(u => u.id !== user.id));
       this.showMessage('success', this.t.translate('common.success'), this.t.translate('settingsOpds.deleteSuccess'));
     });
   }
@@ -207,7 +207,7 @@ export class OpdsSettings implements OnInit {
     if (this.opdsEnabled || this.komgaApiEnabled) {
       this.loadUsers();
     } else {
-      this.users = [];
+      this.users.set([]);
     }
   }
 
@@ -216,7 +216,7 @@ export class OpdsSettings implements OnInit {
     if (this.opdsEnabled || this.komgaApiEnabled) {
       this.loadUsers();
     } else {
-      this.users = [];
+      this.users.set([]);
     }
   }
 
@@ -311,10 +311,15 @@ export class OpdsSettings implements OnInit {
       })
     ).subscribe(updatedUser => {
       if (updatedUser) {
-        const index = this.users.findIndex(u => u.id === user.id);
-        if (index !== -1) {
-          this.users[index] = updatedUser;
-        }
+        this.users.update(users => {
+          const index = users.findIndex(u => u.id === user.id);
+          if (index !== -1) {
+            users[index] = updatedUser;
+          }
+
+          return [...users];
+        })
+
         this.showMessage('success', this.t.translate('common.success'), this.t.translate('settingsOpds.sortUpdateSuccess'));
       }
       this.cancelEdit();

--- a/frontend/src/app/features/settings/opds-settings/opds-settings.ts
+++ b/frontend/src/app/features/settings/opds-settings/opds-settings.ts
@@ -311,14 +311,11 @@ export class OpdsSettings implements OnInit {
       })
     ).subscribe(updatedUser => {
       if (updatedUser) {
-        this.users.update(users => {
-          const index = users.findIndex(u => u.id === user.id);
-          if (index !== -1) {
-            users[index] = updatedUser;
-          }
-
-          return [...users];
-        })
+        this.users.update(
+          users => users.map(
+            u => (u.id === user.id ? updatedUser : u)
+          )
+        );
 
         this.showMessage('success', this.t.translate('common.success'), this.t.translate('settingsOpds.sortUpdateSuccess'));
       }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
The OPDS user page is not using signals and does not react once the data finishes loading.  This PR switches to using signals.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1541

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* Use signal for users array and loading
* Update tests to match

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Opened console
2. Browsed to settings -> opds
3. Saw users appear without any further interaction
4. Saw no error messages in console

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OPDS settings internals to make loading state and user list updates more reliable.

* **Bug Fixes**
  * Toggles (OPDS server, Komga API, Komga unknown-group) now reliably disable during loading.
  * Users list and empty-state display correctly based on updated loading/data handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->