### PR TITLE
fix(author-browser): convert AuthorMatchComponent state to signals

### DIFF
--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.html
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.html
@@ -4,18 +4,19 @@
       <div class="search-fields">
         <div class="field">
           <label for="author-match-name">{{ t('authorNameLabel') }}</label>
-          <input id="author-match-name" pInputText type="text" [(ngModel)]="searchQuery" [placeholder]="t('authorNamePlaceholder')" class="search-input"/>
+          <input id="author-match-name" pInputText type="text" [ngModel]="searchQuery()" (ngModelChange)="searchQuery.set($event)" [placeholder]="t('authorNamePlaceholder')" class="search-input"/>
         </div>
         <div class="field">
           <label for="author-match-asin">{{ t('asinLabel') }}</label>
-          <input id="author-match-asin" pInputText type="text" [(ngModel)]="asinQuery" [placeholder]="t('asinPlaceholder')" class="search-input"/>
+          <input id="author-match-asin" pInputText type="text" [ngModel]="asinQuery()" (ngModelChange)="asinQuery.set($event)" [placeholder]="t('asinPlaceholder')" class="search-input"/>
         </div>
         <div class="field region-field">
           <label for="author-match-region">{{ t('regionLabel') }}</label>
           <p-select
             inputId="author-match-region"
             [options]="regionOptions"
-            [(ngModel)]="selectedRegion"
+            [ngModel]="selectedRegion()"
+            (ngModelChange)="selectedRegion.set($event)"
             optionLabel="label"
             optionValue="value"
             class="region-dropdown">
@@ -26,14 +27,14 @@
             [label]="t('searchBtn')"
             icon="pi pi-search"
             (onClick)="search()"
-            [loading]="searching"
-            [disabled]="!canSearch">
+            [loading]="searching()"
+            [disabled]="!canSearch()">
           </p-button>
         </div>
       </div>
     </div>
 
