### PR TITLE
fix(ui): convert device settings state to signals

### DIFF
--- a/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.html
+++ b/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.html
@@ -67,7 +67,7 @@
                       outlined="true"
                       severity="info"
                       size="small"
-                      (onClick)="copyText(hardcoverApiKey(), 'API Key')"
+                      (onClick)="copyText(hardcoverApiKey(), t('hardcover.apiKey'))"
                       [disabled]="!hardcoverApiKey()">
                     </p-button>
                     <p-button

--- a/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.html
+++ b/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.html
@@ -13,7 +13,7 @@
     </p>
   </div>
 
-  @if (hasPermission) {
+  @if (hasPermission()) {
     <div class="settings-content">
       <div class="preferences-section">
         <div class="section-header">
@@ -33,10 +33,10 @@
                 <span class="setting-label">
                   {{ t('hardcover.syncLabel') }}</span>
                 <p-toggle-switch
-                  id="hardcoverSyncEnabled"
+                  inputId="hardcoverSyncEnabled"
                   name="hardcoverSyncEnabled"
-                  [(ngModel)]="hardcoverSyncEnabled"
-                  (ngModelChange)="onHardcoverSyncToggle()">
+                  [ngModel]="hardcoverSyncEnabled()"
+                  (ngModelChange)="onHardcoverSyncToggle($event)">
                 </p-toggle-switch>
               </div>
               <p class="setting-description">
@@ -45,7 +45,7 @@
             </div>
           </div>
 
-          @if (hardcoverSyncEnabled) {
+          @if (hardcoverSyncEnabled()) {
             <div class="setting-item">
               <div class="setting-info">
                 <div class="setting-label-row">
@@ -54,8 +54,9 @@
                     <input
                       pInputText
                       id="hardcoverApiKey"
-                      [(ngModel)]="hardcoverApiKey"
-                      [type]="showHardcoverApiKey ? 'text' : 'password'"
+                      [ngModel]="hardcoverApiKey()"
+                      (ngModelChange)="hardcoverApiKey.set($event)"
+                      [type]="showHardcoverApiKey() ? 'text' : 'password'"
                       name="hardcoverApiKey"
                       class="token-input"
                       [placeholder]="t('hardcover.apiKeyPlaceholder')"
@@ -66,11 +67,11 @@
                       outlined="true"
                       severity="info"
                       size="small"
-                      (onClick)="copyText(hardcoverApiKey, 'API Key')"
-                      [disabled]="!hardcoverApiKey">
+                      (onClick)="copyText(hardcoverApiKey(), 'API Key')"
+                      [disabled]="!hardcoverApiKey()">
                     </p-button>
                     <p-button
-                      [icon]="showHardcoverApiKey ? 'pi pi-eye-slash' : 'pi pi-eye'"
+                      [icon]="showHardcoverApiKey() ? 'pi pi-eye-slash' : 'pi pi-eye'"
                       outlined="true"
                       severity="info"
                       size="small"

--- a/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.ts
+++ b/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.ts
@@ -42,6 +42,8 @@ export class HardcoverSettingsComponent {
   hardcoverApiKey = signal('');
   showHardcoverApiKey = signal(false);
   private prevHasPermission = false;
+  private savedHardcoverSyncEnabled = false;
+  private savedHardcoverApiKey = '';
 
   constructor() {
     effect(() => {
@@ -60,6 +62,7 @@ export class HardcoverSettingsComponent {
       next: settings => {
         this.hardcoverSyncEnabled.set(settings.hardcoverSyncEnabled ?? false);
         this.hardcoverApiKey.set(settings.hardcoverApiKey ?? '');
+        this.rememberSavedSettings();
       },
       error: () => {
         this.messageService.add({
@@ -97,9 +100,11 @@ export class HardcoverSettingsComponent {
       next: settings => {
         this.hardcoverSyncEnabled.set(settings.hardcoverSyncEnabled ?? false);
         this.hardcoverApiKey.set(settings.hardcoverApiKey ?? '');
+        this.rememberSavedSettings();
         this.messageService.add({severity: 'success', summary: this.t.translate('settingsDevice.hardcover.settingsUpdated'), detail: successMessage});
       },
       error: () => {
+        this.restoreSavedSettings();
         this.messageService.add({
           severity: 'error',
           summary: this.t.translate('settingsDevice.hardcover.updateFailed'),
@@ -107,6 +112,16 @@ export class HardcoverSettingsComponent {
         });
       }
     });
+  }
+
+  private rememberSavedSettings() {
+    this.savedHardcoverSyncEnabled = this.hardcoverSyncEnabled();
+    this.savedHardcoverApiKey = this.hardcoverApiKey();
+  }
+
+  private restoreSavedSettings() {
+    this.hardcoverSyncEnabled.set(this.savedHardcoverSyncEnabled);
+    this.hardcoverApiKey.set(this.savedHardcoverApiKey);
   }
 
   copyText(text: string, label: string = 'Text') {

--- a/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.ts
+++ b/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.ts
@@ -1,4 +1,4 @@
-import {Component, DestroyRef, effect, inject} from '@angular/core';
+import {Component, DestroyRef, computed, effect, inject, signal} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {FormsModule} from '@angular/forms';
 import {InputText} from 'primeng/inputtext';
@@ -34,21 +34,18 @@ export class HardcoverSettingsComponent {
   private readonly t = inject(TranslocoService);
   private readonly destroyRef = inject(DestroyRef);
 
-  hasPermission = false;
-  hardcoverSyncEnabled = false;
-  hardcoverApiKey = '';
-  showHardcoverApiKey = false;
+  readonly hasPermission = computed(() => {
+    const user = this.userService.currentUser();
+    return !!(user?.permissions.canSyncKoReader || user?.permissions.canSyncKobo || user?.permissions.admin);
+  });
+  hardcoverSyncEnabled = signal(false);
+  hardcoverApiKey = signal('');
+  showHardcoverApiKey = signal(false);
   private prevHasPermission = false;
 
   constructor() {
     effect(() => {
-      const user = this.userService.currentUser();
-      if (!user) return;
-
-      const currHasPermission = (user.permissions.canSyncKoReader
-        || user.permissions.canSyncKobo
-        || user.permissions.admin) ?? false;
-      this.hasPermission = currHasPermission;
+      const currHasPermission = this.hasPermission();
       if (currHasPermission && !this.prevHasPermission) {
         this.loadHardcoverSettings();
       }
@@ -61,8 +58,8 @@ export class HardcoverSettingsComponent {
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
       next: settings => {
-        this.hardcoverSyncEnabled = settings.hardcoverSyncEnabled ?? false;
-        this.hardcoverApiKey = settings.hardcoverApiKey ?? '';
+        this.hardcoverSyncEnabled.set(settings.hardcoverSyncEnabled ?? false);
+        this.hardcoverApiKey.set(settings.hardcoverApiKey ?? '');
       },
       error: () => {
         this.messageService.add({
@@ -75,11 +72,12 @@ export class HardcoverSettingsComponent {
   }
 
   toggleShowHardcoverApiKey() {
-    this.showHardcoverApiKey = !this.showHardcoverApiKey;
+    this.showHardcoverApiKey.update(showHardcoverApiKey => !showHardcoverApiKey);
   }
 
-  onHardcoverSyncToggle() {
-    const message = this.hardcoverSyncEnabled
+  onHardcoverSyncToggle(enabled: boolean) {
+    this.hardcoverSyncEnabled.set(enabled);
+    const message = enabled
       ? this.t.translate('settingsDevice.hardcover.syncEnabledMsg')
       : this.t.translate('settingsDevice.hardcover.syncDisabledMsg');
     this.updateHardcoverSettings(message);
@@ -91,14 +89,14 @@ export class HardcoverSettingsComponent {
 
   private updateHardcoverSettings(successMessage: string) {
     this.hardcoverSyncSettingsService.updateSettings({
-      hardcoverSyncEnabled: this.hardcoverSyncEnabled,
-      hardcoverApiKey: this.hardcoverApiKey
+      hardcoverSyncEnabled: this.hardcoverSyncEnabled(),
+      hardcoverApiKey: this.hardcoverApiKey()
     }).pipe(
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
       next: settings => {
-        this.hardcoverSyncEnabled = settings.hardcoverSyncEnabled ?? false;
-        this.hardcoverApiKey = settings.hardcoverApiKey ?? '';
+        this.hardcoverSyncEnabled.set(settings.hardcoverSyncEnabled ?? false);
+        this.hardcoverApiKey.set(settings.hardcoverApiKey ?? '');
         this.messageService.add({severity: 'success', summary: this.t.translate('settingsDevice.hardcover.settingsUpdated'), detail: successMessage});
       },
       error: () => {

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.html
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.html
@@ -111,7 +111,7 @@
                       outlined="true"
                       severity="info"
                       size="small"
-                      (onClick)="copyText(koReaderUsername(), 'Username')"
+                      (onClick)="copyText(koReaderUsername(), t('koreader.username'))"
                       [disabled]="!koReaderUsername()">
                     </p-button>
                   </div>
@@ -119,7 +119,7 @@
                 <p class="setting-description">
                   {{ t('koreader.usernameDesc') }}
                 </p>
-                @if (editMode() && usernameModel.invalid && usernameModel.touched) {
+                @if (!editMode() && usernameModel.invalid && usernameModel.touched) {
                   <small class="error-message">
                     {{ t('koreader.usernameRequired') }}
                   </small>
@@ -150,7 +150,7 @@
                       outlined="true"
                       severity="info"
                       size="small"
-                      (onClick)="copyText(koReaderPassword(), 'Password')"
+                      (onClick)="copyText(koReaderPassword(), t('koreader.password'))"
                       [disabled]="!koReaderPassword()">
                     </p-button>
                     <p-button
@@ -166,7 +166,7 @@
                 <p class="setting-description">
                   {{ t('koreader.passwordDesc') }}
                 </p>
-                @if (editMode() && passwordModel.invalid && passwordModel.touched) {
+                @if (!editMode() && passwordModel.invalid && passwordModel.touched) {
                   <small class="error-message">
                     {{ t('koreader.passwordMinLength') }}
                   </small>

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.html
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.html
@@ -13,7 +13,7 @@
     </p>
   </div>
 
-  @if (hasPermission) {
+  @if (hasPermission()) {
     <div class="settings-content">
       <div class="preferences-section">
         <div class="section-header">
@@ -34,10 +34,10 @@
                   <span class="setting-label">{{ t('koreader.enableSync') }}</span>
                   <p-toggle-switch
                     name="syncEnabled"
-                    [(ngModel)]="koReaderSyncEnabled"
+                    [ngModel]="koReaderSyncEnabled()"
                     (ngModelChange)="onToggleEnabled($event)"
                     inputId="syncEnabled"
-                    [disabled]="!credentialsSaved">
+                    [disabled]="!credentialsSaved()">
                   </p-toggle-switch>
                 </div>
                 <p class="setting-description">
@@ -52,10 +52,10 @@
                   <span class="setting-label">{{ t('koreader.syncWithGrimmory') }}</span>
                   <p-toggle-switch
                     name="syncWithWebReader"
-                    [(ngModel)]="syncWithWebReader"
+                    [ngModel]="syncWithWebReader()"
                     (ngModelChange)="onToggleSyncWithWebReader($event)"
                     inputId="syncWithWebReader"
-                    [disabled]="!credentialsSaved || !koReaderSyncEnabled">
+                    [disabled]="!credentialsSaved() || !koReaderSyncEnabled()">
                   </p-toggle-switch>
                 </div>
                 <p class="setting-description" [innerHTML]="t('koreader.syncWithGrimmoryDesc')">
@@ -100,25 +100,26 @@
                       id="username"
                       name="username"
                       required
-                      [(ngModel)]="koReaderUsername"
+                      [ngModel]="koReaderUsername()"
+                      (ngModelChange)="koReaderUsername.set($event)"
                       #usernameModel="ngModel"
                       [class.p-invalid]="usernameModel.invalid && usernameModel.touched"
-                      [disabled]="editMode"
+                      [disabled]="editMode()"
                       class="token-input"/>
                     <p-button
                       icon="pi pi-copy"
                       outlined="true"
                       severity="info"
                       size="small"
-                      (onClick)="copyText(koReaderUsername, 'Username')"
-                      [disabled]="!koReaderUsername">
+                      (onClick)="copyText(koReaderUsername(), 'Username')"
+                      [disabled]="!koReaderUsername()">
                     </p-button>
                   </div>
                 </div>
                 <p class="setting-description">
                   {{ t('koreader.usernameDesc') }}
                 </p>
-                @if (editMode && usernameModel.invalid && usernameModel.touched) {
+                @if (editMode() && usernameModel.invalid && usernameModel.touched) {
                   <small class="error-message">
                     {{ t('koreader.usernameRequired') }}
                   </small>
@@ -137,34 +138,35 @@
                       name="password"
                       required
                       minlength="6"
-                      [type]="showPassword ? 'text' : 'password'"
-                      [(ngModel)]="koReaderPassword"
+                      [type]="showPassword() ? 'text' : 'password'"
+                      [ngModel]="koReaderPassword()"
+                      (ngModelChange)="koReaderPassword.set($event)"
                       #passwordModel="ngModel"
                       [class.p-invalid]="passwordModel.invalid && passwordModel.touched"
-                      [disabled]="editMode"
+                      [disabled]="editMode()"
                       class="token-input-password"/>
                     <p-button
                       icon="pi pi-copy"
                       outlined="true"
                       severity="info"
                       size="small"
-                      (onClick)="copyText(koReaderPassword, 'Password')"
-                      [disabled]="!koReaderPassword">
+                      (onClick)="copyText(koReaderPassword(), 'Password')"
+                      [disabled]="!koReaderPassword()">
                     </p-button>
                     <p-button
-                      [icon]="showPassword ? 'pi pi-eye-slash' : 'pi pi-eye'"
+                      [icon]="showPassword() ? 'pi pi-eye-slash' : 'pi pi-eye'"
                       outlined="true"
                       severity="info"
                       size="small"
                       (onClick)="toggleShowPassword()"
-                      [disabled]="!koReaderPassword">
+                      [disabled]="!koReaderPassword()">
                     </p-button>
                   </div>
                 </div>
                 <p class="setting-description">
                   {{ t('koreader.passwordDesc') }}
                 </p>
-                @if (editMode && passwordModel.invalid && passwordModel.touched) {
+                @if (editMode() && passwordModel.invalid && passwordModel.touched) {
                   <small class="error-message">
                     {{ t('koreader.passwordMinLength') }}
                   </small>
@@ -177,13 +179,13 @@
                 <div class="setting-label-row">
                   <span class="setting-label">{{ t('koreader.settingsManagement') }}</span>
                   <p-button
-                    [icon]="!editMode ? 'pi pi-save' : 'pi pi-pencil'"
+                    [icon]="!editMode() ? 'pi pi-save' : 'pi pi-pencil'"
                     outlined="true"
-                    [severity]="!editMode ? 'success' : 'warn'"
-                    [label]="!editMode ? ('common.save' | transloco) : ('common.edit' | transloco)"
+                    [severity]="!editMode() ? 'success' : 'warn'"
+                    [label]="!editMode() ? ('common.save' | transloco) : ('common.edit' | transloco)"
                     size="small"
                     (onClick)="onEditSave()"
-                    [disabled]="!editMode && !canSave">
+                    [disabled]="!editMode() && !canSave()">
                   </p-button>
                 </div>
                 <p class="setting-description">

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.ts
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.ts
@@ -1,4 +1,4 @@
-import {Component, DestroyRef, effect, inject} from '@angular/core';
+import {Component, DestroyRef, computed, effect, inject, signal} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import {FormsModule} from '@angular/forms';
@@ -30,13 +30,13 @@ import {TranslocoDirective, TranslocoPipe, TranslocoService} from '@jsverse/tran
   styleUrls: ['./koreader-settings-component.scss']
 })
 export class KoreaderSettingsComponent {
-  editMode = true;
-  showPassword = false;
-  koReaderSyncEnabled = false;
-  syncWithWebReader = false;
-  koReaderUsername = '';
-  koReaderPassword = '';
-  credentialsSaved = false;
+  editMode = signal(true);
+  showPassword = signal(false);
+  koReaderSyncEnabled = signal(false);
+  syncWithWebReader = signal(false);
+  koReaderUsername = signal('');
+  koReaderPassword = signal('');
+  credentialsSaved = signal(false);
   readonly koreaderEndpoint = `${window.location.origin}/api/koreader`;
 
   private readonly messageService = inject(MessageService);
@@ -45,16 +45,21 @@ export class KoreaderSettingsComponent {
   private readonly t = inject(TranslocoService);
   private readonly destroyRef = inject(DestroyRef);
 
-  hasPermission = false;
+  readonly hasPermission = computed(() => {
+    const user = this.userService.currentUser();
+    return !!(user?.permissions.canSyncKoReader || user?.permissions.admin);
+  });
   private prevHasPermission = false;
+
+  readonly canSave = computed(() => {
+    const username = this.koReaderUsername().trim();
+    const password = this.koReaderPassword();
+    return username.length > 0 && password.length >= 6;
+  });
 
   constructor() {
     effect(() => {
-      const user = this.userService.currentUser();
-      if (!user) return;
-
-      const currHasPermission = (user.permissions.canSyncKoReader || user.permissions.admin) ?? false;
-      this.hasPermission = currHasPermission;
+      const currHasPermission = this.hasPermission();
       if (currHasPermission && !this.prevHasPermission) {
         this.loadKoreaderSettings();
       }
@@ -67,11 +72,11 @@ export class KoreaderSettingsComponent {
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
       next: koreaderUser => {
-        this.koReaderUsername = koreaderUser.username;
-        this.koReaderPassword = koreaderUser.password;
-        this.koReaderSyncEnabled = koreaderUser.syncEnabled;
-        this.syncWithWebReader = koreaderUser.syncWithWebReader ?? false;
-        this.credentialsSaved = true;
+        this.koReaderUsername.set(koreaderUser.username);
+        this.koReaderPassword.set(koreaderUser.password);
+        this.koReaderSyncEnabled.set(koreaderUser.syncEnabled);
+        this.syncWithWebReader.set(koreaderUser.syncWithWebReader ?? false);
+        this.credentialsSaved.set(true);
       },
       error: err => {
         if (err.status !== 404) {
@@ -86,25 +91,20 @@ export class KoreaderSettingsComponent {
   }
 
 
-  get canSave(): boolean {
-    const u = this.koReaderUsername?.trim() ?? '';
-    const p = this.koReaderPassword ?? '';
-    return u.length > 0 && p.length >= 6;
-  }
-
   onEditSave() {
-    if (!this.editMode) {
+    if (!this.editMode()) {
       this.saveCredentials();
     }
-    this.editMode = !this.editMode;
+    this.editMode.update(editMode => !editMode);
   }
 
   onToggleEnabled(enabled: boolean) {
+    this.koReaderSyncEnabled.set(enabled);
     this.koreaderService.toggleSync(enabled).pipe(
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
       next: () => {
-        this.koReaderSyncEnabled = enabled;
+        this.koReaderSyncEnabled.set(enabled);
         this.messageService.add({severity: 'success', summary: this.t.translate('settingsDevice.koreader.syncUpdated'), detail: enabled ? this.t.translate('settingsDevice.koreader.syncEnabled') : this.t.translate('settingsDevice.koreader.syncDisabled')});
       },
       error: () => {
@@ -114,11 +114,12 @@ export class KoreaderSettingsComponent {
   }
 
   onToggleSyncWithWebReader(enabled: boolean) {
+    this.syncWithWebReader.set(enabled);
     this.koreaderService.toggleSyncProgressWithWebReader(enabled).pipe(
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
       next: () => {
-        this.syncWithWebReader = enabled;
+        this.syncWithWebReader.set(enabled);
         this.messageService.add({
           severity: 'success',
           summary: this.t.translate('settingsDevice.koreader.syncUpdated'),
@@ -136,16 +137,16 @@ export class KoreaderSettingsComponent {
   }
 
   toggleShowPassword() {
-    this.showPassword = !this.showPassword;
+    this.showPassword.update(showPassword => !showPassword);
   }
 
 
   saveCredentials() {
-    this.koreaderService.createUser(this.koReaderUsername, this.koReaderPassword)
+    this.koreaderService.createUser(this.koReaderUsername(), this.koReaderPassword())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
-          this.credentialsSaved = true;
+          this.credentialsSaved.set(true);
           this.messageService.add({severity: 'success', summary: this.t.translate('settingsDevice.koreader.saved'), detail: this.t.translate('settingsDevice.koreader.credentialsSaved')});
         },
         error: () =>

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.ts
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.ts
@@ -99,6 +99,7 @@ export class KoreaderSettingsComponent {
   }
 
   onToggleEnabled(enabled: boolean) {
+    const previousEnabled = this.koReaderSyncEnabled();
     this.koReaderSyncEnabled.set(enabled);
     this.koreaderService.toggleSync(enabled).pipe(
       takeUntilDestroyed(this.destroyRef)
@@ -108,12 +109,14 @@ export class KoreaderSettingsComponent {
         this.messageService.add({severity: 'success', summary: this.t.translate('settingsDevice.koreader.syncUpdated'), detail: enabled ? this.t.translate('settingsDevice.koreader.syncEnabled') : this.t.translate('settingsDevice.koreader.syncDisabled')});
       },
       error: () => {
+        this.koReaderSyncEnabled.set(previousEnabled);
         this.messageService.add({severity: 'error', summary: this.t.translate('settingsDevice.koreader.syncUpdateFailed'), detail: this.t.translate('settingsDevice.koreader.syncUpdateError')});
       }
     });
   }
 
   onToggleSyncWithWebReader(enabled: boolean) {
+    const previousSyncWithWebReader = this.syncWithWebReader();
     this.syncWithWebReader.set(enabled);
     this.koreaderService.toggleSyncProgressWithWebReader(enabled).pipe(
       takeUntilDestroyed(this.destroyRef)
@@ -127,6 +130,7 @@ export class KoreaderSettingsComponent {
         });
       },
       error: () => {
+        this.syncWithWebReader.set(previousSyncWithWebReader);
         this.messageService.add({
           severity: 'error',
           summary: this.t.translate('settingsDevice.koreader.syncUpdateFailed'),


### PR DESCRIPTION
## Description

Fixes reactivity issues with Hardcover and KOReader settings

## Linked Issue

Fixes #1557 and #1558 

## Changes

- Convert KOReader and Hardcover field data state to signals. 
- Updated save and permissions gating to use computed

## Manual Testing Steps

Open Settings > Device, confirm the two settings blocks are correct without any other UI trigger on the page (E.g. if a user does not have Kobo settings permissions).

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved device settings (Hardcover & KoReader) state handling for more reliable toggles, inputs, copy/visibility buttons, and permission-gated rendering.
  * Save/load flows now better preserve and restore previous values on failure, and optimistic toggle changes show proper success/error notifications.
  * No user-facing settings or behaviors were removed; interactions should feel more responsive and stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->