### PR TITLE
fix(watcher): respect allowed formats for watched files

### DIFF
--- a/backend/src/main/java/org/booklore/service/watcher/BookFileTransactionalHandler.java
+++ b/backend/src/main/java/org/booklore/service/watcher/BookFileTransactionalHandler.java
@@ -58,7 +58,7 @@ public class BookFileTransactionalHandler {
         String filePath = path.toString();
         String fileName = path.getFileName().toString();
         BookFileType fileType = AllowedFormatUtils.resolveBookFileType(fileName)
-                .orElseThrow(() -> new IllegalArgumentException("Unsupported book file type: " + fileName));
+                .orElseThrow(() -> ApiError.UNSUPPORTED_FILE_TYPE.createException("Unsupported book file type: " + fileName));
 
         if (!AllowedFormatUtils.isAllowed(libraryEntity, fileType)) {
             log.debug("[SKIP] File '{}' has disallowed format {} for library {}", filePath, fileType, libraryId);

--- a/backend/src/main/java/org/booklore/service/watcher/BookFileTransactionalHandler.java
+++ b/backend/src/main/java/org/booklore/service/watcher/BookFileTransactionalHandler.java
@@ -17,6 +17,7 @@ import org.booklore.repository.LibraryRepository;
 import org.booklore.service.NotificationService;
 import org.booklore.service.file.FileFingerprint;
 import org.booklore.service.library.LibraryProcessingService;
+import org.booklore.util.AllowedFormatUtils;
 import org.booklore.util.BookFileGroupingUtils;
 import org.booklore.util.FileUtils;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,6 +57,14 @@ public class BookFileTransactionalHandler {
 
         String filePath = path.toString();
         String fileName = path.getFileName().toString();
+        BookFileType fileType = AllowedFormatUtils.resolveBookFileType(fileName)
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported book file type: " + fileName));
+
+        if (!AllowedFormatUtils.isAllowed(libraryEntity, fileType)) {
+            log.debug("[SKIP] File '{}' has disallowed format {} for library {}", filePath, fileType, libraryId);
+            return;
+        }
+
         String libraryPath = bookFilePersistenceService.findMatchingLibraryPath(libraryEntity, path);
 
         notificationService.sendMessageToPermissions(Topic.LOG, LogNotification.info("Started processing file: " + filePath), Set.of(ADMIN, MANAGE_LIBRARY));
@@ -141,8 +150,6 @@ public class BookFileTransactionalHandler {
         } else if (mode == LibraryOrganizationMode.BOOK_PER_FOLDER) {
             matchingBook = findBookInSameFolder(libraryPathEntity.getId(), fileSubPath);
             if (matchingBook == null) {
-                BookFileType fileType = BookFileExtension.fromFileName(fileName)
-                        .map(BookFileExtension::getType).orElse(null);
                 if (fileType == BookFileType.AUDIOBOOK) {
                     matchingBook = findNearestAncestorBookWithEbook(libraryPathEntity.getId(), fileSubPath);
                 }
@@ -160,9 +167,7 @@ public class BookFileTransactionalHandler {
                     .libraryPathEntity(libraryPathEntity)
                     .fileSubPath(fileSubPath)
                     .fileName(fileName)
-                    .bookFileType(BookFileExtension.fromFileName(fileName)
-                            .map(BookFileExtension::getType)
-                            .orElseThrow(() -> new IllegalArgumentException("Unsupported book file type: " + fileName)))
+                    .bookFileType(fileType)
                     .build();
 
             libraryProcessingService.processLibraryFiles(List.of(libraryFile), libraryEntity);
@@ -176,6 +181,11 @@ public class BookFileTransactionalHandler {
     public void handleNewFolderAudiobook(long libraryId, Path folderPath) {
         LibraryEntity libraryEntity = libraryRepository.findById(libraryId)
                 .orElseThrow(() -> ApiError.LIBRARY_NOT_FOUND.createException(libraryId));
+
+        if (!AllowedFormatUtils.isAllowed(libraryEntity, BookFileType.AUDIOBOOK)) {
+            log.debug("[SKIP] Folder audiobook '{}' is disallowed for library {}", folderPath, libraryId);
+            return;
+        }
 
         String folderName = folderPath.getFileName().toString();
         String libraryPath = bookFilePersistenceService.findMatchingLibraryPath(libraryEntity, folderPath);

--- a/backend/src/main/java/org/booklore/service/watcher/LibraryFileEventProcessor.java
+++ b/backend/src/main/java/org/booklore/service/watcher/LibraryFileEventProcessor.java
@@ -13,6 +13,7 @@ import org.booklore.repository.LibraryRepository;
 import org.booklore.service.file.FileFingerprint;
 import org.booklore.service.library.LibraryProcessingService;
 import org.booklore.service.library.LibraryScanListener;
+import org.booklore.util.AllowedFormatUtils;
 import org.booklore.util.FileUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -189,8 +190,15 @@ public class LibraryFileEventProcessor implements SmartLifecycle {
             return;
         }
 
-        if (!isBookFile(fileName)) {
+        Optional<BookFileType> fileType = AllowedFormatUtils.resolveBookFileType(fileName);
+        if (fileType.isEmpty()) {
             log.debug("[SKIP] Ignored non-book file '{}'", fileName);
+            return;
+        }
+
+        if (event.eventKind() != StandardWatchEventKinds.ENTRY_DELETE
+                && !AllowedFormatUtils.isAllowed(library, fileType.get())) {
+            log.debug("[SKIP] Ignored disallowed book file '{}'", fileName);
             return;
         }
 
@@ -301,7 +309,7 @@ public class LibraryFileEventProcessor implements SmartLifecycle {
         try (var stream = Files.walk(folderPath)) {
             stream.filter(Files::isRegularFile)
                     .filter(p -> !isUnderIgnoredDirectory(p, folderPath))
-                    .filter(p -> isBookFile(p.getFileName().toString()))
+                    .filter(p -> AllowedFormatUtils.isAllowedBookFile(library, p.getFileName().toString()))
                     .filter(this::fileHasContent)
                     .forEach(p -> {
                         try {
@@ -327,7 +335,7 @@ public class LibraryFileEventProcessor implements SmartLifecycle {
         try (var stream = Files.walk(folderPath)) {
             stream.filter(Files::isRegularFile)
                     .filter(p -> !isUnderIgnoredDirectory(p, folderPath))
-                    .filter(p -> isBookFile(p.getFileName().toString()))
+                    .filter(p -> AllowedFormatUtils.isAllowedBookFile(library, p.getFileName().toString()))
                     .filter(this::fileHasContent)
                     .forEach(bookFiles::add);
         } catch (IOException e) {
@@ -429,7 +437,7 @@ public class LibraryFileEventProcessor implements SmartLifecycle {
         var trackedFiles = filesFromPendingFolder.stream()
                 .filter(p -> p.startsWith(folderPath))
                 .filter(p -> !isUnderIgnoredDirectory(p, folderPath))
-                .filter(p -> isBookFile(p.getFileName().toString()))
+                .filter(p -> AllowedFormatUtils.isAllowedBookFile(library, p.getFileName().toString()))
                 .filter(this::fileHasContent)
                 .toList();
 
@@ -448,7 +456,7 @@ public class LibraryFileEventProcessor implements SmartLifecycle {
         try (var stream = Files.walk(folderPath)) {
             stream.filter(Files::isRegularFile)
                     .filter(p -> !isUnderIgnoredDirectory(p, folderPath))
-                    .filter(p -> isBookFile(p.getFileName().toString()))
+                    .filter(p -> AllowedFormatUtils.isAllowedBookFile(library, p.getFileName().toString()))
                     .filter(this::fileHasContent)
                     .filter(p -> !trackedFiles.contains(p))
                     .forEach(p -> {
@@ -546,10 +554,6 @@ public class LibraryFileEventProcessor implements SmartLifecycle {
             parent = parent.getParent();
         }
         return false;
-    }
-
-    private boolean isBookFile(String fileName) {
-        return BookFileExtension.fromFileName(fileName).isPresent();
     }
 
     private void scheduleWithStabilityCheck(Path path, Runnable onStable) {

--- a/backend/src/main/java/org/booklore/util/AllowedFormatUtils.java
+++ b/backend/src/main/java/org/booklore/util/AllowedFormatUtils.java
@@ -1,0 +1,29 @@
+package org.booklore.util;
+
+import lombok.experimental.UtilityClass;
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.enums.BookFileExtension;
+import org.booklore.model.enums.BookFileType;
+
+import java.util.List;
+import java.util.Optional;
+
+@UtilityClass
+public class AllowedFormatUtils {
+
+    public Optional<BookFileType> resolveBookFileType(String fileName) {
+        return BookFileExtension.fromFileName(fileName)
+                .map(BookFileExtension::getType);
+    }
+
+    public boolean isAllowed(LibraryEntity library, BookFileType fileType) {
+        List<BookFileType> allowedFormats = library.getAllowedFormats();
+        return allowedFormats == null || allowedFormats.isEmpty() || allowedFormats.contains(fileType);
+    }
+
+    public boolean isAllowedBookFile(LibraryEntity library, String fileName) {
+        return resolveBookFileType(fileName)
+                .filter(fileType -> isAllowed(library, fileType))
+                .isPresent();
+    }
+}

--- a/backend/src/test/java/org/booklore/service/watcher/BookFileTransactionalHandlerTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/BookFileTransactionalHandlerTest.java
@@ -148,6 +148,18 @@ class BookFileTransactionalHandlerTest {
         }
 
         @Test
+        void disallowedFormat_skipsProcessing() {
+            library.setAllowedFormats(List.of(BookFileType.EPUB));
+
+            handler.handleNewBookFile(1L, Path.of("/library/sub/test.pdf"));
+
+            verify(bookFilePersistenceService, never()).findMatchingLibraryPath(any(), any());
+            verify(libraryProcessingService, never()).processLibraryFiles(any(), any());
+            verify(bookAdditionalFileRepository, never()).save(any());
+            verify(notificationService, never()).sendMessageToPermissions(any(), any(), any());
+        }
+
+        @Test
         void existingAtPath_deletedBook_restoresIt() {
             BookEntity book = buildBook(10L, true);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "oldhash");
@@ -563,6 +575,18 @@ class BookFileTransactionalHandlerTest {
 
             assertThrows(Exception.class,
                     () -> handler.handleNewFolderAudiobook(99L, Path.of("/library/audiobook")));
+        }
+
+        @Test
+        void disallowedAudiobook_skipsProcessing() {
+            library.setAllowedFormats(List.of(BookFileType.EPUB));
+
+            handler.handleNewFolderAudiobook(1L, Path.of("/library/sub/audiobook"));
+
+            verify(bookFilePersistenceService, never()).findMatchingLibraryPath(any(), any());
+            verify(libraryProcessingService, never()).processLibraryFiles(any(), any());
+            verify(bookAdditionalFileRepository, never()).save(any());
+            verify(notificationService, never()).sendMessageToPermissions(any(), any(), any());
         }
 
         @Test

--- a/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
@@ -273,6 +273,23 @@ class LibraryFileEventProcessorTest {
         }
 
         @Test
+        void bookPerFolderMode_skipsDisallowedFormats() throws Exception {
+            library.setOrganizationMode(LibraryOrganizationMode.BOOK_PER_FOLDER);
+            library.setAllowedFormats(List.of(BookFileType.EPUB));
+
+            Path folder = tempDir.resolve("pdf-only");
+            Files.createDirectory(folder);
+            Files.writeString(folder.resolve("blocked.pdf"), "content");
+
+            processor.processEvent(StandardWatchEventKinds.ENTRY_CREATE, 1L, folder, true);
+
+            Thread.sleep(8000);
+
+            verify(libraryProcessingService, never()).processLibraryFiles(any(), any());
+            verify(bookFileTransactionalHandler, never()).handleNewBookFile(anyLong(), any());
+        }
+
+        @Test
         void pathOutsideLibrary_skipped() throws Exception {
             Path outsideFolder = Files.createTempDirectory("outside");
             try {
@@ -357,6 +374,29 @@ class LibraryFileEventProcessorTest {
                     .thenReturn(Optional.of(bookFile));
 
             Path file = tempDir.resolve("sub").resolve("test.epub");
+
+            processor.processEvent(StandardWatchEventKinds.ENTRY_DELETE, 1L, file, false);
+
+            Thread.sleep(2000);
+
+            verify(pendingDeletionPool).addFileDeletion(any(), eq(1L), eq(bookFile), eq(book), any());
+        }
+
+        @Test
+        void disallowedBookFileDelete_stillAddsToPool() throws Exception {
+            library.setAllowedFormats(List.of(BookFileType.EPUB));
+
+            BookEntity book = BookEntity.builder()
+                    .id(10L).library(library).libraryPath(libraryPath).deleted(false)
+                    .bookFiles(new ArrayList<>()).build();
+            BookFileEntity bookFile = BookFileEntity.builder()
+                    .id(100L).book(book).fileName("blocked.pdf").fileSubPath("sub")
+                    .currentHash("hash").isBookFormat(true).bookType(BookFileType.PDF).build();
+
+            when(bookFilePersistenceService.findBookFileByLibraryPathSubPathAndFileName(eq(1L), anyString(), eq("blocked.pdf")))
+                    .thenReturn(Optional.of(bookFile));
+
+            Path file = tempDir.resolve("sub").resolve("blocked.pdf");
 
             processor.processEvent(StandardWatchEventKinds.ENTRY_DELETE, 1L, file, false);
 

--- a/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
@@ -283,9 +283,7 @@ class LibraryFileEventProcessorTest {
 
             processor.processEvent(StandardWatchEventKinds.ENTRY_CREATE, 1L, folder, true);
 
-            Thread.sleep(8000);
-
-            verify(libraryProcessingService, never()).processLibraryFiles(any(), any());
+            verify(libraryProcessingService, after(8000).never()).processLibraryFiles(any(), any());
             verify(bookFileTransactionalHandler, never()).handleNewBookFile(anyLong(), any());
         }
 
@@ -400,9 +398,7 @@ class LibraryFileEventProcessorTest {
 
             processor.processEvent(StandardWatchEventKinds.ENTRY_DELETE, 1L, file, false);
 
-            Thread.sleep(2000);
-
-            verify(pendingDeletionPool).addFileDeletion(any(), eq(1L), eq(bookFile), eq(book), any());
+            verify(pendingDeletionPool, timeout(2000)).addFileDeletion(any(), eq(1L), eq(bookFile), eq(book), any());
         }
 
         @Test

--- a/backend/src/test/java/org/booklore/util/AllowedFormatUtilsTest.java
+++ b/backend/src/test/java/org/booklore/util/AllowedFormatUtilsTest.java
@@ -1,0 +1,39 @@
+package org.booklore.util;
+
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.enums.BookFileType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AllowedFormatUtilsTest {
+
+    @Test
+    void isAllowedBookFile_allowsAnySupportedBookFileWhenAllowedFormatsIsNull() {
+        LibraryEntity library = LibraryEntity.builder()
+                .allowedFormats(null)
+                .build();
+
+        assertThat(AllowedFormatUtils.isAllowedBookFile(library, "book.pdf")).isTrue();
+    }
+
+    @Test
+    void isAllowedBookFile_allowsAnySupportedBookFileWhenAllowedFormatsIsEmpty() {
+        LibraryEntity library = LibraryEntity.builder()
+                .allowedFormats(List.of())
+                .build();
+
+        assertThat(AllowedFormatUtils.isAllowedBookFile(library, "book.pdf")).isTrue();
+    }
+
+    @Test
+    void isAllowedBookFile_rejectsBookFileOutsideConfiguredFormats() {
+        LibraryEntity library = LibraryEntity.builder()
+                .allowedFormats(List.of(BookFileType.EPUB))
+                .build();
+
+        assertThat(AllowedFormatUtils.isAllowedBookFile(library, "book.pdf")).isFalse();
+    }
+}

--- a/backend/src/test/java/org/booklore/util/AllowedFormatUtilsTest.java
+++ b/backend/src/test/java/org/booklore/util/AllowedFormatUtilsTest.java
@@ -29,6 +29,15 @@ class AllowedFormatUtilsTest {
     }
 
     @Test
+    void isAllowedBookFile_allowsBookFileInsideConfiguredFormats() {
+        LibraryEntity library = LibraryEntity.builder()
+                .allowedFormats(List.of(BookFileType.EPUB))
+                .build();
+
+        assertThat(AllowedFormatUtils.isAllowedBookFile(library, "book.epub")).isTrue();
+    }
+
+    @Test
     void isAllowedBookFile_rejectsBookFileOutsideConfiguredFormats() {
         LibraryEntity library = LibraryEntity.builder()
                 .allowedFormats(List.of(BookFileType.EPUB))


### PR DESCRIPTION
## Description

Watched-folder imports now respect a library's allowed format settings before processing newly created files. This prevents disallowed watched files, such as PDFs in a library where PDF is disabled, from being imported through the watcher path.

## Linked Issue

Fixes #1477

## Changes

- Skip watched single-file imports when the file type is not in the library's allowed formats.
- Skip watched folder audiobook imports when audiobooks are not allowed.
- Filter disallowed files out of watched folder batch processing before creating `LibraryFile` entries.
- Added focused watcher regression coverage for disallowed file and folder paths.

## Manual Testing Steps

1. `git diff --check`
   - Passed with no whitespace errors.
2. `just api test-class test_class=org.booklore.service.watcher.BookFileTransactionalHandlerTest`
   - Not run: `just` is not installed in this Windows environment.
3. `$env:GRADLE_USER_HOME='C:\Users\aliab\Documents\Codex\2026-06-04\grimmory-oss-pr-agent-backend-docs\work\.gradle'; .\gradlew.bat test --tests "org.booklore.service.watcher.BookFileTransactionalHandlerTest" --no-daemon --parallel --build-cache`
   - Gradle downloaded successfully, then failed before tests because the local machine only has Java 21 and the backend requires Java 25: `Cannot find a Java installation on your machine ... matching: {languageVersion=25 ...}`.

## Screenshots (Optional)

N/A - backend watcher change.

## Additional Context (Optional)

Local test execution is blocked by the missing Java 25 toolchain on this machine. The change is backend-only and should be covered by the backend CI test job's Java 25 setup.

## AI Disclosure

Codex assisted with issue scouting, implementation, focused regression tests, and drafting this PR description. I reviewed the issue, contribution policy, AI policy, relevant watcher code, and the final diff.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized allowed-format checks: libraries can restrict file types and the system now skips unsupported files early across single-file and folder workflows (including folder-as-audio/BOOK_PER_FOLDER), avoiding needless processing while still reusing resolved file-type info where applicable.
  * Disallowed-file deletions are still recorded and queued for cleanup.

* **Tests**
  * Added tests confirming ignored/disallowed formats for single-file events, folder-audiobook and folder-create workflows, BOOK_PER_FOLDER behavior, and deletion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->