### PR TITLE
feat(users): store locale and theme preferences

### DIFF
--- a/backend/src/main/java/org/booklore/controller/UserController.java
+++ b/backend/src/main/java/org/booklore/controller/UserController.java
@@ -4,6 +4,7 @@ import org.booklore.model.dto.request.ChangePasswordRequest;
 import org.booklore.model.dto.request.ChangeUserPasswordRequest;
 import org.booklore.model.dto.request.UpdateUserSettingRequest;
 import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.dto.request.UserProfileUpdateRequest;
 import org.booklore.model.dto.request.UserUpdateRequest;
 import org.booklore.service.user.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -53,7 +54,7 @@ public class UserController {
         return ResponseEntity.ok(userService.getBookLoreUsers());
     }
 
-    @Operation(summary = "Update user", description = "Update a user's profile by their ID. Requires admin.")
+    @Operation(summary = "Update user", description = "Update a user's profile, permissions, and library assignments by their ID. Requires admin.")
     @ApiResponse(responseCode = "200", description = "User updated successfully")
     @PutMapping("/{id}")
     @PreAuthorize("@securityUtil.isAdmin()")
@@ -61,6 +62,17 @@ public class UserController {
             @Parameter(description = "ID of the user") @PathVariable Long id,
             @Parameter(description = "User update request") @Valid @RequestBody UserUpdateRequest updateRequest) {
         BookLoreUser updatedUser = userService.updateUser(id, updateRequest);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    @Operation(summary = "Update user profile", description = "Update a user's profile preferences by their ID. Allowed for admins and the user themself.")
+    @ApiResponse(responseCode = "200", description = "User profile updated successfully")
+    @PutMapping("/{id}/profile")
+    @PreAuthorize("@securityUtil.isAdmin() or @securityUtil.isSelf(#id)")
+    public ResponseEntity<BookLoreUser> updateUserProfile(
+            @Parameter(description = "ID of the user") @PathVariable Long id,
+            @Parameter(description = "User profile update request") @Valid @RequestBody UserProfileUpdateRequest updateRequest) {
+        BookLoreUser updatedUser = userService.updateUserProfile(id, updateRequest);
         return ResponseEntity.ok(updatedUser);
     }
 

--- a/backend/src/main/java/org/booklore/mapper/custom/BookLoreUserTransformer.java
+++ b/backend/src/main/java/org/booklore/mapper/custom/BookLoreUserTransformer.java
@@ -32,6 +32,9 @@ public class BookLoreUserTransformer {
         bookLoreUser.setUsername(userEntity.getUsername());
         bookLoreUser.setName(userEntity.getName());
         bookLoreUser.setEmail(userEntity.getEmail());
+        bookLoreUser.setLocale(userEntity.getLocale());
+        bookLoreUser.setTheme(userEntity.getTheme());
+        bookLoreUser.setThemeAccent(userEntity.getThemeAccent());
         bookLoreUser.setDefaultPassword(userEntity.isDefaultPassword());
         bookLoreUser.setPermissions(permissions);
 

--- a/backend/src/main/java/org/booklore/mapper/custom/BookLoreUserTransformer.java
+++ b/backend/src/main/java/org/booklore/mapper/custom/BookLoreUserTransformer.java
@@ -35,6 +35,7 @@ public class BookLoreUserTransformer {
         bookLoreUser.setLocale(userEntity.getLocale());
         bookLoreUser.setTheme(userEntity.getTheme());
         bookLoreUser.setThemeAccent(userEntity.getThemeAccent());
+        bookLoreUser.setThemeSyncEnabled(userEntity.isThemeSyncEnabled());
         bookLoreUser.setDefaultPassword(userEntity.isDefaultPassword());
         bookLoreUser.setPermissions(permissions);
 

--- a/backend/src/main/java/org/booklore/model/dto/BookLoreUser.java
+++ b/backend/src/main/java/org/booklore/model/dto/BookLoreUser.java
@@ -24,6 +24,7 @@ public class BookLoreUser {
     private String locale;
     private String theme;
     private String themeAccent;
+    private boolean themeSyncEnabled;
     private ProvisioningMethod provisioningMethod;
     private List<Library> assignedLibraries;
     private UserPermissions permissions;

--- a/backend/src/main/java/org/booklore/model/dto/BookLoreUser.java
+++ b/backend/src/main/java/org/booklore/model/dto/BookLoreUser.java
@@ -21,6 +21,9 @@ public class BookLoreUser {
     private boolean isDefaultPassword;
     private String name;
     private String email;
+    private String locale;
+    private String theme;
+    private String themeAccent;
     private ProvisioningMethod provisioningMethod;
     private List<Library> assignedLibraries;
     private UserPermissions permissions;

--- a/backend/src/main/java/org/booklore/model/dto/request/UserProfileUpdateRequest.java
+++ b/backend/src/main/java/org/booklore/model/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,12 @@
+package org.booklore.model.dto.request;
+
+import lombok.Data;
+
+@Data
+public class UserProfileUpdateRequest {
+    private String name;
+    private String email;
+    private String locale;
+    private String theme;
+    private String themeAccent;
+}

--- a/backend/src/main/java/org/booklore/model/dto/request/UserProfileUpdateRequest.java
+++ b/backend/src/main/java/org/booklore/model/dto/request/UserProfileUpdateRequest.java
@@ -9,4 +9,5 @@ public class UserProfileUpdateRequest {
     private String locale;
     private String theme;
     private String themeAccent;
+    private Boolean themeSyncEnabled;
 }

--- a/backend/src/main/java/org/booklore/model/entity/BookLoreUserEntity.java
+++ b/backend/src/main/java/org/booklore/model/entity/BookLoreUserEntity.java
@@ -39,6 +39,17 @@ public class BookLoreUserEntity {
     @Column(unique = true)
     private String email;
 
+    @Builder.Default
+    @Column(nullable = false, length = 16)
+    private String locale = "en";
+
+    @Builder.Default
+    @Column(nullable = false, length = 32)
+    private String theme = "grimmory";
+
+    @Column(name = "theme_accent", length = 32)
+    private String themeAccent;
+
     @Column(name = "provisioning_method")
     @Enumerated(EnumType.STRING)
     private ProvisioningMethod provisioningMethod;

--- a/backend/src/main/java/org/booklore/model/entity/BookLoreUserEntity.java
+++ b/backend/src/main/java/org/booklore/model/entity/BookLoreUserEntity.java
@@ -50,6 +50,10 @@ public class BookLoreUserEntity {
     @Column(name = "theme_accent", length = 32)
     private String themeAccent;
 
+    @Builder.Default
+    @Column(name = "theme_sync_enabled", nullable = false)
+    private boolean themeSyncEnabled = true;
+
     @Column(name = "provisioning_method")
     @Enumerated(EnumType.STRING)
     private ProvisioningMethod provisioningMethod;

--- a/backend/src/main/java/org/booklore/service/user/UserService.java
+++ b/backend/src/main/java/org/booklore/service/user/UserService.java
@@ -106,6 +106,9 @@ public class UserService {
         }
 
         applyThemePreferences(user, updateRequest.getTheme(), updateRequest.getThemeAccent());
+        if (updateRequest.getThemeSyncEnabled() != null) {
+            user.setThemeSyncEnabled(updateRequest.getThemeSyncEnabled());
+        }
 
         userRepository.save(user);
         auditService.log(AuditAction.USER_UPDATED, "User", id, "Updated user profile: " + user.getUsername());

--- a/backend/src/main/java/org/booklore/service/user/UserService.java
+++ b/backend/src/main/java/org/booklore/service/user/UserService.java
@@ -8,6 +8,7 @@ import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.request.ChangePasswordRequest;
 import org.booklore.model.dto.request.ChangeUserPasswordRequest;
 import org.booklore.model.dto.request.UpdateUserSettingRequest;
+import org.booklore.model.dto.request.UserProfileUpdateRequest;
 import org.booklore.model.dto.request.UserUpdateRequest;
 import org.booklore.model.dto.settings.UserSettingKey;
 import org.booklore.model.entity.BookLoreUserEntity;
@@ -30,6 +31,18 @@ import java.util.Set;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+    private static final Set<String> SUPPORTED_LOCALES = Set.of(
+            "en", "es", "it", "de", "fr", "nl", "pl", "pt", "ru", "hr",
+            "sv", "zh", "ja", "hu", "sl", "sk", "uk", "id", "da"
+    );
+    private static final Set<String> SUPPORTED_THEMES = Set.of(
+            "grimmory", "cobalt", "ember", "crimson", "rose", "forest",
+            "meadow", "teal", "lagoon", "violet", "fuchsia", "slate", "custom"
+    );
+    private static final Set<String> SUPPORTED_THEME_ACCENTS = Set.of(
+            "red", "orange", "amber", "yellow", "lime", "green", "emerald", "teal",
+            "cyan", "sky", "blue", "indigo", "violet", "purple", "fuchsia", "pink", "rose"
+    );
 
     private final UserRepository userRepository;
     private final LibraryRepository libraryRepository;
@@ -66,6 +79,36 @@ public class UserService {
 
         userRepository.save(user);
         auditService.log(AuditAction.USER_UPDATED, "User", id, "Updated user: " + user.getUsername());
+        return bookLoreUserTransformer.toDTO(user);
+    }
+
+    @Transactional
+    public BookLoreUser updateUserProfile(Long id, UserProfileUpdateRequest updateRequest) {
+        BookLoreUserEntity user = userRepository.findByIdWithDetails(id).orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(id));
+        BookLoreUser currentUser = getMyself();
+        boolean isAdmin = currentUser.getPermissions().isAdmin();
+
+        if (!isAdmin && !currentUser.getId().equals(id)) {
+            throw ApiError.GENERIC_UNAUTHORIZED.createException("You do not have permission to update this User");
+        }
+
+        if (updateRequest.getName() != null) {
+            user.setName(updateRequest.getName());
+        }
+
+        if (updateRequest.getEmail() != null) {
+            user.setEmail(updateRequest.getEmail());
+        }
+
+        if (updateRequest.getLocale() != null) {
+            validateLocale(updateRequest.getLocale());
+            user.setLocale(updateRequest.getLocale());
+        }
+
+        applyThemePreferences(user, updateRequest.getTheme(), updateRequest.getThemeAccent());
+
+        userRepository.save(user);
+        auditService.log(AuditAction.USER_UPDATED, "User", id, "Updated user profile: " + user.getUsername());
         return bookLoreUserTransformer.toDTO(user);
     }
 
@@ -180,5 +223,46 @@ public class UserService {
 
     private boolean meetsMinimumPasswordRequirements(String password) {
         return password != null && password.length() >= 8;
+    }
+
+    private void validateLocale(String locale) {
+        if (!SUPPORTED_LOCALES.contains(locale)) {
+            throw ApiError.INVALID_INPUT.createException("Unsupported locale: " + locale);
+        }
+    }
+
+    private void validateTheme(String theme) {
+        if (!SUPPORTED_THEMES.contains(theme)) {
+            throw ApiError.INVALID_INPUT.createException("Unsupported theme: " + theme);
+        }
+    }
+
+    private void applyThemePreferences(BookLoreUserEntity user, String theme, String themeAccent) {
+        String nextTheme = theme != null ? theme : user.getTheme();
+        validateTheme(nextTheme);
+
+        if (!"custom".equals(nextTheme)) {
+            if (themeAccent != null) {
+                throw ApiError.INVALID_INPUT.createException("Theme accent can only be set when theme is custom.");
+            }
+            user.setTheme(nextTheme);
+            user.setThemeAccent(null);
+            return;
+        }
+
+        String nextThemeAccent = themeAccent != null ? themeAccent : user.getThemeAccent();
+        if (nextThemeAccent == null) {
+            throw ApiError.INVALID_INPUT.createException("Theme accent is required when theme is custom.");
+        }
+
+        validateThemeAccent(nextThemeAccent);
+        user.setTheme(nextTheme);
+        user.setThemeAccent(nextThemeAccent);
+    }
+
+    private void validateThemeAccent(String themeAccent) {
+        if (!SUPPORTED_THEME_ACCENTS.contains(themeAccent)) {
+            throw ApiError.INVALID_INPUT.createException("Unsupported theme accent: " + themeAccent);
+        }
     }
 }

--- a/backend/src/main/resources/db/migration/V141__Add_user_locale_theme_and_accent.sql
+++ b/backend/src/main/resources/db/migration/V141__Add_user_locale_theme_and_accent.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+    ADD COLUMN locale VARCHAR(16) NOT NULL DEFAULT 'en',
+    ADD COLUMN theme VARCHAR(32) NOT NULL DEFAULT 'grimmory',
+    ADD COLUMN theme_accent VARCHAR(32) NULL;

--- a/backend/src/main/resources/db/migration/V141__Add_user_locale_theme_and_accent.sql
+++ b/backend/src/main/resources/db/migration/V141__Add_user_locale_theme_and_accent.sql
@@ -1,4 +1,5 @@
 ALTER TABLE users
     ADD COLUMN locale VARCHAR(16) NOT NULL DEFAULT 'en',
     ADD COLUMN theme VARCHAR(32) NOT NULL DEFAULT 'grimmory',
-    ADD COLUMN theme_accent VARCHAR(32) NULL;
+    ADD COLUMN theme_accent VARCHAR(32) NULL,
+    ADD COLUMN theme_sync_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/src/test/java/org/booklore/model/entity/BookLoreUserEntityTest.java
+++ b/backend/src/test/java/org/booklore/model/entity/BookLoreUserEntityTest.java
@@ -20,5 +20,8 @@ class BookLoreUserEntityTest {
 
         BookLoreUserEntity defaultUser = BookLoreUserEntity.builder().isDefaultPassword(false).build();
         assertThat(defaultUser.isDefaultPassword()).isFalse();
+        assertThat(defaultUser.getLocale()).isEqualTo("en");
+        assertThat(defaultUser.getTheme()).isEqualTo("grimmory");
+        assertThat(defaultUser.getThemeAccent()).isNull();
     }
 }

--- a/backend/src/test/java/org/booklore/model/entity/BookLoreUserEntityTest.java
+++ b/backend/src/test/java/org/booklore/model/entity/BookLoreUserEntityTest.java
@@ -23,5 +23,6 @@ class BookLoreUserEntityTest {
         assertThat(defaultUser.getLocale()).isEqualTo("en");
         assertThat(defaultUser.getTheme()).isEqualTo("grimmory");
         assertThat(defaultUser.getThemeAccent()).isNull();
+        assertThat(defaultUser.isThemeSyncEnabled()).isTrue();
     }
 }

--- a/backend/src/test/java/org/booklore/service/user/UserProvisioningServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/user/UserProvisioningServiceTest.java
@@ -82,6 +82,9 @@ class UserProvisioningServiceTest {
         assertThat(saved.getOidcSubject()).isEqualTo("sub-123");
         assertThat(saved.getOidcIssuer()).isEqualTo("https://issuer.example.com");
         assertThat(saved.getAvatarUrl()).isEqualTo("https://avatar.example.com/jdoe.png");
+        assertThat(saved.getLocale()).isEqualTo("en");
+        assertThat(saved.getTheme()).isEqualTo("grimmory");
+        assertThat(saved.getThemeAccent()).isNull();
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/user/UserProvisioningServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/user/UserProvisioningServiceTest.java
@@ -85,6 +85,7 @@ class UserProvisioningServiceTest {
         assertThat(saved.getLocale()).isEqualTo("en");
         assertThat(saved.getTheme()).isEqualTo("grimmory");
         assertThat(saved.getThemeAccent()).isNull();
+        assertThat(saved.isThemeSyncEnabled()).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/user/UserServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/user/UserServiceTest.java
@@ -96,6 +96,25 @@ class UserServiceTest {
     }
 
     @Test
+    void updateUserProfile_updatesThemeSyncFlagWithoutClearingAccountTheme() {
+        BookLoreUserEntity user = userEntity(1L);
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setThemeSyncEnabled(false);
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(1L, false));
+        when(userRepository.save(user)).thenReturn(user);
+        when(bookLoreUserTransformer.toDTO(user)).thenAnswer(invocation -> currentUser(1L, false));
+
+        userService.updateUserProfile(1L, request);
+
+        assertThat(user.getTheme()).isEqualTo("grimmory");
+        assertThat(user.getThemeAccent()).isNull();
+        assertThat(user.isThemeSyncEnabled()).isFalse();
+        verify(userRepository).save(user);
+    }
+
+    @Test
     void updateUserProfile_rejectsUnsupportedLocale() {
         BookLoreUserEntity user = userEntity(1L);
         UserProfileUpdateRequest request = new UserProfileUpdateRequest();

--- a/backend/src/test/java/org/booklore/service/user/UserServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/user/UserServiceTest.java
@@ -1,0 +1,219 @@
+package org.booklore.service.user;
+
+import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.exception.APIException;
+import org.booklore.mapper.custom.BookLoreUserTransformer;
+import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.dto.request.UserProfileUpdateRequest;
+import org.booklore.model.entity.BookLoreUserEntity;
+import org.booklore.model.entity.UserPermissionsEntity;
+import org.booklore.repository.LibraryRepository;
+import org.booklore.repository.UserRepository;
+import org.booklore.service.audit.AuditService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private LibraryRepository libraryRepository;
+
+    @Mock
+    private AuthenticationService authenticationService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private BookLoreUserTransformer bookLoreUserTransformer;
+
+    @Mock
+    private AuditService auditService;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void updateUserProfile_allowsSelfToUpdateLocaleAndTheme() {
+        BookLoreUserEntity user = userEntity(1L);
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setLocale("de");
+        request.setTheme("custom");
+        request.setThemeAccent("teal");
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(1L, false));
+        when(userRepository.save(user)).thenReturn(user);
+        when(bookLoreUserTransformer.toDTO(user)).thenAnswer(invocation -> currentUser(1L, false));
+
+        userService.updateUserProfile(1L, request);
+
+        assertThat(user.getLocale()).isEqualTo("de");
+        assertThat(user.getTheme()).isEqualTo("custom");
+        assertThat(user.getThemeAccent()).isEqualTo("teal");
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void updateUserProfile_clearsThemeAccentWhenThemeIsNotCustom() {
+        BookLoreUserEntity user = userEntity(1L);
+        user.setTheme("custom");
+        user.setThemeAccent("teal");
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setTheme("cobalt");
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(1L, false));
+        when(userRepository.save(user)).thenReturn(user);
+        when(bookLoreUserTransformer.toDTO(user)).thenAnswer(invocation -> currentUser(1L, false));
+
+        userService.updateUserProfile(1L, request);
+
+        assertThat(user.getTheme()).isEqualTo("cobalt");
+        assertThat(user.getThemeAccent()).isNull();
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void updateUserProfile_rejectsUnsupportedLocale() {
+        BookLoreUserEntity user = userEntity(1L);
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setLocale("zz");
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(1L, false));
+
+        assertThatThrownBy(() -> userService.updateUserProfile(1L, request))
+                .isInstanceOf(APIException.class)
+                .hasMessageContaining("Unsupported locale");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void updateUserProfile_rejectsUnsupportedTheme() {
+        BookLoreUserEntity user = userEntity(1L);
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setTheme("neon");
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(1L, false));
+
+        assertThatThrownBy(() -> userService.updateUserProfile(1L, request))
+                .isInstanceOf(APIException.class)
+                .hasMessageContaining("Unsupported theme");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void updateUserProfile_rejectsUnsupportedThemeAccent() {
+        BookLoreUserEntity user = userEntity(1L);
+        user.setTheme("custom");
+        user.setThemeAccent("teal");
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setThemeAccent("chartreuse");
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(1L, false));
+
+        assertThatThrownBy(() -> userService.updateUserProfile(1L, request))
+                .isInstanceOf(APIException.class)
+                .hasMessageContaining("Unsupported theme accent");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void updateUserProfile_rejectsThemeAccentWhenThemeIsNotCustom() {
+        BookLoreUserEntity user = userEntity(1L);
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setThemeAccent("teal");
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(1L, false));
+
+        assertThatThrownBy(() -> userService.updateUserProfile(1L, request))
+                .isInstanceOf(APIException.class)
+                .hasMessageContaining("Theme accent can only be set");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void updateUserProfile_rejectsCustomThemeWithoutThemeAccent() {
+        BookLoreUserEntity user = userEntity(1L);
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setTheme("custom");
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(1L, false));
+
+        assertThatThrownBy(() -> userService.updateUserProfile(1L, request))
+                .isInstanceOf(APIException.class)
+                .hasMessageContaining("Theme accent is required");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void updateUserProfile_rejectsNonAdminUpdatingAnotherUser() {
+        BookLoreUserEntity user = userEntity(1L);
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest();
+        request.setLocale("de");
+
+        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(user));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(currentUser(2L, false));
+
+        assertThatThrownBy(() -> userService.updateUserProfile(1L, request))
+                .isInstanceOf(APIException.class)
+                .hasMessageContaining("permission to update this User");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    private BookLoreUserEntity userEntity(Long id) {
+        BookLoreUserEntity user = new BookLoreUserEntity();
+        user.setId(id);
+        user.setUsername("admin");
+        user.setName("Admin");
+        user.setLocale("en");
+        user.setTheme("grimmory");
+        user.setPermissions(new UserPermissionsEntity());
+        return user;
+    }
+
+    private BookLoreUser currentUser(Long id, boolean admin) {
+        BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();
+        permissions.setAdmin(admin);
+        return BookLoreUser.builder()
+                .id(id)
+                .username("admin")
+                .name("Admin")
+                .locale("en")
+                .theme("grimmory")
+                .permissions(permissions)
+                .build();
+    }
+}


### PR DESCRIPTION
## Description

This changeset is the backend PR to implement support for per-user locale and theme preferences, stored on the backend.

## Linked Issue

First PR to implement https://github.com/grimmory-tools/grimmory/issues/1474

## Changes

This change is purely backend. There are no user-facing changes with this PR.

- Introduce a `locale`, `theme`, and `themeAccent` column on the user model
- Serialize these fields on the user model
- Add a new `updateUserProfile` endpoint (`PUT .../api/v1/users/{id}/profile`), permissioned for either an admin or the given user themself
  - This new endpoint allows users to update their own names, emails, locale, and theme preferences
  - Includes validations for safe locales/themes

## Manual Testing Steps

1. Test the endpoints and validate it is successful/errors as expected

## Screenshots (Optional)

N/A

## Additional Context (Optional)

This PR does not result in any user facing changes, and could be rolled back by dropping these columns. There is no breaking change.

The reason we added a new endpoint is because the current update user endpoint is scoped to admin-only (This also means that existing behaviour of the platform is that non-admin users error when trying to update their profile. I know.)

## AI Disclosure

Spec generation

## Checklist

- [ ] This PR links and implements an accepted issue.
- [ ] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [ ] I have disclosed any AI usage as per the organization AI Policy above.
- [ ] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can update profile preferences (locale, theme, theme accent, theme sync) via a new profile update endpoint (self-service, with admin access where allowed). Defaults applied for new preferences.
* **Tests**
  * Comprehensive test coverage for profile updates, validation rules, and permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->