-    @if (searching) {
+    @if (searching()) {
       <div class="search-loading">
         <p-progressSpinner
           [style]="{'width': '40px', 'height': '40px'}"
@@ -45,7 +46,7 @@
       </div>
     }
 
-    @if (!searching && hasSearched && results.length === 0) {
+    @if (!searching() && hasSearched() && results().length === 0) {
       <div class="empty-results">
         <i class="pi pi-info-circle"></i>
         <p>{{ t('noResults') }}</p>
@@ -53,7 +54,7 @@
       </div>
     }
 
-    @if (!searching && !hasSearched) {
+    @if (!searching() && !hasSearched()) {
       <div class="ready-state">
         <i class="pi pi-search"></i>
         <p>{{ t('readyToSearch') }}</p>
@@ -61,12 +62,12 @@
       </div>
     }
 
-    @if (!searching && results.length > 0) {
+    @if (!searching() && results().length > 0) {
       <div class="results-header">
-        <span>{{ t('resultsFound', {count: results.length}) }}</span>
+        <span>{{ t('resultsFound', {count: results().length}) }}</span>
       </div>
       <div class="results-list">
-        @for (result of results; track result.asin) {
+        @for (result of results(); track result.asin) {
           <div class="result-card">
             <div class="result-image">
               @if (result.imageUrl) {
@@ -89,7 +90,7 @@
                 [label]="t('matchBtn')"
                 icon="pi pi-link"
                 severity="success"
-                [loading]="matching"
+                [loading]="matching()"
                 (onClick)="matchAuthor(result)">
               </p-button>
             </div>

--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.spec.ts
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.spec.ts
@@ -62,29 +62,29 @@ describe('AuthorMatchComponent', () => {
 
     component.ngOnInit();
 
-    expect(component.searchQuery).toBe('  Ada Lovelace  ');
-    expect(component.canSearch).toBe(true);
+    expect(component.searchQuery()).toBe('  Ada Lovelace  ');
+    expect(component.canSearch()).toBe(true);
 
-    component.searchQuery = '   ';
-    component.asinQuery = '   ';
-    expect(component.canSearch).toBe(false);
+    component.searchQuery.set('   ');
+    component.asinQuery.set('   ');
+    expect(component.canSearch()).toBe(false);
 
-    component.asinQuery = ' B00TEST ';
-    expect(component.canSearch).toBe(true);
+    component.asinQuery.set(' B00TEST ');
+    expect(component.canSearch()).toBe(true);
   });
 
   it('does not search when both query inputs are blank after trimming', () => {
     const component = createComponent();
-    component.searchQuery = '   ';
-    component.asinQuery = '   ';
-    component.results = [{source: 'seed', asin: 'old', name: 'Existing'}];
+    component.searchQuery.set('   ');
+    component.asinQuery.set('   ');
+    component.results.set([{source: 'seed', asin: 'old', name: 'Existing'}]);
 
     component.search();
 
     expect(searchAuthorMetadata).not.toHaveBeenCalled();
-    expect(component.searching).toBe(false);
-    expect(component.hasSearched).toBe(false);
-    expect(component.results).toEqual([{source: 'seed', asin: 'old', name: 'Existing'}]);
+    expect(component.searching()).toBe(false);
+    expect(component.hasSearched()).toBe(false);
+    expect(component.results()).toEqual([{source: 'seed', asin: 'old', name: 'Existing'}]);
   });
 
   it('searches with trimmed values, clears stale results, and stores returned matches', () => {
@@ -92,17 +92,17 @@ describe('AuthorMatchComponent', () => {
     searchAuthorMetadata.mockReturnValue(results$);
 
     const component = createComponent();
-    component.searchQuery = ' Ada ';
-    component.asinQuery = ' B00MATCH ';
-    component.selectedRegion = 'uk';
-    component.results = [{source: 'seed', asin: 'old', name: 'Existing'}];
+    component.searchQuery.set(' Ada ');
+    component.asinQuery.set(' B00MATCH ');
+    component.selectedRegion.set('uk');
+    component.results.set([{source: 'seed', asin: 'old', name: 'Existing'}]);
 
     component.search();
 
     expect(searchAuthorMetadata).toHaveBeenCalledWith(9, 'Ada', 'uk', 'B00MATCH');
-    expect(component.searching).toBe(true);
-    expect(component.hasSearched).toBe(true);
-    expect(component.results).toEqual([]);
+    expect(component.searching()).toBe(true);
+    expect(component.hasSearched()).toBe(true);
+    expect(component.results()).toEqual([]);
 
     results$.next([
       {source: 'amazon', asin: 'B00MATCH', name: 'Ada Lovelace'},
@@ -110,22 +110,22 @@ describe('AuthorMatchComponent', () => {
     ]);
     results$.complete();
 
-    expect(component.results).toEqual([
+    expect(component.results()).toEqual([
       {source: 'amazon', asin: 'B00MATCH', name: 'Ada Lovelace'},
       {source: 'amazon', asin: 'B00OTHER', name: 'A. Lovelace'},
     ]);
-    expect(component.searching).toBe(false);
+    expect(component.searching()).toBe(false);
   });
 
   it('reports a translated search failure toast when metadata search errors', () => {
     searchAuthorMetadata.mockReturnValue(throwError(() => new Error('boom')));
 
     const component = createComponent();
-    component.searchQuery = 'Ada';
+    component.searchQuery.set('Ada');
 
     component.search();
 
-    expect(component.searching).toBe(false);
+    expect(component.searching()).toBe(false);
     expect(translate).toHaveBeenCalledWith('authorBrowser.match.toast.searchFailedSummary');
     expect(translate).toHaveBeenCalledWith('authorBrowser.match.toast.searchFailedDetail');
     expect(messageService.add).toHaveBeenCalledWith({
@@ -150,7 +150,7 @@ describe('AuthorMatchComponent', () => {
     matchAuthor.mockReturnValue(match$);
 
     const component = createComponent();
-    component.selectedRegion = 'de';
+    component.selectedRegion.set('de');
     const emitSpy = vi.spyOn(component.authorMatched, 'emit');
 
     component.matchAuthor({
@@ -165,12 +165,12 @@ describe('AuthorMatchComponent', () => {
       asin: 'B00MATCH',
       region: 'de',
     });
-    expect(component.matching).toBe(true);
+    expect(component.matching()).toBe(true);
 
     match$.next(updatedAuthor);
     match$.complete();
 
-    expect(component.matching).toBe(false);
+    expect(component.matching()).toBe(false);
     expect(translate).toHaveBeenCalledWith('authorBrowser.match.toast.matchSuccessSummary');
     expect(translate).toHaveBeenCalledWith('authorBrowser.match.toast.matchSuccessDetail');
     expect(messageService.add).toHaveBeenCalledWith({
@@ -193,7 +193,7 @@ describe('AuthorMatchComponent', () => {
       name: 'Ada Lovelace',
     });
 
-    expect(component.matching).toBe(false);
+    expect(component.matching()).toBe(false);
     expect(translate).toHaveBeenCalledWith('authorBrowser.match.toast.matchFailedSummary');
     expect(translate).toHaveBeenCalledWith('authorBrowser.match.toast.matchFailedDetail');
     expect(messageService.add).toHaveBeenCalledWith({

--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.ts
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, inject, Input, OnInit, Output} from '@angular/core';
+import {Component, computed, EventEmitter, inject, Input, OnInit, Output, signal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {Button} from 'primeng/button';
 import {InputText} from 'primeng/inputtext';
@@ -38,13 +38,15 @@ export class AuthorMatchComponent implements OnInit {
   private messageService = inject(MessageService);
   private t = inject(TranslocoService);
 
-  searchQuery = '';
-  asinQuery = '';
-  selectedRegion = 'us';
-  searching = false;
-  matching = false;
-  results: AuthorSearchResult[] = [];
-  hasSearched = false;
+  searchQuery = signal('');
+  asinQuery = signal('');
+  selectedRegion = signal('us');
+  searching = signal(false);
+  matching = signal(false);
+  results = signal<AuthorSearchResult[]>([]);
+  hasSearched = signal(false);
+
+  canSearch = computed(() => !!this.searchQuery().trim() || !!this.asinQuery().trim());
 
   regionOptions: RegionOption[] = [
     {label: 'US', value: 'us'},
@@ -60,29 +62,25 @@ export class AuthorMatchComponent implements OnInit {
   ];
 
   ngOnInit(): void {
-    this.searchQuery = this.authorName;
-  }
-
-  get canSearch(): boolean {
-    return !!this.searchQuery.trim() || !!this.asinQuery.trim();
+    this.searchQuery.set(this.authorName);
   }
 
   search(): void {
-    const asin = this.asinQuery.trim();
-    const query = this.searchQuery.trim();
+    const asin = this.asinQuery().trim();
+    const query = this.searchQuery().trim();
     if (!query && !asin) return;
-    this.searching = true;
-    this.results = [];
-    this.hasSearched = true;
+    this.searching.set(true);
+    this.results.set([]);
+    this.hasSearched.set(true);
 
-    this.authorService.searchAuthorMetadata(this.authorId, query, this.selectedRegion, asin || undefined)
+    this.authorService.searchAuthorMetadata(this.authorId, query, this.selectedRegion(), asin || undefined)
       .subscribe({
-        next: (results) => {
-          this.results = results;
-          this.searching = false;
+        next: (results: AuthorSearchResult[]) => {
+          this.results.set(results);
+          this.searching.set(false);
         },
         error: () => {
-          this.searching = false;
+          this.searching.set(false);
           this.messageService.add({
             severity: 'error',
             summary: this.t.translate('authorBrowser.match.toast.searchFailedSummary'),
@@ -94,16 +92,16 @@ export class AuthorMatchComponent implements OnInit {
   }
 
   matchAuthor(result: AuthorSearchResult): void {
-    this.matching = true;
+    this.matching.set(true);
     const request: AuthorMatchRequest = {
       source: result.source,
       asin: result.asin,
-      region: this.selectedRegion
+      region: this.selectedRegion()
     };
 
     this.authorService.matchAuthor(this.authorId, request).subscribe({
-      next: (updatedAuthor) => {
-        this.matching = false;
+      next: (updatedAuthor: AuthorDetails) => {
+        this.matching.set(false);
         this.messageService.add({
           severity: 'success',
           summary: this.t.translate('authorBrowser.match.toast.matchSuccessSummary'),
@@ -113,7 +111,7 @@ export class AuthorMatchComponent implements OnInit {
         this.authorMatched.emit(updatedAuthor);
       },
       error: () => {
-        this.matching = false;
+        this.matching.set(false);
         this.messageService.add({
           severity: 'error',
           summary: this.t.translate('authorBrowser.match.toast.matchFailedSummary'),

--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.ts
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, EventEmitter, inject, Input, OnInit, Output, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, EventEmitter, inject, Input, OnInit, Output, signal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {Button} from 'primeng/button';
 import {InputText} from 'primeng/inputtext';
@@ -17,6 +17,7 @@ interface RegionOption {
 @Component({
   selector: 'app-author-match',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './author-match.component.html',
   styleUrls: ['./author-match.component.scss'],
   imports: [


### PR DESCRIPTION

<img width="1408" height="760" alt="Screenshot 2026-05-29 at 8 25 12 PM" src="https://github.com/user-attachments/assets/56575265-f648-4f18-b684-3328aa16f840" />
## Description

Converts `AuthorMatchComponent` state from plain class properties to Angular signals, fixing the reactivity bug where author manual search results would not display until another UI interaction triggered change detection.

## Linked Issue

Fixes #1556

## Changes

- `searchQuery`, `asinQuery`, `selectedRegion`, `searching`, `matching`, `results`, `hasSearched` converted from plain properties to `signal()`
- `canSearch` converted from a getter to `computed()`
- Template updated: all bindings read signals via `()`, and `[(ngModel)]` two-way bindings replaced with `[ngModel]` + `(ngModelChange)` to write back to writable signals
- Spec updated: all property reads use signal accessors `signal()` and writes use `.set()`

## Manual Testing Steps

1. Open the Author Browser and navigate to an author without metadata
2. Click **Search Author** tab
3. The author name is pre-filled — click **Search**
4. Verify results appear immediately without needing to click elsewhere on the page

## Screenshots

**After fix — results load immediately on search:**

> Search Author tab showing 4 results for "Stephen King" loading instantly after clicking Search, with no spinner stuck and no extra click needed to trigger the UI update.

_(Screenshot taken locally — search results appear immediately without any additional UI interaction)_

## Additional Context

The root cause was that mutable class properties updated inside an RxJS `subscribe` callback were not tracked by Angular's signal graph, so the template was not notified when search results arrived. Converting to signals makes every state transition explicit and reactive, resolving the indefinite spinner issue without reaching for `ChangeDetectorRef`.

## AI Disclosure

Claude Code — helped convert component state to signals and update tests accordingly. All changes reviewed and understood.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal state management of the author search component for improved code architecture.

* **Tests**
  * Updated test suite to align with internal technical improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory/pull/1581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->