### PR TITLE
docs: document Weblate translation workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ code.
 - [First-Time Contributors](#first-time-contributors)
 - [Quick Guide](#quick-guide)
   - [I'd like to contribute code](#id-like-to-contribute-code)
+  - [I'd like to contribute translations](#id-like-to-contribute-translations)
   - [Something isn't working](#something-isnt-working)
   - [I have an idea or feature request](#i-have-an-idea-or-feature-request)
   - [I've implemented something and want to submit it](#ive-implemented-something-and-want-to-submit-it)
@@ -70,6 +71,26 @@ start working on it. If you need help or guidance, comment on the issue. Issues 
 friendly to newcomers are tagged [`good first issue`][good-first-issue].
 
 [good-first-issue]: https://github.com/grimmory-tools/grimmory/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good+first+issue%22
+
+### I'd like to contribute translations
+
+Please use the [Grimmory Weblate project](https://hosted.weblate.org/engage/grimmory/) for
+non-English localization work. Weblate tracks `develop`, shows missing and outdated strings, and
+sends translation updates back to the repository as reviewed pull requests.
+
+When translating, preserve placeholders exactly, such as `{{ name }}`, `{{ count }}`, and
+`{{ provider }}`. Do not translate placeholder names. Keep HTML tags intact when they appear in a
+source string, and translate naturally for your language rather than copying English phrasing word
+for word.
+
+Do not hand-edit non-English translations in regular code pull requests unless explicitly requested
+to do so by a maintainer. Do not pre-fill other languages' localizations with English. Empty target
+strings make it easier to surface those keys for translators than copied English.
+
+Developers should add and change source strings in `frontend/src/i18n/en/*.json`. Each JSON file is
+a Transloco domain and maps to a Weblate component. When adding a new source-string domain, add the
+English JSON file, add matching empty JSON files for each non-English locale, then import/export the
+domain from each locale `index.ts`.
 
 ### Something isn't working
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 
 [![Release](https://img.shields.io/github/v/release/grimmory-tools/grimmory?color=818CF8&style=flat-square&logo=github)](https://github.com/grimmory-tools/grimmory/releases)
 [![License](https://img.shields.io/github/license/grimmory-tools/grimmory?color=fab005&style=flat-square)](LICENSE)
+<a href="https://hosted.weblate.org/engage/grimmory/"><img src="https://hosted.weblate.org/widget/grimmory/svg-badge.svg" alt="Translation status"></a>
 [![Docker Pulls](https://img.shields.io/docker/pulls/grimmory/grimmory?color=2496ED&style=flat-square&logo=docker&logoColor=white)](https://hub.docker.com/r/grimmory/grimmory)
 [![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/9YJ7HB4n8T)
 
-[Documentation](https://grimmory.org/docs) · [Quick Start](#quick-start) · [Discord](https://discord.gg/9YJ7HB4n8T) · [Releases](https://github.com/grimmory-tools/grimmory/releases)
+[Documentation](https://grimmory.org/docs) · [Quick Start](#quick-start) · [Translations](https://hosted.weblate.org/engage/grimmory/) · [Discord](https://discord.gg/9YJ7HB4n8T) · [Releases](https://github.com/grimmory-tools/grimmory/releases)
 
 <!-- ![Grimmory Demo](assets/demo.gif) -->
 
@@ -181,7 +182,8 @@ Additional deployment examples:
 ## Developer Surfaces
 
 
-Contributor workflow, PR policy, and release semantics live in [CONTRIBUTING.md](CONTRIBUTING.md). 
+Contributor workflow, PR policy, and release semantics live in [CONTRIBUTING.md](CONTRIBUTING.md).
+Non-English translation contributions are managed through [Weblate](https://hosted.weblate.org/engage/grimmory/).
 
 General purpose development guidelines live in [DEVELOPMENT.md](DEVELOPMENT.md). Component-specific implementation guidance lives in:
 


### PR DESCRIPTION
## Description

Updates the README and contribution related docs to surface Weblate details.

## Linked Issue

Resolves https://github.com/grimmory-tools/grimmory/issues/1484

## Changes

- Adds Weblate project details to the repo docs

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidelines with a dedicated translations section directing contributors to use Weblate for non-English localization management, with detailed guidance on translation rules and domain setup processes.
  * Added translation status badge to the project README and updated navigation links to highlight translation contribution opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->