### PR TITLE
fix(auth): render OIDC group mappings after load

### DIFF
--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -557,8 +557,9 @@
           </div>
         </div>
 
-        @if (groupMappings.length > 0) {
-          <p-table [value]="groupMappings" [tableStyle]="{'min-width': '100%'}" styleClass="p-datatable-sm">
+        @let mappings = groupMappings();
+        @if (mappings.length > 0) {
+          <p-table [value]="mappings" [tableStyle]="{'min-width': '100%'}" styleClass="p-datatable-sm">
             <ng-template #header>
               <tr>
                 <th>{{ t('groupMapping.colGroupClaim') }}</th>

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
@@ -1,8 +1,8 @@
 import {HttpErrorResponse} from '@angular/common/http';
-import {TestBed} from '@angular/core/testing';
-import {signal} from '@angular/core';
+import {provideZonelessChangeDetection, signal} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {of, throwError} from 'rxjs';
+import {of, Subject, throwError} from 'rxjs';
 
 import {AppSettingKey, AppSettings, OidcProviderDetails} from '../../../shared/model/app-settings.model';
 import {OidcGroupMapping} from '../../../shared/model/oidc-group-mapping.model';
@@ -177,8 +177,119 @@ describe('AuthenticationSettingsComponent', () => {
       groups: 'memberOf',
     });
     expect(component.mobileRedirectUris).toEqual(['grimmory://oauth2-callback']);
-    expect(component.groupMappings).toEqual(mappings);
+    expect(component.groupMappings()).toEqual(mappings);
     expect(groupMappingService.getAll).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the latest group mappings when refresh responses complete out of order', () => {
+    const firstMappings$ = new Subject<OidcGroupMapping[]>();
+    const secondMappings$ = new Subject<OidcGroupMapping[]>();
+    const staleMappings: OidcGroupMapping[] = [
+      {id: 2, oidcGroupClaim: 'stale', isAdmin: false, permissions: [], libraryIds: [], description: 'Stale'},
+    ];
+    const latestMappings: OidcGroupMapping[] = [
+      {id: 3, oidcGroupClaim: 'latest', isAdmin: true, permissions: ['permissionUpload'], libraryIds: [2], description: 'Latest'},
+    ];
+    groupMappingService.getAll
+      .mockReturnValueOnce(firstMappings$)
+      .mockReturnValueOnce(secondMappings$);
+
+    const enabledSettings = createSettings({
+      oidcEnabled: true,
+      oidcProviderDetails: completeProvider(),
+    });
+    component.loadSettings(enabledSettings);
+    component.loadSettings(enabledSettings);
+
+    secondMappings$.next(latestMappings);
+    firstMappings$.next(staleMappings);
+
+    expect(groupMappingService.getAll).toHaveBeenCalledTimes(2);
+    expect(component.groupMappings()).toEqual(latestMappings);
+
+    firstMappings$.complete();
+    secondMappings$.complete();
+  });
+
+  it('continues refreshing group mappings after a load error', () => {
+    const mappings: OidcGroupMapping[] = [
+      {id: 5, oidcGroupClaim: 'editors', isAdmin: false, permissions: ['permissionUpload'], libraryIds: [2], description: 'Editors'},
+    ];
+    groupMappingService.getAll
+      .mockReturnValueOnce(throwError(() => new HttpErrorResponse({status: 500})))
+      .mockReturnValueOnce(of(mappings));
+
+    const enabledSettings = createSettings({
+      oidcEnabled: true,
+      oidcProviderDetails: completeProvider(),
+    });
+    component.loadSettings(enabledSettings);
+    component.loadSettings(enabledSettings);
+
+    expect(groupMappingService.getAll).toHaveBeenCalledTimes(2);
+    expect(component.groupMappings()).toEqual(mappings);
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'common.error',
+      detail: 'settingsAuth.toast.groupMappingError',
+    });
+  });
+
+  it('renders group mappings loaded after the settings response completes', async () => {
+    const mappings$ = new Subject<OidcGroupMapping[]>();
+    const mappings: OidcGroupMapping[] = [
+      {id: 4, oidcGroupClaim: 'readers', isAdmin: false, permissions: ['permissionRead'], libraryIds: [1], description: 'Readers'},
+    ];
+    groupMappingService.getAll.mockReturnValue(mappings$);
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [AuthenticationSettingsComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        {provide: AppSettingsService, useValue: appSettingsService},
+        {provide: LibraryService, useValue: libraryService},
+        {provide: OidcGroupMappingService, useValue: groupMappingService},
+        {provide: MessageService, useValue: messageService},
+        {provide: TranslocoService, useValue: translocoService},
+      ],
+    })
+    .overrideComponent(AuthenticationSettingsComponent, {
+      set: {
+        template: `
+          @let mappings = groupMappings();
+          @if (mappings.length > 0) {
+            @for (mapping of mappings; track mapping.id) {
+              <span class="group-mapping-row">{{ mapping.oidcGroupClaim }}</span>
+            }
+          }
+        `,
+      },
+    })
+    .compileComponents();
+
+    const fixture: ComponentFixture<AuthenticationSettingsComponent> =
+      TestBed.createComponent(AuthenticationSettingsComponent);
+    const renderedComponent = fixture.componentInstance;
+
+    renderedComponent.loadSettings(createSettings({
+      oidcEnabled: true,
+      oidcProviderDetails: completeProvider(),
+    }));
+    fixture.detectChanges();
+
+    expect(renderedComponent.groupMappings()).toEqual([]);
+    expect(fixture.nativeElement.querySelector('.group-mapping-row')).toBeNull();
+
+    mappings$.next(mappings);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(renderedComponent.groupMappings()).toEqual(mappings);
+    expect(fixture.nativeElement.querySelector('.group-mapping-row').textContent.trim()).toBe('readers');
+
+    mappings$.complete();
+    fixture.destroy();
   });
 
   it('keeps OIDC disabled when the provider form is incomplete', () => {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -1,6 +1,8 @@
 import {HttpErrorResponse} from '@angular/common/http';
-import {Component, effect, inject} from '@angular/core';
+import {Component, DestroyRef, WritableSignal, effect, inject, signal} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {EMPTY, Subject, catchError, switchMap} from 'rxjs';
 import {InputText} from 'primeng/inputtext';
 import {Button} from 'primeng/button';
 import {Checkbox} from 'primeng/checkbox';
@@ -111,7 +113,7 @@ export class AuthenticationSettingsComponent {
     {label: 'On Login (Replace)', value: 'ON_LOGIN'},
     {label: 'On Login (Additive)', value: 'ON_LOGIN_ADDITIVE'}
   ];
-  groupMappings: OidcGroupMapping[] = [];
+  groupMappings: WritableSignal<OidcGroupMapping[]> = signal([]);
   showGroupMappingDialog = false;
   editingGroupMapping: OidcGroupMapping = this.emptyGroupMapping();
   editingGroupMappingPerms: {label: string; value: string; selected: boolean; translationKey: string}[] = [];
@@ -136,14 +138,33 @@ export class AuthenticationSettingsComponent {
   private libraryService = inject(LibraryService);
   private groupMappingService = inject(OidcGroupMappingService);
   private t = inject(TranslocoService);
+  private destroyRef = inject(DestroyRef);
+  private readonly groupMappingsRefresh$ = new Subject<void>();
   get allLibraries() { return this.libraryService.libraries(); }
 
-  private readonly loadSettingsEffect = effect(() => {
-    const settings = this.appSettingsService.appSettings();
-    if (settings) {
-      this.loadSettings(settings);
-    }
-  });
+  constructor() {
+    this.groupMappingsRefresh$.pipe(
+      switchMap(() => this.groupMappingService.getAll().pipe(
+        catchError(() => {
+          this.messageService.add({
+            severity: 'error',
+            summary: this.t.translate('common.error'),
+            detail: this.t.translate('settingsAuth.toast.groupMappingError')
+          });
+          return EMPTY;
+        })
+      )),
+      takeUntilDestroyed(this.destroyRef)
+    )
+    .subscribe(mappings => this.groupMappings.set([...mappings]));
+
+    effect(() => {
+      const settings = this.appSettingsService.appSettings();
+      if (settings) {
+        this.loadSettings(settings);
+      }
+    });
+  }
 
   loadSettings(settings: AppSettings): void {
     this.oidcEnabled = settings.oidcEnabled;
@@ -340,7 +361,7 @@ export class AuthenticationSettingsComponent {
 
   // Group mapping methods
   loadGroupMappings(): void {
-    this.groupMappingService.getAll().subscribe(mappings => this.groupMappings = mappings);
+    this.groupMappingsRefresh$.next();
   }
 
   saveGroupSyncMode(): void {


### PR DESCRIPTION
## Description

Fixes the OIDC group mappings table so mappings loaded after the auth settings request completes update the zoneless Angular UI.

## Linked Issue

Fixes #1549

## Changes

- Stores OIDC group mappings in an Angular signal.
- Updates the auth settings template to read the signal-backed mappings.
- Adds regression coverage that mounts the component and verifies mappings emitted after settings load render in the DOM.
- Cancels older in-flight group mapping refreshes so stale responses cannot overwrite the latest mappings.
- Handles group mapping load failures inside the refresh stream so later refreshes still work.

## Manual Testing Steps

1. `corepack yarn vitest run src/app/core/security/oauth2-management/authentication-settings.component.spec.ts`
   - `Test Files  1 passed (1)`
   - `Tests  24 passed (24)`
2. `corepack yarn typecheck`
   - Passed
3. `corepack yarn lint:eslint`
   - `All files pass linting.`
4. `corepack yarn lint:styles`
   - Passed
5. `CI=1 NG_CLI_ANALYTICS=false corepack yarn build:prod`
   - `Application bundle generation complete.`
6. `corepack yarn test`
   - `Test Files  292 passed | 84 skipped (376)`
   - `Tests  1614 passed | 140 skipped (1754)`
7. After addressing review feedback, including the DOM-render assertion, stale-response refresh guard, constructor cleanup, and refresh error recovery, reran:
   - `corepack yarn vitest run src/app/core/security/oauth2-management/authentication-settings.component.spec.ts`
     - `Test Files  1 passed (1)`
     - `Tests  24 passed (24)`
   - `corepack yarn typecheck`
     - Passed
   - `corepack yarn lint:eslint`
     - `All files pass linting.`
   - `corepack yarn lint:styles`
     - Passed
   - `CI=1 NG_CLI_ANALYTICS=false corepack yarn build:prod`
     - `Application bundle generation complete.`
   - `corepack yarn vitest run src/app/features/book/components/book-browser/book-dialog-helper.service.spec.ts`
     - `Test Files  1 passed (1)`
     - `Tests  3 passed (3)`

Note: two later full-suite reruns after review feedback each hit the same unrelated timeout in `src/app/features/book/components/book-browser/book-dialog-helper.service.spec.ts`; that spec passed when rerun directly, and the full suite had passed before the review-feedback-only cleanup.

## Screenshots (Optional)

Not attached. This change fixes async rendering of existing table data and does not alter layout or styling.

## Additional Context (Optional)

`just` is not installed in my local Windows environment, so I ran the equivalent frontend Yarn commands from `frontend/Justfile` directly with the same local Yarn cache environment.

## AI Disclosure

Codex assisted with issue scouting, code changes, regression test updates, and drafting this PR description. I reviewed the diff and validation output.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.
