### PR TITLE
refactor(ui): convert book details tab state to signals

### DIFF
--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.html
@@ -1,47 +1,27 @@
 <ng-container *transloco="let t; prefix: 'metadata.tabs'">
-<p-tabs lazy class="custom-p-tabs" [value]="defaultTabValue" scrollable (valueChange)="onTabChange($event)">
+@let currentBook = book();
+@let seriesBooks = bookInSeries();
+@let recommendations = recommendedBooks();
+@let currentAudiobookInfo = audiobookInfo();
+@let currentFileState = fileState();
+<p-tabs lazy class="custom-p-tabs" [value]="activeTab()" scrollable (valueChange)="onTabChange($event)">
   <p-tablist>
-    @if (hasSeries) {
-      <p-tab value="series">
-        <i class="pi pi-ethereum"></i> {{ t('moreInSeries') }}
+    @for (tab of availableTabs(); track tab.value) {
+      <p-tab [value]="tab.value">
+        <i [class]="tab.icon"></i> {{ t(tab.labelKey) }}
       </p-tab>
     }
-    <p-tab value="similar">
-      <i class="pi pi-bookmark"></i> {{ t('similarBooks') }}
-    </p-tab>
-    @if (supportsDualCovers()) {
-      <p-tab value="covers">
-        <i class="pi pi-images"></i> {{ t('covers') }}
-      </p-tab>
-    }
-    @if (hasAudiobookFormat()) {
-      <p-tab value="chapters">
-        <i class="pi pi-headphones"></i> {{ t('chapters') }}
-      </p-tab>
-    }
-    <p-tab value="files">
-      <i class="pi pi-folder-open"></i> {{ t('files') }}
-    </p-tab>
-    <p-tab value="notes">
-      <i class="pi pi-pen-to-square"></i> {{ t('notes') }}
-    </p-tab>
-    <p-tab value="sessions">
-      <i class="pi pi-clock"></i> {{ t('readingSessions') }}
-    </p-tab>
-    <p-tab value="reviews">
-      <i class="pi pi-comments"></i> {{ t('reviews') }}
-    </p-tab>
   </p-tablist>
   <p-tabpanels>
     <p-tabpanel value="series">
       <ng-template #content>
         <div class="tab-content">
-          @if (bookInSeries.length > 1) {
+          @if (seriesBooks.length > 1) {
             <div class="dashboard-scroller-infinite" infiniteScroll [infiniteScrollDistance]="2" [infiniteScrollThrottle]="50" [horizontal]="true">
-              @for (bookInSeriesItem of bookInSeries; track bookInSeriesItem.id) {
-                @if (bookInSeriesItem.id !== book.id) {
+              @for (bookInSeriesItem of seriesBooks; track bookInSeriesItem.id) {
+                @if (bookInSeriesItem.id !== currentBook.id) {
                   <div class="dashboard-scroller-card">
-                    <app-book-card-lite-component [book]="bookInSeriesItem" [showSeriesNumber]="true" [isActive]="bookInSeriesItem.id === book.id"></app-book-card-lite-component>
+                    <app-book-card-lite-component [book]="bookInSeriesItem" [showSeriesNumber]="true" [isActive]="bookInSeriesItem.id === currentBook.id"></app-book-card-lite-component>
                   </div>
                 }
               }
@@ -53,9 +33,9 @@
     <p-tabpanel value="similar">
       <ng-template #content>
         <div class="tab-content">
-          @if (recommendedBooks.length > 0) {
+          @if (recommendations.length > 0) {
             <div class="dashboard-scroller-infinite" infiniteScroll [infiniteScrollDistance]="2" [infiniteScrollThrottle]="50" [horizontal]="true">
-              @for (recBook of recommendedBooks; track recBook.book.id) {
+              @for (recBook of recommendations; track recBook.book.id) {
                 <div class="dashboard-scroller-card">
                   <app-book-card-lite-component [book]="recBook.book"></app-book-card-lite-component>
                 </div>
@@ -73,7 +53,7 @@
               <div class="cover-label">
                 <i class="pi pi-book"></i> {{ t('ebookCover') }}
               </div>
-              @if (urlHelper.getCoverUrl(book.id, book.metadata?.coverUpdatedOn); as coverUrl) {
+              @if (urlHelper.getCoverUrl(currentBook.id, currentBook.metadata?.coverUpdatedOn); as coverUrl) {
                 <p-image
                   [src]="coverUrl"
                   [alt]="t('ebookCover')"
@@ -82,14 +62,14 @@
                   [preview]="true">
                 </p-image>
               } @else {
-                <app-cover-placeholder style="width: 200px; height: 280px;" [title]="book.metadata?.title ?? ''" [author]="(book.metadata?.authors ?? []).join(', ')" size="lg" />
+                <app-cover-placeholder style="width: 200px; height: 280px;" [title]="currentBook.metadata?.title ?? ''" [author]="(currentBook.metadata?.authors ?? []).join(', ')" size="lg" />
               }
             </div>
             <div class="cover-item">
               <div class="cover-label audiobook">
                 <i class="pi pi-headphones"></i> {{ t('audiobookCover') }}
               </div>
-              @if (urlHelper.getAudiobookCoverUrl(book.id, book.metadata?.audiobookCoverUpdatedOn); as coverUrl) {
+              @if (urlHelper.getAudiobookCoverUrl(currentBook.id, currentBook.metadata?.audiobookCoverUpdatedOn); as coverUrl) {
                 <p-image
                   [src]="coverUrl"
                   [alt]="t('audiobookCover')"
@@ -99,7 +79,7 @@
                   class="square-cover">
                 </p-image>
               } @else {
-                <app-cover-placeholder style="width: 200px; height: 200px;" [title]="book.metadata?.title ?? ''" [author]="(book.metadata?.authors ?? []).join(', ')" size="lg" />
+                <app-cover-placeholder style="width: 200px; height: 200px;" [title]="currentBook.metadata?.title ?? ''" [author]="(currentBook.metadata?.authors ?? []).join(', ')" size="lg" />
               }
             </div>
           </div>
@@ -108,45 +88,45 @@
     </p-tabpanel>
     <p-tabpanel value="notes">
       <ng-template #content>
-        <app-book-notes-component [bookId]="book.id"></app-book-notes-component>
+        <app-book-notes-component [bookId]="currentBook.id"></app-book-notes-component>
       </ng-template>
     </p-tabpanel>
     <p-tabpanel value="sessions">
       <ng-template #content>
-        <app-book-reading-sessions [bookId]="book.id"></app-book-reading-sessions>
+        <app-book-reading-sessions [bookId]="currentBook.id"></app-book-reading-sessions>
       </ng-template>
     </p-tabpanel>
     <p-tabpanel value="reviews">
       <ng-template #content>
-        <app-book-reviews [bookId]="book.id"></app-book-reviews>
+        <app-book-reviews [bookId]="currentBook.id"></app-book-reviews>
       </ng-template>
     </p-tabpanel>
     <p-tabpanel value="chapters">
       <ng-template #content>
         <div class="chapters-tab-content">
-          @if (chaptersLoading) {
+          @if (chaptersLoading()) {
             <div class="chapters-loading">
               <i class="pi pi-spin pi-spinner"></i>
             </div>
-          } @else if (audiobookInfo) {
+          } @else if (currentAudiobookInfo) {
             <div class="chapters-tech-info">
               <span class="tech-info-item">
-                <i class="pi pi-clock"></i> {{ formatDuration(audiobookInfo.durationMs) }}
+                <i class="pi pi-clock"></i> {{ formatDuration(currentAudiobookInfo.durationMs) }}
               </span>
-              @if (audiobookInfo.codec) {
-                <span class="tech-info-item">{{ audiobookInfo.codec.toUpperCase() }}</span>
+              @if (currentAudiobookInfo.codec) {
+                <span class="tech-info-item">{{ currentAudiobookInfo.codec.toUpperCase() }}</span>
               }
-              @if (audiobookInfo.bitrate) {
-                <span class="tech-info-item">{{ audiobookInfo.bitrate }} kbps</span>
+              @if (currentAudiobookInfo.bitrate) {
+                <span class="tech-info-item">{{ currentAudiobookInfo.bitrate }} kbps</span>
               }
-              @if (audiobookInfo.sampleRate) {
-                <span class="tech-info-item">{{ formatSampleRate(audiobookInfo.sampleRate) }}</span>
+              @if (currentAudiobookInfo.sampleRate) {
+                <span class="tech-info-item">{{ formatSampleRate(currentAudiobookInfo.sampleRate) }}</span>
               }
-              @if (audiobookInfo.channels) {
-                <span class="tech-info-item">{{ getChannelLabel(audiobookInfo.channels) }}</span>
+              @if (currentAudiobookInfo.channels) {
+                <span class="tech-info-item">{{ getChannelLabel(currentAudiobookInfo.channels) }}</span>
               }
             </div>
-            @if (audiobookInfo.folderBased && audiobookInfo.tracks?.length) {
+            @if (currentAudiobookInfo.folderBased && currentAudiobookInfo.tracks?.length) {
               <div class="chapters-table-wrapper">
                 <table class="chapters-table">
                   <thead>
@@ -159,7 +139,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    @for (track of audiobookInfo.tracks; track track.index) {
+                    @for (track of currentAudiobookInfo.tracks; track track.index) {
                       <tr>
                         <td class="chapter-num">{{ track.index + 1 }}</td>
                         <td class="chapter-title">{{ track.title }}</td>
@@ -171,7 +151,7 @@
                   </tbody>
                 </table>
               </div>
-            } @else if (audiobookInfo.chapters?.length) {
+            } @else if (currentAudiobookInfo.chapters?.length) {
               <div class="chapters-table-wrapper">
                 <table class="chapters-table">
                   <thead>
@@ -184,7 +164,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    @for (chapter of audiobookInfo.chapters; track chapter.index) {
+                    @for (chapter of currentAudiobookInfo.chapters; track chapter.index) {
                       <tr>
                         <td class="chapter-num">{{ chapter.index + 1 }}</td>
                         <td class="chapter-title">{{ chapter.title }}</td>
@@ -208,7 +188,7 @@
     <p-tabpanel value="files">
       <ng-template #content>
         <div class="files-tab-content">
-          @if (isPhysicalBook()) {
+          @if (currentFileState.isPhysical) {
             <div class="empty-state">
               <i class="pi pi-book empty-state-icon"></i>
               <h4 class="empty-state-title">{{ t('physicalBookTitle') }}</h4>
@@ -216,33 +196,33 @@
               <p class="empty-state-hint">{{ t('physicalBookHint') }}</p>
             </div>
           } @else {
-            @if (hasMultipleFiles(book)) {
+            @if (currentFileState.hasMultipleContentFiles) {
               <div class="files-section download-all-section">
                 <p-button
-                  [label]="t('downloadAll', { count: getTotalFileCount(book) })"
+                  [label]="t('downloadAll', { count: currentFileState.totalContentFiles })"
                   icon="pi pi-download"
                   severity="info"
                   outlined
-                  (onClick)="downloadAll(book)"
+                  (onClick)="downloadAll(currentBook)"
                   [pTooltip]="t('downloadAllTooltip')"
                   tooltipPosition="top">
                 </p-button>
               </div>
             }
-            @if (book.primaryFile) {
+            @if (currentBook.primaryFile) {
               <div class="files-section">
                 <h4 class="files-section-title">{{ t('primaryFile') }}</h4>
                 <div class="files-list">
                   <div class="file-item primary-file">
                     <div class="file-info">
-                      <span class="file-type-badge" [style.background-color]="getFileTypeBgColor(book.primaryFile.extension)">
-                        {{ book.primaryFile.extension | uppercase }}
+                      <span class="file-type-badge" [style.background-color]="getFileTypeBgColor(currentBook.primaryFile.extension)">
+                        {{ currentBook.primaryFile.extension | uppercase }}
                       </span>
-                      <span class="file-name" [pTooltip]="book.primaryFile.filePath" tooltipPosition="top">{{ book.primaryFile.fileName }}</span>
-                      <span class="file-size">{{ getFileSizeInMB(book.primaryFile) }}</span>
+                      <span class="file-name" [pTooltip]="currentBook.primaryFile.filePath" tooltipPosition="top">{{ currentBook.primaryFile.fileName }}</span>
+                      <span class="file-size">{{ getFileSizeInMB(currentBook.primaryFile) }}</span>
                     </div>
                     <div class="file-actions">
-                      @if (book.primaryFile.bookType === 'EPUB') {
+                      @if (currentBook.primaryFile.bookType === 'EPUB') {
                         <p-button
                           icon="pi pi-book"
                           size="small"
@@ -250,7 +230,7 @@
                           severity="primary"
                           [pTooltip]="t('readTooltip')"
                           tooltipPosition="top"
-                          (onClick)="read(book.id)">
+                          (onClick)="read(currentBook.id)">
                         </p-button>
                         <p-button
                           icon="pi pi-play"
@@ -259,9 +239,9 @@
                           severity="info"
                           [pTooltip]="t('streamingReaderTooltip')"
                           tooltipPosition="top"
-                          (onClick)="read(book.id, 'epub-streaming')">
+                          (onClick)="read(currentBook.id, 'epub-streaming')">
                         </p-button>
-                      } @else if (book.primaryFile.bookType && ['PDF', 'FB2', 'MOBI', 'AZW3', 'CBX'].includes(book.primaryFile.bookType)) {
+                      } @else if (currentBook.primaryFile.bookType && ['PDF', 'FB2', 'MOBI', 'AZW3', 'CBX'].includes(currentBook.primaryFile.bookType)) {
                         <p-button
                           icon="pi pi-book"
                           size="small"
@@ -269,9 +249,9 @@
                           severity="primary"
                           [pTooltip]="t('readTooltip')"
                           tooltipPosition="top"
-                          (onClick)="read(book.id)">
+                          (onClick)="read(currentBook.id)">
                         </p-button>
-                      } @else if (book.primaryFile.bookType === 'AUDIOBOOK') {
+                      } @else if (currentBook.primaryFile.bookType === 'AUDIOBOOK') {
                         <p-button
                           icon="pi pi-play"
                           size="small"
@@ -279,7 +259,7 @@
                           severity="primary"
                           [pTooltip]="t('playTooltip')"
                           tooltipPosition="top"
-                          (onClick)="read(book.id)">
+                          (onClick)="read(currentBook.id)">
                         </p-button>
                       }
                       <p-button
@@ -289,9 +269,9 @@
                         severity="success"
                         [pTooltip]="t('downloadTooltip')"
                         tooltipPosition="top"
-                        (onClick)="download(book)">
+                        (onClick)="download(currentBook)">
                       </p-button>
-                      @if (canDetach(book)) {
+                      @if (currentFileState.canDetach) {
                         <p-button
                           icon="pi pi-external-link"
                           size="small"
@@ -299,7 +279,7 @@
                           severity="warn"
                           [pTooltip]="t('detachTooltip')"
                           tooltipPosition="top"
-                          (onClick)="detachFile(book, book.primaryFile!.id, book.primaryFile!.fileName || 'file')">
+                          (onClick)="detachFile(currentBook, currentBook.primaryFile!.id, currentBook.primaryFile!.fileName || 'file')">
                         </p-button>
                       }
                       <p-button
@@ -309,18 +289,18 @@
                         severity="danger"
                         [pTooltip]="t('deleteTooltip')"
                         tooltipPosition="top"
-                        (onClick)="deleteFile(book, book.primaryFile!.id, book.primaryFile!.fileName || 'file', true)">
+                        (onClick)="deleteFile(currentBook, currentBook.primaryFile!.id, currentBook.primaryFile!.fileName || 'file', true)">
                       </p-button>
                     </div>
                   </div>
                 </div>
               </div>
             }
-            @if (book.alternativeFormats && book.alternativeFormats.length > 0) {
+            @if (currentBook.alternativeFormats && currentBook.alternativeFormats.length > 0) {
               <div class="files-section">
                 <h4 class="files-section-title">{{ t('alternativeFormats') }}</h4>
                 <div class="files-list">
-                  @for (format of book.alternativeFormats; track format.id) {
+                  @for (format of currentBook.alternativeFormats; track format.id) {
                     <div class="file-item">
                       <div class="file-info">
                         <span class="file-type-badge" [style.background-color]="getFileTypeBgColor(format.extension)">
@@ -338,7 +318,7 @@
                             severity="primary"
                             [pTooltip]="t('readTooltip')"
                             tooltipPosition="top"
-                            (onClick)="read(book.id, undefined, format.bookType)">
+                            (onClick)="read(currentBook.id, undefined, format.bookType)">
                           </p-button>
                           <p-button
                             icon="pi pi-play"
@@ -347,7 +327,7 @@
                             severity="info"
                             [pTooltip]="t('streamingReaderTooltip')"
                             tooltipPosition="top"
-                            (onClick)="read(book.id, 'epub-streaming', format.bookType)">
+                            (onClick)="read(currentBook.id, 'epub-streaming', format.bookType)">
                           </p-button>
                         } @else if (format.bookType && ['PDF', 'FB2', 'MOBI', 'AZW3', 'CBX'].includes(format.bookType)) {
                           <p-button
@@ -357,7 +337,7 @@
                             severity="primary"
                             [pTooltip]="t('readTooltip')"
                             tooltipPosition="top"
-                            (onClick)="read(book.id, undefined, format.bookType)">
+                            (onClick)="read(currentBook.id, undefined, format.bookType)">
                           </p-button>
                         } @else if (format.bookType === 'AUDIOBOOK') {
                           <p-button
@@ -367,7 +347,7 @@
                             severity="primary"
                             [pTooltip]="t('playTooltip')"
                             tooltipPosition="top"
-                            (onClick)="read(book.id, undefined, format.bookType)">
+                            (onClick)="read(currentBook.id, undefined, format.bookType)">
                           </p-button>
                         }
                         <p-button
@@ -377,9 +357,9 @@
                           severity="success"
                           [pTooltip]="t('downloadTooltip')"
                           tooltipPosition="top"
-                          (onClick)="downloadAdditionalFile(book, format.id)">
+                          (onClick)="downloadAdditionalFile(currentBook, format.id)">
                         </p-button>
-                        @if (canDetach(book)) {
+                        @if (currentFileState.canDetach) {
                           <p-button
                             icon="pi pi-external-link"
                             size="small"
@@ -387,7 +367,7 @@
                             severity="warn"
                             [pTooltip]="t('detachTooltip')"
                             tooltipPosition="top"
-                            (onClick)="detachFile(book, format.id, format.fileName || 'file')">
+                            (onClick)="detachFile(currentBook, format.id, format.fileName || 'file')">
                           </p-button>
                         }
                         <p-button
@@ -397,7 +377,7 @@
                           severity="danger"
                           [pTooltip]="t('deleteTooltip')"
                           tooltipPosition="top"
-                          (onClick)="deleteFile(book, format.id, format.fileName || 'file', false)">
+                          (onClick)="deleteFile(currentBook, format.id, format.fileName || 'file', false)">
                         </p-button>
                       </div>
                     </div>
@@ -405,11 +385,11 @@
                 </div>
               </div>
             }
-            @if (book.supplementaryFiles && book.supplementaryFiles.length > 0) {
+            @if (currentBook.supplementaryFiles && currentBook.supplementaryFiles.length > 0) {
               <div class="files-section">
                 <h4 class="files-section-title">{{ t('supplementaryFiles') }}</h4>
                 <div class="files-list">
-                  @for (file of book.supplementaryFiles; track file.id) {
+                  @for (file of currentBook.supplementaryFiles; track file.id) {
                     <div class="file-item">
                       <div class="file-info">
                         <i [class]="getFileIcon(getFileExtension(file.filePath))" class="file-icon"></i>
@@ -424,9 +404,9 @@
                           severity="success"
                           [pTooltip]="t('downloadTooltip')"
                           tooltipPosition="top"
-                          (onClick)="downloadAdditionalFile(book, file.id)">
+                          (onClick)="downloadAdditionalFile(currentBook, file.id)">
                         </p-button>
-                        @if (canDetach(book)) {
+                        @if (currentFileState.canDetach) {
                           <p-button
                             icon="pi pi-external-link"
                             size="small"
@@ -434,7 +414,7 @@
                             severity="warn"
                             [pTooltip]="t('detachTooltip')"
                             tooltipPosition="top"
-                            (onClick)="detachFile(book, file.id, file.fileName || 'file')">
+                            (onClick)="detachFile(currentBook, file.id, file.fileName || 'file')">
                           </p-button>
                         }
                         <p-button
@@ -444,7 +424,7 @@
                           severity="danger"
                           [pTooltip]="t('deleteTooltip')"
                           tooltipPosition="top"
-                          (onClick)="deleteSupplementary(book.id, file.id, file.fileName || 'file')">
+                          (onClick)="deleteSupplementary(currentBook.id, file.id, file.fileName || 'file')">
                         </p-button>
                       </div>
                     </div>

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.spec.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.spec.ts
@@ -29,23 +29,23 @@ describe('MetadataTabsComponent default tab selection', () => {
         getTranslocoModule({translocoConfig: {reRenderOnLangChange: false}}),
       ],
       providers: [
-        {provide: UrlHelperService, useValue: {}},
+        {provide: UrlHelperService, useValue: {getCoverUrl: () => null, getAudiobookCoverUrl: () => null}},
         {provide: BookMetadataManageService, useValue: {supportsDualCovers: () => false}},
         {provide: AudiobookService, useValue: {getAudiobookInfo: () => undefined}},
       ],
     });
 
     const fixture = TestBed.createComponent(MetadataTabsComponent);
-    fixture.componentInstance.book = {
+    fixture.componentRef.setInput('book', {
       id: 21,
       libraryId: 1,
       libraryName: 'Library',
       metadata: {bookId: 21, title: 'Test Book', authors: []},
       alternativeFormats: [],
       supplementaryFiles: [],
-    } satisfies Book;
-    fixture.componentInstance.hasSeries = hasSeries;
-    fixture.componentInstance.bookInSeries = [];
+    } satisfies Book);
+    fixture.componentRef.setInput('hasSeries', hasSeries);
+    fixture.componentRef.setInput('bookInSeries', []);
     fixture.detectChanges();
 
     return fixture;
@@ -55,7 +55,7 @@ describe('MetadataTabsComponent default tab selection', () => {
     const fixture = createFixture(true);
     const component = fixture.componentInstance;
 
-    expect(component.defaultTabValue).toBe('series');
+    expect(component.activeTab()).toBe('series');
   });
 });
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.ts
@@ -1,5 +1,6 @@
-import {Component, EventEmitter, inject, Input, Output} from '@angular/core';
+import {ChangeDetectionStrategy, computed, Component, DestroyRef, effect, inject, input, linkedSignal, output, untracked} from '@angular/core';
 import {UpperCasePipe} from '@angular/common';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {Book, BookRecommendation, BookType, FileInfo} from '../../../../../book/model/book.model';
 import {Tab, TabList, TabPanel, TabPanels, Tabs} from 'primeng/tabs';
 import {InfiniteScrollDirective} from 'ngx-infinite-scroll';
@@ -16,6 +17,7 @@ import {BookMetadataManageService} from '../../../../../book/service/book-metada
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {AudiobookService} from '../../../../../readers/audiobook-player/audiobook.service';
 import {AudiobookInfo} from '../../../../../readers/audiobook-player/audiobook.model';
+import {finalize} from 'rxjs/operators';
 
 export interface ReadEvent {
   bookId: number;
@@ -56,9 +58,19 @@ export interface DetachBookFileEvent {
   fileName: string;
 }
 
+type MetadataTabValue = 'series' | 'similar' | 'covers' | 'chapters' | 'files' | 'notes' | 'sessions' | 'reviews';
+interface MetadataTab {
+  value: MetadataTabValue;
+  icon: string;
+  labelKey: string;
+}
+
+const metadataTab = (value: MetadataTabValue, icon: string, labelKey: string): MetadataTab => ({value, icon, labelKey});
+
 @Component({
   selector: 'app-metadata-tabs',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     Tab,
     TabList,
@@ -81,29 +93,73 @@ export interface DetachBookFileEvent {
   styleUrl: './metadata-tabs.component.scss'
 })
 export class MetadataTabsComponent {
-  @Input() book!: Book;
-  @Input() bookInSeries: Book[] = [];
-  @Input() hasSeries = false;
-  @Input() recommendedBooks: BookRecommendation[] = [];
+  readonly book = input.required<Book>();
+  readonly bookInSeries = input<Book[]>([]);
+  readonly hasSeries = input(false);
+  readonly recommendedBooks = input<BookRecommendation[]>([]);
 
   protected urlHelper = inject(UrlHelperService);
   private bookMetadataManageService = inject(BookMetadataManageService);
   private audiobookService = inject(AudiobookService);
   private t = inject(TranslocoService);
+  private destroyRef = inject(DestroyRef);
 
-  audiobookInfo: AudiobookInfo | null = null;
-  chaptersLoading = false;
+  readonly audiobookInfo = linkedSignal<number, AudiobookInfo | null>({
+    source: () => this.book().id,
+    computation: () => null,
+  });
+  readonly chaptersLoading = linkedSignal({
+    source: () => this.book().id,
+    computation: () => false,
+  });
 
-  @Output() readBook = new EventEmitter<ReadEvent>();
-  @Output() downloadBook = new EventEmitter<DownloadEvent>();
-  @Output() downloadFile = new EventEmitter<DownloadAdditionalFileEvent>();
-  @Output() downloadAllFiles = new EventEmitter<DownloadAllFilesEvent>();
-  @Output() deleteBookFile = new EventEmitter<DeleteBookFileEvent>();
-  @Output() deleteSupplementaryFile = new EventEmitter<DeleteSupplementaryFileEvent>();
-  @Output() detachBookFile = new EventEmitter<DetachBookFileEvent>();
+  readonly readBook = output<ReadEvent>();
+  readonly downloadBook = output<DownloadEvent>();
+  readonly downloadFile = output<DownloadAdditionalFileEvent>();
+  readonly downloadAllFiles = output<DownloadAllFilesEvent>();
+  readonly deleteBookFile = output<DeleteBookFileEvent>();
+  readonly deleteSupplementaryFile = output<DeleteSupplementaryFileEvent>();
+  readonly detachBookFile = output<DetachBookFileEvent>();
 
-  get defaultTabValue(): string {
-    return this.hasSeries ? 'series' : 'similar';
+  readonly supportsDualCovers = computed(() => this.bookMetadataManageService.supportsDualCovers(this.book()));
+  readonly fileState = computed(() => {
+    const book = this.book();
+    const contentFileCount = (book.primaryFile ? 1 : 0) + (book.alternativeFormats?.length ?? 0);
+    const allFileCount = contentFileCount + (book.supplementaryFiles?.length ?? 0);
+
+    return {
+      canDetach: allFileCount > 1,
+      hasAudiobookFormat: book.primaryFile?.bookType === 'AUDIOBOOK' || book.alternativeFormats?.some(file => file.bookType === 'AUDIOBOOK') === true,
+      hasMultipleContentFiles: contentFileCount > 1,
+      isPhysical: contentFileCount === 0,
+      totalContentFiles: contentFileCount,
+    };
+  });
+  readonly availableTabs = computed<MetadataTab[]>(() => [
+    ...(this.hasSeries() ? [metadataTab('series', 'pi pi-ethereum', 'moreInSeries')] : []),
+    metadataTab('similar', 'pi pi-bookmark', 'similarBooks'),
+    ...(this.supportsDualCovers() ? [metadataTab('covers', 'pi pi-images', 'covers')] : []),
+    ...(this.fileState().hasAudiobookFormat ? [metadataTab('chapters', 'pi pi-headphones', 'chapters')] : []),
+    metadataTab('files', 'pi pi-folder-open', 'files'),
+    metadataTab('notes', 'pi pi-pen-to-square', 'notes'),
+    metadataTab('sessions', 'pi pi-clock', 'readingSessions'),
+    metadataTab('reviews', 'pi pi-comments', 'reviews'),
+  ]);
+  readonly activeTab = linkedSignal<MetadataTab[], MetadataTabValue>({
+    source: this.availableTabs,
+    computation: (availableTabs, previous) =>
+      previous && availableTabs.some(tab => tab.value === previous.value)
+        ? previous.value
+        : availableTabs[0]?.value ?? 'similar',
+  });
+
+  constructor() {
+    effect(() => {
+      const bookId = this.book().id;
+      if (this.activeTab() === 'chapters') {
+        untracked(() => this.loadChapters(bookId));
+      }
+    });
   }
 
   read(bookId: number, reader?: 'epub-streaming', bookType?: BookType): void {
@@ -133,25 +189,6 @@ export class MetadataTabsComponent {
 
   detachFile(book: Book, fileId: number, fileName: string): void {
     this.detachBookFile.emit({ book, fileId, fileName });
-  }
-
-  canDetach(book: Book): boolean {
-    const totalFiles = (book.primaryFile ? 1 : 0)
-      + (book.alternativeFormats?.length ?? 0)
-      + (book.supplementaryFiles?.length ?? 0);
-    return totalFiles > 1;
-  }
-
-  hasMultipleFiles(book: Book): boolean {
-    const primaryCount = book.primaryFile ? 1 : 0;
-    const altCount = book.alternativeFormats?.length ?? 0;
-    return (primaryCount + altCount) > 1;
-  }
-
-  getTotalFileCount(book: Book): number {
-    const primaryCount = book.primaryFile ? 1 : 0;
-    const altCount = book.alternativeFormats?.length ?? 0;
-    return primaryCount + altCount;
   }
 
   getFileSizeInMB(fileInfo: FileInfo | null | undefined): string {
@@ -196,36 +233,29 @@ export class MetadataTabsComponent {
     return `var(--book-type-${type}-color, var(--p-gray-500))`;
   }
 
-  isPhysicalBook(): boolean {
-    return !this.book?.primaryFile && (!this.book?.alternativeFormats || this.book.alternativeFormats.length === 0);
-  }
-
-  supportsDualCovers(): boolean {
-    return this.bookMetadataManageService.supportsDualCovers(this.book);
-  }
-
   onTabChange(value: string | number | undefined): void {
-    if (value === 'chapters') {
-      this.loadChapters();
+    if (typeof value === 'string' && this.availableTabs().some(tab => tab.value === value)) {
+      this.activeTab.set(value as MetadataTabValue);
     }
   }
 
-  hasAudiobookFormat(): boolean {
-    const allFiles = [this.book.primaryFile, ...(this.book.alternativeFormats || [])].filter(f => f?.bookType);
-    return allFiles.some(f => f!.bookType === 'AUDIOBOOK');
-  }
-
-  loadChapters(): void {
-    if (this.audiobookInfo || this.chaptersLoading) return;
-    this.chaptersLoading = true;
-    this.audiobookService.getAudiobookInfo(this.book.id).subscribe({
+  loadChapters(bookId = this.book().id): void {
+    if (this.audiobookInfo() || this.chaptersLoading()) return;
+    this.chaptersLoading.set(true);
+    this.audiobookService.getAudiobookInfo(bookId).pipe(
+      takeUntilDestroyed(this.destroyRef),
+      finalize(() => {
+        if (this.book().id === bookId) {
+          this.chaptersLoading.set(false);
+        }
+      })
+    ).subscribe({
       next: info => {
-        this.audiobookInfo = info;
-        this.chaptersLoading = false;
+        if (this.book().id === bookId) {
+          this.audiobookInfo.set(info);
+        }
       },
-      error: () => {
-        this.chaptersLoading = false;
-      }
+      error: () => undefined
     });
   }
 


### PR DESCRIPTION
## Description

Converts the remaining UI state for book details metadata tabs (including audiobook chapters) to signals

## Linked Issue

Fixes #1555 

## Changes

- Metadata tabs are now signal based with linkedSignal
- Added computed-based tab availability, including tab header rendering via a single computed tab model. 
- Converted audiobook chapter state to signals to fix reactivity problems. 
- Simplified file tab logic into computed `fileState`
- Updated specs to match new signal state. 

## Manual Testing Steps

Open books and audiobooks in a library, including quick-switching between them with the arrow nav, confirm each book has the correct tabs with filled content. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

There's still a lot of manual behaviorSubject / RXJS code for the data layer, this would need a follow up alongside the rest of the book details page to migrate to the angular query layer. 

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked metadata tabs UI to render dynamically and drive panels from reactive state.
  * Files panel rebuilt for more reliable file handling and clearer primary/alternative/supplementary actions.
  * Covers, series, similar-items, notes, sessions, reviews and chapters panels updated for consistent data and improved loading behavior (chapters load on demand).

* **Tests**
  * Updated component tests to align with the refactor and input/output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->