### PR TITLE
fix(ui): render loaded user management users

### DIFF
--- a/frontend/src/app/features/settings/user-management/user-management.component.html
+++ b/frontend/src/app/features/settings/user-management/user-management.component.html
@@ -34,7 +34,8 @@
     </div>
 
     <div class="section-body">
-      @if (users.length === 0) {
+      @let usersList = users();
+      @if (usersList.length === 0) {
         <div class="empty-state">
           <i class="pi pi-users"></i>
           <p class="empty-title">{{ t('emptyState.title') }}</p>
@@ -42,7 +43,7 @@
         </div>
       } @else {
         <div class="users-list">
-          @for (user of users; track user.id) {
+          @for (user of usersList; track user.id) {
             <div class="user-card" [class.is-expanded]="isRowExpanded(user)" [class.is-admin]="user.permissions.admin">
               <div class="user-card-header">
                 <div class="user-main-info">

--- a/frontend/src/app/features/settings/user-management/user-management.component.spec.ts
+++ b/frontend/src/app/features/settings/user-management/user-management.component.spec.ts
@@ -1,14 +1,177 @@
-import {describe, it} from 'vitest';
+import {signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {of, Subject, type Observable} from 'rxjs';
+import {MessageService} from 'primeng/api';
+import {describe, expect, it, vi} from 'vitest';
 
-// NOTE(frontend-seam): Real coverage here needs seams around table row editing, confirm dialog
-// usage, password dialog state, and dialog-launcher interactions so user administration can be
-// exercised without building the full Prime table and modal stack.
-describe.skip('UserManagementComponent', () => {
-  it('needs service seams to verify user loading, edit toggling, and save payload shaping', () => {
-    // TODO(seam): Cover loadUsers, toggleEdit, and saveUser once the table-editing state and async user-service flows are isolated.
+import {getTranslocoModule} from '../../../core/testing/transloco-testing';
+import {type Library} from '../../book/model/library.model';
+import {LibraryService} from '../../book/service/library.service';
+import {DialogLauncherService} from '../../../shared/services/dialog-launcher.service';
+import {UserManagementComponent} from './user-management.component';
+import {type User, UserService} from './user.service';
+
+function buildPermissions(overrides: Partial<User['permissions']> = {}): User['permissions'] {
+  return {
+    admin: false,
+    canUpload: false,
+    canDownload: false,
+    canEmailBook: false,
+    canDeleteBook: false,
+    canEditMetadata: false,
+    canManageLibrary: false,
+    canManageMetadataConfig: false,
+    canSyncKoReader: false,
+    canSyncKobo: false,
+    canAccessOpds: false,
+    canAccessBookdrop: false,
+    canAccessLibraryStats: false,
+    canAccessUserStats: false,
+    canAccessTaskManager: false,
+    canManageEmailConfig: false,
+    canManageGlobalPreferences: false,
+    canManageIcons: false,
+    canManageFonts: false,
+    demoUser: false,
+    canBulkAutoFetchMetadata: false,
+    canBulkCustomFetchMetadata: false,
+    canBulkEditMetadata: false,
+    canBulkRegenerateCover: false,
+    canMoveOrganizeFiles: false,
+    canBulkLockUnlockMetadata: false,
+    canBulkResetGrimmoryReadProgress: false,
+    canBulkResetBookloreReadProgress: false,
+    canBulkResetKoReaderReadProgress: false,
+    canBulkResetBookReadStatus: false,
+    ...overrides,
+  };
+}
+
+function buildUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    username: 'reader',
+    name: 'Reader',
+    email: 'reader@example.com',
+    locale: 'en',
+    theme: 'grimmory',
+    themeAccent: null,
+    themeSyncEnabled: true,
+    assignedLibraries: [],
+    permissions: buildPermissions(),
+    userSettings: {} as User['userSettings'],
+    ...overrides,
+  };
+}
+
+function buildLibrary(overrides: Partial<Library> = {}): Library {
+  return {
+    id: 1,
+    name: 'Library',
+    watch: false,
+    paths: [],
+    ...overrides,
+  };
+}
+
+interface UserManagementTestEnv {
+  currentUser: ReturnType<typeof signal<User | null>>;
+  getUsers: () => Observable<User[]>;
+}
+
+function setupUserManagementTest(env: UserManagementTestEnv, useRealTemplate = false): void {
+  TestBed.configureTestingModule({
+    imports: [UserManagementComponent, getTranslocoModule()],
+    providers: [
+      {
+        provide: UserService,
+        useValue: {
+          currentUser: () => env.currentUser(),
+          getUsers: env.getUsers,
+        },
+      },
+      {provide: LibraryService, useValue: {libraries: signal([])}},
+      {provide: DialogLauncherService, useValue: {openCreateUserDialog: vi.fn()}},
+      {provide: MessageService, useValue: {add: vi.fn()}},
+    ],
   });
 
-  it('needs dialog seams to verify create-user refresh, delete confirmation, and password-change validation', () => {
-    // TODO(seam): Cover openCreateUserDialog, deleteUser, and submitPasswordChange after extracting confirm and modal runtime concerns.
+  if (useRealTemplate) {
+    return;
+  }
+
+  TestBed.overrideComponent(UserManagementComponent, {
+    set: {
+      template: `
+        @if (users().length === 0) {
+          <p class="empty-state">empty</p>
+        } @else {
+          <ul>
+            @for (user of users(); track user.id) {
+              <li>{{ user.username }}:{{ user.libraryNames }}</li>
+            }
+          </ul>
+        }
+      `,
+    },
+  });
+}
+
+describe('UserManagementComponent', () => {
+  it('renders users when the initial load resolves after the first change detection pass', () => {
+    const usersSubject = new Subject<User[]>();
+    const currentUser = signal<User | null>(buildUser({id: 99, permissions: buildPermissions({admin: true})}));
+    const getUsers = vi.fn(() => usersSubject.asObservable());
+
+    setupUserManagementTest({currentUser, getUsers}, true);
+
+    const fixture = TestBed.createComponent(UserManagementComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.empty-state')).not.toBeNull();
+
+    usersSubject.next([
+      buildUser({
+        id: 7,
+        username: 'slow-reader',
+        assignedLibraries: [buildLibrary({id: 3, name: 'Main Library'})],
+      }),
+    ]);
+    fixture.detectChanges();
+
+    expect(getUsers).toHaveBeenCalledOnce();
+    expect(fixture.nativeElement.querySelector('.empty-state')).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('slow-reader');
+    expect(fixture.componentInstance.users()).toHaveLength(1);
+
+    fixture.destroy();
+  });
+
+  it('keeps loaded users in a fresh mapped array for later refreshes', () => {
+    const currentUser = signal<User | null>(buildUser());
+    const getUsers = vi.fn(() => of([
+      buildUser({
+        id: 8,
+        username: 'library-reader',
+        assignedLibraries: [buildLibrary({id: 2, name: 'Sci-Fi'})],
+      }),
+    ]));
+
+    setupUserManagementTest({currentUser, getUsers});
+
+    const fixture = TestBed.createComponent(UserManagementComponent);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.users()).toEqual([
+      expect.objectContaining({
+        id: 8,
+        username: 'library-reader',
+        isEditing: false,
+        selectedLibraryIds: [2],
+        libraryNames: 'Sci-Fi',
+      }),
+    ]);
+
+    fixture.destroy();
   });
 });

--- a/frontend/src/app/features/settings/user-management/user-management.component.ts
+++ b/frontend/src/app/features/settings/user-management/user-management.component.ts
@@ -1,4 +1,4 @@
-import {Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit, signal, WritableSignal} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {FormsModule} from '@angular/forms';
 import {Button} from 'primeng/button';
@@ -27,6 +27,7 @@ interface UserWithEditing extends User {
 
 @Component({
   selector: 'app-user-management',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FormsModule,
     Button,
@@ -56,7 +57,7 @@ export class UserManagementComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   get allLibraries() { return this.libraryService.libraries(); }
 
-  users: UserWithEditing[] = [];
+  users: WritableSignal<UserWithEditing[]> = signal([]);
   currentUser: User | null = null;
   editingLibraryIds: number[] = [];
   expandedRows: Record<string, boolean> = {};
@@ -82,13 +83,13 @@ export class UserManagementComponent implements OnInit {
   loadUsers() {
     this.userService.getUsers().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (data) => {
-        this.users = data.map((user) => ({
+        this.users.set(data.map((user) => ({
           ...user,
           isEditing: false,
           selectedLibraryIds: user.assignedLibraries?.map((lib) => lib.id!).filter(id => id !== undefined) as number[] || [],
           libraryNames:
             user.assignedLibraries?.map((lib) => lib.name).join(', ') || '',
-        }));
+        })));
       },
       error: () => {
         this.messageService.add({


### PR DESCRIPTION
## Description

Fixes the user-management users list so asynchronously loaded users update the settings UI reliably. The component now stores loaded users in an Angular signal, uses OnPush change detection, and the template reads the signal before rendering the empty state or user cards.

## Linked Issue

Fixes #1550

## Changes

- Converted `UserManagementComponent.users` from a plain array to a `WritableSignal`.
- Updated the users section template to read from `users()`.
- Added `ChangeDetectionStrategy.OnPush` to align the signal-backed component with the frontend component pattern.
- Replaced the skipped user-management placeholder spec with focused Vitest coverage for delayed user loading against the real component template and mapped user-list state.

## Manual Testing Steps

1. `YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=../.yarn/cache corepack yarn vitest run src/app/features/settings/user-management/user-management.component.spec.ts`
   - Result: `Test Files 1 passed (1)`, `Tests 2 passed (2)`.
2. `YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=../.yarn/cache corepack yarn typecheck`
   - Result: passed.
3. `YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=../.yarn/cache corepack yarn lint:eslint`
   - Result: `All files pass linting.`
4. `YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=../.yarn/cache corepack yarn lint:styles`
   - Result: passed.
5. `CI=1 NG_CLI_ANALYTICS=false YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=../.yarn/cache corepack yarn build:prod`
   - Result: `Application bundle generation complete. [24.771 seconds]`.
6. `YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=../.yarn/cache corepack yarn vitest run src/app/features/book/components/book-browser/book-dialog-helper.service.spec.ts`
   - Result: `Test Files 1 passed (1)`, `Tests 3 passed (3)`.

## Screenshots (Optional)

Not included. This fixes data reactivity for the existing user-management layout and does not change visual structure.

## Additional Context

`just` is not available in this local Windows environment, so I ran the equivalent frontend Yarn commands directly. Backend checks were not run because this change is frontend-only.

I also ran `corepack yarn test` to mirror CI after fixing the initial CI compiler error. The user-management spec compiled and passed, but the full local suite timed out twice in unrelated `src/app/features/book/components/book-browser/book-dialog-helper.service.spec.ts`; that same spec passed when rerun directly, so I did not change unrelated book-browser code.

## AI Disclosure

Codex assisted with issue scouting, implementation, focused test authoring, CI log inspection, review feedback handling, and drafting this PR description. I reviewed the scoped code changes and local verification output.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Replaced skipped tests with active coverage verifying empty-state behavior, async load timing, and user-list rendering and mapping.

* **Bug Fixes**
  * Ensured empty state and loaded users toggle reliably after data arrives; fixed template iteration to use a single derived user list.

* **Refactor**
  * Migrated component user state to a signal-backed model and enabled more efficient change detection for steadier UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->