### PR TITLE
fix(bookdrop): update notification progress reactively

### DIFF
--- a/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.html
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.html
@@ -4,10 +4,10 @@
 
     <div class="widget-info">
       <p class="widget-title">{{ t('title') }}</p>
-      <p class="widget-count">{{ pendingCount }}</p>
-      @if (lastUpdatedAt) {
+      <p class="widget-count">{{ summary().pendingCount }}</p>
+      @if (summary().lastUpdatedAt) {
         <p class="widget-date">
-          {{ t('lastUpdated') }} {{ lastUpdatedAt | date: 'short' }}
+          {{ t('lastUpdated') }} {{ summary().lastUpdatedAt | date: 'short' }}
         </p>
       }
     </div>

--- a/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.spec.ts
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.spec.ts
@@ -1,14 +1,57 @@
-import {describe, it} from 'vitest';
+import {provideZonelessChangeDetection} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Router} from '@angular/router';
+import {BehaviorSubject} from 'rxjs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-// NOTE(frontend-seam): Real coverage here needs seams around the live summary stream, router
-// navigation timing, and widget lifecycle teardown so bookdrop notification state can be tested
-// without mounting the live websocket-backed runtime.
-describe.skip('BookdropFilesWidgetComponent', () => {
-  it('needs subscription seams to verify pending-count updates and timestamp hydration from summary notifications', () => {
-    // TODO(seam): Cover ngOnInit once the live summary observable is isolated behind a deterministic subject.
+import {getTranslocoModule} from '../../../../core/testing/transloco-testing';
+import {BookdropFileNotification, BookdropFileService} from '../../service/bookdrop-file.service';
+import {BookdropFilesWidgetComponent} from './bookdrop-files-widget.component';
+
+describe('BookdropFilesWidgetComponent', () => {
+  let fixture: ComponentFixture<BookdropFilesWidgetComponent>;
+  let summary$: BehaviorSubject<BookdropFileNotification>;
+
+  beforeEach(async () => {
+    summary$ = new BehaviorSubject<BookdropFileNotification>({
+      pendingCount: 2,
+      totalCount: 4,
+      lastUpdatedAt: '2026-03-26T00:00:00Z',
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [BookdropFilesWidgetComponent, getTranslocoModule()],
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: BookdropFileService,
+          useValue: {summary$},
+        },
+        {
+          provide: Router,
+          useValue: {navigate: vi.fn()},
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BookdropFilesWidgetComponent);
+    fixture.detectChanges();
   });
 
-  it('needs routing seams to verify review navigation and destroy-time subscription cleanup', () => {
-    // TODO(seam): Cover openReviewDialog and ngOnDestroy after extracting router and subscription lifecycle concerns.
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('renders pending-count updates from live summary notifications', async () => {
+    expect(fixture.nativeElement.querySelector('.widget-count').textContent.trim()).toBe('2');
+
+    summary$.next({
+      pendingCount: 5,
+      totalCount: 7,
+      lastUpdatedAt: '2026-03-26T00:01:00Z',
+    });
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('.widget-count').textContent.trim()).toBe('5');
   });
 });

--- a/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.ts
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.ts
@@ -1,7 +1,6 @@
-import {Component, inject, OnDestroy, OnInit} from '@angular/core';
-import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
-import {BookdropFileNotification, BookdropFileService} from '../../service/bookdrop-file.service';
+import {Component, inject} from '@angular/core';
+import {toSignal} from '@angular/core/rxjs-interop';
+import {BookdropFileService} from '../../service/bookdrop-file.service';
 import {DatePipe} from '@angular/common';
 import {Router} from '@angular/router';
 import {Button} from 'primeng/button';
@@ -18,31 +17,18 @@ import {TranslocoDirective} from '@jsverse/transloco';
     TranslocoDirective
   ]
 })
-export class BookdropFilesWidgetComponent implements OnInit, OnDestroy {
-  pendingCount = 0;
-  totalCount = 0;
-  lastUpdatedAt?: string;
-
-  private destroy$ = new Subject<void>();
-  private bookdropFileService = inject(BookdropFileService);
-  private router = inject(Router);
-
-  ngOnInit(): void {
-    this.bookdropFileService.summary$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((summary: BookdropFileNotification) => {
-        this.pendingCount = summary.pendingCount;
-        this.totalCount = summary.totalCount;
-        this.lastUpdatedAt = summary.lastUpdatedAt;
-      });
-  }
+export class BookdropFilesWidgetComponent {
+  private readonly bookdropFileService = inject(BookdropFileService);
+  private readonly router = inject(Router);
+  protected readonly summary = toSignal(this.bookdropFileService.summary$, {
+    initialValue: {
+      pendingCount: 0,
+      totalCount: 0,
+      lastUpdatedAt: undefined,
+    },
+  });
 
   openReviewDialog(): void {
     this.router.navigate(['/bookdrop'], {queryParams: {reload: Date.now()}});
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
## Description

Fixes #1552

The BookDrop notification widget copied websocket summary emissions into ordinary component fields. Grimmory runs Angular with zoneless change detection, so those assignments did not schedule a repaint. The widget now exposes the existing summary stream through `toSignal`, allowing pending-count and timestamp updates to render live.

## Linked Issue

Fixes #1552

## Changes

- Replace the manual RxJS subscription and teardown bookkeeping with a signal-backed summary view.
- Render pending count and timestamp directly from the summary signal.
- Replace the skipped widget placeholder spec with a zoneless regression test that verifies a live count update from `2` to `5`.

## Manual Testing Steps

1. Ran `corepack yarn test --include src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.spec.ts`.
2. Ran `corepack yarn typecheck`.
3. Ran `corepack yarn lint:eslint`.
4. Ran `corepack yarn lint:styles`.
5. Ran `corepack yarn build:prod`.
6. Ran `corepack yarn test`: 1599 passed, 143 skipped.

## Screenshots (Optional)

Not attached: the visual layout is unchanged. The new zoneless component regression test reproduces the stale render and verifies that an incoming summary updates the rendered count from `2` to `5`.

## Additional Context (Optional)

`just` and Docker were not available in the local Windows environment, so the equivalent frontend Yarn commands were run directly. Backend code was not changed.

## AI Disclosure

Codex - researched the accepted issue and repository policies, traced the websocket-to-widget update path, implemented the signal migration, drafted the regression test, and ran verification. I reviewed the submitted changes and test results.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for the bookdrop files widget.

* **Tests**
  * Added comprehensive unit tests for the bookdrop files widget to ensure the pending count and last updated date display correctly and update as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->