### PR TITLE
fix(metadata): extract epub titles per spec with regards to ordering

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -207,7 +207,6 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
             Map<String, String> titlesById = new HashMap<>();
             Map<String, String> titleTypeById = new HashMap<>();
             boolean hasTitle = false;
-            boolean hasSubtitle = false;
 
             for (int i = 0; i < children.getLength(); i++) {
                 if (!(children.item(i) instanceof Element el)) continue;
@@ -225,9 +224,6 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                         if (!hasTitle) {
                             hasTitle = true;
                             builderMeta.title(text);
-                        } else if (!hasSubtitle) {
-                            hasSubtitle = true;
-                            builderMeta.subtitle(text);
                         }
                     }
                     case "meta" -> {

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -206,6 +206,8 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
             Map<String, String> titlesById = new HashMap<>();
             Map<String, String> titleTypeById = new HashMap<>();
+            boolean hasTitle = false;
+            boolean hasSubtitle = false;
 
             for (int i = 0; i < children.getLength(); i++) {
                 if (!(children.item(i) instanceof Element el)) continue;
@@ -218,8 +220,14 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
                         String id = el.getAttribute("id");
                         if (StringUtils.isNotBlank(id)) {
                             titlesById.put(id, text);
-                        } else {
+                        }
+
+                        if (!hasTitle) {
+                            hasTitle = true;
                             builderMeta.title(text);
+                        } else if (!hasSubtitle) {
+                            hasSubtitle = true;
+                            builderMeta.subtitle(text);
                         }
                     }
                     case "meta" -> {
@@ -404,7 +412,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
             for (Map.Entry<String, String> entry : titlesById.entrySet()) {
                 String id = entry.getKey();
                 String value = entry.getValue();
-                String type = titleTypeById.getOrDefault(id, "main");
+                String type = titleTypeById.get(id);
                 if ("main".equals(type)) builderMeta.title(value);
                 else if ("subtitle".equals(type)) builderMeta.subtitle(value);
             }

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -195,7 +195,7 @@ class EpubMetadataExtractorTest {
             BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
 
             assertThat(metadata.getTitle()).isEqualTo("Main Title");
-            assertThat(metadata.getSubtitle()).isEqualTo("The Subtitle");
+            assertThat(metadata.getSubtitle()).isNull();
         }
 
         @Test
@@ -207,7 +207,7 @@ class EpubMetadataExtractorTest {
             BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
 
             assertThat(metadata.getTitle()).isEqualTo("Main Title");
-            assertThat(metadata.getSubtitle()).isEqualTo("The Subtitle");
+            assertThat(metadata.getSubtitle()).isNull();
         }
 
         @Test
@@ -237,7 +237,7 @@ class EpubMetadataExtractorTest {
             BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
 
             assertThat(metadata.getTitle()).isEqualTo("test");
-            assertThat(metadata.getSubtitle()).isEqualTo("The Subtitle");
+            assertThat(metadata.getSubtitle()).isNull();
         }
 
         @Test

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -229,6 +229,18 @@ class EpubMetadataExtractorTest {
         }
 
         @Test
+        void blankTitlesFallbackToFilename() throws IOException {
+            String opf = wrapOpf("""
+                    <dc:title> </dc:title>
+                    <dc:title>The Subtitle</dc:title>
+                    """);
+            BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
+
+            assertThat(metadata.getTitle()).isEqualTo("test");
+            assertThat(metadata.getSubtitle()).isEqualTo("The Subtitle");
+        }
+
+        @Test
         void titleWithoutIdSetDirectly() throws IOException {
             String opf = wrapOpf("<dc:title>Direct Title</dc:title>");
             BookMetadata metadata = extractor.extractMetadata(createEpub(opf));

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -187,6 +187,48 @@ class EpubMetadataExtractorTest {
         }
 
         @Test
+        void distinguishesMainTitleWithoutRefines() throws IOException {
+            String opf = wrapOpf("""
+                    <dc:title id="maintitle">Main Title</dc:title>
+                    <dc:title id="subtitle">The Subtitle</dc:title>
+                    """);
+            BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
+
+            assertThat(metadata.getTitle()).isEqualTo("Main Title");
+            assertThat(metadata.getSubtitle()).isEqualTo("The Subtitle");
+        }
+
+        @Test
+        void distinguishesMainTitleWithoutIDsOrRefines() throws IOException {
+            String opf = wrapOpf("""
+                    <dc:title>Main Title</dc:title>
+                    <dc:title>The Subtitle</dc:title>
+                    """);
+            BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
+
+            assertThat(metadata.getTitle()).isEqualTo("Main Title");
+            assertThat(metadata.getSubtitle()).isEqualTo("The Subtitle");
+        }
+
+        @Test
+        void distinguishesRefinedOverrideFallbackBehavior() throws IOException {
+            String opf = wrapOpf("""
+                    <dc:title>Something else</dc:title>
+                    <dc:title id="t1">Another something else</dc:title>
+                    <dc:title id="t2">Main Title</dc:title>
+                    <dc:title id="t3">Another title</dc:title>
+                    <dc:title id="t4">The Subtitle</dc:title>
+                    <dc:title>Even more titles</dc:title>
+                    <meta refines="#t2" property="title-type">main</meta>
+                    <meta refines="#t4" property="title-type">subtitle</meta>
+                    """);
+            BookMetadata metadata = extractor.extractMetadata(createEpub(opf));
+
+            assertThat(metadata.getTitle()).isEqualTo("Main Title");
+            assertThat(metadata.getSubtitle()).isEqualTo("The Subtitle");
+        }
+
+        @Test
         void titleWithoutIdSetDirectly() throws IOException {
             String opf = wrapOpf("<dc:title>Direct Title</dc:title>");
             BookMetadata metadata = extractor.extractMetadata(createEpub(opf));


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
Epub title parsing currently relies heavily on the epub3 `refines` meta to understand what is the primary title of a book.  However, in cases where this is not available, the epub spec notes:

> If no means of determining title types is provided, or understood, Reading Systems must treat the first title element in document order as the main title. This specification does not define how additional title elements should be processed in such situations.

This change updates our epub parsing to default the first title by-order as the fallback main title, per spec.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1636 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* Added handling for case where multiple titles exist but do not have refines.
* Updated tests to check various edge cases

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Uploaded books matching each test case (multiple titles, no refines, multiple titles with refines in different orders)
2. Validated values are interpreted as expected

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB title/subtitle detection to prevent incorrect overwrites and misassignment when type information is missing or titles are duplicated or blank; ensures sensible fallback behavior.
* **Tests**
  * Added unit tests validating title/subtitle selection order, metadata-refinement precedence, and fallback behavior for missing or blank metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->