### PR TITLE
fix(ui): dashboard empty icon colour in light mode

### DIFF
--- a/frontend/src/app/features/dashboard/components/dashboard-scroller/dashboard-scroller.component.scss
+++ b/frontend/src/app/features/dashboard/components/dashboard-scroller/dashboard-scroller.component.scss
@@ -55,8 +55,7 @@
 
     i {
       font-size: 2rem;
-      color: white;
-      filter: drop-shadow(0 2px 4px rgb(0 0 0 / 30%));
+      color: var(--color-text);
     }
   }
 


### PR DESCRIPTION
## Description

Changes the empty dashboard icon to use colour-aware token, e.g. black in light mode. Also removed the odd shadow/glow around it. 

## Linked Issue

Fixes #1599 

## Changes

Changes icon token to `color-text`
Removes icon shadow

## Manual Testing Steps

Check scroller with empty book list and confirm icon is legible in light and dark mode. 

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
<img width="1275" height="252" alt="Screenshot 2026-06-01 at 13 36 58" src="https://github.com/user-attachments/assets/635ea8ca-7e3f-4b63-926e-cc06dfd8f469" />

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard icon colors to better align with the app's color theme for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->