### PR TITLE
chore(ui): normalise text size and spacing

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -55,7 +55,7 @@ p {
   color: #fff;
   border: none;
   border-radius: 6px;
-  font-size: 0.83125rem;
+  font-size: 0.8313rem;
   cursor: pointer;
   transition: background-color 0.2s;
 

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -12,7 +12,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .logo {
@@ -22,12 +22,12 @@
 }
 
 h1 {
-  font-size: 1.8rem;
+  font-size: 1.575rem;
   margin: 0;
 }
 
 p {
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   color: #a0a0a0;
   margin: 0;
 }
@@ -39,7 +39,7 @@ p {
   border-top: 4px solid transparent;
   border-radius: 50%;
   animation: spin 1s linear infinite;
-  margin-top: 1rem;
+  margin-top: 0.875rem;
 }
 
 @keyframes spin {
@@ -49,13 +49,13 @@ p {
 }
 
 .retry-btn {
-  margin-top: 1rem;
-  padding: 0.6rem 1.5rem;
+  margin-top: 0.875rem;
+  padding: 0.525rem 1.3125rem;
   background-color: #818cf8;
   color: #fff;
   border: none;
   border-radius: 6px;
-  font-size: 0.95rem;
+  font-size: 0.83125rem;
   cursor: pointer;
   transition: background-color 0.2s;
 

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -146,7 +146,7 @@
       </div>
 
       @if (oidcEnabled) {
-        <div class="config-grid" style="margin-top: 0.75rem;">
+        <div class="config-grid" style="margin-top: 0.65625rem;">
           <div class="config-item">
             <label for="sessionDuration">{{ t('providerConfig.sessionDuration') }}</label>
             <p-inputNumber
@@ -376,8 +376,8 @@
               {{ t('oidcOnly.description') }}
             </p>
             @if (oidcForceOnlyMode) {
-              <p class="toggle-description" style="color: var(--p-yellow-500); margin-top: 0.5rem;">
-                <i class="pi pi-exclamation-triangle" style="margin-right: 0.25rem;"></i>
+              <p class="toggle-description" style="color: var(--p-yellow-500); margin-top: 0.4375rem;">
+                <i class="pi pi-exclamation-triangle" style="margin-right: 0.21875rem;"></i>
                 {{ t('oidcOnly.backdoorHint') }}
               </p>
             }
@@ -437,8 +437,8 @@
               {{ t('provisioning.linkLocalDesc') }}
             </p>
             @if (allowLocalAccountLinking) {
-              <p class="toggle-description" style="color: var(--p-yellow-500); margin-top: 0.5rem;">
-                <i class="pi pi-exclamation-triangle" style="margin-right: 0.25rem;"></i>
+              <p class="toggle-description" style="color: var(--p-yellow-500); margin-top: 0.4375rem;">
+                <i class="pi pi-exclamation-triangle" style="margin-right: 0.21875rem;"></i>
                 {{ t('provisioning.linkLocalWarning') }}
               </p>
             }
@@ -481,7 +481,7 @@
 
             <div class="libraries-group">
               <h4 class="group-title">{{ t('provisioning.defaultLibraryAccess') }}</h4>
-              <div style="display: flex; align-items: center; gap: 0.5rem; justify-content: space-between;">
+              <div style="display: flex; align-items: center; gap: 0.4375rem; justify-content: space-between;">
                 <p-multiSelect
                   [options]="allLibraries"
                   optionLabel="name"
@@ -532,7 +532,7 @@
       </div>
 
       <div class="section-body">
-        <div class="config-grid-2col" style="margin-bottom: 1rem;">
+        <div class="config-grid-2col" style="margin-bottom: 0.875rem;">
           <div class="config-item">
             <label for="groupSyncMode">{{ t('groupMapping.syncModeLabel') }}</label>
             <p-select
@@ -566,7 +566,7 @@
                 <th>{{ t('groupMapping.colPermissions') }}</th>
                 <th>{{ t('groupMapping.colLibraries') }}</th>
                 <th>{{ t('groupMapping.colDescription') }}</th>
-                <th style="width: 8rem;"></th>
+                <th style="width: 7rem;"></th>
               </tr>
             </ng-template>
             <ng-template #body let-mapping>
@@ -579,17 +579,17 @@
                 </td>
                 <td>
                   @for (perm of mapping.permissions; track perm) {
-                    <app-tag [rounded]="true" color="info" size="2xs" style="margin-right: 0.25rem; margin-bottom: 0.25rem;">{{ perm }}</app-tag>
+                    <app-tag [rounded]="true" color="info" size="2xs" style="margin-right: 0.21875rem; margin-bottom: 0.21875rem;">{{ perm }}</app-tag>
                   }
                 </td>
                 <td>
                   @for (libId of mapping.libraryIds; track libId) {
-                    <app-tag [rounded]="true" color="secondary" size="2xs" style="margin-right: 0.25rem; margin-bottom: 0.25rem;">{{ getLibraryName(libId) }}</app-tag>
+                    <app-tag [rounded]="true" color="secondary" size="2xs" style="margin-right: 0.21875rem; margin-bottom: 0.21875rem;">{{ getLibraryName(libId) }}</app-tag>
                   }
                 </td>
                 <td>{{ mapping.description }}</td>
                 <td>
-                  <div style="display: flex; gap: 0.5rem;">
+                  <div style="display: flex; gap: 0.4375rem;">
                     <p-button icon="pi pi-pencil" [rounded]="true" [text]="true" severity="info" size="small" (click)="openEditGroupMapping(mapping)"></p-button>
                     <p-button icon="pi pi-trash" [rounded]="true" [text]="true" severity="danger" size="small" (click)="deleteGroupMapping(mapping)"></p-button>
                   </div>
@@ -607,7 +607,7 @@
       [modal]="true"
       [style]="{width: '550px', maxWidth: '95vw'}"
       [dismissableMask]="true">
-      <div class="config-grid" style="gap: 1rem;">
+      <div class="config-grid" style="gap: 0.875rem;">
         <div class="config-item full-width">
           <label for="gmGroupClaim">{{ t('groupMapping.groupClaimLabel') }}</label>
           <input pInputText id="gmGroupClaim" [(ngModel)]="editingGroupMapping.oidcGroupClaim" [placeholder]="t('groupMapping.groupClaimPlaceholder')"/>

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -146,7 +146,7 @@
       </div>
 
       @if (oidcEnabled) {
-        <div class="config-grid" style="margin-top: 0.65625rem;">
+        <div class="config-grid" style="margin-top: 0.6563rem;">
           <div class="config-item">
             <label for="sessionDuration">{{ t('providerConfig.sessionDuration') }}</label>
             <p-inputNumber
@@ -377,7 +377,7 @@
             </p>
             @if (oidcForceOnlyMode) {
               <p class="toggle-description" style="color: var(--p-yellow-500); margin-top: 0.4375rem;">
-                <i class="pi pi-exclamation-triangle" style="margin-right: 0.21875rem;"></i>
+                <i class="pi pi-exclamation-triangle" style="margin-right: 0.2188rem;"></i>
                 {{ t('oidcOnly.backdoorHint') }}
               </p>
             }
@@ -438,7 +438,7 @@
             </p>
             @if (allowLocalAccountLinking) {
               <p class="toggle-description" style="color: var(--p-yellow-500); margin-top: 0.4375rem;">
-                <i class="pi pi-exclamation-triangle" style="margin-right: 0.21875rem;"></i>
+                <i class="pi pi-exclamation-triangle" style="margin-right: 0.2188rem;"></i>
                 {{ t('provisioning.linkLocalWarning') }}
               </p>
             }
@@ -579,12 +579,12 @@
                 </td>
                 <td>
                   @for (perm of mapping.permissions; track perm) {
-                    <app-tag [rounded]="true" color="info" size="2xs" style="margin-right: 0.21875rem; margin-bottom: 0.21875rem;">{{ perm }}</app-tag>
+                    <app-tag [rounded]="true" color="info" size="2xs" style="margin-right: 0.2188rem; margin-bottom: 0.2188rem;">{{ perm }}</app-tag>
                   }
                 </td>
                 <td>
                   @for (libId of mapping.libraryIds; track libId) {
-                    <app-tag [rounded]="true" color="secondary" size="2xs" style="margin-right: 0.21875rem; margin-bottom: 0.21875rem;">{{ getLibraryName(libId) }}</app-tag>
+                    <app-tag [rounded]="true" color="secondary" size="2xs" style="margin-right: 0.2188rem; margin-bottom: 0.2188rem;">{{ getLibraryName(libId) }}</app-tag>
                   }
                 </td>
                 <td>{{ mapping.description }}</td>

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.scss
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -60,7 +60,7 @@
 .auth-methods-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .auth-method-item {
@@ -86,7 +86,7 @@
 
   @media (width <= 600px) {
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -98,7 +98,7 @@
 .auth-method-header {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.4375rem;
 }
 
@@ -126,7 +126,7 @@
 .auth-method-info {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
 }
 
 .auth-method-label {
@@ -134,7 +134,7 @@
   align-items: center;
   gap: 0.4375rem;
   font-weight: 600;
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   color: var(--p-text-color);
 }
 
@@ -149,7 +149,7 @@
   color: var(--p-text-muted-color);
   line-height: 1.5;
   margin: 0;
-  padding-left: calc(36px + 0.65625rem);
+  padding-left: calc(36px + 0.6563rem);
 
   @media (width <= 600px) {
     padding-left: 0;
@@ -160,14 +160,14 @@
   display: block;
   color: var(--p-orange-400);
   font-weight: 500;
-  margin-top: 0.21875rem;
+  margin-top: 0.2188rem;
 }
 
 // Configuration Grid
 .config-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 900px) {
     grid-template-columns: 1fr 1fr;
@@ -181,7 +181,7 @@
 .config-grid-2col {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 600px) {
     grid-template-columns: 1fr;
@@ -191,7 +191,7 @@
 .config-item {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 
   &.full-width {
     grid-column: 1 / -1;
@@ -208,7 +208,7 @@
   label {
     font-weight: 600;
     color: var(--p-text-color);
-    font-size: 0.71094rem;
+    font-size: 0.7109rem;
   }
 
   input {
@@ -239,22 +239,22 @@
   font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--p-text-color);
-  margin: 0 0 0.21875rem;
+  margin: 0 0 0.2188rem;
 }
 
 .subsection-description {
   font-size: var(--app-text-xs);
   color: var(--p-text-muted-color);
   line-height: 1.4;
-  margin: 0 0 0.65625rem;
+  margin: 0 0 0.6563rem;
 }
 
 .redirect-uri-input {
   display: flex;
   align-items: center;
   width: 100%;
-  min-height: 1.96875rem;
-  padding: 0.21875rem 0.4375rem;
+  min-height: 1.9688rem;
+  padding: 0.2188rem 0.4375rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
   background: var(--p-inputtext-background);
@@ -275,7 +275,7 @@
     background: transparent;
     min-width: 9.625rem;
     flex: 1 1 9.625rem;
-    padding: 0.21875rem 0;
+    padding: 0.2188rem 0;
 
     &:focus {
       box-shadow: none;
@@ -286,7 +286,7 @@
 .redirect-uri-chip-list {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   flex-wrap: wrap;
   width: 100%;
 }
@@ -294,12 +294,12 @@
 .redirect-uri-chip {
   max-width: 100%;
   flex-shrink: 1;
-  font-size: 0.71094rem;
+  font-size: 0.7109rem;
 
   ::ng-deep .p-chip {
-    padding: 0.13676rem 0.35551rem;
-    border-radius: 0.32813rem;
-    line-height: 0.98438rem;
+    padding: 0.1368rem 0.3555rem;
+    border-radius: 0.3281rem;
+    line-height: 0.9844rem;
   }
 
   ::ng-deep .p-chip-label {
@@ -309,7 +309,7 @@
   }
 
   ::ng-deep .p-chip-remove-icon {
-    font-size: 0.56875rem;
+    font-size: 0.5687rem;
     opacity: 0.6;
   }
 }
@@ -317,7 +317,7 @@
 .claims-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 900px) {
     grid-template-columns: 1fr 1fr;
@@ -360,7 +360,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.54688rem 0.76563rem;
+  padding: 0.5469rem 0.7656rem;
   border-radius: 6px;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
@@ -390,8 +390,8 @@
 .test-results-details {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
-  padding: 0.4375rem 0.76563rem 0.54688rem;
+  gap: 0.2188rem;
+  padding: 0.4375rem 0.7656rem 0.5469rem;
   border: 1px solid var(--p-content-border-color);
   border-top: none;
   border-radius: 0 0 6px 6px;
@@ -402,8 +402,8 @@
   display: flex;
   align-items: baseline;
   gap: 0.4375rem;
-  padding: 0.16406rem 0;
-  font-size: 0.71094rem;
+  padding: 0.1641rem 0;
+  font-size: 0.7109rem;
 
   .check-name {
     font-weight: 500;
@@ -419,7 +419,7 @@
   }
 
   .pi {
-    font-size: 0.71094rem;
+    font-size: 0.7109rem;
     flex-shrink: 0;
   }
 }
@@ -438,7 +438,7 @@
 
   @media (width <= 600px) {
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -450,13 +450,13 @@
 .toggle-info {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
   margin-bottom: 0.4375rem;
 }
 
 .toggle-label {
   font-weight: 600;
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   color: var(--p-text-color);
 }
 
@@ -486,11 +486,11 @@
 .libraries-group {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .group-title {
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   font-weight: 600;
   color: var(--p-text-color);
   margin: 0;
@@ -499,7 +499,7 @@
 .permissions-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 0.54688rem;
+  gap: 0.5469rem;
   padding-left: 0.4375rem;
 }
 
@@ -524,17 +524,17 @@
 .info-panel-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .info-panel-item {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .info-panel-label {
-  font-size: 0.71094rem;
+  font-size: 0.7109rem;
   font-weight: 600;
   color: var(--p-text-muted-color);
 }
@@ -547,8 +547,8 @@
 
 .info-panel-value {
   flex: 1;
-  font-size: 0.71094rem;
-  padding: 0.32813rem 0.54688rem;
+  font-size: 0.7109rem;
+  padding: 0.3281rem 0.5469rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.scss
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -28,7 +28,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 767px) {
     flex-direction: column;
@@ -60,20 +60,20 @@
 .auth-methods-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .auth-method-item {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-left-width: 3px;
   border-left-style: solid;
   border-radius: 6px;
-  padding: 1rem;
+  padding: 0.875rem;
   transition: border-color 0.2s ease, background 0.2s ease;
 
   &:hover:not(.is-locked) {
@@ -86,7 +86,7 @@
 
   @media (width <= 600px) {
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
@@ -98,8 +98,8 @@
 .auth-method-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.4375rem;
 }
 
 .auth-method-icon {
@@ -114,7 +114,7 @@
   flex-shrink: 0;
 
   .pi {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   &.oidc {
@@ -126,30 +126,30 @@
 .auth-method-info {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.10938rem;
 }
 
 .auth-method-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   color: var(--p-text-color);
 }
 
 
 .auth-method-status {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
 }
 
 .auth-method-description {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   line-height: 1.5;
   margin: 0;
-  padding-left: calc(36px + 0.75rem);
+  padding-left: calc(36px + 0.65625rem);
 
   @media (width <= 600px) {
     padding-left: 0;
@@ -160,14 +160,14 @@
   display: block;
   color: var(--p-orange-400);
   font-weight: 500;
-  margin-top: 0.25rem;
+  margin-top: 0.21875rem;
 }
 
 // Configuration Grid
 .config-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 900px) {
     grid-template-columns: 1fr 1fr;
@@ -181,7 +181,7 @@
 .config-grid-2col {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 600px) {
     grid-template-columns: 1fr;
@@ -191,7 +191,7 @@
 .config-item {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 
   &.full-width {
     grid-column: 1 / -1;
@@ -208,7 +208,7 @@
   label {
     font-weight: 600;
     color: var(--p-text-color);
-    font-size: 0.8125rem;
+    font-size: 0.71094rem;
   }
 
   input {
@@ -217,44 +217,44 @@
 }
 
 .field-hint {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--p-text-muted-color);
   line-height: 1.4;
 }
 
 .field-error {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--p-red-400);
   line-height: 1.4;
 }
 
 // Claims Section
 .claims-section {
-  margin-top: 1rem;
-  padding-top: 1rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px dashed var(--p-content-border-color);
 }
 
 .subsection-title {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--p-text-color);
-  margin: 0 0 0.25rem;
+  margin: 0 0 0.21875rem;
 }
 
 .subsection-description {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--p-text-muted-color);
   line-height: 1.4;
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.65625rem;
 }
 
 .redirect-uri-input {
   display: flex;
   align-items: center;
   width: 100%;
-  min-height: 2.25rem;
-  padding: 0.25rem 0.5rem;
+  min-height: 1.96875rem;
+  padding: 0.21875rem 0.4375rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
   background: var(--p-inputtext-background);
@@ -273,9 +273,9 @@
     border: 0;
     box-shadow: none;
     background: transparent;
-    min-width: 11rem;
-    flex: 1 1 11rem;
-    padding: 0.25rem 0;
+    min-width: 9.625rem;
+    flex: 1 1 9.625rem;
+    padding: 0.21875rem 0;
 
     &:focus {
       box-shadow: none;
@@ -286,7 +286,7 @@
 .redirect-uri-chip-list {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   flex-wrap: wrap;
   width: 100%;
 }
@@ -294,12 +294,12 @@
 .redirect-uri-chip {
   max-width: 100%;
   flex-shrink: 1;
-  font-size: 0.8125rem;
+  font-size: 0.71094rem;
 
   ::ng-deep .p-chip {
-    padding: 0.1563rem 0.4063rem;
-    border-radius: 0.375rem;
-    line-height: 1.125rem;
+    padding: 0.13676rem 0.35551rem;
+    border-radius: 0.32813rem;
+    line-height: 0.98438rem;
   }
 
   ::ng-deep .p-chip-label {
@@ -309,7 +309,7 @@
   }
 
   ::ng-deep .p-chip-remove-icon {
-    font-size: 0.65rem;
+    font-size: 0.56875rem;
     opacity: 0.6;
   }
 }
@@ -317,7 +317,7 @@
 .claims-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 900px) {
     grid-template-columns: 1fr 1fr;
@@ -333,9 +333,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  margin-top: 1rem;
-  padding-top: 1rem;
+  gap: 0.875rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px dashed var(--p-content-border-color);
 
   @media (width <= 600px) {
@@ -351,7 +351,7 @@
 
 .provider-action-buttons {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-shrink: 0;
 }
 
@@ -359,14 +359,14 @@
 .test-results-toggle {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
+  gap: 0.4375rem;
+  padding: 0.54688rem 0.76563rem;
   border-radius: 6px;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   cursor: pointer;
   user-select: none;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
   color: var(--p-text-color);
   transition: background 0.15s ease;
@@ -376,7 +376,7 @@
   }
 
   .toggle-chevron {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--p-text-muted-color);
     transition: transform 0.2s ease;
     margin-left: auto;
@@ -390,8 +390,8 @@
 .test-results-details {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.5rem 0.875rem 0.625rem;
+  gap: 0.21875rem;
+  padding: 0.4375rem 0.76563rem 0.54688rem;
   border: 1px solid var(--p-content-border-color);
   border-top: none;
   border-radius: 0 0 6px 6px;
@@ -401,9 +401,9 @@
 .test-check-row {
   display: flex;
   align-items: baseline;
-  gap: 0.5rem;
-  padding: 0.1875rem 0;
-  font-size: 0.8125rem;
+  gap: 0.4375rem;
+  padding: 0.16406rem 0;
+  font-size: 0.71094rem;
 
   .check-name {
     font-weight: 500;
@@ -419,7 +419,7 @@
   }
 
   .pi {
-    font-size: 0.8125rem;
+    font-size: 0.71094rem;
     flex-shrink: 0;
   }
 }
@@ -429,16 +429,16 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-left: 3px solid var(--p-primary-color);
   border-radius: 6px;
-  padding: 1rem;
+  padding: 0.875rem;
 
   @media (width <= 600px) {
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
@@ -450,23 +450,23 @@
 .toggle-info {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
-  margin-bottom: 0.5rem;
+  gap: 0.10938rem;
+  margin-bottom: 0.4375rem;
 }
 
 .toggle-label {
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   color: var(--p-text-color);
 }
 
 .toggle-status {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
 }
 
 .toggle-description {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   line-height: 1.5;
   margin: 0;
@@ -476,9 +476,9 @@
 .default-settings {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  margin-top: 1rem;
-  padding-top: 1rem;
+  gap: 1.3125rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px dashed var(--p-content-border-color);
 }
 
@@ -486,11 +486,11 @@
 .libraries-group {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .group-title {
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   font-weight: 600;
   color: var(--p-text-color);
   margin: 0;
@@ -499,17 +499,17 @@
 .permissions-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 0.625rem;
-  padding-left: 0.5rem;
+  gap: 0.54688rem;
+  padding-left: 0.4375rem;
 }
 
 .permission-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--p-text-color);
     cursor: pointer;
   }
@@ -524,17 +524,17 @@
 .info-panel-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .info-panel-item {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .info-panel-label {
-  font-size: 0.8125rem;
+  font-size: 0.71094rem;
   font-weight: 600;
   color: var(--p-text-muted-color);
 }
@@ -542,13 +542,13 @@
 .info-panel-value-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .info-panel-value {
   flex: 1;
-  font-size: 0.8125rem;
-  padding: 0.375rem 0.625rem;
+  font-size: 0.71094rem;
+  padding: 0.32813rem 0.54688rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;

--- a/frontend/src/app/core/security/oidc-callback/oidc-callback.component.scss
+++ b/frontend/src/app/core/security/oidc-callback/oidc-callback.component.scss
@@ -4,15 +4,15 @@
   align-items: center;
   justify-content: center;
   height: 100vh;
-  gap: 1rem;
+  gap: 0.875rem;
   color: var(--text-color);
   background: var(--ground-background);
 
   i {
-    font-size: 2.5rem;
+    font-size: 2.1875rem;
   }
 
   span {
-    font-size: 1.1rem;
+    font-size: 0.9625rem;
   }
 }

--- a/frontend/src/app/core/services/loading.service.ts
+++ b/frontend/src/app/core/services/loading.service.ts
@@ -12,7 +12,7 @@ export class LoadingService {
     loader.innerHTML = `
       <div class="loader-content">
         <i class="pi pi-spin pi-spinner" style="font-size: 3rem; color: var(--primary-color);"></i>
-        <p style="margin-top: 1rem; color: var(--text-color);">${message}</p>
+        <p style="margin-top: 0.875rem; color: var(--text-color);">${message}</p>
       </div>
     `;
     loader.style.cssText = `
@@ -34,7 +34,7 @@ export class LoadingService {
       content.style.cssText = `
         text-align: center;
         background: var(--card-background);
-        padding: 2rem;
+        padding: 1.75rem;
         border-radius: 8px;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
       `;

--- a/frontend/src/app/features/author-browser/components/author-browser/author-browser.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-browser/author-browser.component.scss
@@ -20,13 +20,13 @@
 }
 
 .browse-header {
-  padding: 0.65625rem var(--browser-gutter-inline) 0;
+  padding: 0.6563rem var(--browser-gutter-inline) 0;
 }
 
 .browse-title {
   font-size: 1.3125rem;
   font-weight: 800;
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
   background: linear-gradient(135deg, var(--color-text-strong), var(--color-text-secondary), var(--color-primary));
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -36,7 +36,7 @@
 .browse-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.4375rem;
   align-items: center;
 }
@@ -59,14 +59,14 @@
 
   .search-input {
     width: 100%;
-    padding-left: 1.96875rem;
+    padding-left: 1.9688rem;
     font-size: 0.7875rem;
   }
 }
 
 .filter-sort-wrapper {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
   align-items: center;
 }
@@ -117,7 +117,7 @@
 }
 
 .display-settings-label {
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 600;
   color: var(--color-text);
 }
@@ -125,14 +125,14 @@
 .filter-popover-content {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   min-width: 220px;
 }
 
 .filter-group {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .filter-label {
@@ -142,7 +142,7 @@
 }
 
 .filter-reset-btn {
-  margin-top: 0.21875rem;
+  margin-top: 0.2188rem;
 }
 
 .virtual-scroller {
@@ -220,7 +220,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.65625rem;
+  padding: 0 0.6563rem;
 }
 
 .selected-count-badge {
@@ -243,7 +243,7 @@
 }
 
 .selected-label {
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
 }
 
 .action-buttons-group {

--- a/frontend/src/app/features/author-browser/components/author-browser/author-browser.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-browser/author-browser.component.scss
@@ -7,7 +7,7 @@
   flex-direction: column;
   height: 100%;
   min-height: 0;
-  padding: 1.1rem 0 0;
+  padding: 0.9625rem 0 0;
   position: relative;
 }
 
@@ -20,13 +20,13 @@
 }
 
 .browse-header {
-  padding: 0.75rem var(--browser-gutter-inline) 0;
+  padding: 0.65625rem var(--browser-gutter-inline) 0;
 }
 
 .browse-title {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   font-weight: 800;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
   background: linear-gradient(135deg, var(--color-text-strong), var(--color-text-secondary), var(--color-primary));
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -36,8 +36,8 @@
 .browse-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.4375rem;
   align-items: center;
 }
 
@@ -53,20 +53,20 @@
     top: 50%;
     transform: translateY(-50%);
     color: var(--color-text-muted);
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     z-index: 1;
   }
 
   .search-input {
     width: 100%;
-    padding-left: 2.25rem;
-    font-size: 0.9rem;
+    padding-left: 1.96875rem;
+    font-size: 0.7875rem;
   }
 }
 
 .filter-sort-wrapper {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
   align-items: center;
 }
@@ -112,12 +112,12 @@
 .display-settings-content {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   min-width: 180px;
 }
 
 .display-settings-label {
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   font-weight: 600;
   color: var(--color-text);
 }
@@ -125,36 +125,36 @@
 .filter-popover-content {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   min-width: 220px;
 }
 
 .filter-group {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .filter-label {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   font-weight: 600;
   color: var(--color-text-secondary);
 }
 
 .filter-reset-btn {
-  margin-top: 0.25rem;
+  margin-top: 0.21875rem;
 }
 
 .virtual-scroller {
   flex: 1 1 auto;
   width: 100%;
   min-height: 0;
-  padding: 1rem var(--browser-gutter-inline);
+  padding: 0.875rem var(--browser-gutter-inline);
   box-sizing: border-box;
   overflow-y: auto;
 
   @media #{variables.$mobile-shell-media-query} {
-    padding-block: 0.5rem;
+    padding-block: 0.4375rem;
   }
 }
 
@@ -163,18 +163,18 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 4rem 2rem;
+  padding: 3.5rem 1.75rem;
   text-align: center;
 
   .empty-icon {
-    font-size: 3rem;
+    font-size: 2.625rem;
     color: var(--color-text-muted);
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
   }
 
   p {
     color: var(--color-text-muted);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 500;
   }
 }
@@ -186,7 +186,7 @@
   transform: translateX(-50%);
   display: flex;
   align-items: center;
-  padding: 1rem 0.5rem 0.5rem;
+  padding: 0.875rem 0.4375rem 0.4375rem;
   z-index: 1;
   border-radius: 10px 10px 0 0;
   border: 1px solid rgb(255 255 255 / 50%);
@@ -220,38 +220,38 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.75rem;
+  padding: 0 0.65625rem;
 }
 
 .selected-count-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.5rem 1rem;
-  font-size: 0.9rem;
+  padding: 0.4375rem 0.875rem;
+  font-size: 0.7875rem;
   color: var(--color-text);
 
   i {
-    font-size: 1rem;
-    margin-right: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-right: 0.4375rem;
   }
 }
 
 .selected-count {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   color: var(--color-primary);
 }
 
 .selected-label {
-  margin-left: 0.25rem;
+  margin-left: 0.21875rem;
 }
 
 .action-buttons-group {
   display: flex;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 
   @media #{variables.$mobile-shell-media-query} {
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 }
 
@@ -259,11 +259,11 @@
   .author-browser-page {
     --browser-gutter-inline: var(--space-4);
 
-    padding: 1.5rem 0 0;
+    padding: 1.3125rem 0 0;
   }
 
   .browse-header {
-    padding-top: 0.5rem;
+    padding-top: 0.4375rem;
   }
 
   .browse-controls {

--- a/frontend/src/app/features/author-browser/components/author-card/author-card.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-card/author-card.component.scss
@@ -59,7 +59,7 @@
   background: color-mix(in srgb, var(--color-card), transparent 20%);
 
   i {
-    font-size: 3rem;
+    font-size: 2.625rem;
   }
 }
 
@@ -67,7 +67,7 @@
   position: absolute;
   top: 8px;
   left: 8px;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   font-weight: 700;
   color: #fff;
   background: rgb(0 0 0 / 60%);
@@ -92,13 +92,13 @@
 
 .matched-icon {
   color: var(--color-green-500);
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   flex-shrink: 0;
   filter: drop-shadow(0 1px 2px rgb(0 0 0 / 50%));
 }
 
 .author-name {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   font-weight: 600;
   color: #fff;
   margin: 0;
@@ -116,7 +116,7 @@
 }
 
 ::ng-deep .card-menu-btn .p-button {
-  padding: 0.15rem 0.25rem !important;
+  padding: 0.13125rem 0.21875rem !important;
   color: #fff !important;
 
   &:hover {

--- a/frontend/src/app/features/author-browser/components/author-card/author-card.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-card/author-card.component.scss
@@ -92,7 +92,7 @@
 
 .matched-icon {
   color: var(--color-green-500);
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   flex-shrink: 0;
   filter: drop-shadow(0 1px 2px rgb(0 0 0 / 50%));
 }
@@ -116,7 +116,7 @@
 }
 
 ::ng-deep .card-menu-btn .p-button {
-  padding: 0.13125rem 0.21875rem !important;
+  padding: 0.1313rem 0.2188rem !important;
   color: #fff !important;
 
   &:hover {

--- a/frontend/src/app/features/author-browser/components/author-detail/author-detail.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-detail/author-detail.component.scss
@@ -38,14 +38,14 @@
   justify-content: center;
   align-items: center;
   height: 100%;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .author-header {
   display: flex;
-  gap: 1.5rem;
-  padding: 0.5rem;
-  margin-bottom: 1.5rem;
+  gap: 1.3125rem;
+  padding: 0.4375rem;
+  margin-bottom: 1.3125rem;
 
   @media (width <= 767px) {
     flex-direction: column;
@@ -82,7 +82,7 @@
   color: var(--color-text-secondary);
 
   i {
-    font-size: 4rem;
+    font-size: 3.5rem;
   }
 
   @media (width <= 767px) {
@@ -96,13 +96,13 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .author-title-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
 
   @media (width <= 767px) {
@@ -121,18 +121,18 @@
 }
 
 .author-title {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   font-weight: 800;
   line-height: 1.25;
   margin: 0;
 
   @media (width >= 768px) {
-    font-size: 1.875rem;
+    font-size: 1.64063rem;
   }
 }
 
 .description-box {
-  padding: 1rem 0.5rem 0.5rem;
+  padding: 0.875rem 0.4375rem 0.4375rem;
 
   @media (width <= 767px) {
     text-align: left;
@@ -145,7 +145,7 @@
 }
 
 .readonly-editor {
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   color: var(--color-text-secondary);
   line-height: 1.6;
   white-space: pre-wrap;
@@ -156,13 +156,13 @@
   flex: 1 1 auto;
   flex-direction: column;
   min-height: 0;
-  padding: 0 0.5rem;
+  padding: 0 0.4375rem;
 }
 
 .section-title {
-  font-size: 1.1rem;
+  font-size: 0.9625rem;
   font-weight: 700;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   color: var(--color-text);
 }
 
@@ -179,18 +179,18 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
 
   i {
-    font-size: 2.5rem;
+    font-size: 2.1875rem;
     color: var(--color-text-secondary);
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.65625rem;
   }
 
   p {
     color: var(--color-text-secondary);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     margin: 0;
   }
 }

--- a/frontend/src/app/features/author-browser/components/author-detail/author-detail.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-detail/author-detail.component.scss
@@ -96,13 +96,13 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .author-title-row {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
 
   @media (width <= 767px) {
@@ -127,7 +127,7 @@
   margin: 0;
 
   @media (width >= 768px) {
-    font-size: 1.64063rem;
+    font-size: 1.6406rem;
   }
 }
 
@@ -185,7 +185,7 @@
   i {
     font-size: 2.1875rem;
     color: var(--color-text-secondary);
-    margin-bottom: 0.65625rem;
+    margin-bottom: 0.6563rem;
   }
 
   p {

--- a/frontend/src/app/features/author-browser/components/author-editor/author-editor.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-editor/author-editor.component.scss
@@ -6,9 +6,9 @@
 }
 
 .editor-container {
-  padding: 1rem 0.5rem;
+  padding: 0.875rem 0.4375rem;
   display: flex;
-  gap: 2rem;
+  gap: 1.75rem;
   flex: 1;
 
   @media (width <= 767px) {
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-shrink: 0;
   position: relative;
 }
@@ -37,7 +37,7 @@
   color: var(--color-text-secondary);
 
   i {
-    font-size: 4rem;
+    font-size: 3.5rem;
   }
 }
 
@@ -51,8 +51,8 @@
 .cover-actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding-top: 0.75rem;
+  gap: 0.65625rem;
+  padding-top: 0.65625rem;
 }
 
 .fields-section {
@@ -63,14 +63,14 @@
 }
 
 .field-group {
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.09375rem;
 
   label {
     display: block;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     font-weight: 600;
     color: var(--color-text-secondary);
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.35rem;
   }
 }
 
@@ -115,9 +115,9 @@
 .footer-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   justify-content: flex-end;
-  padding: 0.5rem 0;
+  padding: 0.4375rem 0;
 
   @media (width <= 639px) {
     flex-wrap: wrap;

--- a/frontend/src/app/features/author-browser/components/author-editor/author-editor.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-editor/author-editor.component.scss
@@ -51,8 +51,8 @@
 .cover-actions {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding-top: 0.65625rem;
+  gap: 0.6563rem;
+  padding-top: 0.6563rem;
 }
 
 .fields-section {
@@ -63,11 +63,11 @@
 }
 
 .field-group {
-  margin-bottom: 1.09375rem;
+  margin-bottom: 1.0938rem;
 
   label {
     display: block;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     font-weight: 600;
     color: var(--color-text-secondary);
     margin-bottom: 0.35rem;

--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.scss
@@ -17,7 +17,7 @@
     gap: 0.35rem;
 
     label {
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
       font-weight: 600;
       color: var(--color-text-secondary);
     }
@@ -49,7 +49,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding: 2.625rem;
   color: var(--color-text-secondary);
 }
@@ -65,7 +65,7 @@
   i {
     font-size: 2.1875rem;
     color: var(--color-text-secondary);
-    margin-bottom: 0.65625rem;
+    margin-bottom: 0.6563rem;
   }
 
   p {
@@ -75,9 +75,9 @@
   }
 
   .hint {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     color: var(--color-text-secondary);
-    margin-top: 0.21875rem;
+    margin-top: 0.2188rem;
   }
 }
 
@@ -91,7 +91,7 @@
 .results-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .result-card {
@@ -141,7 +141,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .result-name {
@@ -158,9 +158,9 @@
 }
 
 .result-description {
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   color: var(--color-text-secondary);
-  margin: 0.21875rem 0 0;
+  margin: 0.2188rem 0 0;
   line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 3;

--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.scss
@@ -1,23 +1,23 @@
 .match-container {
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .search-form {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.3125rem;
 }
 
 .search-fields {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
   align-items: flex-end;
 
   .field {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: 0.35rem;
 
     label {
-      font-size: 0.85rem;
+      font-size: 0.74375rem;
       font-weight: 600;
       color: var(--color-text-secondary);
     }
@@ -49,8 +49,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  padding: 3rem;
+  gap: 0.65625rem;
+  padding: 2.625rem;
   color: var(--color-text-secondary);
 }
 
@@ -59,45 +59,45 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
 
   i {
-    font-size: 2.5rem;
+    font-size: 2.1875rem;
     color: var(--color-text-secondary);
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.65625rem;
   }
 
   p {
     color: var(--color-text-secondary);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     margin: 0;
   }
 
   .hint {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     color: var(--color-text-secondary);
-    margin-top: 0.25rem;
+    margin-top: 0.21875rem;
   }
 }
 
 .results-header {
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   color: var(--color-text-secondary);
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   font-weight: 600;
 }
 
 .results-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .result-card {
   display: flex;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 0.875rem;
+  padding: 0.875rem;
   border-radius: 10px;
   border: 1px solid color-mix(in srgb, var(--color-border), transparent 60%);
   background: color-mix(in srgb, var(--color-card), transparent 30%);
@@ -132,7 +132,7 @@
   color: var(--color-text-secondary);
 
   i {
-    font-size: 2rem;
+    font-size: 1.75rem;
   }
 }
 
@@ -141,26 +141,26 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .result-name {
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   font-weight: 700;
   color: var(--color-text);
   margin: 0;
 }
 
 .result-asin {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--color-text-secondary);
   font-family: monospace;
 }
 
 .result-description {
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   color: var(--color-text-secondary);
-  margin: 0.25rem 0 0;
+  margin: 0.21875rem 0 0;
   line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 3;

--- a/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.scss
@@ -10,7 +10,7 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  padding: 0 1.5rem 1.5rem;
+  padding: 0 1.3125rem 1.3125rem;
 }
 
 .search-section {
@@ -18,31 +18,31 @@
   background: var(--color-app);
   border: 1px solid var(--color-border);
   border-radius: 12px;
-  padding: 1.25rem 1.5rem;
-  margin-bottom: 1.5rem;
+  padding: 1.09375rem 1.3125rem;
+  margin-bottom: 1.3125rem;
 
   .form-row {
     display: flex;
     align-items: flex-end;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .form-field {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     flex: 1;
 
     label {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      font-size: 0.875rem;
+      gap: 0.4375rem;
+      font-size: var(--app-text-sm);
       font-weight: 500;
       color: var(--color-text-secondary);
 
       i {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
         color: var(--color-primary);
       }
     }
@@ -55,7 +55,7 @@
   .form-actions {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     padding-bottom: 1px;
   }
 }
@@ -75,22 +75,22 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
   background: var(--color-app);
   border: 1px dashed var(--color-border);
   border-radius: 12px;
 
   h3 {
-    margin: 0 0 0.5rem;
-    font-size: 1.125rem;
+    margin: 0 0 0.4375rem;
+    font-size: var(--app-text-lg);
     font-weight: 600;
     color: var(--color-text);
   }
 
   p {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     color: var(--color-text-secondary);
     max-width: 300px;
   }
@@ -104,10 +104,10 @@
   justify-content: center;
   background: linear-gradient(135deg, var(--color-primary-100), var(--color-primary-50));
   border-radius: 50%;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.3125rem;
 
   i {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: var(--color-primary);
   }
 
@@ -122,23 +122,23 @@
 
 .loading-state {
   p {
-    margin-top: 1rem;
+    margin-top: 0.875rem;
   }
 }
 
 .results-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-  padding-bottom: 0.75rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
+  padding-bottom: 0.65625rem;
   border-bottom: 1px solid var(--color-border);
 
   .results-count {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 0.95rem;
+    gap: 0.4375rem;
+    font-size: 0.83125rem;
     font-weight: 600;
     color: var(--color-text);
 
@@ -151,8 +151,8 @@
 .photos-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 1.25rem;
-  padding: 0.25rem;
+  gap: 1.09375rem;
+  padding: 0.21875rem;
 }
 
 .photo-card {
@@ -204,7 +204,7 @@
     color: white;
     padding: 3px 6px;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
     font-weight: 600;
     z-index: 2;
     pointer-events: none;
@@ -218,7 +218,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.5rem;
+    padding: 0.4375rem;
     background: linear-gradient(to top, rgb(0 0 0 / 80%), transparent);
     opacity: 0;
     z-index: 3;
@@ -233,12 +233,12 @@
     .form-actions {
       flex-direction: row;
       justify-content: flex-end;
-      margin-top: 0.5rem;
+      margin-top: 0.4375rem;
     }
   }
 
   .photos-grid {
     grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }

--- a/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.scss
+++ b/frontend/src/app/features/author-browser/components/author-photo-search/author-photo-search.component.scss
@@ -18,7 +18,7 @@
   background: var(--color-app);
   border: 1px solid var(--color-border);
   border-radius: 12px;
-  padding: 1.09375rem 1.3125rem;
+  padding: 1.0938rem 1.3125rem;
   margin-bottom: 1.3125rem;
 
   .form-row {
@@ -129,16 +129,16 @@
 .results-header {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
-  padding-bottom: 0.65625rem;
+  padding-bottom: 0.6563rem;
   border-bottom: 1px solid var(--color-border);
 
   .results-count {
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    font-size: 0.83125rem;
+    font-size: 0.8313rem;
     font-weight: 600;
     color: var(--color-text);
 
@@ -151,8 +151,8 @@
 .photos-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 1.09375rem;
-  padding: 0.21875rem;
+  gap: 1.0938rem;
+  padding: 0.2188rem;
 }
 
 .photo-card {

--- a/frontend/src/app/features/book/components/add-physical-book-dialog/add-physical-book-dialog.component.scss
+++ b/frontend/src/app/features/book/components/add-physical-book-dialog/add-physical-book-dialog.component.scss
@@ -19,8 +19,8 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 1.25rem;
+  gap: 0.4375rem;
+  padding: 1.09375rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -29,35 +29,35 @@
   max-height: calc(90vh - 200px);
 
   @media (width <= 480px) {
-    padding: 0.75rem;
-    gap: 0.375rem;
+    padding: 0.65625rem;
+    gap: 0.32813rem;
   }
 }
 
 .form-row {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 640px) {
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   &.highlight-group {
-    padding: 0.5rem;
+    padding: 0.4375rem;
   }
 
   @media (width <= 480px) {
-    gap: 0.25rem;
+    gap: 0.21875rem;
 
     &.highlight-group {
-      padding: 0.375rem;
+      padding: 0.32813rem;
     }
   }
 }
@@ -65,8 +65,8 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.9rem;
+  gap: 0.32813rem;
+  font-size: 0.7875rem;
   font-weight: 600;
   color: var(--text-color);
 
@@ -76,11 +76,11 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.125rem;
+    margin-left: 0.10938rem;
   }
 
   @media (width <= 480px) {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
@@ -101,7 +101,7 @@
 .isbn-input-row {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   .input-full {
     flex: 1;
@@ -110,7 +110,7 @@
 
 .top-section {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
   align-items: flex-start;
 
   @media (width <= 640px) {
@@ -124,12 +124,12 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .cover-preview {
   flex-shrink: 0;
-  padding: 0.5rem;
+  padding: 0.4375rem;
 
   img {
     height: 180px;
@@ -178,18 +178,18 @@
   }
 
   .p-autocomplete-input-chip {
-    width: 2rem;
+    width: 1.75rem;
   }
 
   .p-autocomplete-clearable ul {
-    padding-inline-end: 2rem !important;
+    padding-inline-end: 1.75rem !important;
   }
 
   .p-autocomplete-clearable .p-autocomplete-clear-icon {
     right: 0;
-    margin-top: -1rem;
-    width: 2rem;
-    height: 2rem;
-    padding: 0.5rem;
+    margin-top: -0.875rem;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0.4375rem;
   }
 }

--- a/frontend/src/app/features/book/components/add-physical-book-dialog/add-physical-book-dialog.component.scss
+++ b/frontend/src/app/features/book/components/add-physical-book-dialog/add-physical-book-dialog.component.scss
@@ -20,7 +20,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.4375rem;
-  padding: 1.09375rem;
+  padding: 1.0938rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -29,14 +29,14 @@
   max-height: calc(90vh - 200px);
 
   @media (width <= 480px) {
-    padding: 0.65625rem;
-    gap: 0.32813rem;
+    padding: 0.6563rem;
+    gap: 0.3281rem;
   }
 }
 
 .form-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 640px) {
     flex-direction: column;
@@ -47,17 +47,17 @@
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   &.highlight-group {
     padding: 0.4375rem;
   }
 
   @media (width <= 480px) {
-    gap: 0.21875rem;
+    gap: 0.2188rem;
 
     &.highlight-group {
-      padding: 0.32813rem;
+      padding: 0.3281rem;
     }
   }
 }
@@ -65,7 +65,7 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   font-size: 0.7875rem;
   font-weight: 600;
   color: var(--text-color);
@@ -76,11 +76,11 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.10938rem;
+    margin-left: 0.1094rem;
   }
 
   @media (width <= 480px) {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 
@@ -101,7 +101,7 @@
 .isbn-input-row {
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   .input-full {
     flex: 1;

--- a/frontend/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.scss
+++ b/frontend/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.scss
@@ -111,7 +111,7 @@
 }
 
 .status-icon {
-  padding: 0.65625rem;
+  padding: 0.6563rem;
 }
 
 .empty-state {
@@ -126,7 +126,7 @@
   border: 2px solid;
   border-radius: 9999px;
   padding: 1.75rem;
-  font-size: 1.96875rem;
+  font-size: 1.9688rem;
   color: var(--p-text-muted-color);
 }
 

--- a/frontend/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.scss
+++ b/frontend/src/app/features/book/components/additional-file-uploader/additional-file-uploader.component.scss
@@ -16,7 +16,7 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -24,7 +24,7 @@
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 :host ::ng-deep {
@@ -47,26 +47,26 @@
   align-items: center;
   justify-content: center;
   flex: 1;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .action-buttons {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .upload-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  padding: 0 1rem;
+  gap: 1.75rem;
+  padding: 0 0.875rem;
 }
 
 .file-list-scroll {
-  max-height: 24rem;
-  max-width: 22rem;
+  max-height: 21rem;
+  max-width: 19.25rem;
   overflow-y: auto;
-  padding-right: 0.5rem;
+  padding-right: 0.4375rem;
 
   @media (width >= 768px) {
     max-width: none;
@@ -83,13 +83,13 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .file-info {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.875rem;
   overflow: hidden;
   flex: 1;
 }
@@ -111,7 +111,7 @@
 }
 
 .status-icon {
-  padding: 0.75rem;
+  padding: 0.65625rem;
 }
 
 .empty-state {
@@ -125,17 +125,17 @@
 .empty-icon {
   border: 2px solid;
   border-radius: 9999px;
-  padding: 2rem;
-  font-size: 2.25rem;
+  padding: 1.75rem;
+  font-size: 1.96875rem;
   color: var(--p-text-muted-color);
 }
 
 .empty-text {
-  margin-top: 1.5rem;
-  margin-bottom: 0.5rem;
+  margin-top: 1.3125rem;
+  margin-bottom: 0.4375rem;
 }
 
 .empty-subtext {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-top: 0.4375rem;
+  margin-bottom: 0.4375rem;
 }

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.html
@@ -182,7 +182,7 @@
             <i class="pi pi-search"></i>
           </button>
 
-          <p-popover #searchDropdown [dismissable]="true" appendTo="body" [style]="{ width: '24rem' }">
+          <p-popover #searchDropdown [dismissable]="true" appendTo="body" [style]="{ width: '21rem' }">
             <div class="search-popover-content">
               <input
                 type="text"

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.scss
@@ -41,16 +41,16 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.25rem;
-  padding: 0.35rem;
+  gap: 0.21875rem;
+  padding: 0.30625rem;
   margin-right: 2px;
   flex-shrink: 0;
   background-color: var(--color-card);
   border-bottom: 1px solid var(--p-content-border-color);
 
   @media (width >= 768px) {
-    gap: 1rem;
-    padding: 0.5rem 1rem;
+    gap: 0.875rem;
+    padding: 0.4375rem 0.875rem;
   }
 }
 
@@ -66,7 +66,7 @@
 .entity-info {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.10938rem;
   min-width: 0;
   overflow: hidden;
 
@@ -76,20 +76,20 @@
 }
 
 .entity-title {
-  font-size: 1.25rem;
+  font-size: 1.09375rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0;
 
   @media (width <= 767px) {
-    font-size: 1rem;
-    padding-left: 0.25rem;
+    font-size: var(--app-text-base);
+    padding-left: 0.21875rem;
   }
 }
 
 .series-collapsed-info {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
   margin: 0;
 
@@ -102,7 +102,7 @@
 }
 
 .entity-menu-wrapper {
-  margin-left: 0.5rem;
+  margin-left: 0.4375rem;
   flex-shrink: 0;
 }
 
@@ -111,11 +111,11 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
   flex-shrink: 0;
 
   @media (width >= 768px) {
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
@@ -123,10 +123,10 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   @media (width >= 768px) {
-    gap: 1.5rem;
+    gap: 1.3125rem;
   }
 }
 
@@ -143,30 +143,30 @@
 .column-popover-footer {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding-top: 1rem;
-  padding-left: 0.25rem;
+  gap: 0.4375rem;
+  padding-top: 0.875rem;
+  padding-left: 0.21875rem;
 }
 
 .display-settings-popover {
   width: 220px;
-  padding: 0.5rem;
+  padding: 0.4375rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  font-size: 0.875rem;
+  gap: 0.875rem;
+  font-size: var(--app-text-sm);
 }
 
 .display-settings-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .display-settings-checkbox-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .display-settings-label {
@@ -189,7 +189,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 1rem;
+  padding: 0.4375rem 0.875rem;
   cursor: pointer;
 }
 
@@ -222,7 +222,7 @@
 
 .search-clear-btn {
   position: absolute;
-  right: 0.5rem;
+  right: 0.4375rem;
   top: 50%;
   transform: translateY(-50%);
 }
@@ -236,7 +236,7 @@
   display: flex;
   align-items: center;
   overflow: hidden;
-  padding: 1rem 0.5rem 0.5rem;
+  padding: 0.875rem 0.4375rem 0.4375rem;
   z-index: 1;
   border-radius: 10px 10px 0 0;
   border: 1px solid rgb(255 255 255 / 50%);
@@ -268,7 +268,7 @@
 .footer-left {
   display: flex;
   align-items: center;
-  padding-left: 0.5rem;
+  padding-left: 0.4375rem;
   flex-shrink: 0;
   width: 120px;
 
@@ -309,42 +309,42 @@
 .selected-count-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.5rem 1rem;
-  font-size: 0.9rem;
+  padding: 0.4375rem 0.875rem;
+  font-size: 0.7875rem;
   color: var(--color-text);
 
   i {
-    font-size: 1rem;
-    margin-right: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-right: 0.4375rem;
   }
 
   @media (width <= 768px) {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.85rem;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.74375rem;
 
     i {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
     }
   }
 }
 
 .selected-count {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   color: var(--color-primary);
 }
 
 .selected-label {
-  margin-left: 0.25rem;
+  margin-left: 0.21875rem;
 }
 
 .action-buttons-group {
   display: flex;
   flex-shrink: 0;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   @media (width >= 768px) {
-    gap: 1.5rem;
+    gap: 1.3125rem;
   }
 }
 
@@ -357,7 +357,7 @@
 .virtual-scroller {
   width: 100%;
   height: 100%;
-  padding: 1rem;
+  padding: 0.875rem;
   box-sizing: border-box;
   overflow-y: auto;
 }
@@ -384,19 +384,19 @@
 
 // No books state
 .no-books-container {
-  padding-top: 3rem;
+  padding-top: 2.625rem;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
 .no-books-text {
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   font-weight: 500;
   color: var(--color-text);
   background: var(--color-card);
-  padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
+  padding: 0.65625rem 0.875rem;
+  border-radius: 0.4375rem;
 }
 
 // Toolbar actions (icon buttons)
@@ -406,8 +406,8 @@
   justify-content: center;
   flex-shrink: 0;
   border: 1px solid var(--color-border);
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.1875rem;
+  height: 2.1875rem;
   transition: outline-color 0.2s, border-color 0.2s;
   border-radius: 6px;
   margin: 0;
@@ -417,8 +417,8 @@
   cursor: pointer;
 
   @media (width <= 767px) {
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
   }
 
   &:hover {
@@ -427,11 +427,11 @@
 
   i, span {
     color: var(--color-primary);
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     font-weight: 100;
 
     @media (width <= 767px) {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 }
@@ -443,16 +443,16 @@
   left: 10px;
   transform: translateY(-50%);
   color: var(--color-text-secondary);
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   pointer-events: none;
 }
 
 .search-input {
-  min-width: 22rem;
+  min-width: 19.25rem;
   padding-left: 30px;
-  height: 2.5rem;
-  line-height: 2.5rem;
-  font-size: 1rem;
+  height: 2.1875rem;
+  line-height: 2.1875rem;
+  font-size: var(--app-text-base);
   box-sizing: border-box;
 
   @media (width <= 767px) {

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.scss
@@ -41,8 +41,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.21875rem;
-  padding: 0.30625rem;
+  gap: 0.2188rem;
+  padding: 0.3063rem;
   margin-right: 2px;
   flex-shrink: 0;
   background-color: var(--color-card);
@@ -66,7 +66,7 @@
 .entity-info {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
   min-width: 0;
   overflow: hidden;
 
@@ -76,7 +76,7 @@
 }
 
 .entity-title {
-  font-size: 1.09375rem;
+  font-size: 1.0938rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -84,7 +84,7 @@
 
   @media (width <= 767px) {
     font-size: var(--app-text-base);
-    padding-left: 0.21875rem;
+    padding-left: 0.2188rem;
   }
 }
 
@@ -111,7 +111,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   flex-shrink: 0;
 
   @media (width >= 768px) {
@@ -123,7 +123,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   @media (width >= 768px) {
     gap: 1.3125rem;
@@ -145,7 +145,7 @@
   align-items: center;
   gap: 0.4375rem;
   padding-top: 0.875rem;
-  padding-left: 0.21875rem;
+  padding-left: 0.2188rem;
 }
 
 .display-settings-popover {
@@ -320,7 +320,7 @@
 
   @media (width <= 768px) {
     padding: 0.35rem 0.7rem;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
 
     i {
       font-size: 0.7875rem;
@@ -335,7 +335,7 @@
 }
 
 .selected-label {
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
 }
 
 .action-buttons-group {
@@ -395,7 +395,7 @@
   font-weight: 500;
   color: var(--color-text);
   background: var(--color-card);
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   border-radius: 0.4375rem;
 }
 
@@ -427,7 +427,7 @@
 
   i, span {
     color: var(--color-primary);
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     font-weight: 100;
 
     @media (width <= 767px) {

--- a/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.scss
@@ -76,18 +76,18 @@
 
 .book-title {
   flex-grow: 1;
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: center;
   margin: 0;
-  padding-left: 0.5rem;
+  padding-left: 0.4375rem;
 
   @media (width <= 767px) {
-    font-size: 0.75rem;
-    padding-left: 0.25rem;
+    font-size: var(--app-text-xs);
+    padding-left: 0.21875rem;
   }
 }
 
@@ -116,8 +116,8 @@
     }
 
     @media (width <= 767px) {
-      width: clamp(1.5rem, 8vw, 2.5rem);
-      height: clamp(1.5rem, 8vw, 2.5rem);
+      width: clamp(1.3125rem, 8vw, 2.1875rem);
+      height: clamp(1.3125rem, 8vw, 2.1875rem);
       padding: 0;
 
       .pi {
@@ -211,7 +211,7 @@
   left: 8px;
   background-color: rgb(0 0 0 / 70%);
   color: var(--color-white);
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   padding: 1px 3px;
   border-radius: 3px;
   z-index: 3;
@@ -221,7 +221,7 @@
   position: absolute;
   background-color: var(--color-primary);
   color: var(--color-primary-contrast);
-  font-size: 0.7rem;
+  font-size: 0.6125rem;
   padding: 0 5px;
   border-radius: 6px;
   z-index: 3;
@@ -237,7 +237,7 @@
 }
 
 .series-items-count-icon {
-  font-size: 0.6rem;
+  font-size: 0.525rem;
   margin-right: 2px;
 }
 
@@ -245,7 +245,7 @@
   position: absolute;
   background: var(--color-primary);
   color: var(--color-primary-contrast);
-  font-size: 0.675rem;
+  font-size: 0.59063rem;
   font-weight: 700;
   padding: 1px 6px;
   border-radius: 6px;
@@ -282,7 +282,7 @@
   margin: 0;
 
   @media (width <= 767px) {
-    font-size: 0.6rem;
+    font-size: 0.525rem;
     padding: 1px 4px;
   }
 }
@@ -367,7 +367,7 @@
   align-items: center;
   justify-content: center;
   font-weight: bold;
-  margin-left: 0.5rem;
+  margin-left: 0.4375rem;
   cursor: pointer;
   border-radius: 4px;
   transition: opacity 0.15s ease;

--- a/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-card/book-card.component.scss
@@ -87,7 +87,7 @@
 
   @media (width <= 767px) {
     font-size: var(--app-text-xs);
-    padding-left: 0.21875rem;
+    padding-left: 0.2188rem;
   }
 }
 
@@ -245,7 +245,7 @@
   position: absolute;
   background: var(--color-primary);
   color: var(--color-primary-contrast);
-  font-size: 0.59063rem;
+  font-size: 0.5906rem;
   font-weight: 700;
   padding: 1px 6px;
   border-radius: 6px;

--- a/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.component.scss
@@ -1,5 +1,5 @@
 :host ::ng-deep p-accordion {
-  --p-accordion-header-padding: 0.6rem 1rem;
+  --p-accordion-header-padding: 0.525rem 0.875rem;
   --p-accordion-header-background: var(--color-card);
   --p-accordion-header-active-background: var(--color-card);
   --p-accordion-header-hover-background: var(--color-surface-hover);
@@ -12,7 +12,7 @@
 }
 
 :host ::ng-deep .p-togglebutton {
-  --p-togglebutton-content-padding: 0.25rem 0.35rem;
+  --p-togglebutton-content-padding: 0.21875rem 0.30625rem;
 }
 
 :host ::ng-deep .cdk-virtual-scroll-orientation-vertical .cdk-virtual-scroll-content-wrapper {
@@ -34,7 +34,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem;
+  padding: 0.875rem;
   border-bottom: 1px solid var(--p-content-border-color);
 }
 
@@ -43,24 +43,24 @@
 }
 
 .filter-mode-select {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
 }
 
 :host ::ng-deep .filter-mode-select .p-togglebutton-label {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
 }
 
 .filter-content {
   flex: 1;
   overflow-y: auto;
-  padding-bottom: 1rem;
+  padding-bottom: 0.875rem;
   overscroll-behavior: contain;
 }
 
 .filter-type-label {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
   max-width: 100%;
   overflow: hidden;
   min-width: 0;
@@ -75,7 +75,7 @@
 }
 
 .active-filter-count {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-primary);
   flex-shrink: 0;
   white-space: nowrap;
@@ -83,7 +83,7 @@
 }
 
 .filter-list {
-  padding-right: 0.25rem;
+  padding-right: 0.21875rem;
 }
 
 .filter-row {
@@ -93,7 +93,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   max-width: 97%;
   transition: color var(--transition-base);
 
@@ -120,19 +120,19 @@
 }
 
 .truncation-notice {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--color-text-secondary);
   text-align: center;
-  padding-top: 0.5rem;
+  padding-top: 0.4375rem;
   border-top: 1px solid var(--color-border);
 }
 
 .footer-notice {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--color-text-secondary);
   text-align: center;
-  padding-top: 1rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
-  margin-top: 0.5rem;
+  padding-top: 0.875rem;
+  padding-left: 0.875rem;
+  padding-right: 0.875rem;
+  margin-top: 0.4375rem;
 }

--- a/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.component.scss
@@ -12,7 +12,7 @@
 }
 
 :host ::ng-deep .p-togglebutton {
-  --p-togglebutton-content-padding: 0.21875rem 0.30625rem;
+  --p-togglebutton-content-padding: 0.2188rem 0.3063rem;
 }
 
 :host ::ng-deep .cdk-virtual-scroll-orientation-vertical .cdk-virtual-scroll-content-wrapper {
@@ -60,7 +60,7 @@
 .filter-type-label {
   display: inline-flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   max-width: 100%;
   overflow: hidden;
   min-width: 0;
@@ -83,7 +83,7 @@
 }
 
 .filter-list {
-  padding-right: 0.21875rem;
+  padding-right: 0.2188rem;
 }
 
 .filter-row {

--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table-row.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table-row.component.scss
@@ -45,8 +45,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.3125rem;
+  height: 1.3125rem;
   padding: 0;
   border: 0;
   border-radius: 5px;
@@ -79,7 +79,7 @@
 }
 
 .cover-thumbnail {
-  height: 2rem;
+  height: 1.75rem;
   aspect-ratio: 5 / 7;
   object-fit: cover;
   border-radius: 4px;
@@ -96,7 +96,7 @@
   width: 20px;
   height: 20px;
   margin: 0 auto;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 700;
 }
 
@@ -142,7 +142,7 @@
 .cell-action,
 .cell-cover {
   justify-content: center;
-  padding-inline: 0.5rem;
+  padding-inline: 0.4375rem;
 }
 
 .cell-cover {
@@ -159,7 +159,7 @@
   align-items: center;
   justify-content: center;
   gap: var(--book-table-rating-gap);
-  min-width: 7rem;
+  min-width: 6.125rem;
 }
 
 .rating-value {

--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.scss
@@ -8,7 +8,7 @@
   --book-table-border-color: var(--p-datatable-border-color, color-mix(in srgb, var(--p-content-border-color) 82%, black));
   --book-table-header-background: var(--p-datatable-header-cell-background, var(--p-content-background));
   --book-table-header-color: var(--p-datatable-header-cell-color, var(--p-text-color));
-  --book-table-header-padding: var(--p-datatable-header-cell-padding, 0.65625rem 0.875rem);
+  --book-table-header-padding: var(--p-datatable-header-cell-padding, 0.6563rem 0.875rem);
   --book-table-header-weight: var(--p-datatable-column-title-font-weight, 600);
   --book-table-row-background: var(--p-datatable-row-background, var(--p-content-background));
   --book-table-row-color: var(--p-datatable-row-color, var(--p-text-color));
@@ -16,8 +16,8 @@
   --book-table-row-hover-color: var(--p-datatable-row-hover-color, var(--p-text-color));
   --book-table-row-striped-background: var(--p-datatable-row-striped-background, var(--color-app));
   --book-table-cell-border-color: var(--p-datatable-body-cell-border-color, var(--book-table-border-color));
-  --book-table-cell-padding: var(--p-datatable-body-cell-padding, 0.65625rem 0.875rem);
-  --book-table-rating-gap: var(--p-rating-gap, 0.21875rem);
+  --book-table-cell-padding: var(--p-datatable-body-cell-padding, 0.6563rem 0.875rem);
+  --book-table-rating-gap: var(--p-rating-gap, 0.2188rem);
   --book-table-lock-unlocked-color: var(--color-lock-unlocked, var(--color-green-600));
   --book-table-lock-locked-color: var(--color-lock-locked, var(--color-red-600));
   --book-table-status-read-color: var(--color-green-500);
@@ -169,7 +169,7 @@
 .loading-line {
   display: block;
   width: 85%;
-  height: 0.65625rem;
+  height: 0.6563rem;
   border-radius: 999px;
   background: color-mix(in srgb, var(--p-text-color) 14%, transparent);
   animation: loading-line-pulse 1.5s ease-in-out infinite;

--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table.component.scss
@@ -8,7 +8,7 @@
   --book-table-border-color: var(--p-datatable-border-color, color-mix(in srgb, var(--p-content-border-color) 82%, black));
   --book-table-header-background: var(--p-datatable-header-cell-background, var(--p-content-background));
   --book-table-header-color: var(--p-datatable-header-cell-color, var(--p-text-color));
-  --book-table-header-padding: var(--p-datatable-header-cell-padding, 0.75rem 1rem);
+  --book-table-header-padding: var(--p-datatable-header-cell-padding, 0.65625rem 0.875rem);
   --book-table-header-weight: var(--p-datatable-column-title-font-weight, 600);
   --book-table-row-background: var(--p-datatable-row-background, var(--p-content-background));
   --book-table-row-color: var(--p-datatable-row-color, var(--p-text-color));
@@ -16,8 +16,8 @@
   --book-table-row-hover-color: var(--p-datatable-row-hover-color, var(--p-text-color));
   --book-table-row-striped-background: var(--p-datatable-row-striped-background, var(--color-app));
   --book-table-cell-border-color: var(--p-datatable-body-cell-border-color, var(--book-table-border-color));
-  --book-table-cell-padding: var(--p-datatable-body-cell-padding, 0.75rem 1rem);
-  --book-table-rating-gap: var(--p-rating-gap, 0.25rem);
+  --book-table-cell-padding: var(--p-datatable-body-cell-padding, 0.65625rem 0.875rem);
+  --book-table-rating-gap: var(--p-rating-gap, 0.21875rem);
   --book-table-lock-unlocked-color: var(--color-lock-unlocked, var(--color-green-600));
   --book-table-lock-locked-color: var(--color-lock-locked, var(--color-red-600));
   --book-table-status-read-color: var(--color-green-500);
@@ -131,8 +131,8 @@
 }
 
 .cover-preview {
-  width: 14rem;
-  max-height: calc(100dvh - 2rem);
+  width: 12.25rem;
+  max-height: calc(100dvh - 1.75rem);
   border-radius: 6px;
   box-shadow:
     0 18px 48px rgb(0 0 0 / 42%),
@@ -142,7 +142,7 @@
 
 .cover-preview-image {
   width: 100%;
-  max-height: calc(100dvh - 6rem);
+  max-height: calc(100dvh - 5.25rem);
   aspect-ratio: 5 / 7;
   object-fit: cover;
   border-radius: inherit;
@@ -155,7 +155,7 @@
 .cell-action,
 .cell-cover {
   justify-content: center;
-  padding-inline: 0.5rem;
+  padding-inline: 0.4375rem;
 }
 
 .cell-cover {
@@ -169,7 +169,7 @@
 .loading-line {
   display: block;
   width: 85%;
-  height: 0.75rem;
+  height: 0.65625rem;
   border-radius: 999px;
   background: color-mix(in srgb, var(--p-text-color) 14%, transparent);
   animation: loading-line-pulse 1.5s ease-in-out infinite;

--- a/frontend/src/app/features/book/components/book-browser/lock-unlock-metadata-dialog/lock-unlock-metadata-dialog.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/lock-unlock-metadata-dialog/lock-unlock-metadata-dialog.component.scss
@@ -10,7 +10,7 @@
 }
 
 .dialog-content {
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -23,14 +23,14 @@
 
 .footer-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   align-items: center;
 }
 
 .fields-grid {
   display: grid;
   grid-template-columns: repeat(1, minmax(0, 1fr));
-  gap: 1rem 6rem;
+  gap: 0.875rem 5.25rem;
 
   @media (width >= 576px) {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/frontend/src/app/features/book/components/book-browser/sorting/multi-sort-popover/multi-sort-popover.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/sorting/multi-sort-popover/multi-sort-popover.component.scss
@@ -1,35 +1,35 @@
 .multi-sort-container {
   width: 280px;
-  padding: 0.5rem;
+  padding: 0.4375rem;
 }
 
 .multi-sort-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: 0.75rem;
+  padding-bottom: 0.65625rem;
   border-bottom: 1px solid var(--border-color);
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .header-title {
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   color: var(--text-color);
 }
 
 .sort-criteria-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   min-height: 40px;
 }
 
 .sort-criterion {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem;
   background-color: var(--overlay-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -44,8 +44,8 @@
 .cdk-drag-preview {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem;
   background-color: var(--card-background);
   border: 1px solid var(--primary-color);
   border-radius: 6px;
@@ -76,19 +76,19 @@
   }
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
 .criterion-rank {
   font-weight: 600;
   color: var(--primary-color);
-  min-width: 1.25rem;
+  min-width: 1.09375rem;
 }
 
 .criterion-label {
   flex: 1;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -98,7 +98,7 @@
 .criterion-actions {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .direction-btn,
@@ -106,8 +106,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 1.53125rem;
+  height: 1.53125rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -116,7 +116,7 @@
   transition: background-color 0.15s ease;
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 
   &:hover:not(:disabled) {
@@ -138,13 +138,13 @@
 }
 
 .add-sort-section {
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
+  margin-top: 0.65625rem;
+  padding-top: 0.65625rem;
   border-top: 1px solid var(--border-color);
 }
 
 .save-sort-section {
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
+  margin-top: 0.65625rem;
+  padding-top: 0.65625rem;
   border-top: 1px solid var(--border-color);
 }

--- a/frontend/src/app/features/book/components/book-browser/sorting/multi-sort-popover/multi-sort-popover.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/sorting/multi-sort-popover/multi-sort-popover.component.scss
@@ -7,9 +7,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: 0.65625rem;
+  padding-bottom: 0.6563rem;
   border-bottom: 1px solid var(--border-color);
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .header-title {
@@ -76,14 +76,14 @@
   }
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 
 .criterion-rank {
   font-weight: 600;
   color: var(--primary-color);
-  min-width: 1.09375rem;
+  min-width: 1.0938rem;
 }
 
 .criterion-label {
@@ -98,7 +98,7 @@
 .criterion-actions {
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .direction-btn,
@@ -106,8 +106,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.53125rem;
-  height: 1.53125rem;
+  width: 1.5313rem;
+  height: 1.5313rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -116,7 +116,7 @@
   transition: background-color 0.15s ease;
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 
   &:hover:not(:disabled) {
@@ -138,13 +138,13 @@
 }
 
 .add-sort-section {
-  margin-top: 0.65625rem;
-  padding-top: 0.65625rem;
+  margin-top: 0.6563rem;
+  padding-top: 0.6563rem;
   border-top: 1px solid var(--border-color);
 }
 
 .save-sort-section {
-  margin-top: 0.65625rem;
-  padding-top: 0.65625rem;
+  margin-top: 0.6563rem;
+  padding-top: 0.6563rem;
   border-top: 1px solid var(--border-color);
 }

--- a/frontend/src/app/features/book/components/book-card-lite/book-card-lite-component.scss
+++ b/frontend/src/app/features/book/components/book-card-lite/book-card-lite-component.scss
@@ -9,7 +9,7 @@
     aspect-ratio: 5 / 7;
     object-fit: cover;
     display: block;
-    border-radius: 0.5rem;
+    border-radius: 0.4375rem;
   }
 
   &.audiobook-only {
@@ -41,7 +41,7 @@
     left: 4px;
     background-color: rgb(0 0 0 / 70%);
     color: white;
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     padding: 1px 3px;
     border-radius: 3px;
     z-index: 3;

--- a/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.scss
+++ b/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.scss
@@ -31,7 +31,7 @@
   font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--p-text-muted-color);
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -48,14 +48,14 @@
   .book-info-card {
     background: var(--color-card);
     border-radius: 8px;
-    padding: 0.65625rem 0.875rem;
+    padding: 0.6563rem 0.875rem;
     border: 1px solid var(--color-border);
   }
 
   .book-title {
     font-weight: 600;
-    font-size: 0.82031rem;
-    margin-bottom: 0.10938rem;
+    font-size: 0.8203rem;
+    margin-bottom: 0.1094rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -64,7 +64,7 @@
   .book-authors {
     color: var(--p-text-muted-color);
     font-size: var(--app-text-sm);
-    margin-bottom: 0.32813rem;
+    margin-bottom: 0.3281rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -99,12 +99,12 @@
 }
 
 .book-suggestion {
-  padding: 0.21875rem 0;
+  padding: 0.2188rem 0;
   overflow: hidden;
 
   .suggestion-title {
     font-weight: 500;
-    margin-bottom: 0.10938rem;
+    margin-bottom: 0.1094rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -122,7 +122,7 @@
     font-size: var(--app-text-xs);
     color: var(--p-primary-color);
     font-weight: 600;
-    margin-top: 0.21875rem;
+    margin-top: 0.2188rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -132,10 +132,10 @@
 .delete-option {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   .delete-label {
-    font-size: 0.82031rem;
+    font-size: 0.8203rem;
     cursor: pointer;
     user-select: none;
   }
@@ -143,7 +143,7 @@
 
 .warning-message {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding: 0.875rem;
   background: var(--p-yellow-50);
   border: 1px solid var(--p-yellow-200);
@@ -152,8 +152,8 @@
 
   i {
     flex-shrink: 0;
-    font-size: 1.09375rem;
-    margin-top: 0.10938rem;
+    font-size: 1.0938rem;
+    margin-top: 0.1094rem;
   }
 
   .warning-text {
@@ -185,7 +185,7 @@
 .action-buttons {
   display: flex;
   justify-content: flex-end;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-top: auto;
   padding-top: 0.4375rem;
 }

--- a/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.scss
+++ b/frontend/src/app/features/book/components/book-file-attacher/book-file-attacher.component.scss
@@ -16,7 +16,7 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
@@ -24,14 +24,14 @@
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .section-title {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--p-text-muted-color);
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -40,7 +40,7 @@
   .source-books-list {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     max-height: 200px;
     overflow-y: auto;
   }
@@ -48,14 +48,14 @@
   .book-info-card {
     background: var(--color-card);
     border-radius: 8px;
-    padding: 0.75rem 1rem;
+    padding: 0.65625rem 0.875rem;
     border: 1px solid var(--color-border);
   }
 
   .book-title {
     font-weight: 600;
-    font-size: 0.9375rem;
-    margin-bottom: 0.125rem;
+    font-size: 0.82031rem;
+    margin-bottom: 0.10938rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -63,8 +63,8 @@
 
   .book-authors {
     color: var(--p-text-muted-color);
-    font-size: 0.875rem;
-    margin-bottom: 0.375rem;
+    font-size: var(--app-text-sm);
+    margin-bottom: 0.32813rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -73,13 +73,13 @@
   .file-info {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     color: var(--p-primary-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
 
     span {
@@ -99,19 +99,19 @@
 }
 
 .book-suggestion {
-  padding: 0.25rem 0;
+  padding: 0.21875rem 0;
   overflow: hidden;
 
   .suggestion-title {
     font-weight: 500;
-    margin-bottom: 0.125rem;
+    margin-bottom: 0.10938rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .suggestion-authors {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--p-text-muted-color);
     white-space: nowrap;
     overflow: hidden;
@@ -119,10 +119,10 @@
   }
 
   .suggestion-format {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--p-primary-color);
     font-weight: 600;
-    margin-top: 0.25rem;
+    margin-top: 0.21875rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -132,10 +132,10 @@
 .delete-option {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   .delete-label {
-    font-size: 0.9375rem;
+    font-size: 0.82031rem;
     cursor: pointer;
     user-select: none;
   }
@@ -143,8 +143,8 @@
 
 .warning-message {
   display: flex;
-  gap: 0.75rem;
-  padding: 1rem;
+  gap: 0.65625rem;
+  padding: 0.875rem;
   background: var(--p-yellow-50);
   border: 1px solid var(--p-yellow-200);
   border-radius: 8px;
@@ -152,19 +152,19 @@
 
   i {
     flex-shrink: 0;
-    font-size: 1.25rem;
-    margin-top: 0.125rem;
+    font-size: 1.09375rem;
+    margin-top: 0.10938rem;
   }
 
   .warning-text {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     line-height: 1.5;
 
     p {
       margin: 0;
 
       &:not(:last-child) {
-        margin-bottom: 0.5rem;
+        margin-bottom: 0.4375rem;
       }
     }
   }
@@ -185,7 +185,7 @@
 .action-buttons {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   margin-top: auto;
-  padding-top: 0.5rem;
+  padding-top: 0.4375rem;
 }

--- a/frontend/src/app/features/book/components/book-notes/book-notes-component.scss
+++ b/frontend/src/app/features/book/components/book-notes/book-notes-component.scss
@@ -40,7 +40,7 @@
   color: var(--color-text-secondary);
 
   .empty-state-title {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     font-weight: 600;
     margin-top: 0.875rem;
     margin-bottom: 0.4375rem;
@@ -125,13 +125,13 @@
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
-      padding: 0.65625rem;
+      padding: 0.6563rem;
     }
 
     .note-title-group {
       display: flex;
       flex-direction: column;
-      gap: 0.21875rem;
+      gap: 0.2188rem;
     }
 
     .note-title {
@@ -167,7 +167,7 @@
 
     .note-meta-icon {
       font-size: var(--app-text-xs);
-      margin-right: 0.21875rem;
+      margin-right: 0.2188rem;
     }
 
     .note-meta-text {
@@ -253,7 +253,7 @@
 
   @media (width <= 480px) {
     max-height: 120px;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 

--- a/frontend/src/app/features/book/components/book-notes/book-notes-component.scss
+++ b/frontend/src/app/features/book/components/book-notes/book-notes-component.scss
@@ -25,8 +25,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
-  gap: 1rem;
+  padding: 1.75rem;
+  gap: 0.875rem;
 }
 
 .loading-text {
@@ -35,23 +35,23 @@
 
 .empty-state {
   position: relative;
-  padding: 3rem !important;
+  padding: 2.625rem !important;
   text-align: center;
   color: var(--color-text-secondary);
 
   .empty-state-title {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     font-weight: 600;
-    margin-top: 1rem;
-    margin-bottom: 0.5rem;
+    margin-top: 0.875rem;
+    margin-bottom: 0.4375rem;
     color: var(--color-text);
   }
 
   .empty-state-subtitle {
     max-width: 400px;
-    margin: 0.5rem auto 0;
+    margin: 0.4375rem auto 0;
     line-height: 1.6;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text-secondary);
   }
 
@@ -74,8 +74,8 @@
 
 .notes-horizontal-list {
   display: flex;
-  gap: 1.5rem;
-  padding: 0.5rem;
+  gap: 1.3125rem;
+  padding: 0.4375rem;
 }
 
 .note-card {
@@ -125,13 +125,13 @@
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
-      padding: 0.75rem;
+      padding: 0.65625rem;
     }
 
     .note-title-group {
       display: flex;
       flex-direction: column;
-      gap: 0.25rem;
+      gap: 0.21875rem;
     }
 
     .note-title {
@@ -141,17 +141,17 @@
       text-overflow: ellipsis;
       color: var(--color-text);
       font-weight: 500;
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
       margin: 0;
 
       @media (width <= 768px) {
         max-width: 200px;
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       @media (width <= 480px) {
         max-width: 180px;
-        font-size: 0.9rem;
+        font-size: 0.7875rem;
       }
     }
 
@@ -166,18 +166,18 @@
     }
 
     .note-meta-icon {
-      font-size: 0.75rem;
-      margin-right: 0.25rem;
+      font-size: var(--app-text-xs);
+      margin-right: 0.21875rem;
     }
 
     .note-meta-text {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--color-text-secondary);
     }
 
     .note-actions {
       display: flex;
-      gap: 0.5rem;
+      gap: 0.4375rem;
       flex-shrink: 0;
 
       .action-btn-hover {
@@ -202,7 +202,7 @@
     display: flex;
     flex-direction: column;
     position: relative;
-    padding: 1rem;
+    padding: 0.875rem;
 
     .note-fade-overlay {
       position: absolute;
@@ -248,26 +248,26 @@
 
   @media (width <= 768px) {
     max-height: 140px;
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 
   @media (width <= 480px) {
     max-height: 120px;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
 .dialog-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .field-label {
   display: block;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
   color: var(--color-text);
 }
 
@@ -277,7 +277,7 @@
 
 .dialog-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   justify-content: flex-end;
 }
 

--- a/frontend/src/app/features/book/components/book-reviews/book-reviews.component.scss
+++ b/frontend/src/app/features/book/components/book-reviews/book-reviews.component.scss
@@ -74,7 +74,7 @@
   color: var(--color-text-secondary);
 
   .empty-state-title {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     font-weight: 600;
     margin-top: 0.875rem;
     margin-bottom: 0.4375rem;
@@ -181,13 +181,13 @@
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
-      padding: 0.65625rem;
+      padding: 0.6563rem;
     }
 
     .reviewer-info-group {
       display: flex;
       flex-direction: column;
-      gap: 0.21875rem;
+      gap: 0.2188rem;
     }
 
     .reviewer-name-row {
@@ -220,7 +220,7 @@
 
     .review-meta-icon {
       font-size: var(--app-text-xs);
-      margin-right: 0.21875rem;
+      margin-right: 0.2188rem;
     }
 
     .review-meta-text {
@@ -237,7 +237,7 @@
     .rating-wrapper {
       display: flex;
       align-items: center;
-      gap: 0.21875rem;
+      gap: 0.2188rem;
     }
 
     .rating-text {
@@ -315,7 +315,7 @@
   text-overflow: ellipsis;
   cursor: help;
   font-weight: 500;
-  font-size: 1.09375rem;
+  font-size: 1.0938rem;
   color: var(--color-text);
   line-height: 1.25;
   margin: 0;

--- a/frontend/src/app/features/book/components/book-reviews/book-reviews.component.scss
+++ b/frontend/src/app/features/book/components/book-reviews/book-reviews.component.scss
@@ -59,8 +59,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
-  gap: 1rem;
+  padding: 1.75rem;
+  gap: 0.875rem;
 }
 
 .loading-text {
@@ -69,23 +69,23 @@
 
 .empty-state {
   position: relative;
-  padding: 3rem !important;
+  padding: 2.625rem !important;
   text-align: center;
   color: var(--color-text-secondary);
 
   .empty-state-title {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     font-weight: 600;
-    margin-top: 1rem;
-    margin-bottom: 0.5rem;
+    margin-top: 0.875rem;
+    margin-bottom: 0.4375rem;
     color: var(--color-text);
   }
 
   .empty-state-subtitle {
     max-width: 400px;
-    margin: 0.5rem auto 0;
+    margin: 0.4375rem auto 0;
     line-height: 1.6;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text-secondary);
 
     &--warning {
@@ -113,8 +113,8 @@
 
 .reviews-horizontal-list {
   display: flex;
-  gap: 1rem;
-  padding: 0.5rem;
+  gap: 0.875rem;
+  padding: 0.4375rem;
 }
 
 .review-card {
@@ -181,19 +181,19 @@
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
-      padding: 0.75rem;
+      padding: 0.65625rem;
     }
 
     .reviewer-info-group {
       display: flex;
       flex-direction: column;
-      gap: 0.25rem;
+      gap: 0.21875rem;
     }
 
     .reviewer-name-row {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .reviewer-name {
@@ -205,7 +205,7 @@
       background-clip: text;
       -webkit-text-fill-color: transparent;
       font-weight: 500;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
 
     .review-meta {
@@ -219,29 +219,29 @@
     }
 
     .review-meta-icon {
-      font-size: 0.75rem;
-      margin-right: 0.25rem;
+      font-size: var(--app-text-xs);
+      margin-right: 0.21875rem;
     }
 
     .review-meta-text {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--color-text-secondary);
     }
 
     .review-actions {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .rating-wrapper {
       display: flex;
       align-items: center;
-      gap: 0.25rem;
+      gap: 0.21875rem;
     }
 
     .rating-text {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       font-weight: 500;
     }
 
@@ -249,13 +249,13 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 2rem;
-      height: 2rem;
+      width: 1.75rem;
+      height: 1.75rem;
     }
 
     .lock-icon {
       color: var(--color-amber-500);
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
 
     .action-btn-hover {
@@ -315,14 +315,14 @@
   text-overflow: ellipsis;
   cursor: help;
   font-weight: 500;
-  font-size: 1.25rem;
+  font-size: 1.09375rem;
   color: var(--color-text);
   line-height: 1.25;
   margin: 0;
 
   &--blurred {
     filter: blur(4px);
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.4375rem;
   }
 }
 
@@ -344,7 +344,7 @@
 .review-empty-text {
   color: var(--color-text-secondary);
   font-style: italic;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 
   &--blurred {
     filter: blur(4px);

--- a/frontend/src/app/features/book/components/book-sender/book-sender.component.scss
+++ b/frontend/src/app/features/book/components/book-sender/book-sender.component.scss
@@ -14,7 +14,7 @@
 
 .dialog-content {
   flex: 1;
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
@@ -29,17 +29,17 @@
 .form-fields {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .field-label {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
   color: var(--color-text);
 }
@@ -51,14 +51,14 @@
 .format-options {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .format-option {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  gap: 0.65625rem;
+  padding: 0.65625rem;
   border: 1px solid var(--color-border);
   border-radius: 6px;
   cursor: pointer;
@@ -78,7 +78,7 @@
 .format-info {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex: 1;
 }
 
@@ -88,9 +88,9 @@
 }
 
 .primary-badge {
-  font-size: 0.7rem;
+  font-size: 0.6125rem;
   font-weight: 600;
-  padding: 0.125rem 0.375rem;
+  padding: 0.10938rem 0.32813rem;
   background: var(--color-primary);
   color: var(--color-primary-contrast);
   border-radius: 4px;
@@ -99,27 +99,27 @@
 
 .file-size {
   margin-left: auto;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--color-text-secondary);
 }
 
 .warning-banner {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: 0.65625rem;
+  padding: 0.65625rem 0.875rem;
   background: color-mix(in srgb, var(--color-warning) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-warning) 30%, transparent);
   border-radius: 6px;
   color: var(--color-warning);
 
   i {
-    font-size: 1rem;
-    margin-top: 0.125rem;
+    font-size: var(--app-text-base);
+    margin-top: 0.10938rem;
   }
 
   span {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     line-height: 1.4;
   }
 }

--- a/frontend/src/app/features/book/components/book-sender/book-sender.component.scss
+++ b/frontend/src/app/features/book/components/book-sender/book-sender.component.scss
@@ -57,8 +57,8 @@
 .format-option {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.65625rem;
+  gap: 0.6563rem;
+  padding: 0.6563rem;
   border: 1px solid var(--color-border);
   border-radius: 6px;
   cursor: pointer;
@@ -90,7 +90,7 @@
 .primary-badge {
   font-size: 0.6125rem;
   font-weight: 600;
-  padding: 0.10938rem 0.32813rem;
+  padding: 0.1094rem 0.3281rem;
   background: var(--color-primary);
   color: var(--color-primary-contrast);
   border-radius: 4px;
@@ -106,8 +106,8 @@
 .warning-banner {
   display: flex;
   align-items: flex-start;
-  gap: 0.65625rem;
-  padding: 0.65625rem 0.875rem;
+  gap: 0.6563rem;
+  padding: 0.6563rem 0.875rem;
   background: color-mix(in srgb, var(--color-warning) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-warning) 30%, transparent);
   border-radius: 6px;
@@ -115,11 +115,11 @@
 
   i {
     font-size: var(--app-text-base);
-    margin-top: 0.10938rem;
+    margin-top: 0.1094rem;
   }
 
   span {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     line-height: 1.4;
   }
 }

--- a/frontend/src/app/features/book/components/bulk-isbn-import-dialog/bulk-isbn-import-dialog.component.scss
+++ b/frontend/src/app/features/book/components/bulk-isbn-import-dialog/bulk-isbn-import-dialog.component.scss
@@ -19,8 +19,8 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
-  padding: 1.09375rem;
+  gap: 0.6563rem;
+  padding: 1.0938rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -29,7 +29,7 @@
   max-height: calc(90vh - 200px);
 
   @media (width <= 480px) {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
     gap: 0.4375rem;
   }
 }
@@ -37,7 +37,7 @@
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   &.highlight-group {
     padding: 0.4375rem;
@@ -47,7 +47,7 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   font-size: 0.7875rem;
   font-weight: 600;
   color: var(--text-color);
@@ -58,7 +58,7 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.10938rem;
+    margin-left: 0.1094rem;
   }
 }
 
@@ -70,7 +70,7 @@
 .gradient-divider {
   height: 1px;
   background: linear-gradient(to right, transparent, var(--border-color), transparent);
-  margin: 0.21875rem 0;
+  margin: 0.2188rem 0;
 }
 
 // Upload section
@@ -78,7 +78,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding: 1.3125rem;
 
   .upload-hint {
@@ -92,8 +92,8 @@
 .paste-section {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
-  padding: 0.65625rem 0;
+  gap: 0.6563rem;
+  padding: 0.6563rem 0;
 
   p-button {
     align-self: flex-end;
@@ -104,7 +104,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   background: rgb(239 68 68 / 10%);
   border: 1px solid rgb(239 68 68 / 30%);
   border-radius: 6px;
@@ -116,7 +116,7 @@
 .parse-results {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .parse-summary {
@@ -128,10 +128,10 @@
 .summary-stat {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.32813rem 0.65625rem;
+  gap: 0.3281rem;
+  padding: 0.3281rem 0.6563rem;
   border-radius: 6px;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 500;
 
   &.success {
@@ -157,7 +157,7 @@
 .skipped-list {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   padding: 0.4375rem;
   background: rgb(234 179 8 / 5%);
   border: 1px solid rgb(234 179 8 / 20%);
@@ -175,7 +175,7 @@
   code {
     color: var(--text-color);
     background: var(--ground-background);
-    padding: 0.10938rem 0.32813rem;
+    padding: 0.1094rem 0.3281rem;
     border-radius: 3px;
   }
 
@@ -206,7 +206,7 @@
 .preview-list {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   max-height: 200px;
   overflow-y: auto;
   padding: 0.4375rem;
@@ -219,8 +219,8 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.21875rem 0.32813rem;
-  font-size: 0.74375rem;
+  padding: 0.2188rem 0.3281rem;
+  font-size: 0.7438rem;
 
   .preview-index {
     color: var(--text-secondary-color);
@@ -266,7 +266,7 @@
 .progress-stats {
   display: flex;
   gap: 0.875rem;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
 
   .stat-created {
     color: var(--p-green-500);
@@ -281,23 +281,23 @@
   }
 
   i {
-    margin-right: 0.21875rem;
+    margin-right: 0.2188rem;
   }
 }
 
 .isbn-progress-list {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .progress-item {
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.32813rem 0.4375rem;
+  padding: 0.3281rem 0.4375rem;
   border-radius: 4px;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   transition: background-color 0.2s;
 
   &.status-pending {
@@ -322,7 +322,7 @@
 }
 
 .progress-item-icon {
-  width: 1.09375rem;
+  width: 1.0938rem;
   text-align: center;
   flex-shrink: 0;
 
@@ -354,7 +354,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.21875rem 0;
+  padding: 0.2188rem 0;
 
   .summary-title {
     font-size: var(--app-text-base);
@@ -365,8 +365,8 @@
   .summary-library {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
-    font-size: 0.74375rem;
+    gap: 0.3281rem;
+    font-size: 0.7438rem;
     color: var(--text-secondary-color);
 
     i {
@@ -378,21 +378,21 @@
 .summary-results {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65625rem;
-  padding: 0.21875rem 0;
+  gap: 0.6563rem;
+  padding: 0.2188rem 0;
 }
 
 .summary-card {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.65625rem 0.875rem;
+  gap: 0.6563rem;
+  padding: 0.6563rem 0.875rem;
   border-radius: 8px;
   flex: 1;
   min-width: 120px;
 
   > i {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
   }
 
   &.success {
@@ -425,7 +425,7 @@
   flex-direction: column;
 
   .summary-card-count {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     font-weight: 700;
     color: var(--text-color);
   }
@@ -439,17 +439,17 @@
 .summary-detail-list {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
-  margin-top: 0.21875rem;
+  gap: 0.1094rem;
+  margin-top: 0.2188rem;
 }
 
 .summary-detail-item {
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.32813rem 0.4375rem;
+  padding: 0.3281rem 0.4375rem;
   border-radius: 4px;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
 
   &.status-created {
     background: rgb(34 197 94 / 4%);
@@ -465,7 +465,7 @@
 }
 
 .summary-detail-icon {
-  width: 1.09375rem;
+  width: 1.0938rem;
   text-align: center;
   flex-shrink: 0;
 

--- a/frontend/src/app/features/book/components/bulk-isbn-import-dialog/bulk-isbn-import-dialog.component.scss
+++ b/frontend/src/app/features/book/components/bulk-isbn-import-dialog/bulk-isbn-import-dialog.component.scss
@@ -19,8 +19,8 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1.25rem;
+  gap: 0.65625rem;
+  padding: 1.09375rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -29,26 +29,26 @@
   max-height: calc(90vh - 200px);
 
   @media (width <= 480px) {
-    padding: 0.75rem;
-    gap: 0.5rem;
+    padding: 0.65625rem;
+    gap: 0.4375rem;
   }
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   &.highlight-group {
-    padding: 0.5rem;
+    padding: 0.4375rem;
   }
 }
 
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.9rem;
+  gap: 0.32813rem;
+  font-size: 0.7875rem;
   font-weight: 600;
   color: var(--text-color);
 
@@ -58,7 +58,7 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.125rem;
+    margin-left: 0.10938rem;
   }
 }
 
@@ -70,7 +70,7 @@
 .gradient-divider {
   height: 1px;
   background: linear-gradient(to right, transparent, var(--border-color), transparent);
-  margin: 0.25rem 0;
+  margin: 0.21875rem 0;
 }
 
 // Upload section
@@ -78,11 +78,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1.5rem;
+  gap: 0.65625rem;
+  padding: 1.3125rem;
 
   .upload-hint {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     color: var(--text-secondary-color);
     margin: 0;
     text-align: center;
@@ -92,8 +92,8 @@
 .paste-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.75rem 0;
+  gap: 0.65625rem;
+  padding: 0.65625rem 0;
 
   p-button {
     align-self: flex-end;
@@ -103,35 +103,35 @@
 .parse-error {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem 0.875rem;
   background: rgb(239 68 68 / 10%);
   border: 1px solid rgb(239 68 68 / 30%);
   border-radius: 6px;
   color: var(--p-red-500);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 }
 
 // Parse results
 .parse-results {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .parse-summary {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .summary-stat {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem 0.75rem;
+  gap: 0.32813rem;
+  padding: 0.32813rem 0.65625rem;
   border-radius: 6px;
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   font-weight: 500;
 
   &.success {
@@ -157,8 +157,8 @@
 .skipped-list {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.5rem;
+  gap: 0.21875rem;
+  padding: 0.4375rem;
   background: rgb(234 179 8 / 5%);
   border: 1px solid rgb(234 179 8 / 20%);
   border-radius: 6px;
@@ -169,13 +169,13 @@
 .skipped-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.8rem;
+  gap: 0.4375rem;
+  font-size: 0.7rem;
 
   code {
     color: var(--text-color);
     background: var(--ground-background);
-    padding: 0.125rem 0.375rem;
+    padding: 0.10938rem 0.32813rem;
     border-radius: 3px;
   }
 
@@ -188,7 +188,7 @@
 .isbn-preview {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .preview-header {
@@ -197,7 +197,7 @@
   align-items: center;
 
   .preview-label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 600;
     color: var(--text-color);
   }
@@ -206,10 +206,10 @@
 .preview-list {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
   max-height: 200px;
   overflow-y: auto;
-  padding: 0.5rem;
+  padding: 0.4375rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -218,13 +218,13 @@
 .preview-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0.375rem;
-  font-size: 0.85rem;
+  gap: 0.4375rem;
+  padding: 0.21875rem 0.32813rem;
+  font-size: 0.74375rem;
 
   .preview-index {
     color: var(--text-secondary-color);
-    min-width: 2rem;
+    min-width: 1.75rem;
     text-align: right;
   }
 
@@ -241,8 +241,8 @@
 .progress-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.5rem 0;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0;
 }
 
 .progress-header {
@@ -251,13 +251,13 @@
   align-items: center;
 
   .progress-label {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     font-weight: 500;
     color: var(--text-color);
   }
 
   .progress-percent {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     font-weight: 600;
     color: var(--primary-color);
   }
@@ -265,8 +265,8 @@
 
 .progress-stats {
   display: flex;
-  gap: 1rem;
-  font-size: 0.85rem;
+  gap: 0.875rem;
+  font-size: 0.74375rem;
 
   .stat-created {
     color: var(--p-green-500);
@@ -281,23 +281,23 @@
   }
 
   i {
-    margin-right: 0.25rem;
+    margin-right: 0.21875rem;
   }
 }
 
 .isbn-progress-list {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .progress-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  gap: 0.4375rem;
+  padding: 0.32813rem 0.4375rem;
   border-radius: 4px;
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   transition: background-color 0.2s;
 
   &.status-pending {
@@ -322,7 +322,7 @@
 }
 
 .progress-item-icon {
-  width: 1.25rem;
+  width: 1.09375rem;
   text-align: center;
   flex-shrink: 0;
 
@@ -334,7 +334,7 @@
 }
 
 .progress-item-isbn {
-  min-width: 8rem;
+  min-width: 7rem;
   flex-shrink: 0;
   color: var(--text-color);
 }
@@ -346,7 +346,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-secondary-color);
-  font-size: 0.8rem;
+  font-size: 0.7rem;
 }
 
 // Summary phase
@@ -354,10 +354,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.25rem 0;
+  padding: 0.21875rem 0;
 
   .summary-title {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
     color: var(--text-color);
   }
@@ -365,8 +365,8 @@
   .summary-library {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
-    font-size: 0.85rem;
+    gap: 0.32813rem;
+    font-size: 0.74375rem;
     color: var(--text-secondary-color);
 
     i {
@@ -378,21 +378,21 @@
 .summary-results {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  padding: 0.25rem 0;
+  gap: 0.65625rem;
+  padding: 0.21875rem 0;
 }
 
 .summary-card {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: 0.65625rem;
+  padding: 0.65625rem 0.875rem;
   border-radius: 8px;
   flex: 1;
   min-width: 120px;
 
   > i {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
   }
 
   &.success {
@@ -425,13 +425,13 @@
   flex-direction: column;
 
   .summary-card-count {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     font-weight: 700;
     color: var(--text-color);
   }
 
   .summary-card-label {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--text-secondary-color);
   }
 }
@@ -439,17 +439,17 @@
 .summary-detail-list {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
-  margin-top: 0.25rem;
+  gap: 0.10938rem;
+  margin-top: 0.21875rem;
 }
 
 .summary-detail-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  gap: 0.4375rem;
+  padding: 0.32813rem 0.4375rem;
   border-radius: 4px;
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
 
   &.status-created {
     background: rgb(34 197 94 / 4%);
@@ -465,7 +465,7 @@
 }
 
 .summary-detail-icon {
-  width: 1.25rem;
+  width: 1.09375rem;
   text-align: center;
   flex-shrink: 0;
 
@@ -475,10 +475,10 @@
 }
 
 .summary-detail-isbn {
-  min-width: 8rem;
+  min-width: 7rem;
   flex-shrink: 0;
   color: var(--text-color);
-  font-size: 0.8rem;
+  font-size: 0.7rem;
 }
 
 .summary-detail-info {
@@ -487,7 +487,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
 
   .status-created & {
     color: var(--text-color);

--- a/frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.scss
+++ b/frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.scss
@@ -16,7 +16,7 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
@@ -24,7 +24,7 @@
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .preset-section {
@@ -36,38 +36,38 @@
   .advanced-toggle {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     background: none;
     border: none;
     color: var(--p-text-muted-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
     cursor: pointer;
-    padding: 0.25rem 0;
+    padding: 0.21875rem 0;
 
     &:hover {
       color: var(--p-text-color);
     }
 
     i {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
     }
   }
 
   .signal-checkboxes {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem 1.5rem;
-    padding: 0.75rem 0 0;
+    gap: 0.65625rem 1.3125rem;
+    padding: 0.65625rem 0 0;
   }
 
   .signal-checkbox {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     label {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       cursor: pointer;
       user-select: none;
     }
@@ -78,30 +78,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0.75rem 0;
+  gap: 0.875rem;
+  padding: 0.65625rem 0;
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
 
   .action-bar-left {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 
   .action-bar-right {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .delete-option {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     label {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       cursor: pointer;
       user-select: none;
       white-space: nowrap;
@@ -120,24 +120,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 1rem;
+  padding: 2.625rem 0.875rem;
   color: var(--p-text-muted-color);
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   i {
-    font-size: 2.5rem;
+    font-size: 2.1875rem;
   }
 
   p {
     margin: 0;
-    font-size: 0.9375rem;
+    font-size: 0.82031rem;
   }
 }
 
 .groups-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .duplicate-group {
@@ -148,20 +148,20 @@
   .group-header {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 0.5rem 0.75rem;
+    gap: 0.65625rem;
+    padding: 0.4375rem 0.65625rem;
     border-bottom: 1px solid var(--color-border);
 
     .group-label {
       font-weight: 600;
-      font-size: 0.8125rem;
+      font-size: 0.71094rem;
       color: var(--p-text-muted-color);
     }
 
     .group-actions {
       margin-left: auto;
       display: flex;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
   }
 
@@ -174,8 +174,8 @@
 .book-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.625rem 0.75rem;
+  gap: 0.65625rem;
+  padding: 0.54688rem 0.65625rem;
   cursor: pointer;
   transition: background-color 0.1s;
 
@@ -213,18 +213,18 @@
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.0625rem;
+    gap: 0.05469rem;
 
     .book-title {
       font-weight: 600;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
     .book-authors {
-      font-size: 0.8125rem;
+      font-size: 0.71094rem;
       color: var(--p-text-muted-color);
       white-space: nowrap;
       overflow: hidden;
@@ -234,14 +234,14 @@
     .book-formats {
       display: flex;
       flex-wrap: wrap;
-      gap: 0.25rem;
-      margin-top: 0.125rem;
+      gap: 0.21875rem;
+      margin-top: 0.10938rem;
 
       .format-badge {
         display: inline-block;
-        font-size: 0.625rem;
+        font-size: 0.54688rem;
         font-weight: 700;
-        padding: 0.0625rem 0.3125rem;
+        padding: 0.05469rem 0.27344rem;
         border-radius: 3px;
         background: var(--p-primary-100);
         color: var(--p-primary-700);
@@ -250,12 +250,12 @@
       }
 
       .file-count {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         color: var(--p-text-muted-color);
       }
 
       .file-detail {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         color: var(--p-text-muted-color);
       }
     }
@@ -263,16 +263,16 @@
     .book-file-path {
       display: flex;
       align-items: center;
-      gap: 0.25rem;
-      font-size: 0.75rem;
+      gap: 0.21875rem;
+      font-size: var(--app-text-xs);
       color: var(--p-text-muted-color);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      margin-top: 0.125rem;
+      margin-top: 0.10938rem;
 
       i {
-        font-size: 0.6875rem;
+        font-size: 0.60156rem;
         flex-shrink: 0;
       }
     }
@@ -281,11 +281,11 @@
   .book-select {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
     flex-shrink: 0;
 
     .target-label {
-      font-size: 0.6875rem;
+      font-size: 0.60156rem;
       color: var(--p-primary-color);
       text-transform: uppercase;
       font-weight: 700;
@@ -297,9 +297,9 @@
 .help-text {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.625rem 0.75rem;
-  font-size: 0.8125rem;
+  gap: 0.4375rem;
+  padding: 0.54688rem 0.65625rem;
+  font-size: 0.71094rem;
   color: var(--p-text-muted-color);
   background: var(--p-content-hover-background);
   border-radius: 6px;
@@ -307,8 +307,8 @@
 
   i {
     flex-shrink: 0;
-    margin-top: 0.125rem;
-    font-size: 0.875rem;
+    margin-top: 0.10938rem;
+    font-size: var(--app-text-sm);
   }
 }
 

--- a/frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.scss
+++ b/frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.scss
@@ -43,7 +43,7 @@
     font-size: var(--app-text-sm);
     font-weight: 500;
     cursor: pointer;
-    padding: 0.21875rem 0;
+    padding: 0.2188rem 0;
 
     &:hover {
       color: var(--p-text-color);
@@ -57,8 +57,8 @@
   .signal-checkboxes {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.65625rem 1.3125rem;
-    padding: 0.65625rem 0 0;
+    gap: 0.6563rem 1.3125rem;
+    padding: 0.6563rem 0 0;
   }
 
   .signal-checkbox {
@@ -79,14 +79,14 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.875rem;
-  padding: 0.65625rem 0;
+  padding: 0.6563rem 0;
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
 
   .action-bar-left {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 
   .action-bar-right {
@@ -122,7 +122,7 @@
   justify-content: center;
   padding: 2.625rem 0.875rem;
   color: var(--p-text-muted-color);
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   i {
     font-size: 2.1875rem;
@@ -130,14 +130,14 @@
 
   p {
     margin: 0;
-    font-size: 0.82031rem;
+    font-size: 0.8203rem;
   }
 }
 
 .groups-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .duplicate-group {
@@ -148,13 +148,13 @@
   .group-header {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
-    padding: 0.4375rem 0.65625rem;
+    gap: 0.6563rem;
+    padding: 0.4375rem 0.6563rem;
     border-bottom: 1px solid var(--color-border);
 
     .group-label {
       font-weight: 600;
-      font-size: 0.71094rem;
+      font-size: 0.7109rem;
       color: var(--p-text-muted-color);
     }
 
@@ -174,8 +174,8 @@
 .book-row {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.54688rem 0.65625rem;
+  gap: 0.6563rem;
+  padding: 0.5469rem 0.6563rem;
   cursor: pointer;
   transition: background-color 0.1s;
 
@@ -213,7 +213,7 @@
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.05469rem;
+    gap: 0.0547rem;
 
     .book-title {
       font-weight: 600;
@@ -224,7 +224,7 @@
     }
 
     .book-authors {
-      font-size: 0.71094rem;
+      font-size: 0.7109rem;
       color: var(--p-text-muted-color);
       white-space: nowrap;
       overflow: hidden;
@@ -234,14 +234,14 @@
     .book-formats {
       display: flex;
       flex-wrap: wrap;
-      gap: 0.21875rem;
-      margin-top: 0.10938rem;
+      gap: 0.2188rem;
+      margin-top: 0.1094rem;
 
       .format-badge {
         display: inline-block;
-        font-size: 0.54688rem;
+        font-size: 0.5469rem;
         font-weight: 700;
-        padding: 0.05469rem 0.27344rem;
+        padding: 0.0547rem 0.2734rem;
         border-radius: 3px;
         background: var(--p-primary-100);
         color: var(--p-primary-700);
@@ -263,16 +263,16 @@
     .book-file-path {
       display: flex;
       align-items: center;
-      gap: 0.21875rem;
+      gap: 0.2188rem;
       font-size: var(--app-text-xs);
       color: var(--p-text-muted-color);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      margin-top: 0.10938rem;
+      margin-top: 0.1094rem;
 
       i {
-        font-size: 0.60156rem;
+        font-size: 0.6016rem;
         flex-shrink: 0;
       }
     }
@@ -281,11 +281,11 @@
   .book-select {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     flex-shrink: 0;
 
     .target-label {
-      font-size: 0.60156rem;
+      font-size: 0.6016rem;
       color: var(--p-primary-color);
       text-transform: uppercase;
       font-weight: 700;
@@ -298,8 +298,8 @@
   display: flex;
   align-items: flex-start;
   gap: 0.4375rem;
-  padding: 0.54688rem 0.65625rem;
-  font-size: 0.71094rem;
+  padding: 0.5469rem 0.6563rem;
+  font-size: 0.7109rem;
   color: var(--p-text-muted-color);
   background: var(--p-content-hover-background);
   border-radius: 6px;
@@ -307,7 +307,7 @@
 
   i {
     flex-shrink: 0;
-    margin-top: 0.10938rem;
+    margin-top: 0.1094rem;
     font-size: var(--app-text-sm);
   }
 }

--- a/frontend/src/app/features/book/components/series-page/series-page.component.scss
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.scss
@@ -40,7 +40,7 @@
 
 .series-details {
   > * + * {
-    margin-top: 1rem;
+    margin-top: 0.875rem;
   }
 }
 
@@ -48,8 +48,8 @@
 
 .series-hero {
   display: flex;
-  gap: 1.5rem;
-  padding: 0.5rem;
+  gap: 1.3125rem;
+  padding: 0.4375rem;
   align-items: stretch;
 
   @media #{variables.$mobile-shell-media-query} {
@@ -87,22 +87,22 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .series-title {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   font-weight: 800;
   line-height: 1.25;
   margin: 0;
 
   @media (width >= 768px) {
-    font-size: 1.875rem;
+    font-size: 1.64063rem;
   }
 }
 
 .series-authors {
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   margin: 0;
 }
 
@@ -120,8 +120,8 @@
 .metadata-cards {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.5rem;
+  gap: 0.35rem;
+  margin-top: 0.4375rem;
 
   @media (width <= 767px) {
     justify-content: center;
@@ -131,16 +131,16 @@
 .meta-card {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.7rem;
-  border-radius: 0.4rem;
-  font-size: 0.85rem;
+  gap: 0.30625rem;
+  padding: 0.30625rem 0.6125rem;
+  border-radius: 0.35rem;
+  font-size: 0.74375rem;
   font-weight: 600;
   border: 1px solid;
   white-space: nowrap;
 
   i {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
   }
 }
 
@@ -196,7 +196,7 @@ $meta-card-colors: (
 .ratings-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: 0.35rem;
 
   @media (width <= 767px) {
     justify-content: center;
@@ -206,16 +206,16 @@ $meta-card-colors: (
 .rating-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.25rem 0.6rem;
-  border-radius: 0.375rem;
+  gap: 0.2625rem;
+  padding: 0.21875rem 0.525rem;
+  border-radius: 0.32813rem;
   background: color-mix(in srgb, var(--color-border), transparent 50%);
   border: 1px solid var(--color-border);
-  font-size: 0.8rem;
+  font-size: 0.7rem;
 }
 
 .rating-icon {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
 
   &.personal { color: var(--color-yellow-400); }
   &.goodreads { color: var(--color-violet-500); }
@@ -230,7 +230,7 @@ $meta-card-colors: (
 
 .rating-label {
   color: var(--color-text-secondary);
-  font-size: 0.7rem;
+  font-size: 0.6125rem;
 }
 
 // ── Categories ──
@@ -242,7 +242,7 @@ $meta-card-colors: (
 
 .categories-list {
   display: flex;
-  gap: 0.4rem;
+  gap: 0.35rem;
   width: max-content;
 
   @media (width <= 767px) {
@@ -261,9 +261,9 @@ $meta-card-colors: (
 .description-section {
   background: var(--color-card);
   border: 1px solid var(--color-border);
-  border-radius: 0.75rem;
+  border-radius: 0.65625rem;
   overflow: hidden;
-  margin: 0 0.5rem;
+  margin: 0 0.4375rem;
   transition: box-shadow 0.3s ease;
 
   &:hover {
@@ -278,23 +278,23 @@ $meta-card-colors: (
 .description-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
+  gap: 0.4375rem;
+  padding: 0.54688rem 0.76563rem;
   background: var(--color-card);
   border-bottom: 1px solid var(--color-border);
-  border-radius: 0.75rem 0.75rem 0 0;
+  border-radius: 0.65625rem 0.65625rem 0 0;
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text);
 
   i {
-    font-size: 0.95rem;
+    font-size: 0.83125rem;
     color: var(--color-primary);
   }
 }
 
 .description-body {
-  padding: 0.875rem;
+  padding: 0.76563rem;
 }
 
 .description-content {
@@ -313,21 +313,21 @@ $meta-card-colors: (
 .description-html {
   color: var(--color-text-secondary);
   line-height: 1.6;
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   overflow-wrap: break-word;
 }
 
 .expand-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  margin-top: 0.5rem;
-  padding: 0.25rem 0.5rem;
+  gap: 0.32813rem;
+  margin-top: 0.4375rem;
+  padding: 0.21875rem 0.4375rem;
   background: transparent;
   border: none;
-  border-radius: 0.25rem;
+  border-radius: 0.21875rem;
   color: var(--color-primary);
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   font-weight: 500;
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease;
@@ -338,7 +338,7 @@ $meta-card-colors: (
   }
 
   i {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
   }
 }
 
@@ -347,7 +347,7 @@ $meta-card-colors: (
 .hero-status {
   display: flex;
   align-items: flex-end;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   width: 100%;
   margin-top: auto;
 
@@ -363,16 +363,16 @@ $meta-card-colors: (
 .read-progress-card {
   display: flex;
   align-items: center;
-  padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
+  padding: 0.65625rem 0.875rem;
+  border-radius: 0.4375rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
   flex: 1;
   min-width: 0;
 
   @media (width >= 768px) {
-    min-width: 16rem;
-    max-width: 22rem;
+    min-width: 14rem;
+    max-width: 19.25rem;
   }
 }
 
@@ -383,8 +383,8 @@ $meta-card-colors: (
 
 .read-progress-bar {
   display: flex;
-  height: 0.625rem;
-  border-radius: 0.375rem;
+  height: 0.54688rem;
+  border-radius: 0.32813rem;
   overflow: hidden;
   background: color-mix(in srgb, var(--color-border), transparent 50%);
   gap: 2px;
@@ -393,15 +393,15 @@ $meta-card-colors: (
 .read-progress-segment {
   height: 100%;
   min-width: 4px;
-  border-radius: 0.375rem;
+  border-radius: 0.32813rem;
 }
 
 .read-progress-legend {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.5rem;
-  font-size: 0.75rem;
+  gap: 0.35rem;
+  margin-top: 0.4375rem;
+  font-size: var(--app-text-xs);
   color: var(--color-text-secondary);
   align-items: center;
 }
@@ -409,18 +409,18 @@ $meta-card-colors: (
 .legend-item {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.1rem 0.4rem 0.1rem 0.3rem;
+  gap: 0.21875rem;
+  padding: 0.0875rem 0.35rem 0.0875rem 0.2625rem;
   border-radius: 9999px;
   border: 1px solid;
-  font-size: 0.7rem;
+  font-size: 0.6125rem;
   background: color-mix(in srgb, var(--color-border), transparent 60%);
 }
 
 .legend-dot {
   display: inline-block;
-  width: 0.4rem;
-  height: 0.4rem;
+  width: 0.35rem;
+  height: 0.35rem;
   border-radius: 50%;
   flex-shrink: 0;
 }
@@ -428,7 +428,7 @@ $meta-card-colors: (
 .read-percent-label {
   margin-left: auto;
   font-weight: 600;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--color-text-secondary);
 }
 
@@ -437,9 +437,9 @@ $meta-card-colors: (
 .next-up-card {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.6rem 0.85rem;
-  border-radius: 0.5rem;
+  gap: 0.65625rem;
+  padding: 0.525rem 0.74375rem;
+  border-radius: 0.4375rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
   cursor: pointer;
@@ -452,16 +452,16 @@ $meta-card-colors: (
   }
 
   @media (width >= 768px) {
-    min-width: 16rem;
-    max-width: 22rem;
+    min-width: 14rem;
+    max-width: 19.25rem;
   }
 }
 
 .next-up-thumb {
-  width: 2.75rem;
-  height: 4rem;
+  width: 2.40625rem;
+  height: 3.5rem;
   object-fit: cover;
-  border-radius: 0.25rem;
+  border-radius: 0.21875rem;
   flex-shrink: 0;
   box-shadow: 0 2px 6px rgb(0 0 0 / 25%);
 }
@@ -469,30 +469,30 @@ $meta-card-colors: (
 .next-up-info {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.175rem;
   min-width: 0;
   flex: 1;
 }
 
 .next-up-label {
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   font-weight: 700;
   color: var(--color-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   i {
-    font-size: 0.6rem;
+    font-size: 0.525rem;
     color: var(--color-primary-text);
   }
 }
 
 .next-up-title {
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
@@ -502,17 +502,17 @@ $meta-card-colors: (
 .next-up-progress-row {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  margin-top: 0.15rem;
+  gap: 0.35rem;
+  margin-top: 0.13125rem;
 }
 
 .next-up-progress {
   flex: 1;
-  height: 0.25rem;
+  height: 0.21875rem;
 }
 
 .next-up-percent {
-  font-size: 0.7rem;
+  font-size: 0.6125rem;
   font-weight: 600;
   color: var(--color-text-secondary);
   flex-shrink: 0;
@@ -521,18 +521,18 @@ $meta-card-colors: (
 // ── Section title ──
 
 .section-title {
-  font-size: 1.1rem;
+  font-size: 0.9625rem;
   font-weight: 700;
   color: var(--color-text-secondary);
-  margin: 0.75rem 0 0;
+  margin: 0.65625rem 0 0;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 0.5rem 0;
+  gap: 0.4375rem;
+  padding: 0.65625rem 0.4375rem 0;
   border-top: 1px solid var(--color-border);
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     color: var(--color-text-secondary);
   }
 }
@@ -551,7 +551,7 @@ $meta-card-colors: (
   align-items: start;
   justify-content: start;
   width: 100%;
-  padding-inline: 0.5rem;
+  padding-inline: 0.4375rem;
   box-sizing: border-box;
 
   @media #{variables.$mobile-shell-media-query} {
@@ -570,18 +570,18 @@ $meta-card-colors: (
 .book-list-container {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.5rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem;
   min-height: 100%;
 }
 
 .book-list-card {
   display: flex;
   align-items: center;
-  gap: 0.85rem;
-  padding: 0.65rem 0.85rem;
+  gap: 0.74375rem;
+  padding: 0.56875rem 0.74375rem;
   cursor: pointer;
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
   transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
@@ -593,8 +593,8 @@ $meta-card-colors: (
   }
 
   @media (width <= 768px) {
-    gap: 0.5rem;
-    padding: 0.5rem;
+    gap: 0.4375rem;
+    padding: 0.4375rem;
   }
 }
 
@@ -603,23 +603,23 @@ $meta-card-colors: (
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.375rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.32813rem;
   background: color-mix(in srgb, var(--color-primary), transparent 85%);
 }
 
 .list-series-number {
   font-weight: 700;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--color-primary);
 }
 
 .list-thumb {
-  width: 2.75rem;
-  height: 4rem;
+  width: 2.40625rem;
+  height: 3.5rem;
   object-fit: cover;
-  border-radius: 0.375rem;
+  border-radius: 0.32813rem;
   flex-shrink: 0;
   box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
 }
@@ -627,14 +627,14 @@ $meta-card-colors: (
 .list-book-info {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.175rem;
   min-width: 0;
   flex: 1;
 }
 
 .list-book-title {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.83125rem;
   color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
@@ -644,8 +644,8 @@ $meta-card-colors: (
 .list-book-meta {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  font-size: 0.85rem;
+  gap: 0.30625rem;
+  font-size: 0.74375rem;
   color: var(--color-text-secondary);
   flex-wrap: wrap;
 }
@@ -659,7 +659,7 @@ $meta-card-colors: (
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 16rem;
+  max-width: 14rem;
 }
 
 .list-book-year,
@@ -671,21 +671,21 @@ $meta-card-colors: (
 .list-right-col {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-shrink: 0;
 }
 
 .list-badges {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .list-status-badge {
   display: inline-block;
-  padding: 0.25rem 0.6rem;
+  padding: 0.21875rem 0.525rem;
   border-radius: 9999px;
-  font-size: 0.7rem;
+  font-size: 0.6125rem;
   font-weight: 700;
   color: white;
   white-space: nowrap;
@@ -694,9 +694,9 @@ $meta-card-colors: (
 
 .list-format-badge {
   display: inline-block;
-  padding: 0.2rem 0.5rem;
-  border-radius: 0.25rem;
-  font-size: 0.7rem;
+  padding: 0.175rem 0.4375rem;
+  border-radius: 0.21875rem;
+  font-size: 0.6125rem;
   font-weight: 700;
   border: 1px solid;
   white-space: nowrap;
@@ -713,27 +713,27 @@ $meta-card-colors: (
 .list-progress-row {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  margin-top: 0.15rem;
+  gap: 0.35rem;
+  margin-top: 0.13125rem;
 }
 
 .list-progress-bar {
-  width: 5rem;
-  height: 0.25rem;
-  border-radius: 0.25rem;
+  width: 4.375rem;
+  height: 0.21875rem;
+  border-radius: 0.21875rem;
   background: color-mix(in srgb, var(--color-border), transparent 50%);
   overflow: hidden;
 }
 
 .list-progress-fill {
   height: 100%;
-  border-radius: 0.25rem;
+  border-radius: 0.21875rem;
   background: var(--color-primary);
   transition: width 0.3s ease;
 }
 
 .list-progress-text {
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   font-weight: 600;
   color: var(--color-text-secondary);
 }
@@ -743,27 +743,27 @@ $meta-card-colors: (
 .list-rating-row {
   display: flex;
   align-items: center;
-  gap: 0.1rem;
-  margin-top: 0.1rem;
+  gap: 0.0875rem;
+  margin-top: 0.0875rem;
 }
 
 .list-star {
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   color: var(--color-yellow-400);
 }
 
 .list-rating-value {
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   font-weight: 600;
   color: var(--color-text-secondary);
-  margin-left: 0.25rem;
+  margin-left: 0.21875rem;
 }
 
 // ── List: action buttons ──
 
 .list-actions {
   display: flex;
-  gap: 0.35rem;
+  gap: 0.30625rem;
 }
 
 $list-action-btn-colors: (
@@ -775,15 +775,15 @@ $list-action-btn-colors: (
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.1rem;
-  height: 2.1rem;
-  border-radius: 0.4rem;
+  width: 1.8375rem;
+  height: 1.8375rem;
+  border-radius: 0.35rem;
   border: 1px solid;
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 
   @each $variant, $color in $list-action-btn-colors {
@@ -809,7 +809,7 @@ $list-action-btn-colors: (
 
 .empty-state {
   text-align: center;
-  padding: 2rem;
+  padding: 1.75rem;
   color: var(--color-text-secondary);
 }
 
@@ -821,7 +821,7 @@ $list-action-btn-colors: (
   justify-content: center;
   align-items: center;
   height: 100%;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 // ── Footer ──
@@ -851,7 +851,7 @@ $list-action-btn-colors: (
   right: 10%;
   display: flex;
   align-items: center;
-  padding: 1rem 0.5rem 0.5rem;
+  padding: 0.875rem 0.4375rem 0.4375rem;
   z-index: 100;
   border-radius: 10px 10px 0 0;
   border: 1px solid rgb(255 255 255 / 50%);
@@ -876,7 +876,7 @@ $list-action-btn-colors: (
 .footer-left {
   display: flex;
   align-items: center;
-  padding-left: 0.5rem;
+  padding-left: 0.4375rem;
   width: 25%;
 }
 
@@ -892,10 +892,10 @@ $list-action-btn-colors: (
 
 .footer-action-group {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   @media (width >= 768px) {
-    gap: 1.5rem;
+    gap: 1.3125rem;
   }
 }
 
@@ -907,35 +907,35 @@ $list-action-btn-colors: (
 .selected-count-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.5rem 1rem;
-  font-size: 0.9rem;
+  padding: 0.4375rem 0.875rem;
+  font-size: 0.7875rem;
   color: var(--color-text);
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }
 
 .badge-icon {
-  margin-right: 0.5rem;
+  margin-right: 0.4375rem;
 }
 
 .badge-count {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
 }
 
 .badge-label {
-  margin-left: 0.25rem;
+  margin-left: 0.21875rem;
 }
 
 @media (width <= 768px) {
   .selected-count-badge {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.85rem;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.74375rem;
 
     i {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
     }
   }
 }

--- a/frontend/src/app/features/book/components/series-page/series-page.component.scss
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.scss
@@ -97,7 +97,7 @@
   margin: 0;
 
   @media (width >= 768px) {
-    font-size: 1.64063rem;
+    font-size: 1.6406rem;
   }
 }
 
@@ -131,10 +131,10 @@
 .meta-card {
   display: inline-flex;
   align-items: center;
-  gap: 0.30625rem;
-  padding: 0.30625rem 0.6125rem;
+  gap: 0.3063rem;
+  padding: 0.3063rem 0.6125rem;
   border-radius: 0.35rem;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 600;
   border: 1px solid;
   white-space: nowrap;
@@ -207,8 +207,8 @@ $meta-card-colors: (
   display: inline-flex;
   align-items: center;
   gap: 0.2625rem;
-  padding: 0.21875rem 0.525rem;
-  border-radius: 0.32813rem;
+  padding: 0.2188rem 0.525rem;
+  border-radius: 0.3281rem;
   background: color-mix(in srgb, var(--color-border), transparent 50%);
   border: 1px solid var(--color-border);
   font-size: 0.7rem;
@@ -261,7 +261,7 @@ $meta-card-colors: (
 .description-section {
   background: var(--color-card);
   border: 1px solid var(--color-border);
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
   overflow: hidden;
   margin: 0 0.4375rem;
   transition: box-shadow 0.3s ease;
@@ -279,22 +279,22 @@ $meta-card-colors: (
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.54688rem 0.76563rem;
+  padding: 0.5469rem 0.7656rem;
   background: var(--color-card);
   border-bottom: 1px solid var(--color-border);
-  border-radius: 0.65625rem 0.65625rem 0 0;
+  border-radius: 0.6563rem 0.6563rem 0 0;
   font-weight: 600;
   font-size: var(--app-text-sm);
   color: var(--color-text);
 
   i {
-    font-size: 0.83125rem;
+    font-size: 0.8313rem;
     color: var(--color-primary);
   }
 }
 
 .description-body {
-  padding: 0.76563rem;
+  padding: 0.7656rem;
 }
 
 .description-content {
@@ -313,19 +313,19 @@ $meta-card-colors: (
 .description-html {
   color: var(--color-text-secondary);
   line-height: 1.6;
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   overflow-wrap: break-word;
 }
 
 .expand-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   margin-top: 0.4375rem;
-  padding: 0.21875rem 0.4375rem;
+  padding: 0.2188rem 0.4375rem;
   background: transparent;
   border: none;
-  border-radius: 0.21875rem;
+  border-radius: 0.2188rem;
   color: var(--color-primary);
   font-size: 0.7rem;
   font-weight: 500;
@@ -347,7 +347,7 @@ $meta-card-colors: (
 .hero-status {
   display: flex;
   align-items: flex-end;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   width: 100%;
   margin-top: auto;
 
@@ -363,7 +363,7 @@ $meta-card-colors: (
 .read-progress-card {
   display: flex;
   align-items: center;
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   border-radius: 0.4375rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
@@ -383,8 +383,8 @@ $meta-card-colors: (
 
 .read-progress-bar {
   display: flex;
-  height: 0.54688rem;
-  border-radius: 0.32813rem;
+  height: 0.5469rem;
+  border-radius: 0.3281rem;
   overflow: hidden;
   background: color-mix(in srgb, var(--color-border), transparent 50%);
   gap: 2px;
@@ -393,7 +393,7 @@ $meta-card-colors: (
 .read-progress-segment {
   height: 100%;
   min-width: 4px;
-  border-radius: 0.32813rem;
+  border-radius: 0.3281rem;
 }
 
 .read-progress-legend {
@@ -409,7 +409,7 @@ $meta-card-colors: (
 .legend-item {
   display: inline-flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   padding: 0.0875rem 0.35rem 0.0875rem 0.2625rem;
   border-radius: 9999px;
   border: 1px solid;
@@ -437,8 +437,8 @@ $meta-card-colors: (
 .next-up-card {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.525rem 0.74375rem;
+  gap: 0.6563rem;
+  padding: 0.525rem 0.7438rem;
   border-radius: 0.4375rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
@@ -458,10 +458,10 @@ $meta-card-colors: (
 }
 
 .next-up-thumb {
-  width: 2.40625rem;
+  width: 2.4063rem;
   height: 3.5rem;
   object-fit: cover;
-  border-radius: 0.21875rem;
+  border-radius: 0.2188rem;
   flex-shrink: 0;
   box-shadow: 0 2px 6px rgb(0 0 0 / 25%);
 }
@@ -475,14 +475,14 @@ $meta-card-colors: (
 }
 
 .next-up-label {
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   font-weight: 700;
   color: var(--color-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   i {
     font-size: 0.525rem;
@@ -492,7 +492,7 @@ $meta-card-colors: (
 
 .next-up-title {
   font-weight: 600;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
@@ -503,12 +503,12 @@ $meta-card-colors: (
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  margin-top: 0.13125rem;
+  margin-top: 0.1313rem;
 }
 
 .next-up-progress {
   flex: 1;
-  height: 0.21875rem;
+  height: 0.2188rem;
 }
 
 .next-up-percent {
@@ -524,11 +524,11 @@ $meta-card-colors: (
   font-size: 0.9625rem;
   font-weight: 700;
   color: var(--color-text-secondary);
-  margin: 0.65625rem 0 0;
+  margin: 0.6563rem 0 0;
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem 0.4375rem 0;
+  padding: 0.6563rem 0.4375rem 0;
   border-top: 1px solid var(--color-border);
 
   i {
@@ -578,8 +578,8 @@ $meta-card-colors: (
 .book-list-card {
   display: flex;
   align-items: center;
-  gap: 0.74375rem;
-  padding: 0.56875rem 0.74375rem;
+  gap: 0.7438rem;
+  padding: 0.5687rem 0.7438rem;
   cursor: pointer;
   border-radius: 0.4375rem;
   background: var(--color-card);
@@ -605,7 +605,7 @@ $meta-card-colors: (
   justify-content: center;
   width: 1.75rem;
   height: 1.75rem;
-  border-radius: 0.32813rem;
+  border-radius: 0.3281rem;
   background: color-mix(in srgb, var(--color-primary), transparent 85%);
 }
 
@@ -616,10 +616,10 @@ $meta-card-colors: (
 }
 
 .list-thumb {
-  width: 2.40625rem;
+  width: 2.4063rem;
   height: 3.5rem;
   object-fit: cover;
-  border-radius: 0.32813rem;
+  border-radius: 0.3281rem;
   flex-shrink: 0;
   box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
 }
@@ -634,7 +634,7 @@ $meta-card-colors: (
 
 .list-book-title {
   font-weight: 600;
-  font-size: 0.83125rem;
+  font-size: 0.8313rem;
   color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
@@ -644,8 +644,8 @@ $meta-card-colors: (
 .list-book-meta {
   display: flex;
   align-items: center;
-  gap: 0.30625rem;
-  font-size: 0.74375rem;
+  gap: 0.3063rem;
+  font-size: 0.7438rem;
   color: var(--color-text-secondary);
   flex-wrap: wrap;
 }
@@ -671,7 +671,7 @@ $meta-card-colors: (
 .list-right-col {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-shrink: 0;
 }
 
@@ -683,7 +683,7 @@ $meta-card-colors: (
 
 .list-status-badge {
   display: inline-block;
-  padding: 0.21875rem 0.525rem;
+  padding: 0.2188rem 0.525rem;
   border-radius: 9999px;
   font-size: 0.6125rem;
   font-weight: 700;
@@ -695,7 +695,7 @@ $meta-card-colors: (
 .list-format-badge {
   display: inline-block;
   padding: 0.175rem 0.4375rem;
-  border-radius: 0.21875rem;
+  border-radius: 0.2188rem;
   font-size: 0.6125rem;
   font-weight: 700;
   border: 1px solid;
@@ -714,26 +714,26 @@ $meta-card-colors: (
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  margin-top: 0.13125rem;
+  margin-top: 0.1313rem;
 }
 
 .list-progress-bar {
   width: 4.375rem;
-  height: 0.21875rem;
-  border-radius: 0.21875rem;
+  height: 0.2188rem;
+  border-radius: 0.2188rem;
   background: color-mix(in srgb, var(--color-border), transparent 50%);
   overflow: hidden;
 }
 
 .list-progress-fill {
   height: 100%;
-  border-radius: 0.21875rem;
+  border-radius: 0.2188rem;
   background: var(--color-primary);
   transition: width 0.3s ease;
 }
 
 .list-progress-text {
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   font-weight: 600;
   color: var(--color-text-secondary);
 }
@@ -748,22 +748,22 @@ $meta-card-colors: (
 }
 
 .list-star {
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   color: var(--color-yellow-400);
 }
 
 .list-rating-value {
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   font-weight: 600;
   color: var(--color-text-secondary);
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
 }
 
 // ── List: action buttons ──
 
 .list-actions {
   display: flex;
-  gap: 0.30625rem;
+  gap: 0.3063rem;
 }
 
 $list-action-btn-colors: (
@@ -783,7 +783,7 @@ $list-action-btn-colors: (
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 
   @each $variant, $color in $list-action-btn-colors {
@@ -926,13 +926,13 @@ $list-action-btn-colors: (
 }
 
 .badge-label {
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
 }
 
 @media (width <= 768px) {
   .selected-count-badge {
     padding: 0.35rem 0.7rem;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
 
     i {
       font-size: 0.7875rem;

--- a/frontend/src/app/features/book/components/shelf-assigner/shelf-assigner.component.scss
+++ b/frontend/src/app/features/book/components/shelf-assigner/shelf-assigner.component.scss
@@ -21,8 +21,8 @@
 .shelves-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1rem 2rem;
+  gap: 0.875rem;
+  padding: 0.875rem 1.75rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
@@ -31,7 +31,7 @@
   overflow: hidden;
 
   @media (width <= 480px) {
-    padding: 1rem;
+    padding: 0.875rem;
     min-height: 300px;
     max-height: 400px;
   }
@@ -40,7 +40,7 @@
 .shelves-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   height: 100%;
   overflow: hidden;
 }
@@ -49,16 +49,16 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.625rem 0.875rem;
+  padding: 0.54688rem 0.76563rem;
   background: var(--overlay-background);
   border-radius: 6px;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   .shelf-count {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
-    font-size: 0.9rem;
+    gap: 0.32813rem;
+    font-size: 0.7875rem;
     font-weight: 600;
     color: var(--text-color);
     white-space: nowrap;
@@ -75,18 +75,18 @@
 
     input {
       width: 100%;
-      font-size: 0.85rem;
-      padding: 0.375rem 2rem;
+      font-size: 0.74375rem;
+      padding: 0.32813rem 1.75rem;
     }
 
     .clear-icon {
       position: absolute;
-      right: 0.5rem;
+      right: 0.4375rem;
       top: 50%;
       transform: translateY(-50%);
       cursor: pointer;
       color: var(--text-secondary-color);
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       z-index: 1;
 
       &:hover {
@@ -96,11 +96,11 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.5rem 0.625rem;
+    padding: 0.4375rem 0.54688rem;
     flex-wrap: wrap;
 
     .shelf-count {
-      font-size: 0.85rem;
+      font-size: 0.74375rem;
     }
 
     .shelf-search {
@@ -113,18 +113,18 @@
 .shelves-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   overflow-y: auto;
   flex: 1;
-  padding-right: 0.25rem;
+  padding-right: 0.21875rem;
   min-height: 0;
 }
 
 .shelf-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 1rem;
+  gap: 0.65625rem;
+  padding: 0.4375rem 0.875rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -163,7 +163,7 @@
     flex: 1;
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     cursor: pointer;
     min-width: 0;
 
@@ -181,14 +181,14 @@
       flex-shrink: 0;
 
       .shelf-icon {
-        font-size: 1.125rem;
+        font-size: var(--app-text-lg);
         color: var(--text-secondary-color);
         transition: all 0.3s ease;
       }
     }
 
     .shelf-name {
-      font-size: 0.9375rem;
+      font-size: 0.82031rem;
       color: var(--text-color);
       font-weight: 500;
       overflow: hidden;
@@ -198,23 +198,23 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.625rem;
-    gap: 0.5rem;
+    padding: 0.54688rem;
+    gap: 0.4375rem;
 
     .shelf-label {
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       .shelf-icon-wrapper, .shelf-icon-wrapper-empty {
         width: 32px;
         height: 32px;
 
         .shelf-icon {
-          font-size: 1rem;
+          font-size: var(--app-text-base);
         }
       }
 
       .shelf-name {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
     }
   }
@@ -226,7 +226,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 2rem 1rem;
+  padding: 1.75rem 0.875rem;
   flex: 1;
 
   .empty-icon-wrapper {
@@ -237,48 +237,48 @@
     height: 80px;
     background: var(--overlay-background);
     border-radius: 50%;
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
 
     .empty-icon {
-      font-size: 2.5rem;
+      font-size: 2.1875rem;
       color: var(--text-secondary-color);
       opacity: 0.5;
     }
   }
 
   .empty-title {
-    margin: 0 0 0.5rem;
-    font-size: 1.125rem;
+    margin: 0 0 0.4375rem;
+    font-size: var(--app-text-lg);
     font-weight: 600;
     color: var(--text-color);
   }
 
   .empty-description {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-secondary-color);
     max-width: 350px;
     line-height: 1.5;
   }
 
   @media (width <= 480px) {
-    padding: 1.5rem 0.75rem;
+    padding: 1.3125rem 0.65625rem;
 
     .empty-icon-wrapper {
       width: 60px;
       height: 60px;
 
       .empty-icon {
-        font-size: 2rem;
+        font-size: 1.75rem;
       }
     }
 
     .empty-title {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
 
     .empty-description {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
       max-width: 100%;
     }
   }

--- a/frontend/src/app/features/book/components/shelf-assigner/shelf-assigner.component.scss
+++ b/frontend/src/app/features/book/components/shelf-assigner/shelf-assigner.component.scss
@@ -40,7 +40,7 @@
 .shelves-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   height: 100%;
   overflow: hidden;
 }
@@ -49,7 +49,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.54688rem 0.76563rem;
+  padding: 0.5469rem 0.7656rem;
   background: var(--overlay-background);
   border-radius: 6px;
   gap: 0.4375rem;
@@ -57,7 +57,7 @@
   .shelf-count {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     font-size: 0.7875rem;
     font-weight: 600;
     color: var(--text-color);
@@ -75,8 +75,8 @@
 
     input {
       width: 100%;
-      font-size: 0.74375rem;
-      padding: 0.32813rem 1.75rem;
+      font-size: 0.7438rem;
+      padding: 0.3281rem 1.75rem;
     }
 
     .clear-icon {
@@ -96,11 +96,11 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.4375rem 0.54688rem;
+    padding: 0.4375rem 0.5469rem;
     flex-wrap: wrap;
 
     .shelf-count {
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
     }
 
     .shelf-search {
@@ -113,17 +113,17 @@
 .shelves-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   overflow-y: auto;
   flex: 1;
-  padding-right: 0.21875rem;
+  padding-right: 0.2188rem;
   min-height: 0;
 }
 
 .shelf-item {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding: 0.4375rem 0.875rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
@@ -163,7 +163,7 @@
     flex: 1;
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     cursor: pointer;
     min-width: 0;
 
@@ -188,7 +188,7 @@
     }
 
     .shelf-name {
-      font-size: 0.82031rem;
+      font-size: 0.8203rem;
       color: var(--text-color);
       font-weight: 500;
       overflow: hidden;
@@ -198,7 +198,7 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.54688rem;
+    padding: 0.5469rem;
     gap: 0.4375rem;
 
     .shelf-label {
@@ -262,7 +262,7 @@
   }
 
   @media (width <= 480px) {
-    padding: 1.3125rem 0.65625rem;
+    padding: 1.3125rem 0.6563rem;
 
     .empty-icon-wrapper {
       width: 60px;

--- a/frontend/src/app/features/book/components/shelf-creator/shelf-creator.component.html
+++ b/frontend/src/app/features/book/components/shelf-creator/shelf-creator.component.html
@@ -98,7 +98,7 @@
           <i class="pi pi-globe label-icon"></i>
           {{ t('visibilityLabel') }}
         </span>
-        <div class="input-wrapper" style="display: flex; align-items: center; gap: 0.5rem;">
+        <div class="input-wrapper" style="display: flex; align-items: center; gap: 0.4375rem;">
           <p-checkbox [(ngModel)]="isPublic" [binary]="true" inputId="publicShelf"></p-checkbox>
           <label for="publicShelf" style="cursor: pointer">{{ t('makePublicLabel') }}</label>
         </div>

--- a/frontend/src/app/features/book/components/shelf-creator/shelf-creator.component.scss
+++ b/frontend/src/app/features/book/components/shelf-creator/shelf-creator.component.scss
@@ -18,33 +18,33 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 1.5rem;
+  gap: 1.3125rem;
+  padding: 1.3125rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
 
   @media (width <= 480px) {
-    padding: 1rem;
-    gap: 1rem;
+    padding: 0.875rem;
+    gap: 0.875rem;
   }
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   &.highlight-group {
-    padding: 0.875rem;
+    padding: 0.76563rem;
   }
 
   @media (width <= 480px) {
-    gap: 0.375rem;
+    gap: 0.32813rem;
 
     &.highlight-group {
-      padding: 0.625rem;
+      padding: 0.54688rem;
     }
   }
 }
@@ -52,8 +52,8 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.95rem;
+  gap: 0.32813rem;
+  font-size: 0.83125rem;
   font-weight: 600;
   color: var(--color-text);
 
@@ -63,11 +63,11 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.125rem;
+    margin-left: 0.10938rem;
   }
 
   @media (width <= 480px) {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -76,16 +76,16 @@
 
   .input-full {
     width: 100%;
-    padding-right: 2.5rem;
+    padding-right: 2.1875rem;
     box-sizing: border-box;
   }
 
   .input-icon {
     position: absolute;
-    right: 0.75rem;
+    right: 0.65625rem;
     top: 50%;
     transform: translateY(-50%);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     pointer-events: none;
 
     &.success {
@@ -98,14 +98,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   width: 100%;
-  padding: 1rem;
+  padding: 0.875rem;
   background: var(--color-page);
   border: 1px dashed var(--color-border);
   border-radius: 8px;
   color: var(--color-text);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -119,41 +119,41 @@
   }
 
   i {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
   }
 
   .btn-content {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.125rem;
+    gap: 0.10938rem;
 
     .btn-title {
-      font-size: 0.9375rem;
+      font-size: 0.82031rem;
       font-weight: 600;
     }
 
     .btn-subtitle {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
       opacity: 0.85;
     }
   }
 
   @media (width <= 480px) {
-    padding: 0.75rem;
-    gap: 0.5rem;
+    padding: 0.65625rem;
+    gap: 0.4375rem;
 
     i {
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
     }
 
     .btn-content {
       .btn-title {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
 
       .btn-subtitle {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
       }
     }
   }
@@ -162,8 +162,8 @@
 .selected-icon-display {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.875rem;
+  gap: 0.65625rem;
+  padding: 0.76563rem;
   border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--color-page);
@@ -185,15 +185,15 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 0.125rem;
+    gap: 0.10938rem;
 
     .icon-label {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
       color: var(--color-text-secondary);
     }
 
     .icon-name {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       font-weight: 500;
       color: var(--color-text);
       font-family: monospace;
@@ -201,8 +201,8 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.625rem;
-    gap: 0.5rem;
+    padding: 0.54688rem;
+    gap: 0.4375rem;
 
     .icon-preview {
       width: 36px;
@@ -211,11 +211,11 @@
 
     .icon-info {
       .icon-label {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
       }
 
       .icon-name {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/book/components/shelf-creator/shelf-creator.component.scss
+++ b/frontend/src/app/features/book/components/shelf-creator/shelf-creator.component.scss
@@ -37,14 +37,14 @@
   gap: 0.4375rem;
 
   &.highlight-group {
-    padding: 0.76563rem;
+    padding: 0.7656rem;
   }
 
   @media (width <= 480px) {
-    gap: 0.32813rem;
+    gap: 0.3281rem;
 
     &.highlight-group {
-      padding: 0.54688rem;
+      padding: 0.5469rem;
     }
   }
 }
@@ -52,8 +52,8 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  font-size: 0.83125rem;
+  gap: 0.3281rem;
+  font-size: 0.8313rem;
   font-weight: 600;
   color: var(--color-text);
 
@@ -63,7 +63,7 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.10938rem;
+    margin-left: 0.1094rem;
   }
 
   @media (width <= 480px) {
@@ -82,7 +82,7 @@
 
   .input-icon {
     position: absolute;
-    right: 0.65625rem;
+    right: 0.6563rem;
     top: 50%;
     transform: translateY(-50%);
     font-size: var(--app-text-base);
@@ -98,7 +98,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   width: 100%;
   padding: 0.875rem;
   background: var(--color-page);
@@ -119,17 +119,17 @@
   }
 
   i {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
   }
 
   .btn-content {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.10938rem;
+    gap: 0.1094rem;
 
     .btn-title {
-      font-size: 0.82031rem;
+      font-size: 0.8203rem;
       font-weight: 600;
     }
 
@@ -140,7 +140,7 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
     gap: 0.4375rem;
 
     i {
@@ -162,8 +162,8 @@
 .selected-icon-display {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.76563rem;
+  gap: 0.6563rem;
+  padding: 0.7656rem;
   border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--color-page);
@@ -185,7 +185,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 0.10938rem;
+    gap: 0.1094rem;
 
     .icon-label {
       font-size: 0.7rem;
@@ -201,7 +201,7 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.54688rem;
+    padding: 0.5469rem;
     gap: 0.4375rem;
 
     .icon-preview {

--- a/frontend/src/app/features/book/components/shelf-edit-dialog/shelf-edit-dialog.component.html
+++ b/frontend/src/app/features/book/components/shelf-edit-dialog/shelf-edit-dialog.component.html
@@ -52,7 +52,7 @@
       @if (isAdmin) {
         <div class="shelf-row">
         <span class="label">{{ t('visibilityLabel') }}</span>
-          <div class="visibility-section" style="display: flex; align-items: center; gap: 0.5rem;">
+          <div class="visibility-section" style="display: flex; align-items: center; gap: 0.4375rem;">
             <p-checkbox [(ngModel)]="isPublic" [binary]="true" inputId="publicShelf"></p-checkbox>
             <label for="publicShelf" style="cursor: pointer; user-select: none;">{{ t('publicShelfLabel') }}</label>
           </div>

--- a/frontend/src/app/features/book/components/shelf-edit-dialog/shelf-edit-dialog.component.scss
+++ b/frontend/src/app/features/book/components/shelf-edit-dialog/shelf-edit-dialog.component.scss
@@ -22,7 +22,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
-  padding: 1.53125rem;
+  padding: 1.5313rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
@@ -54,7 +54,7 @@
 .label {
   width: 6.125rem;
   font-weight: 600;
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   color: var(--color-text);
   margin: 0;
 
@@ -81,8 +81,8 @@
 .icon-container {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.4375rem 0.65625rem;
+  gap: 0.6563rem;
+  padding: 0.4375rem 0.6563rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-radius: 8px;

--- a/frontend/src/app/features/book/components/shelf-edit-dialog/shelf-edit-dialog.component.scss
+++ b/frontend/src/app/features/book/components/shelf-edit-dialog/shelf-edit-dialog.component.scss
@@ -21,40 +21,40 @@
 .shelf-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.75rem;
+  gap: 0.875rem;
+  padding: 1.53125rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
   min-height: 200px;
 
   @media (width <= 480px) {
-    padding: 1rem;
+    padding: 0.875rem;
   }
 }
 
 .shelf-fields {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .shelf-row {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 480px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 }
 
 .label {
-  width: 7rem;
+  width: 6.125rem;
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   color: var(--color-text);
   margin: 0;
 
@@ -81,8 +81,8 @@
 .icon-container {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.65625rem;
+  padding: 0.4375rem 0.65625rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-radius: 8px;

--- a/frontend/src/app/features/bookdrop/component/bookdrop-bulk-edit-dialog/bookdrop-bulk-edit-dialog.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-bulk-edit-dialog/bookdrop-bulk-edit-dialog.component.scss
@@ -26,15 +26,15 @@
 .info-banner {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.65625rem 0.875rem;
+  gap: 0.6563rem;
+  padding: 0.6563rem 0.875rem;
   background: rgb(59 130 246 / 8%);
   border: 1px solid var(--p-primary-color);
   border-radius: 6px;
   color: var(--p-text-color);
 
   i {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     color: var(--p-primary-color);
   }
 }
@@ -42,7 +42,7 @@
 .fields-section {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   h4 {
     margin: 0;
@@ -64,7 +64,7 @@
   gap: 0.4375rem;
 
   .merge-label {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     color: var(--p-text-secondary-color);
   }
 }
@@ -78,7 +78,7 @@
 .field-row {
   display: grid;
   grid-template-columns: auto 5.25rem 1fr;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   align-items: center;
 }
 
@@ -99,6 +99,6 @@
 .dialog-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding-top: 0.4375rem;
 }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-bulk-edit-dialog/bookdrop-bulk-edit-dialog.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-bulk-edit-dialog/bookdrop-bulk-edit-dialog.component.scss
@@ -1,24 +1,24 @@
 .bulk-edit-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 0 1rem;
+  gap: 0.875rem;
+  padding: 0 0.875rem;
 
   @media (width <= 768px) {
     padding: 0;
   }
 
   .helper-text {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-color-secondary);
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     margin: 0;
-    padding: 0.5rem 0;
+    padding: 0.4375rem 0;
 
     i {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 }
@@ -26,15 +26,15 @@
 .info-banner {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: 0.65625rem;
+  padding: 0.65625rem 0.875rem;
   background: rgb(59 130 246 / 8%);
   border: 1px solid var(--p-primary-color);
   border-radius: 6px;
   color: var(--p-text-color);
 
   i {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     color: var(--p-primary-color);
   }
 }
@@ -42,11 +42,11 @@
 .fields-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   h4 {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     font-weight: 600;
     color: var(--p-text-secondary-color);
   }
@@ -61,10 +61,10 @@
 .merge-toggle {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   .merge-label {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     color: var(--p-text-secondary-color);
   }
 }
@@ -72,18 +72,18 @@
 .field-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .field-row {
   display: grid;
-  grid-template-columns: auto 6rem 1fr;
-  gap: 0.75rem;
+  grid-template-columns: auto 5.25rem 1fr;
+  gap: 0.65625rem;
   align-items: center;
 }
 
 .field-label {
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   font-weight: 500;
   color: var(--p-text-color);
 }
@@ -99,6 +99,6 @@
 .dialog-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
-  padding-top: 0.5rem;
+  gap: 0.65625rem;
+  padding-top: 0.4375rem;
 }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
@@ -1,14 +1,14 @@
  .thumbnail {
   border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
   box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
-  margin: 0 auto 1rem;
+  margin: 0 auto 0.875rem;
 }
 
 ::ng-deep .metapicker .thumbnail {
   img {
-    border-radius: 0.5rem;
-    max-height: 14rem;
+    border-radius: 0.4375rem;
+    max-height: 12.25rem;
     max-width: 10em;
   }
 
@@ -20,9 +20,9 @@
 .metapicker div.thumbnail {
   background-color: var(--p-inputtext-disabled-background);
   color: var(--p-inputtext-disabled-color);
-  width: 9rem;
-  height: 14rem;
-  padding: 1rem;
+  width: 7.875rem;
+  height: 12.25rem;
+  padding: 0.875rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -31,7 +31,7 @@
 }
 
 ::ng-deep .metaeditor img.thumbnail {
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
   max-width: 100%;
   max-height: 100%;
   height: auto;
@@ -63,7 +63,7 @@ textarea.changed,
 }
 
 ::ng-deep .p-autocomplete-input-chip {
-  width: 2rem;
+  width: 1.75rem;
 }
 
 .metapicker, .metaeditor {
@@ -82,27 +82,27 @@ textarea.changed,
 }
 
 .field-label {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 
   @media (width >= 768px) {
-    width: 8rem;
+    width: 7rem;
   }
 }
 
 .field-label-fixed {
-  width: 8rem;
+  width: 7rem;
 }
 
 .column-headers {
   display: flex;
   align-items: center;
-  padding: 1rem;
+  padding: 0.875rem;
   border-bottom: 1px dotted var(--border-color);
 
   @media (width >= 768px) {
     &::before {
       content: '';
-      min-width: 8rem;
+      min-width: 7rem;
       flex-shrink: 0;
     }
   }
@@ -112,16 +112,16 @@ textarea.changed,
     align-items: center;
     flex: 1;
     color: var(--text-color-secondary);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
 
     &.current {
       justify-content: flex-end;
-      padding-right: 1rem;
+      padding-right: 0.875rem;
     }
 
     &.fetched {
       justify-content: flex-start;
-      padding-left: 1rem;
+      padding-left: 0.875rem;
     }
   }
 
@@ -129,7 +129,7 @@ textarea.changed,
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     flex-shrink: 0;
   }
 }
@@ -147,7 +147,7 @@ textarea.changed,
 }
 
 .no-cover-text {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 }
 
 .full-width {
@@ -157,7 +157,7 @@ textarea.changed,
 .metabody {
   display: flex;
   flex-direction: column;
-  padding: 1rem;
+  padding: 0.875rem;
 
   @media (width >= 768px) {
     flex-direction: row;
@@ -211,11 +211,11 @@ textarea.changed,
 
 ::ng-deep .metapicker {
   .dest, .src {
-    width: calc(50% - 2rem);
+    width: calc(50% - 1.75rem);
   }
 
   .arrow-button {
-    margin: auto 1rem;
+    margin: auto 0.875rem;
   }
 
   @media (width >= 768px) {
@@ -249,16 +249,16 @@ textarea.changed,
   display: flex;
   align-items: center;
   border-bottom: 1px dotted var(--border-color);
-  padding: 1rem;
+  padding: 0.875rem;
   justify-content: space-between;
 }
 
 .metacontent {
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .metaeditor .metacontent {
-  padding: 0 0 0 1rem;
+  padding: 0 0 0 0.875rem;
 
   @media (width <= 768px) {
     padding: 0;
@@ -311,7 +311,7 @@ textarea.changed,
 @media (width >= 768px) {
   .metapicker .metacontent,
   .metaeditor .metabody {
-    padding-left: 3.25rem;
+    padding-left: 2.84375rem;
   }
 }
 
@@ -415,22 +415,22 @@ textarea.changed,
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem;
-  min-height: 2.25rem;
+  gap: 0.32813rem;
+  padding: 0.32813rem;
+  min-height: 1.96875rem;
   border: 1px solid var(--p-inputtext-border-color);
   border-radius: 6px;
   background: var(--p-inputtext-background);
 }
 
 .author-add-input {
-  flex: 1 1 6rem;
-  min-width: 6rem;
+  flex: 1 1 5.25rem;
+  min-width: 5.25rem;
 
   ::ng-deep input {
     border: none !important;
     background: transparent !important;
-    padding: 0.25rem;
+    padding: 0.21875rem;
     box-shadow: none !important;
     outline: none !important;
   }
@@ -439,12 +439,12 @@ textarea.changed,
 .author-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 1rem;
+  gap: 0.21875rem;
+  padding: 0.21875rem 0.4375rem;
+  border-radius: 0.875rem;
   background: var(--p-chip-background);
   color: var(--p-chip-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   cursor: grab;
   user-select: none;
 }
@@ -453,27 +453,27 @@ textarea.changed,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1rem;
-  height: 1rem;
+  width: 0.875rem;
+  height: 0.875rem;
   border-radius: 50%;
   background: var(--p-primary-color);
   color: var(--p-primary-contrast-color);
-  font-size: 0.6rem;
+  font-size: 0.525rem;
   font-weight: 700;
   flex-shrink: 0;
 }
 
 .author-chip-remove {
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   cursor: pointer;
   opacity: 0.6;
-  padding: 0.15rem;
+  padding: 0.13125rem;
   &:hover { opacity: 1; }
 }
 
 .cdk-drag-preview {
   box-sizing: border-box;
-  border-radius: 1rem;
+  border-radius: 0.875rem;
   box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
 }
 

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-metadata-picker/bookdrop-file-metadata-picker.component.scss
@@ -311,7 +311,7 @@ textarea.changed,
 @media (width >= 768px) {
   .metapicker .metacontent,
   .metaeditor .metabody {
-    padding-left: 2.84375rem;
+    padding-left: 2.8438rem;
   }
 }
 
@@ -415,9 +415,9 @@ textarea.changed,
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.32813rem;
-  min-height: 1.96875rem;
+  gap: 0.3281rem;
+  padding: 0.3281rem;
+  min-height: 1.9688rem;
   border: 1px solid var(--p-inputtext-border-color);
   border-radius: 6px;
   background: var(--p-inputtext-background);
@@ -430,7 +430,7 @@ textarea.changed,
   ::ng-deep input {
     border: none !important;
     background: transparent !important;
-    padding: 0.21875rem;
+    padding: 0.2188rem;
     box-shadow: none !important;
     outline: none !important;
   }
@@ -439,8 +439,8 @@ textarea.changed,
 .author-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.21875rem;
-  padding: 0.21875rem 0.4375rem;
+  gap: 0.2188rem;
+  padding: 0.2188rem 0.4375rem;
   border-radius: 0.875rem;
   background: var(--p-chip-background);
   color: var(--p-chip-color);
@@ -464,10 +464,10 @@ textarea.changed,
 }
 
 .author-chip-remove {
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   cursor: pointer;
   opacity: 0.6;
-  padding: 0.13125rem;
+  padding: 0.1313rem;
   &:hover { opacity: 1; }
 }
 

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.scss
@@ -29,9 +29,9 @@
 
 .header-content {
   h2 {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     font-weight: 600;
-    padding-bottom: 0.21875rem;
+    padding-bottom: 0.2188rem;
     display: flex;
     align-items: center;
     gap: 0.4375rem;
@@ -89,7 +89,7 @@
   align-items: center;
 
   > * + * {
-    margin-top: 0.65625rem;
+    margin-top: 0.6563rem;
   }
 
   span {
@@ -119,7 +119,7 @@
   z-index: 50;
 
   > * + * {
-    margin-top: 0.65625rem;
+    margin-top: 0.6563rem;
   }
 
   p-progressspinner {
@@ -131,7 +131,7 @@
 .saving-message {
   background: var(--color-card);
   padding: 0.4375rem 0.875rem;
-  border-radius: 0.32813rem;
+  border-radius: 0.3281rem;
 
   span {
     font-size: var(--app-text-sm);
@@ -282,7 +282,7 @@ p-inputgroup.disabled {
 .cover-image {
   width: 1.3125rem;
   height: 1.75rem;
-  border-radius: 0.10938rem;
+  border-radius: 0.1094rem;
   object-fit: cover;
   cursor: pointer;
   transition: transform 0.2s;

--- a/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-file-review/bookdrop-file-review.component.scss
@@ -14,31 +14,31 @@
 }
 
 .header {
-  padding: 1.5rem;
+  padding: 1.3125rem;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid var(--p-content-border-color);
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media #{variables.$mobile-shell-media-query} {
-    padding: 1rem;
+    padding: 0.875rem;
   }
 }
 
 .header-content {
   h2 {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     font-weight: 600;
-    padding-bottom: 0.25rem;
+    padding-bottom: 0.21875rem;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   p {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text-secondary);
 
     strong {
@@ -64,7 +64,7 @@
 .external-link-icon {
   color: rgb(2 132 199);
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
 }
 
 .card-body {
@@ -89,7 +89,7 @@
   align-items: center;
 
   > * + * {
-    margin-top: 0.75rem;
+    margin-top: 0.65625rem;
   }
 
   span {
@@ -97,13 +97,13 @@
   }
 
   p-progressspinner {
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
   }
 }
 
 .controls-section {
-  padding: 1rem;
+  padding: 0.875rem;
   margin: 0;
   border-bottom: 1px solid var(--p-content-border-color);
 }
@@ -119,22 +119,22 @@
   z-index: 50;
 
   > * + * {
-    margin-top: 0.75rem;
+    margin-top: 0.65625rem;
   }
 
   p-progressspinner {
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
   }
 }
 
 .saving-message {
   background: var(--color-card);
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
+  padding: 0.4375rem 0.875rem;
+  border-radius: 0.32813rem;
 
   span {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text);
     text-align: center;
   }
@@ -144,11 +144,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
+  gap: 0.875rem;
   flex-wrap: wrap;
 
   label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text-secondary);
     font-weight: 500;
   }
@@ -157,12 +157,12 @@
 .default-controls {
   display: flex;
   flex-grow: 1;
-  gap: 1rem;
+  gap: 0.875rem;
   align-items: center;
   justify-content: flex-end;
 
   p-select {
-    width: 8rem;
+    width: 7rem;
   }
 
   @media #{variables.$mobile-shell-media-query} {
@@ -212,7 +212,7 @@ p-inputgroup.disabled {
 
 .action-buttons {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
   align-items: center;
 
   @media (width <= 640px) {
@@ -232,7 +232,7 @@ p-inputgroup.disabled {
     }
 
     p-button.bulkedit, p-button.extractpattern {
-      width: calc(50% - 0.5rem);
+      width: calc(50% - 0.4375rem);
 
       ::ng-deep button {
         width: 100%;
@@ -254,7 +254,7 @@ p-inputgroup.disabled {
   justify-content: center;
   color: var(--color-text-secondary);
   font-style: italic;
-  padding: 2rem 0;
+  padding: 1.75rem 0;
 }
 
 .file-item {
@@ -265,9 +265,9 @@ p-inputgroup.disabled {
 .file-row {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.875rem;
   border-bottom: 1px solid var(--color-border);
-  padding: 1rem;
+  padding: 0.875rem;
   flex-wrap: wrap;
 }
 
@@ -276,13 +276,13 @@ p-inputgroup.disabled {
 }
 
 .status-indicator {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
 }
 
 .cover-image {
-  width: 1.5rem;
-  height: 2rem;
-  border-radius: 0.125rem;
+  width: 1.3125rem;
+  height: 1.75rem;
+  border-radius: 0.10938rem;
   object-fit: cover;
   cursor: pointer;
   transition: transform 0.2s;
@@ -301,13 +301,13 @@ div.cover-image {
   display: block;
   background-color: rgb(255 255 255 / 10%);
   text-align: center;
-  line-height: 2rem;
+  line-height: 1.75rem;
 }
 
 .file-name {
   flex: 1;
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: wrap;
@@ -333,7 +333,7 @@ div.cover-image {
 
 .file-library {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
   justify-content: flex-end;
   align-items: center;
 
@@ -344,7 +344,7 @@ div.cover-image {
 
 .library-select,
 .path-select {
-  width: 8rem;
+  width: 7rem;
 
   @media #{variables.$mobile-shell-media-query} {
     flex-basis: 50%;
@@ -356,11 +356,11 @@ div.cover-image {
 }
 
 .footer, .footer-mobile {
-  padding: 1rem;
+  padding: 0.875rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .footer {
@@ -382,7 +382,7 @@ div.cover-image {
 .footer-left,
 .footer-right {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
   align-items: center;
 }
 
@@ -428,17 +428,17 @@ div.cover-image {
 }
 
 .spacer {
-  min-width: 10rem;
+  min-width: 8.75rem;
 }
 
 .icon-padding-left {
-  padding-left: 0.5rem;
+  padding-left: 0.4375rem;
 }
 
 .cover-placeholder {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 }
 
 .selected-count-label {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.scss
@@ -1,8 +1,8 @@
 .staging-border {
   background: var(--color-card);
   border: 1px solid var(--color-primary);
-  border-radius: 0.5rem;
-  padding: 1rem;
+  border-radius: 0.4375rem;
+  padding: 0.875rem;
 }
 
 .widget-row {
@@ -23,15 +23,15 @@
 }
 
 .widget-count {
-  font-size: 1.125rem;
+  font-size: var(--app-text-lg);
   font-weight: 700;
   color: var(--color-primary);
 }
 
 .widget-date {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--color-text-secondary);
-  margin-top: 0.25rem;
+  margin-top: 0.21875rem;
 }
 
 .widget-actions {

--- a/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-files-widget/bookdrop-files-widget.component.scss
@@ -31,7 +31,7 @@
 .widget-date {
   font-size: var(--app-text-xs);
   color: var(--color-text-secondary);
-  margin-top: 0.21875rem;
+  margin-top: 0.2188rem;
 }
 
 .widget-actions {

--- a/frontend/src/app/features/bookdrop/component/bookdrop-finalize-result-dialog/bookdrop-finalize-result-dialog.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-finalize-result-dialog/bookdrop-finalize-result-dialog.component.scss
@@ -38,9 +38,9 @@
   border-radius: 8px;
 
   .stat-value {
-    font-size: 1.64063rem;
+    font-size: 1.6406rem;
     font-weight: 700;
-    margin-bottom: 0.21875rem;
+    margin-bottom: 0.2188rem;
 
     &.total {
       color: var(--primary-color);
@@ -71,7 +71,7 @@
   .processed-label {
     font-size: var(--app-text-sm);
     color: var(--text-secondary-color);
-    margin-bottom: 0.21875rem;
+    margin-bottom: 0.2188rem;
   }
 
   .processed-time {
@@ -92,14 +92,14 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .file-item {
   display: flex;
   align-items: flex-start;
-  gap: 0.65625rem;
-  padding: 0.65625rem;
+  gap: 0.6563rem;
+  padding: 0.6563rem;
   border-radius: 8px;
   border: 1px solid;
   transition: all 0.2s ease;
@@ -123,8 +123,8 @@
   }
 
   .status-icon {
-    font-size: 1.09375rem;
-    margin-top: 0.10938rem;
+    font-size: 1.0938rem;
+    margin-top: 0.1094rem;
     flex-shrink: 0;
   }
 

--- a/frontend/src/app/features/bookdrop/component/bookdrop-finalize-result-dialog/bookdrop-finalize-result-dialog.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-finalize-result-dialog/bookdrop-finalize-result-dialog.component.scss
@@ -12,7 +12,7 @@
 }
 
 .dialog-content {
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -23,8 +23,8 @@
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: 0.875rem;
+  margin-bottom: 1.3125rem;
 
   @media (width <= 480px) {
     grid-template-columns: 1fr;
@@ -33,14 +33,14 @@
 
 .stat-card {
   text-align: center;
-  padding: 1rem;
+  padding: 0.875rem;
   background: var(--overlay-background);
   border-radius: 8px;
 
   .stat-value {
-    font-size: 1.875rem;
+    font-size: 1.64063rem;
     font-weight: 700;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.21875rem;
 
     &.total {
       color: var(--primary-color);
@@ -56,7 +56,7 @@
   }
 
   .stat-label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
     color: var(--text-secondary-color);
   }
@@ -64,18 +64,18 @@
 
 .processed-info {
   text-align: center;
-  padding: 1rem;
+  padding: 0.875rem;
   border-top: 1px solid var(--border-color);
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 
   .processed-label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-secondary-color);
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.21875rem;
   }
 
   .processed-time {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-family: monospace;
     color: var(--text-color);
   }
@@ -92,14 +92,14 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .file-item {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  gap: 0.65625rem;
+  padding: 0.65625rem;
   border-radius: 8px;
   border: 1px solid;
   transition: all 0.2s ease;
@@ -123,8 +123,8 @@
   }
 
   .status-icon {
-    font-size: 1.25rem;
-    margin-top: 0.125rem;
+    font-size: 1.09375rem;
+    margin-top: 0.10938rem;
     flex-shrink: 0;
   }
 
@@ -134,12 +134,12 @@
 
     .file-name {
       font-weight: 500;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--text-color);
     }
 
     .file-message {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--text-secondary-color);
     }
   }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-pattern-extract-dialog/bookdrop-pattern-extract-dialog.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-pattern-extract-dialog/bookdrop-pattern-extract-dialog.component.scss
@@ -1,8 +1,8 @@
 .pattern-extract-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 0 1rem;
+  gap: 0.875rem;
+  padding: 0 0.875rem;
   max-height: 70vh;
 
   @media (width <= 768px) {
@@ -14,22 +14,22 @@
 .info-banner {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: 0.65625rem;
+  padding: 0.65625rem 0.875rem;
   background: rgb(59 130 246 / 8%);
   border: 1px solid var(--p-primary-color);
   border-radius: 6px;
   color: var(--p-text-color);
 
   i {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     color: var(--p-primary-color);
     margin-top: 2px;
   }
 
   code {
     background: rgb(255 255 255 / 10%);
-    padding: 0.1rem 0.3rem;
+    padding: 0.0875rem 0.2625rem;
     border-radius: 4px;
     font-family: monospace;
   }
@@ -41,11 +41,11 @@
 .preview-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   h4 {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     font-weight: 600;
     color: var(--p-text-secondary-color);
   }
@@ -53,7 +53,7 @@
 
 .pattern-input-row {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   align-items: center;
 }
 
@@ -65,13 +65,13 @@
 .placeholder-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 :host ::ng-deep .placeholder-chip {
   cursor: pointer;
   font-family: monospace;
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
 
   &:hover {
     background-color: var(--p-primary-color);
@@ -82,19 +82,19 @@
 .common-pattern-buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .preview-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   max-height: 200px;
   overflow-y: auto;
 }
 
 .preview-item {
-  padding: 0.75rem;
+  padding: 0.65625rem;
   border-radius: 6px;
   border: 1px solid var(--color-border);
 
@@ -112,12 +112,12 @@
 .preview-filename {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-weight: 500;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   .pi-check-circle {
@@ -132,14 +132,14 @@
 .preview-extracted {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-  padding-left: 1.5rem;
+  gap: 0.4375rem 0.875rem;
+  padding-left: 1.3125rem;
 }
 
 .extracted-field {
   display: flex;
-  gap: 0.25rem;
-  font-size: 0.85rem;
+  gap: 0.21875rem;
+  font-size: 0.74375rem;
 
   .field-name {
     color: var(--p-text-secondary-color);
@@ -152,8 +152,8 @@
 }
 
 .preview-error {
-  padding-left: 1.5rem;
-  font-size: 0.85rem;
+  padding-left: 1.3125rem;
+  font-size: 0.74375rem;
   color: var(--p-text-secondary-color);
   font-style: italic;
 }
@@ -162,14 +162,14 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 0.75rem;
-  padding-top: 0.5rem;
+  gap: 0.65625rem;
+  padding-top: 0.4375rem;
 }
 
 .extracting-indicator {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   margin-right: auto;
   color: var(--p-text-secondary-color);
 }

--- a/frontend/src/app/features/bookdrop/component/bookdrop-pattern-extract-dialog/bookdrop-pattern-extract-dialog.component.scss
+++ b/frontend/src/app/features/bookdrop/component/bookdrop-pattern-extract-dialog/bookdrop-pattern-extract-dialog.component.scss
@@ -14,15 +14,15 @@
 .info-banner {
   display: flex;
   align-items: flex-start;
-  gap: 0.65625rem;
-  padding: 0.65625rem 0.875rem;
+  gap: 0.6563rem;
+  padding: 0.6563rem 0.875rem;
   background: rgb(59 130 246 / 8%);
   border: 1px solid var(--p-primary-color);
   border-radius: 6px;
   color: var(--p-text-color);
 
   i {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     color: var(--p-primary-color);
     margin-top: 2px;
   }
@@ -71,7 +71,7 @@
 :host ::ng-deep .placeholder-chip {
   cursor: pointer;
   font-family: monospace;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
 
   &:hover {
     background-color: var(--p-primary-color);
@@ -94,7 +94,7 @@
 }
 
 .preview-item {
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   border-radius: 6px;
   border: 1px solid var(--color-border);
 
@@ -138,8 +138,8 @@
 
 .extracted-field {
   display: flex;
-  gap: 0.21875rem;
-  font-size: 0.74375rem;
+  gap: 0.2188rem;
+  font-size: 0.7438rem;
 
   .field-name {
     color: var(--p-text-secondary-color);
@@ -153,7 +153,7 @@
 
 .preview-error {
   padding-left: 1.3125rem;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   color: var(--p-text-secondary-color);
   font-style: italic;
 }
@@ -162,7 +162,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding-top: 0.4375rem;
 }
 

--- a/frontend/src/app/features/command-palette/command-palette.component.scss
+++ b/frontend/src/app/features/command-palette/command-palette.component.scss
@@ -6,14 +6,14 @@
 
 .command-palette-shell {
   position: relative;
-  width: min(640px, calc(100vw - 2rem));
+  width: min(640px, calc(100vw - 1.75rem));
 }
 
 .command-palette {
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-height: min(70vh, calc(100dvh - 4rem));
+  max-height: min(70vh, calc(100dvh - 3.5rem));
   background: color-mix(in srgb, var(--color-page) 64%, var(--color-card));
   color: var(--color-text);
   border: 1px solid var(--color-border);
@@ -38,7 +38,7 @@
 
   i {
     color: var(--color-text-secondary);
-    font-size: var(--text-lg);
+    font-size: var(--app-text-lg);
   }
 }
 
@@ -50,7 +50,7 @@
   border: none;
   outline: none;
   color: inherit;
-  font-size: var(--text-lg);
+  font-size: var(--app-text-lg);
   line-height: 1.4;
   appearance: none;
 
@@ -70,8 +70,8 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.1875rem;
+  height: 2.1875rem;
   padding: 0;
   background: transparent;
   border: 0;
@@ -89,7 +89,7 @@
   }
 
   i {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
   }
 }
 
@@ -103,7 +103,7 @@
   padding: var(--space-6) var(--space-4);
   color: var(--color-text-secondary);
   text-align: center;
-  font-size: var(--text-sm);
+  font-size: var(--app-text-sm);
 }
 
 .command-palette-group {
@@ -116,7 +116,7 @@
 
 .command-palette-group-label {
   padding: var(--space-2) var(--space-2) var(--space-1);
-  font-size: var(--text-xs);
+  font-size: var(--app-text-xs);
   font-weight: 500;
   color: var(--color-text-secondary);
 }
@@ -187,7 +187,7 @@
 }
 
 .command-palette-book-title {
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
   font-weight: 600;
   line-height: 1.3;
   overflow: hidden;
@@ -200,7 +200,7 @@
   flex-wrap: wrap;
   align-items: center;
   min-width: 0;
-  font-size: var(--text-sm);
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
 
   > * + *::before {
@@ -212,7 +212,7 @@
 .command-palette-item-title {
   flex: 0 1 auto;
   min-width: 0;
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -223,7 +223,7 @@
   min-width: 0;
   margin-left: var(--space-2);
   color: var(--color-text-secondary);
-  font-size: var(--text-sm);
+  font-size: var(--app-text-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -237,7 +237,7 @@
   padding: var(--space-2) var(--space-4);
   border-top: 1px solid var(--color-border);
   color: var(--color-text-secondary);
-  font-size: var(--text-xs);
+  font-size: var(--app-text-xs);
 }
 
 .command-palette-hint-item {
@@ -250,12 +250,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 1.25rem;
+  min-width: 1.09375rem;
   padding: 0 var(--space-1);
   border-radius: var(--radius-sm);
   background: var(--color-surface-hover);
   font-family: inherit;
-  font-size: var(--text-xs);
+  font-size: var(--app-text-xs);
   line-height: 1.5;
   color: var(--color-text);
 }
@@ -276,7 +276,7 @@
   .command-palette-form {
     box-sizing: border-box;
     flex-shrink: 0;
-    height: 3.5rem;
+    height: 3.0625rem;
     background: var(--color-app);
     border-bottom: 1px solid var(--color-border);
 
@@ -288,24 +288,24 @@
   .command-palette-input-row {
     box-sizing: border-box;
     height: 100%;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     padding:
       0
-      calc(0.75rem + env(safe-area-inset-right))
+      calc(0.65625rem + env(safe-area-inset-right))
       0
-      calc(0.75rem + env(safe-area-inset-left));
+      calc(0.65625rem + env(safe-area-inset-left));
 
     > .pi-search {
       display: inline-flex;
       align-items: center;
       justify-content: center;
       flex-shrink: 0;
-      width: 2.5rem;
+      width: 2.1875rem;
     }
   }
 
   .command-palette-input {
-    padding-right: 0.5rem;
+    padding-right: 0.4375rem;
   }
 
   .command-palette-close-button {

--- a/frontend/src/app/features/command-palette/command-palette.component.scss
+++ b/frontend/src/app/features/command-palette/command-palette.component.scss
@@ -89,7 +89,7 @@
   }
 
   i {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
   }
 }
 
@@ -250,7 +250,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 1.09375rem;
+  min-width: 1.0938rem;
   padding: 0 var(--space-1);
   border-radius: var(--radius-sm);
   background: var(--color-surface-hover);
@@ -291,9 +291,9 @@
     gap: 0.4375rem;
     padding:
       0
-      calc(0.65625rem + env(safe-area-inset-right))
+      calc(0.6563rem + env(safe-area-inset-right))
       0
-      calc(0.65625rem + env(safe-area-inset-left));
+      calc(0.6563rem + env(safe-area-inset-left));
 
     > .pi-search {
       display: inline-flex;

--- a/frontend/src/app/features/dashboard/components/dashboard-scroller/dashboard-scroller.component.scss
+++ b/frontend/src/app/features/dashboard/components/dashboard-scroller/dashboard-scroller.component.scss
@@ -1,7 +1,7 @@
 .dashboard-scroller-container {
   border-radius: 20px;
-  padding: 1rem 2rem 0;
-  margin-bottom: 2rem;
+  padding: 0.875rem 1.75rem 0;
+  margin-bottom: 1.75rem;
   position: relative;
   overflow: hidden;
   background: transparent;
@@ -10,9 +10,9 @@
 
 .dashboard-scroller-title {
   text-align: left;
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   font-weight: 800;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   padding: 0;
   background: linear-gradient(135deg, var(--color-text), var(--color-text-secondary), var(--color-primary));
   background-clip: text;
@@ -34,7 +34,7 @@
 }
 
 .dashboard-scroller-no-books {
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -50,18 +50,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 2rem;
+    margin-bottom: 1.75rem;
     position: relative;
 
     i {
-      font-size: 2rem;
+      font-size: 1.75rem;
       color: var(--color-text);
     }
   }
 
   p {
     color: var(--color-text-secondary);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 500;
     max-width: 400px;
     line-height: 1.7;
@@ -72,8 +72,8 @@
   display: flex;
   overflow: auto hidden;
   scroll-snap-type: x mandatory;
-  padding: 1rem 0.5rem;
-  gap: 2rem;
+  padding: 0.875rem 0.4375rem;
+  gap: 1.75rem;
   width: 100%;
   position: relative;
   z-index: 2;
@@ -97,7 +97,7 @@
 }
 
 .magic-shelf-icon {
-  margin-left: 0.5rem;
+  margin-left: 0.4375rem;
   color: var(--color-primary) !important;
   background: none !important;
   background-clip: unset !important;
@@ -118,19 +118,19 @@
   }
 
   .dashboard-scroller-no-books {
-    padding: 4rem 1rem;
+    padding: 3.5rem 0.875rem;
 
     .empty-state-icon {
       width: 80px;
       height: 80px;
 
       i {
-        font-size: 2rem;
+        font-size: 1.75rem;
       }
     }
 
     p {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
   }
 }

--- a/frontend/src/app/features/dashboard/components/dashboard-settings/dashboard-settings.component.scss
+++ b/frontend/src/app/features/dashboard/components/dashboard-settings/dashboard-settings.component.scss
@@ -17,8 +17,8 @@
 .settings-controls {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1rem 2rem;
+  gap: 0.65625rem;
+  padding: 0.875rem 1.75rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
@@ -26,17 +26,17 @@
   .settings-info {
     .info-content {
       display: flex;
-      gap: 0.75rem;
-      padding: 0.75rem;
+      gap: 0.65625rem;
+      padding: 0.65625rem;
       background: var(--color-page);
       border-radius: 6px;
       border: 1px solid var(--p-primary-300);
 
       .info-icon {
         color: var(--color-primary);
-        font-size: 1.125rem;
+        font-size: var(--app-text-lg);
         flex-shrink: 0;
-        margin-top: 0.125rem;
+        margin-top: 0.10938rem;
       }
 
       .info-text {
@@ -45,7 +45,7 @@
         p {
           margin: 0;
           line-height: 1.5;
-          font-size: 0.875rem;
+          font-size: var(--app-text-sm);
           color: var(--color-text-secondary);
         }
       }
@@ -53,20 +53,20 @@
   }
 
   @media (width <= 480px) {
-    padding: 1rem;
-    gap: 0.5rem;
+    padding: 0.875rem;
+    gap: 0.4375rem;
 
     .settings-info {
       .info-content {
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.4375rem;
       }
     }
   }
 }
 
 .scrollers-container {
-  padding: 1.5rem 2rem;
+  padding: 1.3125rem 1.75rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
@@ -75,7 +75,7 @@
   overflow-y: auto;
 
   @media (width <= 480px) {
-    padding: 1rem;
+    padding: 0.875rem;
     max-height: 400px;
   }
 }
@@ -85,31 +85,31 @@
   transition: all 0.2s;
   border-color: var(--p-content-border-color);
   background: var(--p-content-background);
-  padding: 1rem;
-  margin-bottom: 0.75rem;
-  border-radius: 0.375rem;
+  padding: 0.875rem;
+  margin-bottom: 0.65625rem;
+  border-radius: 0.32813rem;
 
   @media (width <= 768px) {
-    padding: 0.75rem !important;
+    padding: 0.65625rem !important;
   }
 }
 
 .scroller-content {
   display: flex;
   align-items: flex-end;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 768px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
 .scroller-controls-left {
   display: flex;
   align-items: center;
-  padding-bottom: 0.65rem;
+  padding-bottom: 0.56875rem;
 
   @media (width <= 768px) {
     padding-bottom: 0;
@@ -119,8 +119,8 @@
 
 .scroller-controls-right {
   display: flex;
-  gap: 0.5rem;
-  padding-bottom: 0.25rem;
+  gap: 0.4375rem;
+  padding-bottom: 0.21875rem;
 
   @media (width <= 768px) {
     padding-bottom: 0;
@@ -131,23 +131,23 @@
 .scroller-fields {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex: 1;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 
   @media (width <= 640px) {
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 }
 
 .scroller-field {
   label {
     display: block;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.4375rem;
   }
 
   &.expanded {
@@ -160,7 +160,7 @@
 }
 
 .max-items-field {
-  max-width: 9rem;
+  max-width: 7.875rem;
   flex-shrink: 0;
 
   @media (width <= 768px) {
@@ -170,7 +170,7 @@
 
 label {
   color: var(--color-text-secondary);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
 }
 
@@ -182,13 +182,13 @@ label {
   .footer-left {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   @media (width <= 640px) {
     .footer-left {
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       ::ng-deep .p-button {
         width: 100%;

--- a/frontend/src/app/features/dashboard/components/dashboard-settings/dashboard-settings.component.scss
+++ b/frontend/src/app/features/dashboard/components/dashboard-settings/dashboard-settings.component.scss
@@ -17,7 +17,7 @@
 .settings-controls {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding: 0.875rem 1.75rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
@@ -26,8 +26,8 @@
   .settings-info {
     .info-content {
       display: flex;
-      gap: 0.65625rem;
-      padding: 0.65625rem;
+      gap: 0.6563rem;
+      padding: 0.6563rem;
       background: var(--color-page);
       border-radius: 6px;
       border: 1px solid var(--p-primary-300);
@@ -36,7 +36,7 @@
         color: var(--color-primary);
         font-size: var(--app-text-lg);
         flex-shrink: 0;
-        margin-top: 0.10938rem;
+        margin-top: 0.1094rem;
       }
 
       .info-text {
@@ -86,18 +86,18 @@
   border-color: var(--p-content-border-color);
   background: var(--p-content-background);
   padding: 0.875rem;
-  margin-bottom: 0.65625rem;
-  border-radius: 0.32813rem;
+  margin-bottom: 0.6563rem;
+  border-radius: 0.3281rem;
 
   @media (width <= 768px) {
-    padding: 0.65625rem !important;
+    padding: 0.6563rem !important;
   }
 }
 
 .scroller-content {
   display: flex;
   align-items: flex-end;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 768px) {
     flex-direction: column;
@@ -109,7 +109,7 @@
 .scroller-controls-left {
   display: flex;
   align-items: center;
-  padding-bottom: 0.56875rem;
+  padding-bottom: 0.5687rem;
 
   @media (width <= 768px) {
     padding-bottom: 0;
@@ -120,7 +120,7 @@
 .scroller-controls-right {
   display: flex;
   gap: 0.4375rem;
-  padding-bottom: 0.21875rem;
+  padding-bottom: 0.2188rem;
 
   @media (width <= 768px) {
     padding-bottom: 0;
@@ -131,12 +131,12 @@
 .scroller-fields {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex: 1;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 
   @media (width <= 640px) {

--- a/frontend/src/app/features/dashboard/components/main-dashboard/main-dashboard.component.scss
+++ b/frontend/src/app/features/dashboard/components/main-dashboard/main-dashboard.component.scss
@@ -11,7 +11,7 @@
   align-items: center;
   justify-content: center;
   min-height: 100%;
-  padding: 1.1rem 1.1rem 0;
+  padding: 0.9625rem 0.9625rem 0;
   text-align: center;
   position: relative;
   z-index: 1;
@@ -19,7 +19,7 @@
 
 @media (width <= 768px) {
   .dashboard {
-    padding: 0.5rem 0.5rem 0;
+    padding: 0.4375rem 0.4375rem 0;
   }
 }
 
@@ -36,16 +36,16 @@
 
 .welcome-description {
   color: var(--color-text-secondary);
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
   margin-left: auto;
   margin-right: auto;
   line-height: 1.625;
 }
 
 .dashboard .no-library-header {
-  font-size: 1.75rem;
+  font-size: 1.53125rem;
   font-weight: 700;
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
   background: linear-gradient(135deg, var(--color-text), var(--color-text-secondary), var(--color-primary));
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -54,7 +54,7 @@
 }
 
 .dashboard-no-library {
-  padding: 3rem;
+  padding: 2.625rem;
   background: transparent;
   border-radius: 24px;
   border: 1px solid var(--color-border);
@@ -72,8 +72,8 @@
 
 .dashboard-settings-button {
   position: fixed;
-  top: 6rem;
-  right: 2rem;
+  top: 5.25rem;
+  right: 1.75rem;
   z-index: 100;
 
   ::ng-deep .p-button {
@@ -91,17 +91,17 @@
 
 @media (width <= 768px) {
   .dashboard-settings-button {
-    top: 5rem;
-    right: 1rem;
+    top: 4.375rem;
+    right: 0.875rem;
 
     ::ng-deep .p-button {
-      width: 2.5rem;
-      height: 2.5rem;
+      width: 2.1875rem;
+      height: 2.1875rem;
     }
   }
 }
 
 .scroller-placeholder {
   height: 260px;
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
 }

--- a/frontend/src/app/features/dashboard/components/main-dashboard/main-dashboard.component.scss
+++ b/frontend/src/app/features/dashboard/components/main-dashboard/main-dashboard.component.scss
@@ -43,7 +43,7 @@
 }
 
 .dashboard .no-library-header {
-  font-size: 1.53125rem;
+  font-size: 1.5313rem;
   font-weight: 700;
   margin-bottom: 1.75rem;
   background: linear-gradient(135deg, var(--color-text), var(--color-text-secondary), var(--color-primary));

--- a/frontend/src/app/features/library-creator/library-creator.component.scss
+++ b/frontend/src/app/features/library-creator/library-creator.component.scss
@@ -14,14 +14,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.25rem 1.5rem;
+  padding: 1.09375rem 1.3125rem;
   background: var(--overlay-background);
   border-bottom: 1px solid var(--border-color);
 
   .header-content {
     display: flex;
     align-items: center;
-    gap: 0.875rem;
+    gap: 0.76563rem;
   }
 
   .header-icon {
@@ -34,7 +34,7 @@
     border-radius: 10px;
 
     i {
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       color: var(--primary-contrast-color);
     }
   }
@@ -42,14 +42,14 @@
   .header-text {
     h1 {
       margin: 0;
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 600;
       color: var(--text-color);
     }
 
     p {
-      margin: 0.125rem 0 0;
-      font-size: 0.875rem;
+      margin: 0.10938rem 0 0;
+      font-size: var(--app-text-sm);
       color: var(--text-secondary-color);
     }
   }
@@ -59,10 +59,10 @@
 .dialog-body {
   flex: 1;
   overflow-y: auto;
-  padding: 1.75rem 2rem;
+  padding: 1.53125rem 1.75rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 // Sections
@@ -70,16 +70,16 @@
   .section-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
-    font-size: 0.85rem;
+    gap: 0.4375rem;
+    margin-bottom: 0.65625rem;
+    font-size: 0.74375rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
     color: var(--text-secondary-color);
 
     i {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       color: var(--primary-color);
     }
 
@@ -89,11 +89,11 @@
       justify-content: center;
       min-width: 20px;
       height: 20px;
-      padding: 0 0.375rem;
+      padding: 0 0.32813rem;
       background: var(--primary-color);
       color: var(--primary-contrast-color);
       border-radius: 10px;
-      font-size: 0.7rem;
+      font-size: 0.6125rem;
       font-weight: 600;
     }
   }
@@ -102,7 +102,7 @@
 // Form Fields
 .form-row {
   display: flex;
-  gap: 1.25rem;
+  gap: 1.09375rem;
 
   &.two-col {
     .form-field {
@@ -119,10 +119,10 @@
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   label {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     font-weight: 500;
     color: var(--text-color);
 
@@ -136,15 +136,15 @@
 
     .input-full {
       width: 100%;
-      padding-right: 2.25rem;
+      padding-right: 1.96875rem;
     }
 
     .field-status {
       position: absolute;
-      right: 0.75rem;
+      right: 0.65625rem;
       top: 50%;
       transform: translateY(-50%);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
 
       &.success {
         color: var(--p-green-500);
@@ -158,14 +158,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   width: 100%;
-  padding: 0.875rem 1rem;
+  padding: 0.76563rem 0.875rem;
   background: var(--ground-background);
   border: 1px dashed var(--border-color);
   border-radius: 8px;
   color: var(--text-secondary-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   cursor: pointer;
   transition: all 0.2s ease;
 
@@ -176,15 +176,15 @@
   }
 
   i {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
 .icon-selected {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  padding: 0.625rem 0.875rem;
+  gap: 0.54688rem;
+  padding: 0.54688rem 0.76563rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -202,7 +202,7 @@
 
   .icon-value {
     flex: 1;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-family: monospace;
     color: var(--text-color);
     overflow: hidden;
@@ -229,7 +229,7 @@
     }
 
     i {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
     }
   }
 }
@@ -237,17 +237,17 @@
 .folder-structure-hint {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  padding: 0.625rem 0.75rem;
+  gap: 0.54688rem;
+  padding: 0.54688rem 0.65625rem;
   background: rgb(234 179 8 / 8%);
   border: 1px solid rgb(234 179 8 / 25%);
   border-radius: 6px;
-  font-size: 0.8125rem;
+  font-size: 0.71094rem;
   color: var(--text-secondary-color);
   line-height: 1.5;
 
   i {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     color: rgb(234 179 8);
     flex-shrink: 0;
   }
@@ -267,8 +267,8 @@
 .folders-zone {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.25rem;
+  gap: 0.875rem;
+  padding: 1.09375rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -278,14 +278,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   width: 100%;
-  padding: 0.875rem;
+  padding: 0.76563rem;
   background: transparent;
   border: 1px dashed var(--border-color);
   border-radius: 6px;
   color: var(--primary-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -296,14 +296,14 @@
   }
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }
 
 .folders-list {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 0.54688rem;
   max-height: 180px;
   overflow-y: auto;
 }
@@ -311,8 +311,8 @@
 .folder-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 0.875rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem 0.76563rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -330,18 +330,18 @@
     flex: 1;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     min-width: 0;
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--text-secondary-color);
       flex-shrink: 0;
       transition: color 0.2s ease;
     }
 
     .folder-path {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--text-color);
       overflow: hidden;
       text-overflow: ellipsis;
@@ -370,7 +370,7 @@
     }
 
     i {
-      font-size: 0.6875rem;
+      font-size: 0.60156rem;
     }
   }
 }
@@ -379,13 +379,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 1rem;
+  gap: 0.4375rem;
+  padding: 0.875rem;
   color: var(--text-secondary-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 
   i {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     opacity: 0.7;
   }
 }
@@ -394,8 +394,8 @@
 .options-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
+  gap: 0.875rem;
+  padding: 0.875rem 1.09375rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -405,7 +405,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 
   p-toggleswitch {
     --p-toggleswitch-checked-background: var(--p-green-500);
@@ -415,26 +415,26 @@
   &.option-row-stacked {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.625rem;
+    gap: 0.54688rem;
   }
 }
 
 .option-divider {
   height: 1px;
   background: var(--border-color);
-  margin: 0.25rem 0;
+  margin: 0.21875rem 0;
 }
 
 .option-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.875rem;
+  gap: 0.32813rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
   color: var(--text-color);
 
   .info-icon {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     color: var(--text-secondary-color);
     opacity: 0.6;
     cursor: help;
@@ -451,10 +451,10 @@
 .allow-all-toggle {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   .allow-all-label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-color);
     cursor: pointer;
   }
@@ -463,8 +463,8 @@
 .format-checkboxes {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.625rem 1.25rem;
-  padding: 0.875rem;
+  gap: 0.54688rem 1.09375rem;
+  padding: 0.76563rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -473,19 +473,19 @@
 .format-checkbox-item {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   min-width: 90px;
 
   .format-checkbox-label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-color);
     cursor: pointer;
   }
 
   .warning-icon {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--p-orange-400);
-    margin-left: 0.125rem;
+    margin-left: 0.10938rem;
   }
 
   &.has-warning {
@@ -502,17 +502,17 @@
 .format-warning-message {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.54688rem 0.65625rem;
   background: rgb(234 179 8 / 10%);
   border: 1px solid var(--p-orange-400);
   border-radius: 6px;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--p-orange-400);
 
   i {
     flex-shrink: 0;
-    font-size: 0.8rem;
+    font-size: 0.7rem;
   }
 }
 
@@ -520,15 +520,15 @@
 .format-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   width: 100%;
 }
 
 .format-chip {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.625rem;
+  gap: 0.4375rem;
+  padding: 0.35rem 0.54688rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -548,18 +548,18 @@
     background: var(--primary-color);
     color: var(--primary-contrast-color);
     border-radius: 50%;
-    font-size: 0.625rem;
+    font-size: 0.54688rem;
     font-weight: 600;
   }
 
   .chip-label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
     color: var(--text-color);
   }
 
   .drag-indicator {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--text-secondary-color);
     opacity: 0.5;
     cursor: grab;
@@ -592,8 +592,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.5rem;
+  gap: 0.875rem;
+  padding: 0.875rem 1.3125rem;
   background: var(--overlay-background);
   border-top: 1px solid var(--border-color);
 }
@@ -605,12 +605,12 @@
   .status-message {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
-    font-size: 0.875rem;
+    gap: 0.32813rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
 
     i {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
     }
 
     &.warning {
@@ -625,7 +625,7 @@
 
 .footer-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-shrink: 0;
 }
 
@@ -639,31 +639,31 @@
   }
 
   .dialog-header {
-    padding: 1rem;
+    padding: 0.875rem;
 
     .header-icon {
       width: 36px;
       height: 36px;
 
       i {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
     }
 
     .header-text h1 {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 
   .dialog-body {
-    padding: 1.5rem;
-    gap: 1.75rem;
+    padding: 1.3125rem;
+    gap: 1.53125rem;
   }
 
   .dialog-footer {
     flex-direction: column;
-    padding: 1rem;
-    gap: 0.75rem;
+    padding: 0.875rem;
+    gap: 0.65625rem;
 
     .validation-status {
       width: 100%;

--- a/frontend/src/app/features/library-creator/library-creator.component.scss
+++ b/frontend/src/app/features/library-creator/library-creator.component.scss
@@ -14,14 +14,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.09375rem 1.3125rem;
+  padding: 1.0938rem 1.3125rem;
   background: var(--overlay-background);
   border-bottom: 1px solid var(--border-color);
 
   .header-content {
     display: flex;
     align-items: center;
-    gap: 0.76563rem;
+    gap: 0.7656rem;
   }
 
   .header-icon {
@@ -34,7 +34,7 @@
     border-radius: 10px;
 
     i {
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       color: var(--primary-contrast-color);
     }
   }
@@ -42,13 +42,13 @@
   .header-text {
     h1 {
       margin: 0;
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 600;
       color: var(--text-color);
     }
 
     p {
-      margin: 0.10938rem 0 0;
+      margin: 0.1094rem 0 0;
       font-size: var(--app-text-sm);
       color: var(--text-secondary-color);
     }
@@ -59,7 +59,7 @@
 .dialog-body {
   flex: 1;
   overflow-y: auto;
-  padding: 1.53125rem 1.75rem;
+  padding: 1.5313rem 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
@@ -71,8 +71,8 @@
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    margin-bottom: 0.65625rem;
-    font-size: 0.74375rem;
+    margin-bottom: 0.6563rem;
+    font-size: 0.7438rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
@@ -89,7 +89,7 @@
       justify-content: center;
       min-width: 20px;
       height: 20px;
-      padding: 0 0.32813rem;
+      padding: 0 0.3281rem;
       background: var(--primary-color);
       color: var(--primary-contrast-color);
       border-radius: 10px;
@@ -102,7 +102,7 @@
 // Form Fields
 .form-row {
   display: flex;
-  gap: 1.09375rem;
+  gap: 1.0938rem;
 
   &.two-col {
     .form-field {
@@ -119,7 +119,7 @@
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   label {
     font-size: 0.7875rem;
@@ -136,12 +136,12 @@
 
     .input-full {
       width: 100%;
-      padding-right: 1.96875rem;
+      padding-right: 1.9688rem;
     }
 
     .field-status {
       position: absolute;
-      right: 0.65625rem;
+      right: 0.6563rem;
       top: 50%;
       transform: translateY(-50%);
       font-size: 0.7875rem;
@@ -160,7 +160,7 @@
   justify-content: center;
   gap: 0.4375rem;
   width: 100%;
-  padding: 0.76563rem 0.875rem;
+  padding: 0.7656rem 0.875rem;
   background: var(--ground-background);
   border: 1px dashed var(--border-color);
   border-radius: 8px;
@@ -183,8 +183,8 @@
 .icon-selected {
   display: flex;
   align-items: center;
-  gap: 0.54688rem;
-  padding: 0.54688rem 0.76563rem;
+  gap: 0.5469rem;
+  padding: 0.5469rem 0.7656rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -237,12 +237,12 @@
 .folder-structure-hint {
   display: flex;
   align-items: center;
-  gap: 0.54688rem;
-  padding: 0.54688rem 0.65625rem;
+  gap: 0.5469rem;
+  padding: 0.5469rem 0.6563rem;
   background: rgb(234 179 8 / 8%);
   border: 1px solid rgb(234 179 8 / 25%);
   border-radius: 6px;
-  font-size: 0.71094rem;
+  font-size: 0.7109rem;
   color: var(--text-secondary-color);
   line-height: 1.5;
 
@@ -268,7 +268,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
-  padding: 1.09375rem;
+  padding: 1.0938rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -280,7 +280,7 @@
   justify-content: center;
   gap: 0.4375rem;
   width: 100%;
-  padding: 0.76563rem;
+  padding: 0.7656rem;
   background: transparent;
   border: 1px dashed var(--border-color);
   border-radius: 6px;
@@ -303,7 +303,7 @@
 .folders-list {
   display: flex;
   flex-direction: column;
-  gap: 0.54688rem;
+  gap: 0.5469rem;
   max-height: 180px;
   overflow-y: auto;
 }
@@ -312,7 +312,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem 0.76563rem;
+  padding: 0.6563rem 0.7656rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -370,7 +370,7 @@
     }
 
     i {
-      font-size: 0.60156rem;
+      font-size: 0.6016rem;
     }
   }
 }
@@ -395,7 +395,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
-  padding: 0.875rem 1.09375rem;
+  padding: 0.875rem 1.0938rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -415,20 +415,20 @@
   &.option-row-stacked {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.54688rem;
+    gap: 0.5469rem;
   }
 }
 
 .option-divider {
   height: 1px;
   background: var(--border-color);
-  margin: 0.21875rem 0;
+  margin: 0.2188rem 0;
 }
 
 .option-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   font-size: var(--app-text-sm);
   font-weight: 500;
   color: var(--text-color);
@@ -463,8 +463,8 @@
 .format-checkboxes {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.54688rem 1.09375rem;
-  padding: 0.76563rem;
+  gap: 0.5469rem 1.0938rem;
+  padding: 0.7656rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -473,7 +473,7 @@
 .format-checkbox-item {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   min-width: 90px;
 
   .format-checkbox-label {
@@ -485,7 +485,7 @@
   .warning-icon {
     font-size: var(--app-text-xs);
     color: var(--p-orange-400);
-    margin-left: 0.10938rem;
+    margin-left: 0.1094rem;
   }
 
   &.has-warning {
@@ -503,7 +503,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.54688rem 0.65625rem;
+  padding: 0.5469rem 0.6563rem;
   background: rgb(234 179 8 / 10%);
   border: 1px solid var(--p-orange-400);
   border-radius: 6px;
@@ -528,7 +528,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.35rem 0.54688rem;
+  padding: 0.35rem 0.5469rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -548,7 +548,7 @@
     background: var(--primary-color);
     color: var(--primary-contrast-color);
     border-radius: 50%;
-    font-size: 0.54688rem;
+    font-size: 0.5469rem;
     font-weight: 600;
   }
 
@@ -605,7 +605,7 @@
   .status-message {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     font-size: var(--app-text-sm);
     font-weight: 500;
 
@@ -625,7 +625,7 @@
 
 .footer-actions {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-shrink: 0;
 }
 
@@ -657,13 +657,13 @@
 
   .dialog-body {
     padding: 1.3125rem;
-    gap: 1.53125rem;
+    gap: 1.5313rem;
   }
 
   .dialog-footer {
     flex-direction: column;
     padding: 0.875rem;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
 
     .validation-status {
       width: 100%;

--- a/frontend/src/app/features/magic-shelf/component/magic-shelf-component.scss
+++ b/frontend/src/app/features/magic-shelf/component/magic-shelf-component.scss
@@ -17,8 +17,8 @@
 }
 
 .import-panel {
-  margin-bottom: 0.75rem;
-  padding: 1rem;
+  margin-bottom: 0.65625rem;
+  padding: 0.875rem;
   background: var(--overlay-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -26,20 +26,20 @@
   .import-textarea {
     width: 100%;
     font-family: monospace;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     resize: vertical;
   }
 
   .import-actions {
     display: flex;
     justify-content: flex-end;
-    gap: 0.5rem;
-    margin-top: 0.75rem;
+    gap: 0.4375rem;
+    margin-top: 0.65625rem;
   }
 }
 
 .magic-shelf-content {
-  padding: 2rem;
+  padding: 1.75rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-bottom: none;
@@ -47,24 +47,24 @@
   min-height: 450px;
 
   @media (width <= 480px) {
-    padding: 1rem;
+    padding: 0.875rem;
     min-height: 350px;
   }
 }
 
 .form-header {
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
   display: flex;
   width: 100%;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 0.875rem;
+  padding: 0.875rem;
   background: var(--overlay-background);
   border-radius: 8px;
   border: 1px solid var(--border-color);
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
@@ -73,10 +73,10 @@
 
   label {
     display: block;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.4375rem;
     font-weight: 600;
     color: var(--text-color);
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 
   input {
@@ -91,23 +91,23 @@
   .icon-picker-wrapper {
     label {
       display: block;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
       font-weight: 600;
       color: var(--text-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
     }
 
     .selected-icon-display {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .icon-display-container {
       display: flex;
       align-items: center;
-      gap: 0.75rem;
-      padding: 0.625rem 1rem;
+      gap: 0.65625rem;
+      padding: 0.54688rem 0.875rem;
       border: 1px solid var(--border-color);
       border-radius: 6px;
       cursor: pointer;
@@ -128,7 +128,7 @@
       }
 
       .icon-label {
-        font-size: 0.95rem;
+        font-size: 0.83125rem;
         color: var(--text-secondary-color);
         white-space: nowrap;
       }
@@ -136,16 +136,16 @@
       .icon-placeholder {
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: 0.4375rem;
         color: var(--text-secondary-color);
 
         i {
-          font-size: 1.125rem;
+          font-size: var(--app-text-lg);
           color: var(--primary-color)
         }
 
         span {
-          font-size: 0.875rem;
+          font-size: var(--app-text-sm);
         }
       }
     }
@@ -163,10 +163,10 @@
   .checkbox-wrapper {
     display: flex;
     align-items: center;
-    padding: 0.625rem 0;
+    padding: 0.54688rem 0;
 
     label {
-      margin-left: 0.5rem;
+      margin-left: 0.4375rem;
       font-weight: 500;
       color: var(--text-color);
       cursor: pointer;
@@ -177,18 +177,18 @@
     align-items: flex-start;
 
     .checkbox-wrapper {
-      padding: 0.5rem 0;
+      padding: 0.4375rem 0;
     }
   }
 }
 
 .rules-container {
   overflow: auto;
-  max-height: 40rem;
-  padding: 0.5rem;
+  max-height: 35rem;
+  padding: 0.4375rem;
 
   @media (width <= 768px) {
-    max-height: 35rem;
+    max-height: 30.625rem;
   }
 }
 
@@ -199,8 +199,8 @@
 }
 
 .save-button-section {
-  margin: 1.5rem 0 0;
-  padding: 1rem;
+  margin: 1.3125rem 0 0;
+  padding: 0.875rem;
   background: var(--overlay-background);
   border-radius: 8px;
   border: 1px solid var(--border-color);
@@ -208,9 +208,9 @@
 }
 
 .group-container {
-  padding: 1rem;
+  padding: 0.875rem;
   border-left: 4px solid var(--primary-color);
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
   width: 100%;
   border-radius: 8px;
   border-top: 1px solid var(--border-color);
@@ -223,50 +223,50 @@
   }
 
   @media (width <= 768px) {
-    padding: 0.75rem;
+    padding: 0.65625rem;
   }
 }
 
 .group-header {
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
 
   label {
     font-weight: 600;
     color: var(--text-color);
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 
   .condition-select {
-    width: 9rem;
+    width: 7.875rem;
   }
 
   @media (width <= 640px) {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .condition-select {
       width: 100%;
-      max-width: 9rem;
+      max-width: 7.875rem;
     }
   }
 }
 
 .rule-item {
-  margin-left: 1rem;
-  margin-top: 0.75rem;
+  margin-left: 0.875rem;
+  margin-top: 0.65625rem;
   display: flex;
   align-items: center;
-  padding: 0.125rem;
-  gap: 0.75rem;
+  padding: 0.10938rem;
+  gap: 0.65625rem;
   background: var(--overlay-background);
   transition: all 0.2s ease;
 
   .field-select,
   .operator-select {
-    min-width: 14rem;
+    min-width: 12.25rem;
   }
 
   .value-input,
@@ -276,12 +276,12 @@
 
   @media (width <= 1024px) {
     flex-wrap: wrap;
-    margin-left: 0.5rem;
-    gap: 0.5rem;
+    margin-left: 0.4375rem;
+    gap: 0.4375rem;
 
     .field-select,
     .operator-select {
-      min-width: 12rem;
+      min-width: 10.5rem;
       flex: 1;
     }
 
@@ -294,7 +294,7 @@
 
   @media (width <= 640px) {
     margin-left: 0;
-    padding: 0.5rem;
+    padding: 0.4375rem;
 
     .field-select,
     .operator-select {

--- a/frontend/src/app/features/magic-shelf/component/magic-shelf-component.scss
+++ b/frontend/src/app/features/magic-shelf/component/magic-shelf-component.scss
@@ -17,7 +17,7 @@
 }
 
 .import-panel {
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
   padding: 0.875rem;
   background: var(--overlay-background);
   border: 1px solid var(--border-color);
@@ -26,7 +26,7 @@
   .import-textarea {
     width: 100%;
     font-family: monospace;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     resize: vertical;
   }
 
@@ -34,7 +34,7 @@
     display: flex;
     justify-content: flex-end;
     gap: 0.4375rem;
-    margin-top: 0.65625rem;
+    margin-top: 0.6563rem;
   }
 }
 
@@ -53,7 +53,7 @@
 }
 
 .form-header {
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
   display: flex;
   width: 100%;
   gap: 0.875rem;
@@ -64,7 +64,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -106,8 +106,8 @@
     .icon-display-container {
       display: flex;
       align-items: center;
-      gap: 0.65625rem;
-      padding: 0.54688rem 0.875rem;
+      gap: 0.6563rem;
+      padding: 0.5469rem 0.875rem;
       border: 1px solid var(--border-color);
       border-radius: 6px;
       cursor: pointer;
@@ -128,7 +128,7 @@
       }
 
       .icon-label {
-        font-size: 0.83125rem;
+        font-size: 0.8313rem;
         color: var(--text-secondary-color);
         white-space: nowrap;
       }
@@ -163,7 +163,7 @@
   .checkbox-wrapper {
     display: flex;
     align-items: center;
-    padding: 0.54688rem 0;
+    padding: 0.5469rem 0;
 
     label {
       margin-left: 0.4375rem;
@@ -210,7 +210,7 @@
 .group-container {
   padding: 0.875rem;
   border-left: 4px solid var(--primary-color);
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
   width: 100%;
   border-radius: 8px;
   border-top: 1px solid var(--border-color);
@@ -223,15 +223,15 @@
   }
 
   @media (width <= 768px) {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
   }
 }
 
 .group-header {
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
 
   label {
@@ -256,11 +256,11 @@
 
 .rule-item {
   margin-left: 0.875rem;
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
   display: flex;
   align-items: center;
-  padding: 0.10938rem;
-  gap: 0.65625rem;
+  padding: 0.1094rem;
+  gap: 0.6563rem;
   background: var(--overlay-background);
   transition: all 0.2s ease;
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.scss
@@ -31,7 +31,7 @@
 
 .dialog-mode {
   border: 1px solid var(--p-content-border-color);
-  border-radius: 0 0 0.75rem 0.75rem !important;
+  border-radius: 0 0 0.65625rem 0.65625rem !important;
   border-width: 1px 0 0 !important;
 }
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.scss
@@ -31,7 +31,7 @@
 
 .dialog-mode {
   border: 1px solid var(--p-content-border-color);
-  border-radius: 0 0 0.65625rem 0.65625rem !important;
+  border-radius: 0 0 0.6563rem 0.6563rem !important;
   border-width: 1px 0 0 !important;
 }
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-reading-sessions/book-reading-sessions.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-reading-sessions/book-reading-sessions.component.scss
@@ -1,5 +1,5 @@
 .reading-sessions-container {
-  padding: 1rem 0;
+  padding: 0.875rem 0;
 }
 
 .loading-state,
@@ -8,29 +8,29 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
-  gap: 1rem;
+  padding: 2.625rem;
+  gap: 0.875rem;
 }
 
 .loading-text {
   color: var(--text-color-secondary);
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
 }
 
 .empty-state p {
   color: var(--text-color-secondary);
-  font-size: 1rem;
+  font-size: var(--app-text-base);
 }
 
 .location-text {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--text-color);
 }
 
 .session-time {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.10938rem;
 
   .session-date {
     font-weight: 500;
@@ -38,7 +38,7 @@
   }
 
   .session-range {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     color: var(--text-color-secondary);
   }
 }
@@ -46,14 +46,14 @@
 .book-type-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.375rem;
-  font-size: 0.8rem;
+  gap: 0.32813rem;
+  padding: 0.21875rem 0.4375rem;
+  border-radius: 0.32813rem;
+  font-size: 0.7rem;
   font-weight: 600;
 
   i {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
   }
 
   &.book-type-pdf {
@@ -98,14 +98,14 @@
 .progress-delta-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.375rem;
-  font-size: 0.8rem;
+  gap: 0.32813rem;
+  padding: 0.21875rem 0.4375rem;
+  border-radius: 0.32813rem;
+  font-size: 0.7rem;
   font-weight: 600;
 
   i {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
   }
 
   &.progress-positive {
@@ -130,14 +130,14 @@
       background-color: var(--card-background);
       color: var(--text-color);
       font-weight: 600;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       white-space: nowrap;
       border-color: var(--border-color);
     }
 
     .p-datatable-tbody > tr > td {
-      padding: 0.35rem 0.65rem;
-      font-size: 0.875rem;
+      padding: 0.30625rem 0.56875rem;
+      font-size: var(--app-text-sm);
       border-color: var(--border-color);
     }
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-reading-sessions/book-reading-sessions.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-reading-sessions/book-reading-sessions.component.scss
@@ -30,7 +30,7 @@
 .session-time {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
 
   .session-date {
     font-weight: 500;
@@ -46,9 +46,9 @@
 .book-type-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.21875rem 0.4375rem;
-  border-radius: 0.32813rem;
+  gap: 0.3281rem;
+  padding: 0.2188rem 0.4375rem;
+  border-radius: 0.3281rem;
   font-size: 0.7rem;
   font-weight: 600;
 
@@ -98,9 +98,9 @@
 .progress-delta-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.21875rem 0.4375rem;
-  border-radius: 0.32813rem;
+  gap: 0.3281rem;
+  padding: 0.2188rem 0.4375rem;
+  border-radius: 0.3281rem;
   font-size: 0.7rem;
   font-weight: 600;
 
@@ -136,7 +136,7 @@
     }
 
     .p-datatable-tbody > tr > td {
-      padding: 0.30625rem 0.56875rem;
+      padding: 0.3063rem 0.5687rem;
       font-size: var(--app-text-sm);
       border-color: var(--border-color);
     }

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
@@ -157,9 +157,9 @@ label {
   gap: 0.4375rem;
   font-size: 0.7rem;
   font-weight: 600;
-  padding: 0.21875rem 0.65625rem;
+  padding: 0.2188rem 0.6563rem;
   border-radius: 0.4375rem;
-  margin-bottom: 0.21875rem;
+  margin-bottom: 0.2188rem;
 
   i {
     font-size: 0.7875rem;
@@ -187,8 +187,8 @@ label {
 .cover-actions {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding-top: 0.65625rem;
+  gap: 0.6563rem;
+  padding-top: 0.6563rem;
 }
 
 .fields-section {
@@ -207,7 +207,7 @@ label {
   width: 100%;
   gap: 0.875rem;
   margin-top: 0.4375rem;
-  padding-bottom: 0.21875rem;
+  padding-bottom: 0.2188rem;
 
   @media (width >= 768px) {
     flex-direction: row;
@@ -217,7 +217,7 @@ label {
 .field-group {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   label {
     font-size: var(--app-text-sm);
@@ -254,9 +254,9 @@ label {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.32813rem;
-  min-height: 1.96875rem;
+  gap: 0.3281rem;
+  padding: 0.3281rem;
+  min-height: 1.9688rem;
   border: 1px solid var(--p-inputtext-border-color);
   border-radius: 6px;
   background: var(--p-inputtext-background);
@@ -281,7 +281,7 @@ label {
   ::ng-deep input {
     border: none !important;
     background: transparent !important;
-    padding: 0.21875rem;
+    padding: 0.2188rem;
     box-shadow: none !important;
     outline: none !important;
   }
@@ -290,8 +290,8 @@ label {
 .author-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.21875rem;
-  padding: 0.21875rem 0.4375rem;
+  gap: 0.2188rem;
+  padding: 0.2188rem 0.4375rem;
   border-radius: 0.875rem;
   background: var(--p-chip-background);
   color: var(--p-chip-color);
@@ -315,10 +315,10 @@ label {
 }
 
 .author-chip-remove {
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   cursor: pointer;
   opacity: 0.6;
-  padding: 0.13125rem;
+  padding: 0.1313rem;
   &:hover { opacity: 1; }
 }
 
@@ -401,16 +401,16 @@ label {
   width: 100%;
   background: var(--color-page);
   border: 1px solid var(--color-border);
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
 
   .collapsible-header {
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    padding: 0.65625rem 0.875rem;
+    padding: 0.6563rem 0.875rem;
     min-height: 2.1875rem;
     background: var(--color-card);
-    border-radius: 0.65625rem;
+    border-radius: 0.6563rem;
     font-size: var(--app-text-sm);
     font-weight: 600;
     color: var(--color-text);
@@ -435,11 +435,11 @@ label {
   }
 
   &.expanded .collapsible-header {
-    border-radius: 0.65625rem 0.65625rem 0 0;
+    border-radius: 0.6563rem 0.6563rem 0 0;
   }
 
   .collapsible-content {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
     border-top: 1px solid var(--color-border);
   }
 }
@@ -596,9 +596,9 @@ label {
 }
 
 .embeddable-indicator {
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   color: var(--p-green-500);
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
   vertical-align: super;
 }
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
@@ -1,5 +1,5 @@
 ::ng-deep .p-tabpanels .custom-tab-padding {
-  padding: 1rem 0 0 0.5rem !important;
+  padding: 0.875rem 0 0 0.4375rem !important;
 
   @media (width >= 640px) {
     padding: var(--p-tabs-tabpanel-padding) !important;
@@ -19,19 +19,19 @@
 }
 
 ::ng-deep .p-autocomplete-input-chip {
-  width: 2rem;
+  width: 1.75rem;
 }
 
 ::ng-deep .p-autocomplete-clearable ul {
-  padding-inline-end: 2rem !important;
+  padding-inline-end: 1.75rem !important;
 }
 
 ::ng-deep .p-autocomplete-clearable .p-autocomplete-clear-icon {
   right: 0;
-  margin-top: -1rem;
-  width: 2rem;
-  height: 2rem;
-  padding: 0.5rem;
+  margin-top: -0.875rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0.4375rem;
 }
 
 ::ng-deep .withbutton input,
@@ -58,7 +58,7 @@
 }
 
 ::ng-deep p-fileupload .p-button {
-  padding: 0.6rem 0.5rem;
+  padding: 0.525rem 0.4375rem;
 }
 
 label {
@@ -73,7 +73,7 @@ label {
   animation: fadeIn 0.3s ease-in;
 
   @media (width >= 768px) {
-    min-width: 60rem;
+    min-width: 52.5rem;
   }
 }
 
@@ -100,7 +100,7 @@ label {
   height: 72.5dvh;
 
   @media (width >= 768px) {
-    padding: 0.5rem;
+    padding: 0.4375rem;
   }
 }
 
@@ -108,8 +108,8 @@ label {
   display: flex;
   flex-direction: column;
   width: 100%;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.875rem;
+  margin-bottom: 0.875rem;
 
   @media (width >= 768px) {
     flex-direction: row;
@@ -119,13 +119,13 @@ label {
 .covers-section {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
   flex-shrink: 0;
   margin: 0 auto;
 
   &.dual-covers {
     flex-direction: row;
-    gap: 1rem;
+    gap: 0.875rem;
 
     @media (width <= 767px) {
       flex-direction: column;
@@ -138,7 +138,7 @@ label {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   position: relative;
   flex-shrink: 0;
 
@@ -146,7 +146,7 @@ label {
     ::ng-deep .square-cover img {
       aspect-ratio: 1;
       object-fit: cover;
-      border-radius: 0.5rem;
+      border-radius: 0.4375rem;
     }
   }
 }
@@ -154,15 +154,15 @@ label {
 .cover-type-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.8rem;
+  gap: 0.4375rem;
+  font-size: 0.7rem;
   font-weight: 600;
-  padding: 0.25rem 0.75rem;
-  border-radius: 0.5rem;
-  margin-bottom: 0.25rem;
+  padding: 0.21875rem 0.65625rem;
+  border-radius: 0.4375rem;
+  margin-bottom: 0.21875rem;
 
   i {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 
   &.ebook {
@@ -187,8 +187,8 @@ label {
 .cover-actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding-top: 0.75rem;
+  gap: 0.65625rem;
+  padding-top: 0.65625rem;
 }
 
 .fields-section {
@@ -197,7 +197,7 @@ label {
   flex-grow: 1;
 
   @media (width >= 768px) {
-    padding-left: 0.5rem;
+    padding-left: 0.4375rem;
   }
 }
 
@@ -205,9 +205,9 @@ label {
   display: flex;
   flex-direction: column;
   width: 100%;
-  gap: 1rem;
-  margin-top: 0.5rem;
-  padding-bottom: 0.25rem;
+  gap: 0.875rem;
+  margin-top: 0.4375rem;
+  padding-bottom: 0.21875rem;
 
   @media (width >= 768px) {
     flex-direction: row;
@@ -217,10 +217,10 @@ label {
 .field-group {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -239,7 +239,7 @@ label {
 
 .language-field {
   @media (width >= 768px) {
-    width: 11rem;
+    width: 9.625rem;
   }
 }
 
@@ -254,9 +254,9 @@ label {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem;
-  min-height: 2.25rem;
+  gap: 0.32813rem;
+  padding: 0.32813rem;
+  min-height: 1.96875rem;
   border: 1px solid var(--p-inputtext-border-color);
   border-radius: 6px;
   background: var(--p-inputtext-background);
@@ -275,13 +275,13 @@ label {
 }
 
 .author-add-input {
-  flex: 1 1 6rem;
-  min-width: 6rem;
+  flex: 1 1 5.25rem;
+  min-width: 5.25rem;
 
   ::ng-deep input {
     border: none !important;
     background: transparent !important;
-    padding: 0.25rem;
+    padding: 0.21875rem;
     box-shadow: none !important;
     outline: none !important;
   }
@@ -290,12 +290,12 @@ label {
 .author-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 1rem;
+  gap: 0.21875rem;
+  padding: 0.21875rem 0.4375rem;
+  border-radius: 0.875rem;
   background: var(--p-chip-background);
   color: var(--p-chip-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   cursor: grab;
   user-select: none;
 }
@@ -304,27 +304,27 @@ label {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1rem;
-  height: 1rem;
+  width: 0.875rem;
+  height: 0.875rem;
   border-radius: 50%;
   background: var(--p-primary-color);
   color: var(--p-primary-contrast-color);
-  font-size: 0.6rem;
+  font-size: 0.525rem;
   font-weight: 700;
   flex-shrink: 0;
 }
 
 .author-chip-remove {
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   cursor: pointer;
   opacity: 0.6;
-  padding: 0.15rem;
+  padding: 0.13125rem;
   &:hover { opacity: 1; }
 }
 
 .cdk-drag-preview {
   box-sizing: border-box;
-  border-radius: 1rem;
+  border-radius: 0.875rem;
   box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
 }
 
@@ -348,7 +348,7 @@ label {
 
     p-datepicker {
       width: 100%;
-      min-width: 7.5rem;
+      min-width: 6.5625rem;
     }
   }
 }
@@ -382,7 +382,7 @@ label {
 .metadata-ids-row {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
+  gap: 0.875rem;
   width: 100%;
 
   .metadata-id-field {
@@ -397,21 +397,21 @@ label {
 }
 
 .collapsible-section {
-  margin-top: 1rem;
+  margin-top: 0.875rem;
   width: 100%;
   background: var(--color-page);
   border: 1px solid var(--color-border);
-  border-radius: 0.75rem;
+  border-radius: 0.65625rem;
 
   .collapsible-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
-    min-height: 2.5rem;
+    gap: 0.4375rem;
+    padding: 0.65625rem 0.875rem;
+    min-height: 2.1875rem;
     background: var(--color-card);
-    border-radius: 0.75rem;
-    font-size: 0.875rem;
+    border-radius: 0.65625rem;
+    font-size: var(--app-text-sm);
     font-weight: 600;
     color: var(--color-text);
     cursor: pointer;
@@ -423,23 +423,23 @@ label {
     }
 
     i:first-child {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       color: var(--color-primary);
     }
 
     .section-toggle {
       margin-left: auto;
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
     }
   }
 
   &.expanded .collapsible-header {
-    border-radius: 0.75rem 0.75rem 0 0;
+    border-radius: 0.65625rem 0.65625rem 0 0;
   }
 
   .collapsible-content {
-    padding: 0.75rem;
+    padding: 0.65625rem;
     border-top: 1px solid var(--color-border);
   }
 }
@@ -447,8 +447,8 @@ label {
 .comic-text-grid {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.875rem;
+  margin-bottom: 0.875rem;
 
   @media (width <= 767px) {
     grid-template-columns: repeat(2, 1fr);
@@ -458,8 +458,8 @@ label {
 .comic-array-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.875rem;
+  margin-bottom: 0.875rem;
 
   @media (width <= 767px) {
     grid-template-columns: 1fr;
@@ -471,9 +471,9 @@ label {
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
-  gap: 1rem;
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.875rem;
+  margin-top: 0.875rem;
+  margin-bottom: 0.875rem;
 
   @media (width >= 768px) {
     flex-direction: row;
@@ -522,13 +522,13 @@ label {
 .footer-actions {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   padding: 0;
-  padding-top: 1rem;
+  padding-top: 0.875rem;
   z-index: 10;
 
   @media (width >= 768px) {
-    padding: 1rem;
+    padding: 0.875rem;
   }
 }
 
@@ -536,7 +536,7 @@ label {
   display: none;
   justify-content: space-between;
   width: 100%;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width >= 640px) {
     display: flex;
@@ -545,17 +545,17 @@ label {
 
 .navigation-left {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .navigation-center {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   align-items: center;
 }
 
 .navigation-position {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-surface-600);
 
   :host-context(.dark) & {
@@ -565,7 +565,7 @@ label {
 
 .actions-right {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
   align-items: center;
   margin-left: auto;
 }
@@ -583,7 +583,7 @@ label {
 
 .mobile-nav-buttons {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
 }
 
@@ -592,19 +592,19 @@ label {
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .embeddable-indicator {
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   color: var(--p-green-500);
-  margin-left: 0.25rem;
+  margin-left: 0.21875rem;
   vertical-align: super;
 }
 
 .mobile-lock-actions {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .mobile-save-action {

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-picker/metadata-picker.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-picker/metadata-picker.component.scss
@@ -30,18 +30,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1rem;
+  gap: 0.4375rem;
+  padding: 0.54688rem 0.875rem;
   background: rgb(34 197 94 / 10%);
   border: 1px solid rgb(34 197 94 / 30%);
   border-radius: 8px;
   color: var(--p-green-400);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
   animation: fade-in 0.3s ease-in;
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }
 
@@ -49,10 +49,10 @@
 .dialog-body {
   flex: 1;
   overflow-y: auto;
-  padding: 1.25rem;
+  padding: 1.09375rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 // Column Headers - mirrors field-row structure for alignment (desktop only)
@@ -60,8 +60,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.875rem 1rem;
-  margin-bottom: 0.5rem;
+  padding: 0.76563rem 0.875rem;
+  margin-bottom: 0.4375rem;
   background: var(--overlay-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -85,8 +85,8 @@
   .column-label {
     display: none;
     align-items: center;
-    gap: 0.625rem;
-    font-size: 1rem;
+    gap: 0.54688rem;
+    font-size: var(--app-text-base);
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -97,19 +97,19 @@
     }
 
     i {
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
     }
 
     &.current {
       color: var(--primary-color);
       justify-content: flex-end;
-      padding-right: 1rem;
+      padding-right: 0.875rem;
     }
 
     &.fetched {
       color: var(--p-blue-400);
       justify-content: flex-start;
-      padding-left: 1rem;
+      padding-left: 0.875rem;
     }
   }
 
@@ -117,10 +117,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     flex-shrink: 0;
-    margin-left: 0.75rem;
-    margin-right:  0.75rem;
+    margin-left: 0.65625rem;
+    margin-right:  0.65625rem;
   }
 }
 
@@ -129,16 +129,16 @@
   .section-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
-    font-size: 0.85rem;
+    gap: 0.4375rem;
+    margin-bottom: 0.65625rem;
+    font-size: 0.74375rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
     color: var(--text-secondary-color);
 
     i {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       color: var(--primary-color);
     }
 
@@ -153,13 +153,13 @@
 
       .section-toggle {
         margin-left: auto;
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         color: var(--text-secondary-color);
       }
     }
 
     .section-empty-badge {
-      font-size: 0.7rem;
+      font-size: 0.6125rem;
       font-weight: 500;
       text-transform: none;
       letter-spacing: normal;
@@ -167,7 +167,7 @@
       background: var(--ground-background);
       border: 1px solid var(--border-color);
       border-radius: 4px;
-      padding: 0.125rem 0.5rem;
+      padding: 0.10938rem 0.4375rem;
       opacity: 0.8;
     }
   }
@@ -219,7 +219,7 @@
   transition: all 0.2s ease;
 
   i {
-    font-size: 0.625rem;
+    font-size: 0.54688rem;
     color: white;
   }
 
@@ -233,7 +233,7 @@
 }
 
 .cover-label {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;
@@ -242,8 +242,8 @@
 
 // Cover type icon in label
 .cover-type-icon {
-  font-size: 0.8rem;
-  margin-right: 0.25rem;
+  font-size: 0.7rem;
+  margin-right: 0.21875rem;
 }
 
 // Square cover for audiobooks
@@ -287,13 +287,13 @@
   }
 
   i {
-    font-size: 1.75rem;
-    margin-bottom: 0.5rem;
+    font-size: 1.53125rem;
+    margin-bottom: 0.4375rem;
     opacity: 0.5;
   }
 
   span {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     text-transform: uppercase;
     letter-spacing: 0.05em;
   }
@@ -304,8 +304,8 @@
 .field-row {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.875rem 1rem;
+  gap: 0.4375rem;
+  padding: 0.76563rem 0.875rem;
   border-bottom: 1px solid var(--border-color);
 
   &:last-child {
@@ -315,17 +315,17 @@
   @media (width >= 768px) {
     flex-direction: row;
     align-items: center;
-    padding: 0.75rem 1rem;
+    padding: 0.65625rem 0.875rem;
   }
 }
 
 // Cover field row specific styles
 .cover-field-row {
-  padding: 1rem;
+  padding: 0.875rem;
 
   .field-label {
     text-align: center;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.4375rem;
 
     @media (width >= 768px) {
       text-align: left;
@@ -335,10 +335,10 @@
 
   .field-content {
     align-items: center;
-    gap: 1rem;
+    gap: 0.875rem;
 
     @media (width >= 768px) {
-      gap: 1.5rem;
+      gap: 1.3125rem;
     }
   }
 
@@ -346,7 +346,7 @@
   .field-side {
     flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     @media (width >= 768px) {
       flex-direction: row;
@@ -355,7 +355,7 @@
 
   // Position covers towards the arrow on desktop only
   @media (width >= 768px) {
-    padding: 1rem;
+    padding: 0.875rem;
 
     .field-side.current {
       justify-content: flex-end;
@@ -368,7 +368,7 @@
 }
 
 .field-label {
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   font-weight: 500;
   color: var(--text-color);
   min-width: 100px;
@@ -382,20 +382,20 @@
 .field-content {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex: 1;
 
   @media (width >= 768px) {
     flex-direction: row;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .field-side {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex: 1;
   min-width: 0;
 
@@ -422,7 +422,7 @@
   transition: all 0.2s ease;
 
   i {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: white;
   }
 
@@ -473,13 +473,13 @@
 
   .lock-btn {
     @media (width >= 768px) {
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
     }
   }
 
   .transfer-btn {
     @media (width >= 768px) {
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
     }
   }
 }
@@ -499,7 +499,7 @@
   transition: all 0.2s ease;
 
   i {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-secondary-color);
   }
 
@@ -545,8 +545,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
+  gap: 0.875rem;
+  padding: 0.875rem 1.09375rem;
   background: var(--overlay-background);
   border-top: 1px solid var(--border-color);
   flex-shrink: 0;
@@ -560,14 +560,14 @@
 .footer-right {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .footer-divider {
   width: 1px;
   height: 24px;
   background: var(--border-color);
-  margin: 0 0.25rem;
+  margin: 0 0.21875rem;
 }
 
 // AutoComplete overrides
@@ -593,14 +593,14 @@
 // Mobile optimizations
 @media (width <= 767px) {
   .dialog-body {
-    padding: 1rem;
-    gap: 1.25rem;
+    padding: 0.875rem;
+    gap: 1.09375rem;
   }
 
   .dialog-footer {
     flex-direction: column;
-    padding: 0.875rem 1rem;
-    gap: 0.75rem;
+    padding: 0.76563rem 0.875rem;
+    gap: 0.65625rem;
 
     .footer-left,
     .footer-right {
@@ -610,7 +610,7 @@
   }
 
   .field-label {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     font-weight: 600;
   }
 }
@@ -619,9 +619,9 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem;
-  min-height: 2.25rem;
+  gap: 0.32813rem;
+  padding: 0.32813rem;
+  min-height: 1.96875rem;
   border: 1px solid var(--p-inputtext-border-color);
   border-radius: 6px;
   background: var(--p-inputtext-background);
@@ -640,13 +640,13 @@
 }
 
 .author-add-input {
-  flex: 1 1 6rem;
-  min-width: 6rem;
+  flex: 1 1 5.25rem;
+  min-width: 5.25rem;
 
   ::ng-deep input {
     border: none !important;
     background: transparent !important;
-    padding: 0.25rem;
+    padding: 0.21875rem;
     box-shadow: none !important;
     outline: none !important;
   }
@@ -655,12 +655,12 @@
 .author-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 1rem;
+  gap: 0.21875rem;
+  padding: 0.21875rem 0.4375rem;
+  border-radius: 0.875rem;
   background: var(--p-chip-background);
   color: var(--p-chip-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   cursor: grab;
   user-select: none;
 }
@@ -669,27 +669,27 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1rem;
-  height: 1rem;
+  width: 0.875rem;
+  height: 0.875rem;
   border-radius: 50%;
   background: var(--p-primary-color);
   color: var(--p-primary-contrast-color);
-  font-size: 0.6rem;
+  font-size: 0.525rem;
   font-weight: 700;
   flex-shrink: 0;
 }
 
 .author-chip-remove {
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   cursor: pointer;
   opacity: 0.6;
-  padding: 0.15rem;
+  padding: 0.13125rem;
   &:hover { opacity: 1; }
 }
 
 .cdk-drag-preview {
   box-sizing: border-box;
-  border-radius: 1rem;
+  border-radius: 0.875rem;
   box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
 }
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-picker/metadata-picker.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-picker/metadata-picker.component.scss
@@ -31,7 +31,7 @@
   align-items: center;
   justify-content: center;
   gap: 0.4375rem;
-  padding: 0.54688rem 0.875rem;
+  padding: 0.5469rem 0.875rem;
   background: rgb(34 197 94 / 10%);
   border: 1px solid rgb(34 197 94 / 30%);
   border-radius: 8px;
@@ -49,7 +49,7 @@
 .dialog-body {
   flex: 1;
   overflow-y: auto;
-  padding: 1.09375rem;
+  padding: 1.0938rem;
   display: flex;
   flex-direction: column;
   gap: 1.3125rem;
@@ -60,7 +60,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.76563rem 0.875rem;
+  padding: 0.7656rem 0.875rem;
   margin-bottom: 0.4375rem;
   background: var(--overlay-background);
   border: 1px solid var(--border-color);
@@ -85,7 +85,7 @@
   .column-label {
     display: none;
     align-items: center;
-    gap: 0.54688rem;
+    gap: 0.5469rem;
     font-size: var(--app-text-base);
     font-weight: 500;
     text-transform: uppercase;
@@ -119,8 +119,8 @@
     justify-content: center;
     gap: 0.4375rem;
     flex-shrink: 0;
-    margin-left: 0.65625rem;
-    margin-right:  0.65625rem;
+    margin-left: 0.6563rem;
+    margin-right:  0.6563rem;
   }
 }
 
@@ -130,8 +130,8 @@
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    margin-bottom: 0.65625rem;
-    font-size: 0.74375rem;
+    margin-bottom: 0.6563rem;
+    font-size: 0.7438rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
@@ -167,7 +167,7 @@
       background: var(--ground-background);
       border: 1px solid var(--border-color);
       border-radius: 4px;
-      padding: 0.10938rem 0.4375rem;
+      padding: 0.1094rem 0.4375rem;
       opacity: 0.8;
     }
   }
@@ -219,7 +219,7 @@
   transition: all 0.2s ease;
 
   i {
-    font-size: 0.54688rem;
+    font-size: 0.5469rem;
     color: white;
   }
 
@@ -243,7 +243,7 @@
 // Cover type icon in label
 .cover-type-icon {
   font-size: 0.7rem;
-  margin-right: 0.21875rem;
+  margin-right: 0.2188rem;
 }
 
 // Square cover for audiobooks
@@ -287,7 +287,7 @@
   }
 
   i {
-    font-size: 1.53125rem;
+    font-size: 1.5313rem;
     margin-bottom: 0.4375rem;
     opacity: 0.5;
   }
@@ -305,7 +305,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.4375rem;
-  padding: 0.76563rem 0.875rem;
+  padding: 0.7656rem 0.875rem;
   border-bottom: 1px solid var(--border-color);
 
   &:last-child {
@@ -315,7 +315,7 @@
   @media (width >= 768px) {
     flex-direction: row;
     align-items: center;
-    padding: 0.65625rem 0.875rem;
+    padding: 0.6563rem 0.875rem;
   }
 }
 
@@ -368,7 +368,7 @@
 }
 
 .field-label {
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 500;
   color: var(--text-color);
   min-width: 100px;
@@ -388,7 +388,7 @@
   @media (width >= 768px) {
     flex-direction: row;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -473,13 +473,13 @@
 
   .lock-btn {
     @media (width >= 768px) {
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
     }
   }
 
   .transfer-btn {
     @media (width >= 768px) {
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
     }
   }
 }
@@ -546,7 +546,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.875rem;
-  padding: 0.875rem 1.09375rem;
+  padding: 0.875rem 1.0938rem;
   background: var(--overlay-background);
   border-top: 1px solid var(--border-color);
   flex-shrink: 0;
@@ -567,7 +567,7 @@
   width: 1px;
   height: 24px;
   background: var(--border-color);
-  margin: 0 0.21875rem;
+  margin: 0 0.2188rem;
 }
 
 // AutoComplete overrides
@@ -594,13 +594,13 @@
 @media (width <= 767px) {
   .dialog-body {
     padding: 0.875rem;
-    gap: 1.09375rem;
+    gap: 1.0938rem;
   }
 
   .dialog-footer {
     flex-direction: column;
-    padding: 0.76563rem 0.875rem;
-    gap: 0.65625rem;
+    padding: 0.7656rem 0.875rem;
+    gap: 0.6563rem;
 
     .footer-left,
     .footer-right {
@@ -619,9 +619,9 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.32813rem;
-  min-height: 1.96875rem;
+  gap: 0.3281rem;
+  padding: 0.3281rem;
+  min-height: 1.9688rem;
   border: 1px solid var(--p-inputtext-border-color);
   border-radius: 6px;
   background: var(--p-inputtext-background);
@@ -646,7 +646,7 @@
   ::ng-deep input {
     border: none !important;
     background: transparent !important;
-    padding: 0.21875rem;
+    padding: 0.2188rem;
     box-shadow: none !important;
     outline: none !important;
   }
@@ -655,8 +655,8 @@
 .author-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.21875rem;
-  padding: 0.21875rem 0.4375rem;
+  gap: 0.2188rem;
+  padding: 0.2188rem 0.4375rem;
   border-radius: 0.875rem;
   background: var(--p-chip-background);
   color: var(--p-chip-color);
@@ -680,10 +680,10 @@
 }
 
 .author-chip-remove {
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   cursor: pointer;
   opacity: 0.6;
-  padding: 0.13125rem;
+  padding: 0.1313rem;
   &:hover { opacity: 1; }
 }
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
@@ -35,7 +35,7 @@
               class="pi pi-info-circle"
               [pTooltip]="t('isbnTooltip')"
               tooltipPosition="right"
-              style="margin-left: 0.25rem; color: var(--primary-color); cursor: pointer;"
+              style="margin-left: 0.21875rem; color: var(--primary-color); cursor: pointer;"
             ></i>
           </label>
           <input

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
@@ -35,7 +35,7 @@
               class="pi pi-info-circle"
               [pTooltip]="t('isbnTooltip')"
               tooltipPosition="right"
-              style="margin-left: 0.21875rem; color: var(--primary-color); cursor: pointer;"
+              style="margin-left: 0.2188rem; color: var(--primary-color); cursor: pointer;"
             ></i>
           </label>
           <input

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.scss
@@ -31,7 +31,7 @@ $provider-colors: (
   .header-title {
     font-size: 1.3125rem;
     font-weight: 700;
-    margin: 0 0 0.32813rem;
+    margin: 0 0 0.3281rem;
     color: var(--color-text);
     display: flex;
     align-items: center;
@@ -53,11 +53,11 @@ $provider-colors: (
 
 .search-card {
   background: var(--color-card);
-  border-radius: 0.65625rem;
-  padding: 1.09375rem;
+  border-radius: 0.6563rem;
+  padding: 1.0938rem;
   box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   border: 1px solid var(--color-border);
-  margin-bottom: 1.09375rem;
+  margin-bottom: 1.0938rem;
   transition: all 0.3s ease;
 
   &:hover {
@@ -84,7 +84,7 @@ $provider-colors: (
 .search-field {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 
   label {
     font-weight: 600;
@@ -92,7 +92,7 @@ $provider-colors: (
     color: var(--color-text);
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
 
     i {
       color: var(--color-primary);
@@ -126,7 +126,7 @@ $provider-colors: (
     width: 100%;
     height: 2.1875rem;
     font-weight: 600;
-    font-size: 0.82031rem;
+    font-size: 0.8203rem;
     border-radius: 0.4375rem;
 
     @media (width >= 1024px) {
@@ -140,7 +140,7 @@ $provider-colors: (
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   background: var(--color-card);
   border-radius: 0.4375rem;
   font-size: var(--app-text-sm);
@@ -149,18 +149,18 @@ $provider-colors: (
 
   i {
     color: var(--color-primary);
-    font-size: 0.82031rem;
+    font-size: 0.8203rem;
     flex-shrink: 0;
   }
 }
 
 .provider-status {
   background: var(--color-card);
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
   padding: 0.875rem;
   box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   border: 1px solid var(--color-border);
-  margin-bottom: 1.09375rem;
+  margin-bottom: 1.0938rem;
   animation: slide-in 0.3s ease-out;
 }
 
@@ -194,31 +194,31 @@ $provider-colors: (
   align-items: center;
   margin-bottom: 0.875rem;
   flex-wrap: wrap;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   .results-info {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 
   h3 {
     margin: 0;
-    font-size: 0.92969rem;
+    font-size: 0.9297rem;
     font-weight: 600;
     color: var(--color-text);
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
 
     i {
       color: var(--color-primary);
-      font-size: 0.82031rem;
+      font-size: 0.8203rem;
     }
   }
 
   .results-count {
-    padding: 0.21875rem 0.65625rem;
+    padding: 0.2188rem 0.6563rem;
     background: color-mix(in srgb, var(--color-primary) 20%, transparent);
     color: var(--color-primary);
     border-radius: 1.75rem;
@@ -231,12 +231,12 @@ $provider-colors: (
 .fetching-badge {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.21875rem 0.74375rem;
+  gap: 0.3281rem;
+  padding: 0.2188rem 0.7438rem;
   background: rgb(34 197 94 / 80%);
   color: white;
   border-radius: 1.75rem;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 700;
   box-shadow: 0 2px 8px rgb(34 197 94 / 35%);
 }
@@ -244,14 +244,14 @@ $provider-colors: (
 .provider-pills {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .provider-pill {
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.4375rem 0.65625rem;
+  padding: 0.4375rem 0.6563rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
   border-radius: 0.4375rem;
@@ -360,13 +360,13 @@ $provider-colors: (
   width: 1.75rem;
   height: 1.75rem;
   background: var(--color-border);
-  border-radius: 0.32813rem;
+  border-radius: 0.3281rem;
   color: var(--color-text-secondary);
   flex-shrink: 0;
   transition: all 0.3s ease;
 
   i {
-    font-size: 0.82031rem;
+    font-size: 0.8203rem;
   }
 }
 
@@ -378,7 +378,7 @@ $provider-colors: (
 
   .pill-name {
     font-weight: 700;
-    font-size: 0.83125rem;
+    font-size: 0.8313rem;
     color: var(--color-text);
   }
 
@@ -386,9 +386,9 @@ $provider-colors: (
     display: flex;
     align-items: center;
     justify-content: center;
-    min-width: 1.53125rem;
-    height: 1.53125rem;
-    padding: 0 0.32813rem;
+    min-width: 1.5313rem;
+    height: 1.5313rem;
+    padding: 0 0.3281rem;
     background: var(--color-border);
     color: var(--color-text);
     border-radius: 1.75rem;
@@ -431,8 +431,8 @@ $provider-colors: (
   }
 
   h3 {
-    margin: 0 0 0.32813rem;
-    font-size: 1.09375rem;
+    margin: 0 0 0.3281rem;
+    font-size: 1.0938rem;
     font-weight: 600;
     color: var(--color-text);
   }
@@ -452,11 +452,11 @@ $provider-colors: (
 .results-toolbar {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
   padding: 0.875rem;
   background: var(--color-card);
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
   box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   border: 1px solid var(--color-border);
 
@@ -470,31 +470,31 @@ $provider-colors: (
 .results-info {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 
   @media (width >= 768px) {
     flex-direction: row;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 
   h3 {
     margin: 0;
-    font-size: 0.92969rem;
+    font-size: 0.9297rem;
     font-weight: 600;
     color: var(--color-text);
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
 
     i {
       color: var(--color-primary);
-      font-size: 0.82031rem;
+      font-size: 0.8203rem;
     }
   }
 
   .results-count {
-    padding: 0.16406rem 0.54688rem;
+    padding: 0.1641rem 0.5469rem;
     background: var(--color-card);
     color: var(--color-primary);
     border-radius: 1.75rem;
@@ -514,7 +514,7 @@ $provider-colors: (
     color: var(--color-text);
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     white-space: nowrap;
 
     i {
@@ -544,7 +544,7 @@ $provider-colors: (
 
 .metadata-card {
   background: var(--color-card);
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
   overflow: hidden;
   box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
   border: 1px solid var(--color-border);
@@ -597,7 +597,7 @@ $provider-colors: (
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     opacity: 0;
     transition: opacity 0.3s ease;
     color: white;
@@ -617,7 +617,7 @@ $provider-colors: (
   padding: 0.875rem;
   display: flex;
   flex-direction: column;
-  gap: 0.54688rem;
+  gap: 0.5469rem;
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -626,7 +626,7 @@ $provider-colors: (
 .card-header {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 }
 
 .card-title {
@@ -666,7 +666,7 @@ $provider-colors: (
   color: var(--color-text-secondary);
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -682,24 +682,24 @@ $provider-colors: (
 .card-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 }
 
 .meta-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   padding: 0.4375rem 0.4375rem 0.4375rem 0;
   background: var(--color-card);
-  border-radius: 0.21875rem;
+  border-radius: 0.2188rem;
   font-size: 0.7rem;
   color: var(--color-text-secondary);
   font-weight: 500;
   white-space: nowrap;
 
   i {
-    padding-right: 0.21875rem;
-    font-size: 0.60156rem;
+    padding-right: 0.2188rem;
+    font-size: 0.6016rem;
     color: var(--color-primary);
     flex-shrink: 0;
   }

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.scss
@@ -22,30 +22,30 @@ $provider-colors: (
 }
 
 .search-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.3125rem;
 
   .header-content {
     text-align: center;
   }
 
   .header-title {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
     font-weight: 700;
-    margin: 0 0 0.375rem;
+    margin: 0 0 0.32813rem;
     color: var(--color-text);
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     i {
       color: var(--color-primary);
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
     }
   }
 
   .header-subtitle {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text-secondary);
     margin: 0;
   }
@@ -53,11 +53,11 @@ $provider-colors: (
 
 .search-card {
   background: var(--color-card);
-  border-radius: 0.75rem;
-  padding: 1.25rem;
+  border-radius: 0.65625rem;
+  padding: 1.09375rem;
   box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   border: 1px solid var(--color-border);
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.09375rem;
   transition: all 0.3s ease;
 
   &:hover {
@@ -68,8 +68,8 @@ $provider-colors: (
 .search-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.875rem;
+  margin-bottom: 0.875rem;
 
   @media (width >= 640px) {
     grid-template-columns: repeat(2, 1fr);
@@ -84,19 +84,19 @@ $provider-colors: (
 .search-field {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 
   label {
     font-weight: 600;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text);
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
 
     i {
       color: var(--color-primary);
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 
@@ -124,14 +124,14 @@ $provider-colors: (
 ::ng-deep {
   .custom-search-button {
     width: 100%;
-    height: 2.5rem;
+    height: 2.1875rem;
     font-weight: 600;
-    font-size: 0.9375rem;
-    border-radius: 0.5rem;
+    font-size: 0.82031rem;
+    border-radius: 0.4375rem;
 
     @media (width >= 1024px) {
       width: auto;
-      min-width: 8rem;
+      min-width: 7rem;
     }
   }
 }
@@ -139,28 +139,28 @@ $provider-colors: (
 .search-info {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem;
   background: var(--color-card);
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
+  border-radius: 0.4375rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
   border-left: 3px solid var(--color-primary);
 
   i {
     color: var(--color-primary);
-    font-size: 0.9375rem;
+    font-size: 0.82031rem;
     flex-shrink: 0;
   }
 }
 
 .provider-status {
   background: var(--color-card);
-  border-radius: 0.75rem;
-  padding: 1rem;
+  border-radius: 0.65625rem;
+  padding: 0.875rem;
   box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   border: 1px solid var(--color-border);
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.09375rem;
   animation: slide-in 0.3s ease-out;
 }
 
@@ -192,37 +192,37 @@ $provider-colors: (
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   .results-info {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 
   h3 {
     margin: 0;
-    font-size: 1.0625rem;
+    font-size: 0.92969rem;
     font-weight: 600;
     color: var(--color-text);
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
 
     i {
       color: var(--color-primary);
-      font-size: 0.9375rem;
+      font-size: 0.82031rem;
     }
   }
 
   .results-count {
-    padding: 0.25rem 0.75rem;
+    padding: 0.21875rem 0.65625rem;
     background: color-mix(in srgb, var(--color-primary) 20%, transparent);
     color: var(--color-primary);
-    border-radius: 2rem;
-    font-size: 0.875rem;
+    border-radius: 1.75rem;
+    font-size: var(--app-text-sm);
     font-weight: 700;
     border: 1px solid var(--color-primary);
   }
@@ -231,12 +231,12 @@ $provider-colors: (
 .fetching-badge {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.85rem;
+  gap: 0.32813rem;
+  padding: 0.21875rem 0.74375rem;
   background: rgb(34 197 94 / 80%);
   color: white;
-  border-radius: 2rem;
-  font-size: 0.85rem;
+  border-radius: 1.75rem;
+  font-size: 0.74375rem;
   font-weight: 700;
   box-shadow: 0 2px 8px rgb(34 197 94 / 35%);
 }
@@ -244,17 +244,17 @@ $provider-colors: (
 .provider-pills {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .provider-pill {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0.65625rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
   transition: all 0.3s ease;
   user-select: none;
 
@@ -357,16 +357,16 @@ $provider-colors: (
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 1.75rem;
+  height: 1.75rem;
   background: var(--color-border);
-  border-radius: 0.375rem;
+  border-radius: 0.32813rem;
   color: var(--color-text-secondary);
   flex-shrink: 0;
   transition: all 0.3s ease;
 
   i {
-    font-size: 0.9375rem;
+    font-size: 0.82031rem;
   }
 }
 
@@ -378,7 +378,7 @@ $provider-colors: (
 
   .pill-name {
     font-weight: 700;
-    font-size: 0.95rem;
+    font-size: 0.83125rem;
     color: var(--color-text);
   }
 
@@ -386,14 +386,14 @@ $provider-colors: (
     display: flex;
     align-items: center;
     justify-content: center;
-    min-width: 1.75rem;
-    height: 1.75rem;
-    padding: 0 0.375rem;
+    min-width: 1.53125rem;
+    height: 1.53125rem;
+    padding: 0 0.32813rem;
     background: var(--color-border);
     color: var(--color-text);
-    border-radius: 2rem;
+    border-radius: 1.75rem;
     font-weight: 800;
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     text-shadow: 0 1px 2px rgb(0 0 0 / 12%);
   }
 }
@@ -403,21 +403,21 @@ $provider-colors: (
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 1.5rem;
+  padding: 2.625rem 1.3125rem;
   text-align: center;
 
   .empty-icon {
-    width: 4rem;
-    height: 4rem;
+    width: 3.5rem;
+    height: 3.5rem;
     display: flex;
     align-items: center;
     justify-content: center;
     background: var(--color-card);
     border-radius: 50%;
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
 
     i {
-      font-size: 2rem;
+      font-size: 1.75rem;
       color: var(--color-primary);
     }
 
@@ -431,15 +431,15 @@ $provider-colors: (
   }
 
   h3 {
-    margin: 0 0 0.375rem;
-    font-size: 1.25rem;
+    margin: 0 0 0.32813rem;
+    font-size: 1.09375rem;
     font-weight: 600;
     color: var(--color-text);
   }
 
   p {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text-secondary);
     max-width: 500px;
   }
@@ -452,11 +452,11 @@ $provider-colors: (
 .results-toolbar {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-  padding: 1rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
+  padding: 0.875rem;
   background: var(--color-card);
-  border-radius: 0.75rem;
+  border-radius: 0.65625rem;
   box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
   border: 1px solid var(--color-border);
 
@@ -470,35 +470,35 @@ $provider-colors: (
 .results-info {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 
   @media (width >= 768px) {
     flex-direction: row;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 
   h3 {
     margin: 0;
-    font-size: 1.0625rem;
+    font-size: 0.92969rem;
     font-weight: 600;
     color: var(--color-text);
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
 
     i {
       color: var(--color-primary);
-      font-size: 0.9375rem;
+      font-size: 0.82031rem;
     }
   }
 
   .results-count {
-    padding: 0.1875rem 0.625rem;
+    padding: 0.16406rem 0.54688rem;
     background: var(--color-card);
     color: var(--color-primary);
-    border-radius: 2rem;
-    font-size: 0.875rem;
+    border-radius: 1.75rem;
+    font-size: var(--app-text-sm);
     font-weight: 600;
   }
 }
@@ -506,20 +506,20 @@ $provider-colors: (
 .results-filter {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   label {
     font-weight: 600;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--color-text);
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
     white-space: nowrap;
 
     i {
       color: var(--color-primary);
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 
@@ -531,7 +531,7 @@ $provider-colors: (
 .results-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width >= 768px) {
     grid-template-columns: repeat(2, 1fr);
@@ -544,7 +544,7 @@ $provider-colors: (
 
 .metadata-card {
   background: var(--color-card);
-  border-radius: 0.75rem;
+  border-radius: 0.65625rem;
   overflow: hidden;
   box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
   border: 1px solid var(--color-border);
@@ -597,27 +597,27 @@ $provider-colors: (
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
     opacity: 0;
     transition: opacity 0.3s ease;
     color: white;
 
     i {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
     }
 
     span {
       font-weight: 600;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 }
 
 .card-content {
-  padding: 1rem;
+  padding: 0.875rem;
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 0.54688rem;
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -626,12 +626,12 @@ $provider-colors: (
 .card-header {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 }
 
 .card-title {
   margin: 0;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   font-weight: 700;
   color: var(--color-text);
   line-height: 1.3;
@@ -642,7 +642,7 @@ $provider-colors: (
 }
 
 .card-provider {
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
 
   ::ng-deep a {
     text-decoration: none;
@@ -662,11 +662,11 @@ $provider-colors: (
 
 .card-authors {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   color: var(--color-text-secondary);
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -674,7 +674,7 @@ $provider-colors: (
 
   i {
     color: var(--color-primary);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     flex-shrink: 0;
   }
 }
@@ -682,24 +682,24 @@ $provider-colors: (
 .card-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 }
 
 .meta-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.5rem 0.5rem 0.5rem 0;
+  gap: 0.21875rem;
+  padding: 0.4375rem 0.4375rem 0.4375rem 0;
   background: var(--color-card);
-  border-radius: 0.25rem;
-  font-size: 0.8rem;
+  border-radius: 0.21875rem;
+  font-size: 0.7rem;
   color: var(--color-text-secondary);
   font-weight: 500;
   white-space: nowrap;
 
   i {
-    padding-right: 0.25rem;
-    font-size: 0.6875rem;
+    padding-right: 0.21875rem;
+    font-size: 0.60156rem;
     color: var(--color-primary);
     flex-shrink: 0;
   }
@@ -707,7 +707,7 @@ $provider-colors: (
 
 .card-description {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
   line-height: 1.4;
   display: -webkit-box;

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.scss
@@ -1,17 +1,17 @@
 .custom-p-tabs ::ng-deep .p-tabpanels {
-  padding: 0.5rem 0 0 !important;
+  padding: 0.4375rem 0 0 !important;
 }
 
 .tab-content {
-  padding: 0.5rem 0;
+  padding: 0.4375rem 0;
 }
 
 .dashboard-scroller-infinite {
   display: flex;
   overflow: auto hidden;
   scroll-snap-type: x mandatory;
-  padding: 0.5rem;
-  gap: 1rem;
+  padding: 0.4375rem;
+  gap: 0.875rem;
   width: 100%;
 }
 
@@ -29,7 +29,7 @@
   scroll-snap-align: start;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
 }
 
 .dashboard-scroller-card:hover {
@@ -58,45 +58,45 @@
 .files-tab-content {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 0.5rem 0;
+  gap: 1.3125rem;
+  padding: 0.4375rem 0;
 }
 
 .files-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   &.download-all-section {
     align-items: flex-end;
-    margin-bottom: -1.5rem;
-    margin-top: 1rem;
+    margin-bottom: -1.3125rem;
+    margin-top: 0.875rem;
   }
 }
 
 .files-section-title {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--text-color);
   margin: 0;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.4375rem;
   border-bottom: 1px solid var(--border-color);
 }
 
 .files-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .file-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem;
+  padding: 0.65625rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
   transition: background 0.2s ease, border-color 0.2s ease;
 
   &:hover {
@@ -112,28 +112,28 @@
 .file-info {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   min-width: 0;
   flex: 1;
 }
 
 .file-type-badge {
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
-  font-size: 0.8rem;
+  padding: 0.21875rem 0.4375rem;
+  border-radius: 0.21875rem;
+  font-size: 0.7rem;
   font-weight: 600;
   color: #fff;
   flex-shrink: 0;
 }
 
 .file-icon {
-  font-size: 1.25rem;
+  font-size: 1.09375rem;
   color: var(--text-color-secondary);
   flex-shrink: 0;
 }
 
 .file-name {
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   color: var(--text-color);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -143,7 +143,7 @@
 }
 
 .file-size {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--text-color-secondary);
   flex-shrink: 0;
 }
@@ -151,15 +151,15 @@
 .file-actions {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
   flex-shrink: 0;
 
   ::ng-deep .p-button-sm {
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
 
     .p-button-icon {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 }
@@ -170,32 +170,32 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 1rem;
+  padding: 2.625rem 0.875rem;
   text-align: center;
   color: var(--text-color-secondary);
 }
 
 .empty-state-icon {
-  font-size: 3rem;
+  font-size: 2.625rem;
   color: var(--book-type-physical-color);
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .empty-state-title {
-  font-size: 1.25rem;
+  font-size: 1.09375rem;
   font-weight: 600;
   color: var(--text-color);
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 }
 
 .empty-state-message {
-  font-size: 0.9rem;
-  margin: 0 0 0.5rem;
+  font-size: 0.7875rem;
+  margin: 0 0 0.4375rem;
   max-width: 400px;
 }
 
 .empty-state-hint {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   font-style: italic;
   margin: 0;
   opacity: 0.8;
@@ -203,14 +203,14 @@
 
 // Chapters tab styles
 .chapters-tab-content {
-  padding: 0.5rem 0;
+  padding: 0.4375rem 0;
 }
 
 .chapters-loading {
   display: flex;
   justify-content: center;
-  padding: 2rem;
-  font-size: 1.5rem;
+  padding: 1.75rem;
+  font-size: 1.3125rem;
   color: var(--text-color-secondary);
 }
 
@@ -218,23 +218,23 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-  font-size: 0.8rem;
+  gap: 0.4375rem;
+  margin-bottom: 0.875rem;
+  font-size: 0.7rem;
   color: var(--text-color-secondary);
 
   .tech-info-item {
     display: flex;
     align-items: center;
-    gap: 0.25rem;
-    padding: 0.25rem 0.625rem;
+    gap: 0.21875rem;
+    padding: 0.21875rem 0.54688rem;
     background: var(--highlight-background);
     border: 1px solid var(--border-color);
     border-radius: 9999px;
     white-space: nowrap;
 
     i {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--primary-color);
     }
   }
@@ -243,16 +243,16 @@
 .chapters-table-wrapper {
   overflow-x: auto;
   border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
 }
 
 .chapters-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 
   th, td {
-    padding: 0.625rem 0.75rem;
+    padding: 0.54688rem 0.65625rem;
     text-align: left;
   }
 
@@ -264,7 +264,7 @@
   th {
     font-weight: 600;
     color: var(--text-color-secondary);
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.025em;
   }
@@ -287,25 +287,25 @@
   }
 
   .chapter-num {
-    width: 3rem;
+    width: 2.625rem;
     text-align: center;
     color: var(--text-color-secondary);
   }
 
   .chapter-title {
-    min-width: 10rem;
+    min-width: 8.75rem;
   }
 
   .chapter-file {
-    min-width: 8rem;
+    min-width: 7rem;
     color: var(--text-color-secondary);
-    font-size: 0.8rem;
+    font-size: 0.7rem;
   }
 
   .chapter-time {
-    width: 6rem;
+    width: 5.25rem;
     font-family: monospace;
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     color: var(--text-color-secondary);
     white-space: nowrap;
   }
@@ -314,19 +314,19 @@
 .chapters-empty {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 2rem;
+  gap: 0.4375rem;
+  padding: 1.75rem;
   justify-content: center;
   color: var(--text-color-secondary);
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
 }
 
 @media (width <= 576px) {
   .chapters-table {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
 
     th, td {
-      padding: 0.5rem;
+      padding: 0.4375rem;
     }
 
     .chapter-file {
@@ -341,13 +341,13 @@
 
 // Covers tab styles
 .covers-tab-content {
-  padding: 1rem 0;
+  padding: 0.875rem 0;
 }
 
 .covers-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 2rem;
+  gap: 1.75rem;
   justify-content: center;
 
   @media (width >= 768px) {
@@ -359,28 +359,28 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   ::ng-deep .square-cover img {
     aspect-ratio: 1;
     object-fit: cover;
-    border-radius: 0.5rem;
+    border-radius: 0.4375rem;
   }
 }
 
 .cover-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
+  gap: 0.4375rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--primary-color);
-  padding: 0.25rem 0.75rem;
+  padding: 0.21875rem 0.65625rem;
   background: color-mix(in srgb, var(--primary-color) 15%, transparent);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   &.audiobook {

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.scss
@@ -65,7 +65,7 @@
 .files-section {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   &.download-all-section {
     align-items: flex-end;
@@ -93,7 +93,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 0.4375rem;
@@ -112,14 +112,14 @@
 .file-info {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   min-width: 0;
   flex: 1;
 }
 
 .file-type-badge {
-  padding: 0.21875rem 0.4375rem;
-  border-radius: 0.21875rem;
+  padding: 0.2188rem 0.4375rem;
+  border-radius: 0.2188rem;
   font-size: 0.7rem;
   font-weight: 600;
   color: #fff;
@@ -127,7 +127,7 @@
 }
 
 .file-icon {
-  font-size: 1.09375rem;
+  font-size: 1.0938rem;
   color: var(--text-color-secondary);
   flex-shrink: 0;
 }
@@ -151,7 +151,7 @@
 .file-actions {
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   flex-shrink: 0;
 
   ::ng-deep .p-button-sm {
@@ -182,7 +182,7 @@
 }
 
 .empty-state-title {
-  font-size: 1.09375rem;
+  font-size: 1.0938rem;
   font-weight: 600;
   color: var(--text-color);
   margin: 0 0 0.4375rem;
@@ -226,8 +226,8 @@
   .tech-info-item {
     display: flex;
     align-items: center;
-    gap: 0.21875rem;
-    padding: 0.21875rem 0.54688rem;
+    gap: 0.2188rem;
+    padding: 0.2188rem 0.5469rem;
     background: var(--highlight-background);
     border: 1px solid var(--border-color);
     border-radius: 9999px;
@@ -252,7 +252,7 @@
   font-size: var(--app-text-sm);
 
   th, td {
-    padding: 0.54688rem 0.65625rem;
+    padding: 0.5469rem 0.6563rem;
     text-align: left;
   }
 
@@ -359,7 +359,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   ::ng-deep .square-cover img {
     aspect-ratio: 1;
@@ -375,7 +375,7 @@
   font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--primary-color);
-  padding: 0.21875rem 0.65625rem;
+  padding: 0.2188rem 0.6563rem;
   background: color-mix(in srgb, var(--primary-color) 15%, transparent);
   border-radius: 0.4375rem;
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.scss
@@ -1,27 +1,27 @@
 .metadata-viewer-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
   padding: 0;
   width: 100%;
   min-height: 100%;
   animation: fadeIn 0.3s ease-in;
 
   @media (width >= 768px) {
-    padding: 0.5rem;
+    padding: 0.4375rem;
   }
 }
 
 .metadata-header {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding-bottom: 1rem;
+  gap: 0.875rem;
+  padding-bottom: 0.875rem;
   border-bottom: 1px solid var(--color-border);
 
   @media (width >= 768px) {
     flex-direction: row;
-    gap: 1.5rem;
+    gap: 1.3125rem;
   }
 }
 
@@ -31,7 +31,7 @@
   justify-content: center;
   align-items: center;
   flex-shrink: 0;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width >= 768px) {
     justify-content: flex-start;
@@ -51,13 +51,13 @@
 
 .series-badge {
   position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
+  top: 0.4375rem;
+  left: 0.4375rem;
   background: var(--color-page);
   color: var(--color-text);
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.5rem;
-  font-size: 0.75rem;
+  padding: 0.21875rem 0.4375rem;
+  border-radius: 0.4375rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
   border: 1px solid var(--color-border);
   backdrop-filter: blur(8px);
@@ -117,20 +117,20 @@
   flex-direction: column;
   justify-content: space-between;
   flex-grow: 1;
-  gap: 1rem;
+  gap: 0.875rem;
   min-width: 0;
 }
 
 .info-content {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .title-group {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   text-align: center;
 
   @media (width >= 768px) {
@@ -141,7 +141,7 @@
 .series-link {
   color: var(--color-primary);
   cursor: pointer;
-  font-size: 0.95rem;
+  font-size: 0.83125rem;
   font-weight: 500;
   font-style: italic;
   transition: color 0.2s ease;
@@ -155,7 +155,7 @@
 .title-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   align-items: center;
 
   @media (width >= 768px) {
@@ -166,7 +166,7 @@
 .title-content {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
   justify-content: center;
 
@@ -176,19 +176,19 @@
 }
 
 .book-title {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   font-weight: 800;
   color: var(--color-text);
   line-height: 1.2;
   margin: 0;
 
   @media (width >= 768px) {
-    font-size: 1.875rem;
+    font-size: 1.64063rem;
   }
 }
 
 .lock-icon {
-  font-size: 1.1rem;
+  font-size: 0.9625rem;
   transition: transform 0.2s ease;
 }
 
@@ -205,7 +205,7 @@
 }
 
 .authors {
-  font-size: 1.125rem;
+  font-size: var(--app-text-lg);
   color: var(--color-text-secondary);
   margin: 0;
 }
@@ -225,13 +225,13 @@
 .first-author-badge {
   display: inline-flex;
   align-items: center;
-  font-size: 0.55rem;
+  font-size: 0.48125rem;
   font-weight: 700;
   color: var(--color-warning);
   text-transform: uppercase;
   letter-spacing: 0.3px;
-  margin-left: 0.25rem;
-  padding: 0.1rem 0.3rem;
+  margin-left: 0.21875rem;
+  padding: 0.0875rem 0.2625rem;
   border: 1px solid color-mix(in srgb, var(--color-warning) 65%, transparent);
   border-radius: 3px;
   line-height: 1;
@@ -241,7 +241,7 @@
 .formats-inline {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
   justify-content: center;
 
@@ -253,7 +253,7 @@
 .format-pipe {
   color: var(--color-text-secondary);
   font-weight: 300;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   line-height: 1;
   user-select: none;
 
@@ -266,7 +266,7 @@
 .ratings-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   align-items: center;
 
   @media (width >= 640px) {
@@ -283,22 +283,22 @@
 .rating-group {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .rating-icon {
   color: orange;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
 }
 
 .reset-button ::ng-deep .p-button {
-  padding: 0.375rem;
+  padding: 0.32813rem;
 }
 
 .divider {
   display: none;
   width: 1px;
-  height: 2rem;
+  height: 1.75rem;
   background: var(--color-border);
 }
 
@@ -311,7 +311,7 @@
 .external-ratings {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   justify-content: center;
 
   @media (width >= 640px) {
@@ -322,7 +322,7 @@
 .rating-link {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   text-decoration: none;
   color: var(--color-text);
   transition: transform 0.2s ease;
@@ -338,34 +338,34 @@
 }
 
 .rating-favicon {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.09375rem;
+  height: 1.09375rem;
   object-fit: contain;
   transition: transform 0.2s ease, filter 0.2s ease;
 }
 
 .rating-value {
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text);
 }
 
 .tags-section {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .tag-row {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  min-height: 1.75rem;
+  gap: 0.21875rem;
+  min-height: 1.53125rem;
 }
 
 .tag-label {
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text);
   flex: 0 0 56px;
   min-width: 56px;
@@ -391,7 +391,7 @@
 
 .tag-container {
   display: flex;
-  gap: 0.375rem; /* slightly smaller gap between tags */
+  gap: 0.32813rem; /* slightly smaller gap between tags */
   width: max-content;
   max-width: 1150px;
 }
@@ -410,26 +410,26 @@
 .metadata-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 0.5rem;
-  padding: 0.5rem 0;
-  font-size: 0.875rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0;
+  font-size: var(--app-text-sm);
 }
 
 @media (width >= 768px) {
   .metadata-grid {
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 }
 
 .metadata-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   color: var(--color-text-secondary);
   white-space: nowrap;
   overflow: hidden;
-  min-height: 1.5rem;
+  min-height: 1.3125rem;
 }
 
 .metadata-key {
@@ -447,13 +447,13 @@
 .metadata-value-group {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   flex-wrap: wrap;
 }
 
 .separator {
   color: var(--color-text-secondary);
-  margin-right: 0.25rem;
+  margin-right: 0.21875rem;
 }
 
 .format-tags {
@@ -481,13 +481,13 @@
 .format-badge {
   display: none;
   align-items: center;
-  font-size: 0.55rem;
+  font-size: 0.48125rem;
   font-weight: 700;
   color: var(--color-primary);
   text-transform: uppercase;
   letter-spacing: 0.3px;
-  margin-left: 0.25rem;
-  padding: 0.1rem 0.3rem;
+  margin-left: 0.21875rem;
+  padding: 0.0875rem 0.2625rem;
   border: 1px solid var(--color-primary);
   border-radius: 3px;
   line-height: 1;
@@ -508,7 +508,7 @@
 .edit-icon {
   color: var(--color-primary-text);
   cursor: pointer;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   transition: color 0.2s ease, transform 0.2s ease;
 }
 
@@ -524,11 +524,11 @@
 .file-path-section {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-top: -1.25rem;
-  padding: 0.5rem 0;
+  gap: 0.4375rem;
+  margin-top: -1.09375rem;
+  padding: 0.4375rem 0;
   border-top: none;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 }
 
 .eye-icon {
@@ -542,7 +542,7 @@
 }
 
 .file-path-code {
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -552,26 +552,26 @@
 
 .action-buttons-container {
   margin-top: auto;
-  padding-top: 0.75rem;
+  padding-top: 0.65625rem;
   border-top: 1px solid var(--color-border);
 }
 
 .action-buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   align-items: center;
 }
 
 .action-group {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 
   &.navigation-group {
-    padding-right: 0.5rem;
+    padding-right: 0.4375rem;
     border-right: 1px solid var(--color-border);
-    margin-right: 0.25rem;
+    margin-right: 0.21875rem;
 
     @media (width <= 767px) {
       display: none;
@@ -580,15 +580,15 @@
 
   &.primary-actions {
     @media (width >= 768px) {
-      padding-right: 0.5rem;
+      padding-right: 0.4375rem;
       border-right: 1px solid var(--color-border);
-      margin-right: 0.25rem;
+      margin-right: 0.21875rem;
     }
   }
 
   &.secondary-actions {
     display: flex;
-    gap: 0.375rem;
+    gap: 0.32813rem;
   }
 }
 
@@ -621,7 +621,7 @@
   ::ng-deep .read-button-responsive .p-button-label::after,
   ::ng-deep .read-button-responsive.p-splitbutton .p-button-label::after {
     content: "Read";
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -629,7 +629,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   @media (width >= 768px) {
     display: none;
@@ -640,12 +640,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.625rem 0.875rem;
+  padding: 0.54688rem 0.76563rem;
   background: var(--color-page);
   border-bottom: 1px solid var(--color-border);
-  border-radius: 0.75rem 0.75rem 0 0;
+  border-radius: 0.65625rem 0.65625rem 0 0;
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text);
 
   &.clickable {
@@ -660,23 +660,23 @@
 
   i:first-child {
     color: var(--color-primary);
-    margin-right: 0.5rem;
+    margin-right: 0.4375rem;
   }
 }
 
 .section-header-left {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   i {
-    font-size: 0.95rem;
+    font-size: 0.83125rem;
     color: var(--color-primary);
   }
 }
 
 .section-toggle-icon {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--color-text-secondary);
   transition: transform 0.3s ease;
 }
@@ -684,7 +684,7 @@
 .description-section {
   background: var(--color-card);
   border: 1px solid var(--color-border);
-  border-radius: 0.75rem;
+  border-radius: 0.65625rem;
   overflow: hidden;
   transition: box-shadow 0.3s ease;
 
@@ -698,7 +698,7 @@
 }
 
 .description-body {
-  padding: 0.875rem;
+  padding: 0.76563rem;
 }
 
 .description-content {
@@ -717,14 +717,14 @@
 .expand-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  margin-top: 0.5rem;
-  padding: 0.25rem 0.5rem;
+  gap: 0.32813rem;
+  margin-top: 0.4375rem;
+  padding: 0.21875rem 0.4375rem;
   background: transparent;
   border: none;
-  border-radius: 0.25rem;
+  border-radius: 0.21875rem;
   color: var(--color-primary);
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   font-weight: 500;
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease;
@@ -735,14 +735,14 @@
   }
 
   i {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
   }
 }
 
 .description-html {
   color: var(--color-text-secondary);
   line-height: 1.6;
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   overflow-wrap: break-word;
 }
 
@@ -752,13 +752,13 @@
   justify-content: center;
   align-items: center;
   height: 100%;
-  gap: 1rem;
-  padding: 2rem;
+  gap: 0.875rem;
+  padding: 1.75rem;
 }
 
 .loading-text {
   color: var(--color-primary);
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   font-weight: 500;
 }
 
@@ -772,7 +772,7 @@
 }
 
 .navigation-position {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
 }
 
@@ -780,7 +780,7 @@
 .comic-metadata-section {
   background: var(--color-page);
   border: 1px solid var(--color-border);
-  border-radius: 0.75rem;
+  border-radius: 0.65625rem;
   overflow: hidden;
   transition: box-shadow 0.3s ease;
 
@@ -790,10 +790,10 @@
 }
 
 .comic-metadata-content {
-  padding: 0.875rem;
+  padding: 0.76563rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
   max-height: 1000px;
   overflow: hidden;
   transition: max-height 0.3s ease, padding 0.3s ease, opacity 0.3s ease;
@@ -801,7 +801,7 @@
 
   &.collapsed {
     max-height: 0;
-    padding: 0 0.875rem;
+    padding: 0 0.76563rem;
     opacity: 0;
   }
 }
@@ -809,17 +809,17 @@
 .comic-info-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .comic-info-item {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.10938rem;
 }
 
 .comic-info-label {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
   color: var(--color-text-secondary);
   text-transform: uppercase;
@@ -827,7 +827,7 @@
 }
 
 .comic-info-value {
-  font-size: 0.95rem;
+  font-size: 0.83125rem;
   color: var(--color-text);
   font-weight: 500;
 }
@@ -836,25 +836,25 @@
 .comic-arc-number {
   color: var(--color-text-secondary);
   font-weight: 400;
-  margin-left: 0.25rem;
+  margin-left: 0.21875rem;
 }
 
 .comic-subsection {
   border-top: 1px solid var(--color-border);
-  padding-top: 0.75rem;
+  padding-top: 0.65625rem;
 }
 
 .comic-subsection-title {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.85rem;
+  gap: 0.32813rem;
+  font-size: 0.74375rem;
   font-weight: 600;
   color: var(--color-text);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   i {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     color: var(--color-primary);
   }
 }
@@ -862,34 +862,34 @@
 .comic-creators-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 }
 
 .comic-creator-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  font-size: 0.9rem;
+  gap: 0.4375rem;
+  font-size: 0.7875rem;
 }
 
 .comic-creator-role {
   flex: 0 0 95px;
   font-weight: 500;
   color: var(--color-text-secondary);
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
 }
 
 .comic-creator-names {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem 0.5rem;
+  gap: 0.21875rem 0.4375rem;
 }
 
 .comic-creator-link {
   color: var(--color-primary);
   cursor: pointer;
   transition: color 0.2s ease;
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
 
   &:hover {
     color: var(--color-primary-hover);
@@ -905,27 +905,27 @@
 .comic-tags-container {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .comic-tag-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .comic-tag-label {
   flex: 0 0 80px;
   font-weight: 500;
   color: var(--color-text-secondary);
-  font-size: 0.85rem;
-  padding-top: 0.125rem;
+  font-size: 0.74375rem;
+  padding-top: 0.10938rem;
 }
 
 .comic-tag-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 }
 
 .comic-tag-clickable {
@@ -940,22 +940,22 @@
 .comic-properties {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  padding-top: 0.5rem;
+  gap: 0.4375rem;
+  padding-top: 0.4375rem;
   border-top: 1px solid var(--color-border);
 }
 
 .comic-property-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.625rem;
+  gap: 0.21875rem;
+  padding: 0.21875rem 0.54688rem;
   border-radius: 9999px;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
 
   i {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
   }
 
   &.manga {
@@ -975,21 +975,21 @@
 }
 
 .comic-web-link {
-  padding-top: 0.5rem;
+  padding-top: 0.4375rem;
   border-top: 1px solid var(--color-border);
 }
 
 .comic-external-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   color: var(--color-primary);
   text-decoration: none;
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   transition: color 0.2s ease;
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 
   &:hover {
@@ -999,27 +999,27 @@
 }
 
 .comic-notes {
-  padding-top: 0.5rem;
+  padding-top: 0.4375rem;
   border-top: 1px solid var(--color-border);
 }
 
 .comic-notes-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.85rem;
+  gap: 0.32813rem;
+  font-size: 0.74375rem;
   font-weight: 600;
   color: var(--color-text);
-  margin-bottom: 0.375rem;
+  margin-bottom: 0.32813rem;
 
   i {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     color: var(--color-primary);
   }
 }
 
 .comic-notes-content {
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   color: var(--color-text-secondary);
   line-height: 1.5;
   margin: 0;
@@ -1030,11 +1030,11 @@
 .detach-dialog-content {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 
   .detach-dialog-option {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 }

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.scss
@@ -55,7 +55,7 @@
   left: 0.4375rem;
   background: var(--color-page);
   color: var(--color-text);
-  padding: 0.21875rem 0.4375rem;
+  padding: 0.2188rem 0.4375rem;
   border-radius: 0.4375rem;
   font-size: var(--app-text-xs);
   font-weight: 600;
@@ -130,7 +130,7 @@
 .title-group {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   text-align: center;
 
   @media (width >= 768px) {
@@ -141,7 +141,7 @@
 .series-link {
   color: var(--color-primary);
   cursor: pointer;
-  font-size: 0.83125rem;
+  font-size: 0.8313rem;
   font-weight: 500;
   font-style: italic;
   transition: color 0.2s ease;
@@ -155,7 +155,7 @@
 .title-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   align-items: center;
 
   @media (width >= 768px) {
@@ -183,7 +183,7 @@
   margin: 0;
 
   @media (width >= 768px) {
-    font-size: 1.64063rem;
+    font-size: 1.6406rem;
   }
 }
 
@@ -225,12 +225,12 @@
 .first-author-badge {
   display: inline-flex;
   align-items: center;
-  font-size: 0.48125rem;
+  font-size: 0.4813rem;
   font-weight: 700;
   color: var(--color-warning);
   text-transform: uppercase;
   letter-spacing: 0.3px;
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
   padding: 0.0875rem 0.2625rem;
   border: 1px solid color-mix(in srgb, var(--color-warning) 65%, transparent);
   border-radius: 3px;
@@ -266,7 +266,7 @@
 .ratings-section {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   align-items: center;
 
   @media (width >= 640px) {
@@ -292,7 +292,7 @@
 }
 
 .reset-button ::ng-deep .p-button {
-  padding: 0.32813rem;
+  padding: 0.3281rem;
 }
 
 .divider {
@@ -311,7 +311,7 @@
 .external-ratings {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   justify-content: center;
 
   @media (width >= 640px) {
@@ -322,7 +322,7 @@
 .rating-link {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   text-decoration: none;
   color: var(--color-text);
   transition: transform 0.2s ease;
@@ -338,8 +338,8 @@
 }
 
 .rating-favicon {
-  width: 1.09375rem;
-  height: 1.09375rem;
+  width: 1.0938rem;
+  height: 1.0938rem;
   object-fit: contain;
   transition: transform 0.2s ease, filter 0.2s ease;
 }
@@ -353,14 +353,14 @@
 .tags-section {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .tag-row {
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
-  min-height: 1.53125rem;
+  gap: 0.2188rem;
+  min-height: 1.5313rem;
 }
 
 .tag-label {
@@ -391,7 +391,7 @@
 
 .tag-container {
   display: flex;
-  gap: 0.32813rem; /* slightly smaller gap between tags */
+  gap: 0.3281rem; /* slightly smaller gap between tags */
   width: max-content;
   max-width: 1150px;
 }
@@ -447,13 +447,13 @@
 .metadata-value-group {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   flex-wrap: wrap;
 }
 
 .separator {
   color: var(--color-text-secondary);
-  margin-right: 0.21875rem;
+  margin-right: 0.2188rem;
 }
 
 .format-tags {
@@ -481,12 +481,12 @@
 .format-badge {
   display: none;
   align-items: center;
-  font-size: 0.48125rem;
+  font-size: 0.4813rem;
   font-weight: 700;
   color: var(--color-primary);
   text-transform: uppercase;
   letter-spacing: 0.3px;
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
   padding: 0.0875rem 0.2625rem;
   border: 1px solid var(--color-primary);
   border-radius: 3px;
@@ -525,7 +525,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  margin-top: -1.09375rem;
+  margin-top: -1.0938rem;
   padding: 0.4375rem 0;
   border-top: none;
   font-size: var(--app-text-sm);
@@ -542,7 +542,7 @@
 }
 
 .file-path-code {
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -552,7 +552,7 @@
 
 .action-buttons-container {
   margin-top: auto;
-  padding-top: 0.65625rem;
+  padding-top: 0.6563rem;
   border-top: 1px solid var(--color-border);
 }
 
@@ -566,12 +566,12 @@
 .action-group {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 
   &.navigation-group {
     padding-right: 0.4375rem;
     border-right: 1px solid var(--color-border);
-    margin-right: 0.21875rem;
+    margin-right: 0.2188rem;
 
     @media (width <= 767px) {
       display: none;
@@ -582,13 +582,13 @@
     @media (width >= 768px) {
       padding-right: 0.4375rem;
       border-right: 1px solid var(--color-border);
-      margin-right: 0.21875rem;
+      margin-right: 0.2188rem;
     }
   }
 
   &.secondary-actions {
     display: flex;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
   }
 }
 
@@ -640,10 +640,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.54688rem 0.76563rem;
+  padding: 0.5469rem 0.7656rem;
   background: var(--color-page);
   border-bottom: 1px solid var(--color-border);
-  border-radius: 0.65625rem 0.65625rem 0 0;
+  border-radius: 0.6563rem 0.6563rem 0 0;
   font-weight: 600;
   font-size: var(--app-text-sm);
   color: var(--color-text);
@@ -670,7 +670,7 @@
   gap: 0.4375rem;
 
   i {
-    font-size: 0.83125rem;
+    font-size: 0.8313rem;
     color: var(--color-primary);
   }
 }
@@ -684,7 +684,7 @@
 .description-section {
   background: var(--color-card);
   border: 1px solid var(--color-border);
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
   overflow: hidden;
   transition: box-shadow 0.3s ease;
 
@@ -698,7 +698,7 @@
 }
 
 .description-body {
-  padding: 0.76563rem;
+  padding: 0.7656rem;
 }
 
 .description-content {
@@ -717,12 +717,12 @@
 .expand-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   margin-top: 0.4375rem;
-  padding: 0.21875rem 0.4375rem;
+  padding: 0.2188rem 0.4375rem;
   background: transparent;
   border: none;
-  border-radius: 0.21875rem;
+  border-radius: 0.2188rem;
   color: var(--color-primary);
   font-size: 0.7rem;
   font-weight: 500;
@@ -742,7 +742,7 @@
 .description-html {
   color: var(--color-text-secondary);
   line-height: 1.6;
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   overflow-wrap: break-word;
 }
 
@@ -780,7 +780,7 @@
 .comic-metadata-section {
   background: var(--color-page);
   border: 1px solid var(--color-border);
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
   overflow: hidden;
   transition: box-shadow 0.3s ease;
 
@@ -790,7 +790,7 @@
 }
 
 .comic-metadata-content {
-  padding: 0.76563rem;
+  padding: 0.7656rem;
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
@@ -801,7 +801,7 @@
 
   &.collapsed {
     max-height: 0;
-    padding: 0 0.76563rem;
+    padding: 0 0.7656rem;
     opacity: 0;
   }
 }
@@ -809,13 +809,13 @@
 .comic-info-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .comic-info-item {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
 }
 
 .comic-info-label {
@@ -827,7 +827,7 @@
 }
 
 .comic-info-value {
-  font-size: 0.83125rem;
+  font-size: 0.8313rem;
   color: var(--color-text);
   font-weight: 500;
 }
@@ -836,19 +836,19 @@
 .comic-arc-number {
   color: var(--color-text-secondary);
   font-weight: 400;
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
 }
 
 .comic-subsection {
   border-top: 1px solid var(--color-border);
-  padding-top: 0.65625rem;
+  padding-top: 0.6563rem;
 }
 
 .comic-subsection-title {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  font-size: 0.74375rem;
+  gap: 0.3281rem;
+  font-size: 0.7438rem;
   font-weight: 600;
   color: var(--color-text);
   margin-bottom: 0.4375rem;
@@ -862,7 +862,7 @@
 .comic-creators-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 }
 
 .comic-creator-row {
@@ -876,13 +876,13 @@
   flex: 0 0 95px;
   font-weight: 500;
   color: var(--color-text-secondary);
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
 }
 
 .comic-creator-names {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.21875rem 0.4375rem;
+  gap: 0.2188rem 0.4375rem;
 }
 
 .comic-creator-link {
@@ -918,14 +918,14 @@
   flex: 0 0 80px;
   font-weight: 500;
   color: var(--color-text-secondary);
-  font-size: 0.74375rem;
-  padding-top: 0.10938rem;
+  font-size: 0.7438rem;
+  padding-top: 0.1094rem;
 }
 
 .comic-tag-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 }
 
 .comic-tag-clickable {
@@ -948,8 +948,8 @@
 .comic-property-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.21875rem;
-  padding: 0.21875rem 0.54688rem;
+  gap: 0.2188rem;
+  padding: 0.2188rem 0.5469rem;
   border-radius: 9999px;
   font-size: var(--app-text-xs);
   font-weight: 600;
@@ -982,14 +982,14 @@
 .comic-external-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   color: var(--color-primary);
   text-decoration: none;
   font-size: 0.7875rem;
   transition: color 0.2s ease;
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 
   &:hover {
@@ -1006,11 +1006,11 @@
 .comic-notes-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  font-size: 0.74375rem;
+  gap: 0.3281rem;
+  font-size: 0.7438rem;
   font-weight: 600;
   color: var(--color-text);
-  margin-bottom: 0.32813rem;
+  margin-bottom: 0.3281rem;
 
   i {
     font-size: 0.7875rem;

--- a/frontend/src/app/features/metadata/component/book-metadata-center/sidecar-viewer/sidecar-viewer.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/sidecar-viewer/sidecar-viewer.component.scss
@@ -29,11 +29,11 @@
 .header-info {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   h3 {
     margin: 0;
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     font-weight: 600;
     color: var(--text-color);
   }
@@ -71,14 +71,14 @@
   }
 
   span {
-    font-size: 0.83125rem;
+    font-size: 0.8313rem;
   }
 }
 
 .sidecar-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .empty-state {
@@ -90,7 +90,7 @@
   text-align: center;
   background: var(--ground-background);
   border: 1px dashed var(--border-color);
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
 
   i {
     font-size: 2.625rem;
@@ -124,7 +124,7 @@
 .content-header {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .content-meta {
@@ -136,7 +136,7 @@
 .meta-item {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   font-size: 0.7rem;
   color: var(--text-color-secondary);
 
@@ -170,7 +170,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 0.4375rem;

--- a/frontend/src/app/features/metadata/component/book-metadata-center/sidecar-viewer/sidecar-viewer.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/sidecar-viewer/sidecar-viewer.component.scss
@@ -1,22 +1,22 @@
 .sidecar-viewer {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
   padding: 0;
   width: 100%;
   min-height: 100%;
   animation: fade-in 0.3s ease-in;
 
   @media (width >= 768px) {
-    padding: 0.5rem;
+    padding: 0.4375rem;
   }
 }
 
 .sidecar-header {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding-bottom: 1rem;
+  gap: 0.875rem;
+  padding-bottom: 0.875rem;
   border-bottom: 1px solid var(--border-color);
 
   @media (width >= 640px) {
@@ -29,18 +29,18 @@
 .header-info {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   h3 {
     margin: 0;
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     font-weight: 600;
     color: var(--text-color);
   }
 
   .header-description {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-color-secondary);
   }
 }
@@ -48,11 +48,11 @@
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 ::ng-deep .sync-status-tag {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
 }
 
@@ -61,24 +61,24 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 3rem;
-  gap: 1rem;
+  padding: 2.625rem;
+  gap: 0.875rem;
   color: var(--text-color-secondary);
 
   i {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: var(--primary-color);
   }
 
   span {
-    font-size: 0.95rem;
+    font-size: 0.83125rem;
   }
 }
 
 .sidecar-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .empty-state {
@@ -86,29 +86,29 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   text-align: center;
   background: var(--ground-background);
   border: 1px dashed var(--border-color);
-  border-radius: 0.75rem;
+  border-radius: 0.65625rem;
 
   i {
-    font-size: 3rem;
+    font-size: 2.625rem;
     color: var(--text-color-secondary);
     opacity: 0.5;
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
   }
 
   h4 {
-    margin: 0 0 0.5rem;
-    font-size: 1.125rem;
+    margin: 0 0 0.4375rem;
+    font-size: var(--app-text-lg);
     font-weight: 600;
     color: var(--text-color);
   }
 
   p {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-color-secondary);
     max-width: 400px;
     line-height: 1.5;
@@ -118,30 +118,30 @@
 .sidecar-content {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .content-header {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .content-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .meta-item {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.8rem;
+  gap: 0.32813rem;
+  font-size: 0.7rem;
   color: var(--text-color-secondary);
 
   i {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--primary-color);
   }
 }
@@ -149,15 +149,15 @@
 .json-viewer {
   background: var(--ground-background);
   border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
   overflow: hidden;
 }
 
 .json-content {
   margin: 0;
-  padding: 1rem;
+  padding: 0.875rem;
   font-family: 'SF Mono', Consolas, Monaco, Menlo, monospace;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   line-height: 1.6;
   color: var(--text-color);
   overflow: auto;
@@ -169,12 +169,12 @@
 .cover-info {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem 0.875rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
+  border-radius: 0.4375rem;
+  font-size: var(--app-text-sm);
   color: var(--text-color);
 
   i {

--- a/frontend/src/app/features/metadata/component/bulk-metadata-update/bulk-metadata-update-component.scss
+++ b/frontend/src/app/features/metadata/component/bulk-metadata-update/bulk-metadata-update-component.scss
@@ -37,7 +37,7 @@
 .info-box {
   padding: 0.875rem;
   border: 1px solid var(--color-border);
-  border-radius: 0.32813rem;
+  border-radius: 0.3281rem;
   margin-bottom: 0.875rem;
   background: var(--color-page);
   color: var(--color-text);
@@ -72,17 +72,17 @@
   overflow-y: auto;
   border-top: 1px solid var(--color-border);
   padding-top: 0.4375rem;
-  padding-left: 0.21875rem;
+  padding-left: 0.2188rem;
   font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
 }
 
 .book-list {
   list-style-type: disc;
-  padding-left: 1.09375rem;
+  padding-left: 1.0938rem;
 
   li + li {
-    margin-top: 0.21875rem;
+    margin-top: 0.2188rem;
   }
 }
 
@@ -94,7 +94,7 @@
 }
 
 .warning-icon {
-  margin-right: 0.21875rem;
+  margin-right: 0.2188rem;
 }
 
 .bulk-form {
@@ -108,7 +108,7 @@
 .form-row {
   display: flex;
   justify-content: space-between;
-  gap: 1.53125rem;
+  gap: 1.5313rem;
 }
 
 .field-group {
@@ -151,7 +151,7 @@
 .clear-checkbox {
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .clear-label {
@@ -182,7 +182,7 @@
   flex-direction: column;
   gap: 0.4375rem;
   border: 1px solid var(--color-border);
-  border-radius: 0.32813rem;
+  border-radius: 0.3281rem;
   padding: 0.875rem;
   background: var(--color-page);
 }

--- a/frontend/src/app/features/metadata/component/bulk-metadata-update/bulk-metadata-update-component.scss
+++ b/frontend/src/app/features/metadata/component/bulk-metadata-update/bulk-metadata-update-component.scss
@@ -15,7 +15,7 @@
 .dialog-content {
   flex: 1;
   overflow-y: auto;
-  padding: 1rem;
+  padding: 0.875rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
@@ -35,10 +35,10 @@
 }
 
 .info-box {
-  padding: 1rem;
+  padding: 0.875rem;
   border: 1px solid var(--color-border);
-  border-radius: 0.375rem;
-  margin-bottom: 1rem;
+  border-radius: 0.32813rem;
+  margin-bottom: 0.875rem;
   background: var(--color-page);
   color: var(--color-text);
 }
@@ -47,16 +47,16 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 }
 
 .info-title {
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   font-weight: 600;
 }
 
 .toggle-list-btn {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-primary-text);
   background: none;
   border: none;
@@ -68,53 +68,53 @@
 }
 
 .book-list-panel {
-  max-height: 12rem;
+  max-height: 10.5rem;
   overflow-y: auto;
   border-top: 1px solid var(--color-border);
-  padding-top: 0.5rem;
-  padding-left: 0.25rem;
-  font-size: 0.875rem;
+  padding-top: 0.4375rem;
+  padding-left: 0.21875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
 }
 
 .book-list {
   list-style-type: disc;
-  padding-left: 1.25rem;
+  padding-left: 1.09375rem;
 
   li + li {
-    margin-top: 0.25rem;
+    margin-top: 0.21875rem;
   }
 }
 
 .warning-text {
-  padding: 0 1rem;
-  font-size: 0.875rem;
+  padding: 0 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-warning);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 }
 
 .warning-icon {
-  margin-right: 0.25rem;
+  margin-right: 0.21875rem;
 }
 
 .bulk-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
   width: 100%;
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .form-row {
   display: flex;
   justify-content: space-between;
-  gap: 1.75rem;
+  gap: 1.53125rem;
 }
 
 .field-group {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   &--wide {
     width: 100%;
@@ -135,13 +135,13 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .field-label-text {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .info-icon {
@@ -151,11 +151,11 @@
 .clear-checkbox {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .clear-label {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
   cursor: pointer;
 }
@@ -166,52 +166,52 @@
 
 .datepicker-min-width {
   @media (width >= 768px) {
-    min-width: 9rem;
+    min-width: 7.875rem;
   }
 }
 
 .merge-option {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
+  gap: 0.4375rem;
+  margin-top: 0.4375rem;
 }
 
 .cover-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   border: 1px solid var(--color-border);
-  border-radius: 0.375rem;
-  padding: 1rem;
+  border-radius: 0.32813rem;
+  padding: 0.875rem;
   background: var(--color-page);
 }
 
 .cover-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 1rem;
+  gap: 0.4375rem;
+  font-size: var(--app-text-base);
   font-weight: 600;
 }
 
 .cover-description {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
 }
 
 .cover-actions {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-top: 0.5rem;
+  gap: 0.875rem;
+  margin-top: 0.4375rem;
 }
 
 .cover-file-info {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
+  gap: 0.4375rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
 }
 
@@ -222,7 +222,7 @@
 .form-submit {
   display: flex;
   justify-content: flex-end;
-  margin-top: 1rem;
+  margin-top: 0.875rem;
 }
 
 ::ng-deep .p-inputchips {

--- a/frontend/src/app/features/metadata/component/cover-search/cover-search.component.scss
+++ b/frontend/src/app/features/metadata/component/cover-search/cover-search.component.scss
@@ -25,7 +25,7 @@
     flex-direction: column;
     overflow-y: auto;
     min-height: 0;
-    padding: 1.5rem;
+    padding: 1.3125rem;
     background: var(--color-page);
     border: 1px solid var(--color-border);
     border-top: none;
@@ -40,19 +40,19 @@
   background: var(--color-card);
   border: 1px solid var(--color-border);
   border-radius: 12px;
-  padding: 1.25rem 1.5rem;
-  margin-bottom: 1.5rem;
+  padding: 1.09375rem 1.3125rem;
+  margin-bottom: 1.3125rem;
 
   .form-row {
     display: flex;
     align-items: flex-end;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .form-field {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     &.title-field {
       flex: 1.2;
@@ -65,13 +65,13 @@
     label {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      font-size: 0.875rem;
+      gap: 0.4375rem;
+      font-size: var(--app-text-sm);
       font-weight: 500;
       color: var(--color-text-secondary);
 
       i {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
         color: var(--color-primary);
       }
 
@@ -87,12 +87,12 @@
     .error-message {
       display: flex;
       align-items: center;
-      gap: 0.35rem;
+      gap: 0.30625rem;
       color: var(--red-400);
-      font-size: 0.8rem;
+      font-size: 0.7rem;
 
       i {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
       }
     }
   }
@@ -100,7 +100,7 @@
   .form-actions {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     padding-bottom: 1px;
   }
 }
@@ -121,22 +121,22 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
   background: var(--color-card);
   border: 1px dashed var(--color-border);
   border-radius: 12px;
 
   h3 {
-    margin: 0 0 0.5rem;
-    font-size: 1.125rem;
+    margin: 0 0 0.4375rem;
+    font-size: var(--app-text-lg);
     font-weight: 600;
     color: var(--color-text);
   }
 
   p {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     color: var(--color-text-secondary);
     max-width: 300px;
   }
@@ -150,10 +150,10 @@
   justify-content: center;
   background: linear-gradient(135deg, var(--color-primary-100), var(--color-primary-50));
   border-radius: 50%;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.3125rem;
 
   i {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: var(--color-primary);
   }
 
@@ -168,7 +168,7 @@
 
 .loading-state {
   p {
-    margin-top: 1rem;
+    margin-top: 0.875rem;
   }
 }
 
@@ -178,16 +178,16 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-  padding-bottom: 0.75rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
+  padding-bottom: 0.65625rem;
   border-bottom: 1px solid var(--color-border);
 
   .results-count {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 0.95rem;
+    gap: 0.4375rem;
+    font-size: 0.83125rem;
     font-weight: 600;
     color: var(--color-text);
 
@@ -199,12 +199,12 @@
   .results-hint {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
-    font-size: 0.8rem;
+    gap: 0.35rem;
+    font-size: 0.7rem;
     color: var(--color-text-secondary);
 
     i {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
     }
   }
 }
@@ -213,8 +213,8 @@
 .covers-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 1.25rem;
-  padding: 0.25rem;
+  gap: 1.09375rem;
+  padding: 0.21875rem;
 }
 
 .cover-card {
@@ -274,7 +274,7 @@
     color: white;
     padding: 3px 6px;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
     font-weight: 600;
     z-index: 2;
     pointer-events: none;
@@ -288,7 +288,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.5rem;
+    padding: 0.4375rem;
     background: linear-gradient(to top, rgb(0 0 0 / 80%), transparent);
     opacity: 0;
     z-index: 3;
@@ -311,7 +311,7 @@
     .form-actions {
       flex-direction: row;
       justify-content: flex-end;
-      margin-top: 0.5rem;
+      margin-top: 0.4375rem;
 
       ::ng-deep .p-button:not(.p-button-icon-only) {
         flex: 1;
@@ -326,6 +326,6 @@
 
   .covers-grid {
     grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }

--- a/frontend/src/app/features/metadata/component/cover-search/cover-search.component.scss
+++ b/frontend/src/app/features/metadata/component/cover-search/cover-search.component.scss
@@ -40,7 +40,7 @@
   background: var(--color-card);
   border: 1px solid var(--color-border);
   border-radius: 12px;
-  padding: 1.09375rem 1.3125rem;
+  padding: 1.0938rem 1.3125rem;
   margin-bottom: 1.3125rem;
 
   .form-row {
@@ -87,7 +87,7 @@
     .error-message {
       display: flex;
       align-items: center;
-      gap: 0.30625rem;
+      gap: 0.3063rem;
       color: var(--red-400);
       font-size: 0.7rem;
 
@@ -178,16 +178,16 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
-  padding-bottom: 0.65625rem;
+  padding-bottom: 0.6563rem;
   border-bottom: 1px solid var(--color-border);
 
   .results-count {
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    font-size: 0.83125rem;
+    font-size: 0.8313rem;
     font-weight: 600;
     color: var(--color-text);
 
@@ -213,8 +213,8 @@
 .covers-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 1.09375rem;
-  padding: 0.21875rem;
+  gap: 1.0938rem;
+  padding: 0.2188rem;
 }
 
 .cover-card {

--- a/frontend/src/app/features/metadata/component/metadata-manager/metadata-manager.component.html
+++ b/frontend/src/app/features/metadata/component/metadata-manager/metadata-manager.component.html
@@ -79,7 +79,7 @@
                 scrollHeight="flex">
                 <ng-template pTemplate="header">
                   <tr>
-                    <th style="width: 3rem">
+                    <th style="width: 2.625rem">
                       <div class="header-content">
                         <p-checkbox
                           [binary]="true"
@@ -169,7 +169,7 @@
     [(visible)]="showMergeDialog"
     [modal]="true"
     class="user-dialog"
-    [style]="{width: '50rem'}">
+    [style]="{width: '43.75rem'}">
     <div class="dialog-form">
       <p>{{ t('mergeSplitDescription', { count: getSelectedItems(currentMergeType).length, type: getTypeLabel(currentMergeType, true) }) }}</p>
       <ul class="selected-items">
@@ -228,7 +228,7 @@
     [(visible)]="showRenameDialog"
     [modal]="true"
     class="user-dialog"
-    [style]="{width: '40rem'}">
+    [style]="{width: '35rem'}">
     <div class="dialog-form">
       <p>{{ t('renameSplitDescription') }}</p>
       <div class="current-value">
@@ -285,7 +285,7 @@
     [(visible)]="showDeleteDialog"
     [modal]="true"
     class="user-dialog"
-    [style]="{width: '40rem'}">
+    [style]="{width: '35rem'}">
     <div class="dialog-form">
       <div class="warning-message">
         <i class="pi pi-exclamation-triangle"></i>

--- a/frontend/src/app/features/metadata/component/metadata-manager/metadata-manager.component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-manager/metadata-manager.component.scss
@@ -129,7 +129,7 @@
 }
 
 .settings-header {
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
   flex-shrink: 0;
 
   @media (width >= 768px) {
@@ -140,15 +140,15 @@
 .settings-title {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  font-size: 1.09375rem;
+  gap: 0.6563rem;
+  font-size: 1.0938rem;
   font-weight: 700;
   color: var(--p-text-color);
-  margin: 0 0 0.65625rem;
+  margin: 0 0 0.6563rem;
 
   .pi {
     color: var(--p-primary-color);
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
   }
 }
 
@@ -183,8 +183,8 @@
   display: flex;
   align-items: flex-start;
   gap: 0.4375rem;
-  padding: 0.4375rem 0.65625rem;
-  margin-bottom: 1.09375rem;
+  padding: 0.4375rem 0.6563rem;
+  margin-bottom: 1.0938rem;
   background: rgb(251 146 60 / 5%);
   border: 1px solid rgb(251 146 60 / 30%);
   border-radius: 6px;
@@ -338,7 +338,7 @@
   .warning-message {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     padding: 0.875rem;
     background: rgb(251 146 60 / 15%);
     border: 1px solid var(--p-orange-500);
@@ -374,7 +374,7 @@
       list-style-type: disc;
 
       li {
-        margin-bottom: 0.21875rem;
+        margin-bottom: 0.2188rem;
         color: var(--p-text-color);
 
         strong {
@@ -442,14 +442,14 @@
 .dialog-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .processing-note {
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   margin-top: 0.875rem;
   border-left: 3px solid var(--color-warning);
   border-top: 1px solid var(--color-warning);

--- a/frontend/src/app/features/metadata/component/metadata-manager/metadata-manager.component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-manager/metadata-manager.component.scss
@@ -1,30 +1,30 @@
 @use "../../../../../assets/layout/styles/layout/variables";
 
 .metadata-manager {
-  padding: 1.5rem;
+  padding: 1.3125rem;
   display: flex;
   flex-direction: column;
   height: 100%;
 
   h2 {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.4375rem;
   }
 
   .description {
     color: var(--color-text-secondary);
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.3125rem;
   }
 
   .table-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1rem;
-    gap: 1rem;
+    margin-bottom: 0.875rem;
+    gap: 0.875rem;
 
     .actions {
       display: flex;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
   }
 
@@ -62,8 +62,8 @@
     }
 
     .p-datatable-tbody > tr > td {
-      padding-top: 0.5rem;
-      padding-bottom: 0.5rem;
+      padding-top: 0.4375rem;
+      padding-bottom: 0.4375rem;
       vertical-align: top;
     }
 
@@ -75,7 +75,7 @@
     .p-datatable-thead > tr > th .header-content {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
   }
 }
@@ -84,31 +84,31 @@
   .selected-items {
     max-height: 200px;
     overflow-y: auto;
-    margin: 1rem 0;
-    padding-left: 1.5rem;
+    margin: 0.875rem 0;
+    padding-left: 1.3125rem;
 
     li {
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
 
       .count {
         color: var(--color-text-secondary);
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
     }
   }
 
   .field {
-    margin-top: 1.5rem;
+    margin-top: 1.3125rem;
 
     label {
       display: block;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
       font-weight: 600;
     }
 
     small {
       display: block;
-      margin-top: 0.5rem;
+      margin-top: 0.4375rem;
       color: var(--color-text-secondary);
     }
   }
@@ -117,7 +117,7 @@
 .main-container {
   width: 100%;
   box-sizing: border-box;
-  padding: 1rem 0;
+  padding: 0.875rem 0;
   height: 100%;
   min-height: 0;
   display: flex;
@@ -129,40 +129,40 @@
 }
 
 .settings-header {
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
   flex-shrink: 0;
 
   @media (width >= 768px) {
-    padding: 0 1rem;
+    padding: 0 0.875rem;
   }
 }
 
 .settings-title {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  font-size: 1.25rem;
+  gap: 0.65625rem;
+  font-size: 1.09375rem;
   font-weight: 700;
   color: var(--p-text-color);
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.65625rem;
 
   .pi {
     color: var(--p-primary-color);
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
   }
 }
 
 .settings-description {
   opacity: 0.7;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   line-height: 1.5;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   .info-icon {
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
     color: red;
     cursor: help;
     transition: opacity 0.2s;
@@ -182,24 +182,24 @@
 .warning-message {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  margin-bottom: 1.25rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0.65625rem;
+  margin-bottom: 1.09375rem;
   background: rgb(251 146 60 / 5%);
   border: 1px solid rgb(251 146 60 / 30%);
   border-radius: 6px;
   color: var(--p-text-color-secondary);
 
   .pi-exclamation-triangle {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     color: rgb(251 146 60 / 70%);
     flex-shrink: 0;
-    margin-top: 0.1rem;
+    margin-top: 0.0875rem;
   }
 
   p {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     line-height: 1.45;
 
     strong {
@@ -212,13 +212,13 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
 
   @media (width >= 768px) {
-    padding: 0.5rem 1rem 0;
+    padding: 0.4375rem 0.875rem 0;
   }
 }
 
@@ -226,13 +226,13 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.875rem;
+  margin-bottom: 0.875rem;
   flex-shrink: 0;
 
   .actions {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     flex-shrink: 0;
   }
 }
@@ -241,11 +241,11 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 
   .actions {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 }
 
@@ -301,7 +301,7 @@
 
 .actions-cell {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   align-items: center;
   justify-content: center;
 
@@ -322,31 +322,31 @@
 
 .user-dialog {
   .p-dialog-content {
-    padding: 1.5rem;
+    padding: 1.3125rem;
   }
 
   .p-dialog-footer {
-    padding: 1rem 1.5rem;
+    padding: 0.875rem 1.3125rem;
   }
 }
 
 .dialog-form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 
   .warning-message {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 1rem;
+    gap: 0.65625rem;
+    padding: 0.875rem;
     background: rgb(251 146 60 / 15%);
     border: 1px solid var(--p-orange-500);
     border-radius: 8px;
     color: var(--p-text-color);
 
     .pi-exclamation-triangle {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       color: var(--p-orange-500);
     }
 
@@ -357,24 +357,24 @@
   }
 
   .delete-info {
-    padding: 1rem;
+    padding: 0.875rem;
     background: var(--color-card);
     border-radius: 8px;
     border: 1px solid rgb(128 128 128 / 20%);
 
     p {
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       font-weight: 600;
       color: var(--p-text-color);
     }
 
     ul {
       margin: 0;
-      padding-left: 1.5rem;
+      padding-left: 1.3125rem;
       list-style-type: disc;
 
       li {
-        margin-bottom: 0.25rem;
+        margin-bottom: 0.21875rem;
         color: var(--p-text-color);
 
         strong {
@@ -388,49 +388,49 @@
     max-height: 200px;
     overflow-y: auto;
     margin: 0;
-    padding-left: 1.5rem;
+    padding-left: 1.3125rem;
 
     li {
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
       color: var(--p-text-color);
 
       .count {
         opacity: 0.7;
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
     }
   }
 
   .current-value {
-    padding: 1rem;
+    padding: 0.875rem;
     background: var(--color-card);
     border: 1px solid rgb(128 128 128 / 20%);
     border-radius: 8px;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.3125rem;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     strong {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
       color: var(--p-primary-color);
     }
 
     .count {
       opacity: 0.7;
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
     }
   }
 
   .form-field {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     label {
       font-weight: 600;
       color: var(--p-text-color);
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
 
     small {
@@ -442,24 +442,24 @@
 .dialog-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .processing-note {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem;
-  margin-top: 1rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem;
+  margin-top: 0.875rem;
   border-left: 3px solid var(--color-warning);
   border-top: 1px solid var(--color-warning);
   border-bottom: 1px solid var(--color-warning);
   border-right: 1px solid var(--color-warning);
   border-radius: 4px;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }
 

--- a/frontend/src/app/features/metadata/component/metadata-options-dialog/metadata-advanced-fetch-options/metadata-advanced-fetch-options.component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-options-dialog/metadata-advanced-fetch-options/metadata-advanced-fetch-options.component.scss
@@ -1,8 +1,8 @@
 .options-container {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 1rem;
+  gap: 1.3125rem;
+  padding: 0.875rem;
 }
 
 .custom-table {
@@ -15,7 +15,7 @@
 }
 
 .table-header {
-  padding: 0.375rem 1rem;
+  padding: 0.32813rem 0.875rem;
   text-align: left;
   font-weight: 600;
   color: var(--color-text);
@@ -23,22 +23,22 @@
 }
 
 .help-icon {
-  margin-left: 0.25rem;
-  font-size: 0.75rem;
+  margin-left: 0.21875rem;
+  font-size: var(--app-text-xs);
 }
 
 .metadata-table-cell {
-  padding: 0.5rem 1rem;
+  padding: 0.4375rem 0.875rem;
   color: var(--color-text);
 }
 
 .metadata-table-cell-sm {
-  padding: 0.375rem 1rem;
+  padding: 0.32813rem 0.875rem;
   color: var(--color-text);
 }
 
 .set-all-label {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
   font-style: italic;
 }
@@ -55,18 +55,18 @@
 .provider-specific-section {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .section-title {
-  font-size: 1.125rem;
+  font-size: var(--app-text-lg);
   font-weight: 600;
   color: var(--color-text);
   margin: 0;
 }
 
 .section-description {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
   margin: 0;
 }
@@ -74,7 +74,7 @@
 .fields-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width >= 768px) {
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -88,15 +88,15 @@
 .field-card {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  gap: 0.65625rem;
+  padding: 0.65625rem;
   border: 1px solid var(--color-border);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
   background: var(--color-page);
 }
 
 .field-card-label {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text);
 }
 
@@ -106,7 +106,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
   width: 100%;
 }
 
@@ -114,14 +114,14 @@
   display: flex;
   flex-flow: row wrap;
   align-items: center;
-  gap: 1rem 2.5rem;
+  gap: 0.875rem 2.1875rem;
 }
 
 .option-item {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   p {
     margin: 0;
@@ -133,7 +133,7 @@
 .action-buttons {
   display: flex;
   flex-direction: row;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 // Select styles
@@ -143,6 +143,6 @@
   }
 
   .select-mode {
-    min-width: 10rem;
+    min-width: 8.75rem;
   }
 }

--- a/frontend/src/app/features/metadata/component/metadata-options-dialog/metadata-advanced-fetch-options/metadata-advanced-fetch-options.component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-options-dialog/metadata-advanced-fetch-options/metadata-advanced-fetch-options.component.scss
@@ -15,7 +15,7 @@
 }
 
 .table-header {
-  padding: 0.32813rem 0.875rem;
+  padding: 0.3281rem 0.875rem;
   text-align: left;
   font-weight: 600;
   color: var(--color-text);
@@ -23,7 +23,7 @@
 }
 
 .help-icon {
-  margin-left: 0.21875rem;
+  margin-left: 0.2188rem;
   font-size: var(--app-text-xs);
 }
 
@@ -33,7 +33,7 @@
 }
 
 .metadata-table-cell-sm {
-  padding: 0.32813rem 0.875rem;
+  padding: 0.3281rem 0.875rem;
   color: var(--color-text);
 }
 
@@ -88,8 +88,8 @@
 .field-card {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.65625rem;
+  gap: 0.6563rem;
+  padding: 0.6563rem;
   border: 1px solid var(--color-border);
   border-radius: 0.4375rem;
   background: var(--color-page);

--- a/frontend/src/app/features/metadata/component/metadata-provider-field-selector/metadata-provider-field-selector.component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-provider-field-selector/metadata-provider-field-selector.component.scss
@@ -1,91 +1,91 @@
 .settings-card {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.09375rem;
   background: var(--color-page);
   border: 1px solid var(--p-content-border-color);
   border-radius: 8px;
-  padding: 1.5rem;
+  padding: 1.3125rem;
 
   @media (width <= 768px) {
-    padding: 1rem;
-    gap: 1rem;
+    padding: 0.875rem;
+    gap: 0.875rem;
   }
 }
 
 .section-header {
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.21875rem;
 }
 
 .section-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 1.25rem;
+  gap: 0.4375rem;
+  font-size: 1.09375rem;
   font-weight: 600;
   color: var(--color-text);
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 
   .pi {
     color: var(--color-primary);
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
   }
 }
 
 .section-description {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   line-height: 1.5;
   color: var(--p-text-muted-color);
   margin: 0;
 }
 
 .section-body {
-  padding-left: 1rem;
+  padding-left: 0.875rem;
 
   @media (width <= 768px) {
-    padding-left: 0.5rem;
+    padding-left: 0.4375rem;
   }
 }
 
 .provider-groups-container {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .provider-group {
-  padding: 0.875rem 1rem;
+  padding: 0.76563rem 0.875rem;
   border-radius: 6px;
   border-left: 3px solid var(--color-primary);
   background: var(--color-page);
 
   @media (width <= 768px) {
-    padding: 0.75rem;
+    padding: 0.65625rem;
   }
 }
 
 .group-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.625rem;
-  padding-bottom: 0.5rem;
+  gap: 0.4375rem;
+  margin-bottom: 0.54688rem;
+  padding-bottom: 0.4375rem;
   border-bottom: 1px dashed var(--p-content-border-color);
 }
 
 .group-icon {
   color: var(--color-primary);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   flex-shrink: 0;
 }
 
 .group-label {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--color-text);
   margin: 0;
@@ -94,14 +94,14 @@
 .field-list {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .field-item {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  padding: 0.3125rem 0.5rem;
+  gap: 0.54688rem;
+  padding: 0.27344rem 0.4375rem;
   border-radius: 4px;
   transition: background-color 0.15s ease;
 
@@ -111,7 +111,7 @@
 
   label {
     cursor: pointer;
-    font-size: 0.9375rem;
+    font-size: 0.82031rem;
     font-weight: 400;
     user-select: none;
     color: var(--color-text);

--- a/frontend/src/app/features/metadata/component/metadata-provider-field-selector/metadata-provider-field-selector.component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-provider-field-selector/metadata-provider-field-selector.component.scss
@@ -1,7 +1,7 @@
 .settings-card {
   display: flex;
   flex-direction: column;
-  gap: 1.09375rem;
+  gap: 1.0938rem;
   background: var(--color-page);
   border: 1px solid var(--p-content-border-color);
   border-radius: 8px;
@@ -14,14 +14,14 @@
 }
 
 .section-header {
-  margin-bottom: 0.21875rem;
+  margin-bottom: 0.2188rem;
 }
 
 .section-title {
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  font-size: 1.09375rem;
+  font-size: 1.0938rem;
   font-weight: 600;
   color: var(--color-text);
   margin: 0 0 0.4375rem;
@@ -54,18 +54,18 @@
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
 .provider-group {
-  padding: 0.76563rem 0.875rem;
+  padding: 0.7656rem 0.875rem;
   border-radius: 6px;
   border-left: 3px solid var(--color-primary);
   background: var(--color-page);
 
   @media (width <= 768px) {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
   }
 }
 
@@ -73,7 +73,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  margin-bottom: 0.54688rem;
+  margin-bottom: 0.5469rem;
   padding-bottom: 0.4375rem;
   border-bottom: 1px dashed var(--p-content-border-color);
 }
@@ -94,14 +94,14 @@
 .field-list {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .field-item {
   display: flex;
   align-items: center;
-  gap: 0.54688rem;
-  padding: 0.27344rem 0.4375rem;
+  gap: 0.5469rem;
+  padding: 0.2734rem 0.4375rem;
   border-radius: 4px;
   transition: background-color 0.15s ease;
 
@@ -111,7 +111,7 @@
 
   label {
     cursor: pointer;
-    font-size: 0.82031rem;
+    font-size: 0.8203rem;
     font-weight: 400;
     user-select: none;
     color: var(--color-text);

--- a/frontend/src/app/features/metadata/component/metadata-review-dialog/metadata-review-dialog-component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-review-dialog/metadata-review-dialog-component.scss
@@ -57,7 +57,7 @@
 
   .progress-bar {
     width: 8.75rem;
-    height: 0.65625rem;
+    height: 0.6563rem;
 
     @media (width <= 640px) {
       width: 100%;

--- a/frontend/src/app/features/metadata/component/metadata-review-dialog/metadata-review-dialog-component.scss
+++ b/frontend/src/app/features/metadata/component/metadata-review-dialog/metadata-review-dialog-component.scss
@@ -15,7 +15,7 @@
 .dialog-content {
   height: calc(95dvh - 90px - 80px);
   overflow-y: auto;
-  padding: 1rem;
+  padding: 0.875rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -28,8 +28,8 @@
   }
 
   .spinner {
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
   }
 }
 
@@ -46,7 +46,7 @@
   .progress-group {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     cursor: help;
     transition: all 0.3s ease;
 
@@ -56,8 +56,8 @@
   }
 
   .progress-bar {
-    width: 10rem;
-    height: 0.75rem;
+    width: 8.75rem;
+    height: 0.65625rem;
 
     @media (width <= 640px) {
       width: 100%;
@@ -65,7 +65,7 @@
   }
 
   .progress-text {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
     color: var(--text-secondary-color);
     white-space: nowrap;
@@ -75,7 +75,7 @@
   .footer-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     justify-content: flex-end;
   }
 

--- a/frontend/src/app/features/metadata/component/multi-book-metadata-fetch/multi-book-metadata-fetch-component.scss
+++ b/frontend/src/app/features/metadata/component/multi-book-metadata-fetch/multi-book-metadata-fetch-component.scss
@@ -26,7 +26,7 @@
   flex-direction: column;
   overflow-y: auto;
   min-height: 0;
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
@@ -36,24 +36,24 @@
 
 .book-list-section {
   flex-shrink: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .book-list-container {
-  max-height: 6rem;
+  max-height: 5.25rem;
   overflow: auto;
   border: 1px solid var(--color-border);
-  border-radius: 0.25rem;
-  padding: 0.5rem;
-  font-size: 0.875rem;
+  border-radius: 0.21875rem;
+  padding: 0.4375rem;
+  font-size: var(--app-text-sm);
 }
 
 .book-list {
   list-style-type: disc;
-  padding-left: 1.25rem;
+  padding-left: 1.09375rem;
 
   li {
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.21875rem;
 
     &:last-child {
       margin-bottom: 0;

--- a/frontend/src/app/features/metadata/component/multi-book-metadata-fetch/multi-book-metadata-fetch-component.scss
+++ b/frontend/src/app/features/metadata/component/multi-book-metadata-fetch/multi-book-metadata-fetch-component.scss
@@ -43,17 +43,17 @@
   max-height: 5.25rem;
   overflow: auto;
   border: 1px solid var(--color-border);
-  border-radius: 0.21875rem;
+  border-radius: 0.2188rem;
   padding: 0.4375rem;
   font-size: var(--app-text-sm);
 }
 
 .book-list {
   list-style-type: disc;
-  padding-left: 1.09375rem;
+  padding-left: 1.0938rem;
 
   li {
-    margin-bottom: 0.21875rem;
+    margin-bottom: 0.2188rem;
 
     &:last-child {
       margin-bottom: 0;

--- a/frontend/src/app/features/notebook/components/notebook/notebook.component.scss
+++ b/frontend/src/app/features/notebook/components/notebook/notebook.component.scss
@@ -12,15 +12,15 @@
 
 .main-container > .settings-header,
 .main-container > .settings-card {
-  margin-inline: 1.1rem;
+  margin-inline: 0.9625rem;
 }
 
 .main-container > .settings-header {
-  margin-top: 1.1rem;
+  margin-top: 0.9625rem;
 }
 
 .main-container > .settings-card {
-  margin-top: 1.5rem;
+  margin-top: 1.3125rem;
 }
 
 @media #{variables.$mobile-shell-media-query} {
@@ -41,11 +41,11 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 1.5rem 1.1rem 0;
+  gap: 1.3125rem;
+  padding: 1.3125rem 0.9625rem 0;
 
   @media #{variables.$mobile-shell-media-query} {
-    padding: 1.5rem var(--space-4) 0;
+    padding: 1.3125rem var(--space-4) 0;
   }
 }
 
@@ -59,7 +59,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -70,7 +70,7 @@
 .settings-card {
   @include settings.settings-card;
 
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 // ============================================================================
@@ -80,14 +80,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
   flex-wrap: wrap;
 }
 
 .filters-left {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
   flex: 1;
   min-width: 0;
@@ -96,7 +96,7 @@
 .filters-right {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
 }
 
@@ -105,17 +105,17 @@
 
   i {
     position: absolute;
-    left: 0.75rem;
+    left: 0.65625rem;
     top: 50%;
     transform: translateY(-50%);
     color: var(--p-text-muted-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 
   .search-input {
-    padding-left: 2.25rem;
+    padding-left: 1.96875rem;
     width: 200px;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -136,12 +136,12 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   text-align: center;
   color: var(--p-text-muted-color);
 
   .pi-spinner {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: var(--p-primary-color);
   }
 }
@@ -155,10 +155,10 @@
   background: color-mix(in srgb, var(--p-primary-color) 12%, transparent);
   color: var(--p-primary-color);
   border-radius: 50%;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 
   .pi {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
   }
 
   &.warn {
@@ -168,14 +168,14 @@
 }
 
 .state-title {
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   font-weight: 600;
   color: var(--p-text-color);
-  margin: 0 0 0.25rem;
+  margin: 0 0 0.21875rem;
 }
 
 .state-hint {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   margin: 0;
 }
@@ -191,8 +191,8 @@
 .book-group-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1rem 1.25rem;
+  gap: 0.65625rem;
+  padding: 0.875rem 1.09375rem;
   cursor: pointer;
   transition: background 0.15s ease;
   border-radius: 8px;
@@ -216,12 +216,12 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.10938rem;
 }
 
 .book-title {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   color: var(--p-text-color);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -229,13 +229,13 @@
 }
 
 .book-entry-count {
-  font-size: 0.8125rem;
+  font-size: 0.71094rem;
   color: var(--p-text-muted-color);
 }
 
 .toggle-icon {
   color: var(--p-text-muted-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   flex-shrink: 0;
   transition: transform 0.2s ease;
 }
@@ -246,12 +246,12 @@
 .entries-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0 1.25rem 1.25rem;
+  gap: 0.4375rem;
+  padding: 0 1.09375rem 1.09375rem;
 }
 
 .entry-item {
-  padding: 0.75rem 1rem;
+  padding: 0.65625rem 0.875rem;
   border-radius: 6px;
   border-left: 3px solid var(--p-primary-color);
   background: var(--color-card);
@@ -265,22 +265,22 @@
 .entry-top-row {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  margin-bottom: 0.5rem;
+  gap: 0.54688rem;
+  margin-bottom: 0.4375rem;
   flex-wrap: wrap;
 }
 
 .entry-type-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.125rem 0.5rem;
+  gap: 0.2625rem;
+  padding: 0.10938rem 0.4375rem;
   border-radius: 12px;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
 
   .pi {
-    font-size: 0.6875rem;
+    font-size: 0.60156rem;
   }
 
   &.type-highlight {
@@ -302,25 +302,25 @@
 .entry-chapter {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  font-size: 0.8125rem;
+  gap: 0.2625rem;
+  font-size: 0.71094rem;
   color: var(--p-text-muted-color);
 
   .pi {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
   }
 }
 
 .entry-date {
   margin-left: auto;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--p-text-muted-color);
   white-space: nowrap;
 }
 
 .entry-text {
   color: var(--p-text-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   line-height: 1.55;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -329,18 +329,18 @@
 .entry-note {
   display: flex;
   align-items: flex-start;
-  gap: 0.375rem;
-  margin-top: 0.5rem;
-  padding-top: 0.5rem;
+  gap: 0.32813rem;
+  margin-top: 0.4375rem;
+  padding-top: 0.4375rem;
   border-top: 1px dashed var(--p-content-border-color);
   color: var(--p-text-muted-color);
-  font-size: 0.8125rem;
+  font-size: 0.71094rem;
   font-style: italic;
   line-height: 1.5;
 
   .pi {
-    font-size: 0.75rem;
-    margin-top: 0.125rem;
+    font-size: var(--app-text-xs);
+    margin-top: 0.10938rem;
     flex-shrink: 0;
     color: var(--p-primary-color);
   }
@@ -352,7 +352,7 @@
 .pagination-card {
   display: flex;
   justify-content: center;
-  padding: 0.5rem;
+  padding: 0.4375rem;
 }
 
 // ============================================================================
@@ -389,7 +389,7 @@
   .entry-top-row {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.375rem;
+    gap: 0.32813rem;
   }
 
   .entry-date {

--- a/frontend/src/app/features/notebook/components/notebook/notebook.component.scss
+++ b/frontend/src/app/features/notebook/components/notebook/notebook.component.scss
@@ -59,7 +59,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -105,7 +105,7 @@
 
   i {
     position: absolute;
-    left: 0.65625rem;
+    left: 0.6563rem;
     top: 50%;
     transform: translateY(-50%);
     color: var(--p-text-muted-color);
@@ -113,7 +113,7 @@
   }
 
   .search-input {
-    padding-left: 1.96875rem;
+    padding-left: 1.9688rem;
     width: 200px;
     font-size: var(--app-text-sm);
   }
@@ -171,7 +171,7 @@
   font-size: var(--app-text-base);
   font-weight: 600;
   color: var(--p-text-color);
-  margin: 0 0 0.21875rem;
+  margin: 0 0 0.2188rem;
 }
 
 .state-hint {
@@ -191,8 +191,8 @@
 .book-group-header {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.875rem 1.09375rem;
+  gap: 0.6563rem;
+  padding: 0.875rem 1.0938rem;
   cursor: pointer;
   transition: background 0.15s ease;
   border-radius: 8px;
@@ -216,7 +216,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
 }
 
 .book-title {
@@ -229,7 +229,7 @@
 }
 
 .book-entry-count {
-  font-size: 0.71094rem;
+  font-size: 0.7109rem;
   color: var(--p-text-muted-color);
 }
 
@@ -247,11 +247,11 @@
   display: flex;
   flex-direction: column;
   gap: 0.4375rem;
-  padding: 0 1.09375rem 1.09375rem;
+  padding: 0 1.0938rem 1.0938rem;
 }
 
 .entry-item {
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   border-radius: 6px;
   border-left: 3px solid var(--p-primary-color);
   background: var(--color-card);
@@ -265,7 +265,7 @@
 .entry-top-row {
   display: flex;
   align-items: center;
-  gap: 0.54688rem;
+  gap: 0.5469rem;
   margin-bottom: 0.4375rem;
   flex-wrap: wrap;
 }
@@ -274,13 +274,13 @@
   display: inline-flex;
   align-items: center;
   gap: 0.2625rem;
-  padding: 0.10938rem 0.4375rem;
+  padding: 0.1094rem 0.4375rem;
   border-radius: 12px;
   font-size: var(--app-text-xs);
   font-weight: 600;
 
   .pi {
-    font-size: 0.60156rem;
+    font-size: 0.6016rem;
   }
 
   &.type-highlight {
@@ -303,7 +303,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.2625rem;
-  font-size: 0.71094rem;
+  font-size: 0.7109rem;
   color: var(--p-text-muted-color);
 
   .pi {
@@ -329,18 +329,18 @@
 .entry-note {
   display: flex;
   align-items: flex-start;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   margin-top: 0.4375rem;
   padding-top: 0.4375rem;
   border-top: 1px dashed var(--p-content-border-color);
   color: var(--p-text-muted-color);
-  font-size: 0.71094rem;
+  font-size: 0.7109rem;
   font-style: italic;
   line-height: 1.5;
 
   .pi {
     font-size: var(--app-text-xs);
-    margin-top: 0.10938rem;
+    margin-top: 0.1094rem;
     flex-shrink: 0;
     color: var(--p-primary-color);
   }
@@ -389,7 +389,7 @@
   .entry-top-row {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
   }
 
   .entry-date {

--- a/frontend/src/app/features/readers/audiobook-player/audiobook-player.component.scss
+++ b/frontend/src/app/features/readers/audiobook-player/audiobook-player.component.scss
@@ -42,11 +42,11 @@ $border-color: rgb(255 255 255 / 10%);
 
   @include gradient-bg;
 
-  gap: 1rem;
+  gap: 0.875rem;
 
   .loading-text {
     color: $text-secondary;
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 
   ::ng-deep .p-progress-spinner-circle {
@@ -83,7 +83,7 @@ $border-color: rgb(255 255 255 / 10%);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
+  padding: 0.875rem 1.3125rem;
   background: rgb(0 0 0 / 40%);
   backdrop-filter: blur(20px);
   border-bottom: 1px solid $border-color;
@@ -93,11 +93,11 @@ $border-color: rgb(255 255 255 / 10%);
   .header-info {
     flex: 1;
     text-align: center;
-    padding: 0 1rem;
+    padding: 0 0.875rem;
     overflow: hidden;
 
     .book-title {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
       font-weight: 600;
       margin: 0;
       white-space: nowrap;
@@ -109,14 +109,14 @@ $border-color: rgb(255 255 255 / 10%);
     }
 
     .book-author {
-      font-size: 0.85rem;
+      font-size: 0.74375rem;
       color: $text-secondary;
     }
   }
 
   .header-actions {
     display: flex;
-    gap: 0.25rem;
+    gap: 0.21875rem;
   }
 
   ::ng-deep .p-button {
@@ -137,9 +137,9 @@ $border-color: rgb(255 255 255 / 10%);
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 2rem 1.5rem;
+  padding: 1.75rem 1.3125rem;
   overflow-y: auto;
-  gap: 1.5rem;
+  gap: 1.3125rem;
   position: relative;
   z-index: 1;
 }
@@ -201,7 +201,7 @@ $border-color: rgb(255 255 255 / 10%);
       opacity: 0.8;
 
       i {
-        font-size: 5rem;
+        font-size: 4.375rem;
         color: rgb(255 255 255 / 90%);
         text-shadow: 0 0 30px rgb(255 255 255 / 50%);
       }
@@ -212,18 +212,18 @@ $border-color: rgb(255 255 255 / 10%);
 // Track info
 .track-info {
   text-align: center;
-  min-height: 3rem;
+  min-height: 2.625rem;
 
   .track-title {
     display: block;
-    font-size: 1.1rem;
+    font-size: 0.9625rem;
     font-weight: 600;
     color: $text-primary;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.21875rem;
   }
 
   .track-number {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     color: var(--accent-color);
     font-weight: 500;
   }
@@ -237,8 +237,8 @@ $border-color: rgb(255 255 255 / 10%);
   .time-display {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 0.75rem;
-    font-size: 0.85rem;
+    margin-bottom: 0.65625rem;
+    font-size: 0.74375rem;
     color: $text-secondary;
     font-variant-numeric: tabular-nums;
     font-weight: 500;
@@ -304,13 +304,13 @@ $border-color: rgb(255 255 255 / 10%);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
+  gap: 0.875rem;
 
   ::ng-deep .play-button {
     .p-button {
       width: 72px;
       height: 72px;
-      font-size: 1.75rem;
+      font-size: 1.53125rem;
 
       @include accent-gradient;
 
@@ -330,7 +330,7 @@ $border-color: rgb(255 255 255 / 10%);
       }
 
       .p-button-icon {
-        font-size: 1.75rem;
+        font-size: 1.53125rem;
       }
     }
   }
@@ -365,16 +365,16 @@ $border-color: rgb(255 255 255 / 10%);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 2rem;
+  gap: 1.75rem;
   width: 100%;
   max-width: 500px;
-  padding: 1rem 0;
+  padding: 0.875rem 0;
 }
 
 .volume-control {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   ::ng-deep .p-button.p-button-text {
     color: $text-secondary;
@@ -412,8 +412,8 @@ $border-color: rgb(255 255 255 / 10%);
 .speed-control {
   ::ng-deep .p-selectbutton {
     .p-button {
-      padding: 0.5rem 0.75rem;
-      font-size: 0.8rem;
+      padding: 0.4375rem 0.65625rem;
+      font-size: 0.7rem;
       font-weight: 600;
       background: rgb(255 255 255 / 8%);
       border: 1px solid rgb(255 255 255 / 10%);
@@ -443,25 +443,25 @@ $border-color: rgb(255 255 255 / 10%);
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 1.25rem;
-  padding: 1rem;
+  gap: 1.09375rem;
+  padding: 0.875rem;
   color: $text-tertiary;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   background: rgb(255 255 255 / 3%);
   border-radius: 12px;
-  margin-top: 0.5rem;
+  margin-top: 0.4375rem;
 
   .detail-item {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
+    gap: 0.4375rem;
+    padding: 0.4375rem 0.65625rem;
     background: rgb(255 255 255 / 5%);
     border-radius: 8px;
     white-space: nowrap;
 
     i {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       color: $accent-tertiary;
     }
   }
@@ -472,13 +472,13 @@ $border-color: rgb(255 255 255 / 10%);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  padding-top: 0.5rem;
+  gap: 0.875rem;
+  padding-top: 0.4375rem;
 
   ::ng-deep .p-button {
     &.p-button-text {
       color: $text-secondary;
-      font-size: 0.85rem;
+      font-size: 0.74375rem;
 
       &:hover {
         color: $text-primary;
@@ -486,7 +486,7 @@ $border-color: rgb(255 255 255 / 10%);
       }
 
       .p-button-icon {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
     }
 
@@ -506,25 +506,25 @@ $border-color: rgb(255 255 255 / 10%);
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 1.5rem;
+  padding: 2.625rem 1.3125rem;
   text-align: center;
   color: $text-tertiary;
 
   i {
-    font-size: 3rem;
-    margin-bottom: 1rem;
+    font-size: 2.625rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   p {
-    margin: 0 0 0.5rem;
-    font-size: 1rem;
+    margin: 0 0 0.4375rem;
+    font-size: var(--app-text-base);
     font-weight: 500;
     color: $text-secondary;
   }
 
   span {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
@@ -532,7 +532,7 @@ $border-color: rgb(255 255 255 / 10%);
 .bookmark-item {
   .bookmark-icon {
     color: var(--accent-color);
-    font-size: 1.1rem;
+    font-size: 0.9625rem;
     flex-shrink: 0;
   }
 
@@ -580,13 +580,13 @@ $border-color: rgb(255 255 255 / 10%);
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1.25rem 1.5rem;
+    padding: 1.09375rem 1.3125rem;
     border-bottom: 1px solid $border-color;
     background: rgb(0 0 0 / 20%);
 
     h2 {
       margin: 0;
-      font-size: 1.2rem;
+      font-size: 1.05rem;
       font-weight: 600;
       background: linear-gradient(90deg, $text-primary, var(--accent-color));
       background-clip: text;
@@ -606,7 +606,7 @@ $border-color: rgb(255 255 255 / 10%);
   .sidebar-content {
     flex: 1;
     overflow-y: auto;
-    padding: 0.5rem 0;
+    padding: 0.4375rem 0;
   }
 }
 
@@ -618,10 +618,10 @@ $border-color: rgb(255 255 255 / 10%);
   .track-item {
     display: flex;
     align-items: center;
-    padding: 1rem 1.5rem;
+    padding: 0.875rem 1.3125rem;
     cursor: pointer;
     transition: all 0.2s ease;
-    gap: 1rem;
+    gap: 0.875rem;
     border-left: 3px solid transparent;
 
     &:hover {
@@ -644,9 +644,9 @@ $border-color: rgb(255 255 255 / 10%);
     }
 
     .track-index {
-      width: 2rem;
+      width: 1.75rem;
       text-align: center;
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       color: $text-tertiary;
       flex-shrink: 0;
       font-weight: 600;
@@ -658,7 +658,7 @@ $border-color: rgb(255 255 255 / 10%);
 
       .track-name {
         display: block;
-        font-size: 0.95rem;
+        font-size: 0.83125rem;
         color: $text-primary;
         white-space: nowrap;
         overflow: hidden;
@@ -667,16 +667,16 @@ $border-color: rgb(255 255 255 / 10%);
       }
 
       .track-duration {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
         color: $text-tertiary;
-        margin-top: 0.2rem;
+        margin-top: 0.175rem;
       }
     }
 
     .playing-indicator {
       color: var(--accent-color);
       animation: pulse 1.5s ease-in-out infinite;
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
 
     @keyframes pulse {
@@ -696,8 +696,8 @@ $border-color: rgb(255 255 255 / 10%);
 // Responsive adjustments
 @media (width <= 768px) {
   .reader-main {
-    padding: 1rem;
-    gap: 1rem;
+    padding: 0.875rem;
+    gap: 0.875rem;
   }
 
   .cover-container {
@@ -706,7 +706,7 @@ $border-color: rgb(255 255 255 / 10%);
 
   .secondary-controls {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .volume-control {
@@ -720,15 +720,15 @@ $border-color: rgb(255 255 255 / 10%);
   }
 
   .audio-details {
-    gap: 0.75rem;
-    padding: 0.75rem;
+    gap: 0.65625rem;
+    padding: 0.65625rem;
 
     .detail-item {
-      padding: 0.4rem 0.6rem;
-      font-size: 0.75rem;
+      padding: 0.35rem 0.525rem;
+      font-size: var(--app-text-xs);
 
       i {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }
@@ -740,7 +740,7 @@ $border-color: rgb(255 255 255 / 10%);
   }
 
   .playback-controls {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     ::ng-deep .play-button {
       .p-button {
@@ -758,7 +758,7 @@ $border-color: rgb(255 255 255 / 10%);
   .audio-details {
     flex-flow: row wrap;
     justify-content: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .detail-item {
       flex: 0 1 auto;
@@ -771,7 +771,7 @@ $border-color: rgb(255 255 255 / 10%);
   .reader-main {
     flex-flow: row wrap;
     justify-content: center;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .cover-container {

--- a/frontend/src/app/features/readers/audiobook-player/audiobook-player.component.scss
+++ b/frontend/src/app/features/readers/audiobook-player/audiobook-player.component.scss
@@ -109,14 +109,14 @@ $border-color: rgb(255 255 255 / 10%);
     }
 
     .book-author {
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
       color: $text-secondary;
     }
   }
 
   .header-actions {
     display: flex;
-    gap: 0.21875rem;
+    gap: 0.2188rem;
   }
 
   ::ng-deep .p-button {
@@ -219,11 +219,11 @@ $border-color: rgb(255 255 255 / 10%);
     font-size: 0.9625rem;
     font-weight: 600;
     color: $text-primary;
-    margin-bottom: 0.21875rem;
+    margin-bottom: 0.2188rem;
   }
 
   .track-number {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     color: var(--accent-color);
     font-weight: 500;
   }
@@ -237,8 +237,8 @@ $border-color: rgb(255 255 255 / 10%);
   .time-display {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 0.65625rem;
-    font-size: 0.74375rem;
+    margin-bottom: 0.6563rem;
+    font-size: 0.7438rem;
     color: $text-secondary;
     font-variant-numeric: tabular-nums;
     font-weight: 500;
@@ -310,7 +310,7 @@ $border-color: rgb(255 255 255 / 10%);
     .p-button {
       width: 72px;
       height: 72px;
-      font-size: 1.53125rem;
+      font-size: 1.5313rem;
 
       @include accent-gradient;
 
@@ -330,7 +330,7 @@ $border-color: rgb(255 255 255 / 10%);
       }
 
       .p-button-icon {
-        font-size: 1.53125rem;
+        font-size: 1.5313rem;
       }
     }
   }
@@ -374,7 +374,7 @@ $border-color: rgb(255 255 255 / 10%);
 .volume-control {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   ::ng-deep .p-button.p-button-text {
     color: $text-secondary;
@@ -412,7 +412,7 @@ $border-color: rgb(255 255 255 / 10%);
 .speed-control {
   ::ng-deep .p-selectbutton {
     .p-button {
-      padding: 0.4375rem 0.65625rem;
+      padding: 0.4375rem 0.6563rem;
       font-size: 0.7rem;
       font-weight: 600;
       background: rgb(255 255 255 / 8%);
@@ -443,7 +443,7 @@ $border-color: rgb(255 255 255 / 10%);
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 1.09375rem;
+  gap: 1.0938rem;
   padding: 0.875rem;
   color: $text-tertiary;
   font-size: 0.7rem;
@@ -455,7 +455,7 @@ $border-color: rgb(255 255 255 / 10%);
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    padding: 0.4375rem 0.65625rem;
+    padding: 0.4375rem 0.6563rem;
     background: rgb(255 255 255 / 5%);
     border-radius: 8px;
     white-space: nowrap;
@@ -478,7 +478,7 @@ $border-color: rgb(255 255 255 / 10%);
   ::ng-deep .p-button {
     &.p-button-text {
       color: $text-secondary;
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
 
       &:hover {
         color: $text-primary;
@@ -524,7 +524,7 @@ $border-color: rgb(255 255 255 / 10%);
   }
 
   span {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 
@@ -580,7 +580,7 @@ $border-color: rgb(255 255 255 / 10%);
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1.09375rem 1.3125rem;
+    padding: 1.0938rem 1.3125rem;
     border-bottom: 1px solid $border-color;
     background: rgb(0 0 0 / 20%);
 
@@ -658,7 +658,7 @@ $border-color: rgb(255 255 255 / 10%);
 
       .track-name {
         display: block;
-        font-size: 0.83125rem;
+        font-size: 0.8313rem;
         color: $text-primary;
         white-space: nowrap;
         overflow: hidden;
@@ -720,8 +720,8 @@ $border-color: rgb(255 255 255 / 10%);
   }
 
   .audio-details {
-    gap: 0.65625rem;
-    padding: 0.65625rem;
+    gap: 0.6563rem;
+    padding: 0.6563rem;
 
     .detail-item {
       padding: 0.35rem 0.525rem;

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -10,7 +10,7 @@
     flex: 0 0 auto;
     width: 100%;
     text-align: center;
-    font-size: 0.88rem;
+    font-size: 0.77rem;
     color: rgb(255 255 255 / 45%);
     opacity: 0;
     transform: translateY(6px);
@@ -55,9 +55,9 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75rem 1rem;
-    padding: 0.65rem 1rem;
-    margin: 0 0.5rem;
+    gap: 0.65625rem 0.875rem;
+    padding: 0.56875rem 0.875rem;
+    margin: 0 0.4375rem;
     background: rgb(30 40 55 / 95%);
     border: 1px solid rgb(255 255 255 / 12%);
     border-radius: 8px;
@@ -68,7 +68,7 @@
   .webtoon-suggestion-text {
     margin: 0;
     flex: 1 1 200px;
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     line-height: 1.35;
     color: rgb(255 255 255 / 88%);
   }
@@ -76,17 +76,17 @@
   .webtoon-suggestion-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     align-items: center;
   }
 
   .webtoon-btn {
-    padding: 0.4rem 0.75rem;
+    padding: 0.35rem 0.65625rem;
     border-radius: 6px;
     border: 1px solid rgb(255 255 255 / 20%);
     background: rgb(255 255 255 / 8%);
     color: #fff;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     cursor: pointer;
     transition: background 0.15s ease, border-color 0.15s ease;
 
@@ -107,7 +107,7 @@
       border-color: transparent;
       background: transparent;
       color: rgb(255 255 255 / 55%);
-      font-size: 0.8rem;
+      font-size: 0.7rem;
 
       &:hover {
         color: rgb(255 255 255 / 85%);
@@ -186,7 +186,7 @@
     justify-content: center;
     align-items: center;
     overflow: hidden;
-    padding: 0.5rem;
+    padding: 0.4375rem;
     background: #0f0f0f;
     min-height: 0;
 
@@ -204,7 +204,7 @@
 
       .end-of-comic-action {
         flex: 0 0 auto;
-        margin-top: 1rem;
+        margin-top: 0.875rem;
       }
     }
 
@@ -227,7 +227,7 @@
     &:not(.infinite-scroll) {
       .pages-wrapper {
         display: flex;
-        gap: 1rem;
+        gap: 0.875rem;
         align-items: center;
         justify-content: center;
         width: 100%;
@@ -238,7 +238,7 @@
       .previous-page-layer,
       .current-page-layer {
         display: flex;
-        gap: 1rem;
+        gap: 0.875rem;
         align-items: center;
         justify-content: center;
         width: 100%;
@@ -306,7 +306,7 @@
           .current-page-layer {
             display: grid;
             grid-template-columns: repeat(2, minmax(0, 1fr));
-            gap: 1rem;
+            gap: 0.875rem;
             width: 100%;
           }
 
@@ -341,7 +341,7 @@
 
         .page-image {
           width: auto;
-          height: calc(100dvh - 1rem);
+          height: calc(100dvh - 0.875rem);
           max-width: none;
         }
 
@@ -361,7 +361,7 @@
 
           .page-image {
             width: auto;
-            height: calc(100dvh - 1rem);
+            height: calc(100dvh - 0.875rem);
             max-width: none;
           }
 
@@ -432,7 +432,7 @@
 
         &.two-page-view {
           .page-image {
-            max-width: calc(50% - 0.5rem);
+            max-width: calc(50% - 0.4375rem);
             max-height: 100%;
             width: auto;
             height: auto;
@@ -456,7 +456,7 @@
 
         &.two-page-view {
           .page-image {
-            max-width: calc(50% - 0.5rem);
+            max-width: calc(50% - 0.4375rem);
             max-height: 100%;
             width: auto;
             height: auto;
@@ -481,10 +481,10 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        gap: 1rem;
+        gap: 0.875rem;
         width: 100%;
         min-width: 0;
-        padding: 1rem 0;
+        padding: 0.875rem 0;
         overflow-anchor: none;
       }
 
@@ -498,13 +498,13 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        gap: 1rem;
+        gap: 0.875rem;
       }
 
       @include cbx-reader-continuation-affordance;
 
       .cbx-continuation-hint {
-        padding: 0.5rem 1rem 1rem;
+        padding: 0.4375rem 0.875rem 0.875rem;
       }
 
       .page-image {
@@ -529,7 +529,7 @@
 
         .page-image {
           width: auto;
-          height: calc(100vh - 2rem);
+          height: calc(100vh - 1.75rem);
           max-width: 100%;
         }
       }
@@ -558,7 +558,7 @@
 
         .page-image {
           max-width: 100%;
-          max-height: calc(100vh - 2rem);
+          max-height: calc(100vh - 1.75rem);
           width: auto;
           height: auto;
         }
@@ -571,14 +571,14 @@
 
         .page-image {
           max-width: 100%;
-          max-height: calc(100vh - 2rem);
+          max-height: calc(100vh - 1.75rem);
           width: auto;
           height: auto;
         }
       }
 
       .loading-more {
-        padding: 2rem;
+        padding: 1.75rem;
         display: flex;
         justify-content: center;
       }
@@ -616,7 +616,7 @@
       @include cbx-reader-continuation-affordance;
 
       .cbx-continuation-hint {
-        padding: 0.75rem 1rem 1.25rem;
+        padding: 0.65625rem 0.875rem 1.09375rem;
       }
 
       .long-strip-image {
@@ -643,7 +643,7 @@
 
         .long-strip-image {
           width: auto;
-          height: calc(100vh - 2rem);
+          height: calc(100vh - 1.75rem);
           max-width: 100%;
         }
       }
@@ -671,7 +671,7 @@
 
         .long-strip-image {
           max-width: 100%;
-          max-height: calc(100vh - 2rem);
+          max-height: calc(100vh - 1.75rem);
           width: auto;
           height: auto;
         }
@@ -684,7 +684,7 @@
 
         .long-strip-image {
           max-width: 100%;
-          max-height: calc(100vh - 2rem);
+          max-height: calc(100vh - 1.75rem);
           width: auto;
           height: auto;
         }
@@ -702,7 +702,7 @@
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      gap: 1.5rem;
+      gap: 1.3125rem;
       text-align: center;
 
       .loading-text {
@@ -724,14 +724,14 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 2rem 1rem;
+    padding: 1.75rem 0.875rem;
 
     .next-book-action-button {
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 0.75rem;
-      padding: 2rem 3rem;
+      gap: 0.65625rem;
+      padding: 1.75rem 2.625rem;
       background: linear-gradient(135deg, #4a90e2 0%, #357abd 100%);
       border: none;
       border-radius: 12px;
@@ -753,15 +753,15 @@
       }
 
       .action-icon {
-        font-size: 2.5rem;
+        font-size: 2.1875rem;
       }
 
       .action-text {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .book-title {
-        font-size: 0.95rem;
+        font-size: 0.83125rem;
         font-weight: 400;
         opacity: 0.9;
         max-width: 350px;
@@ -785,22 +785,22 @@
     }
 
     .end-of-comic-action {
-      padding: 1.5rem 1rem;
+      padding: 1.3125rem 0.875rem;
 
       .next-book-action-button {
         min-width: 240px;
-        padding: 1.5rem 2rem;
+        padding: 1.3125rem 1.75rem;
 
         .action-icon {
-          font-size: 2rem;
+          font-size: 1.75rem;
         }
 
         .action-text {
-          font-size: 1rem;
+          font-size: var(--app-text-base);
         }
 
         .book-title {
-          font-size: 0.85rem;
+          font-size: 0.74375rem;
           max-width: 250px;
         }
       }
@@ -822,7 +822,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .spinner {
@@ -836,7 +836,7 @@
 
 .loader-text {
   color: #fff;
-  font-size: 1.1rem;
+  font-size: 0.9625rem;
   margin: 0;
   font-weight: 500;
 }
@@ -884,7 +884,7 @@
   }
 
   .zone-arrow {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: rgb(255 255 255 / 30%);
     opacity: 0;
     transition: opacity 0.3s ease;

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.scss
@@ -55,8 +55,8 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 0.65625rem 0.875rem;
-    padding: 0.56875rem 0.875rem;
+    gap: 0.6563rem 0.875rem;
+    padding: 0.5687rem 0.875rem;
     margin: 0 0.4375rem;
     background: rgb(30 40 55 / 95%);
     border: 1px solid rgb(255 255 255 / 12%);
@@ -81,12 +81,12 @@
   }
 
   .webtoon-btn {
-    padding: 0.35rem 0.65625rem;
+    padding: 0.35rem 0.6563rem;
     border-radius: 6px;
     border: 1px solid rgb(255 255 255 / 20%);
     background: rgb(255 255 255 / 8%);
     color: #fff;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     cursor: pointer;
     transition: background 0.15s ease, border-color 0.15s ease;
 
@@ -616,7 +616,7 @@
       @include cbx-reader-continuation-affordance;
 
       .cbx-continuation-hint {
-        padding: 0.65625rem 0.875rem 1.09375rem;
+        padding: 0.6563rem 0.875rem 1.0938rem;
       }
 
       .long-strip-image {
@@ -730,7 +730,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 0.65625rem;
+      gap: 0.6563rem;
       padding: 1.75rem 2.625rem;
       background: linear-gradient(135deg, #4a90e2 0%, #357abd 100%);
       border: none;
@@ -761,7 +761,7 @@
       }
 
       .book-title {
-        font-size: 0.83125rem;
+        font-size: 0.8313rem;
         font-weight: 400;
         opacity: 0.9;
         max-width: 350px;
@@ -800,7 +800,7 @@
         }
 
         .book-title {
-          font-size: 0.74375rem;
+          font-size: 0.7438rem;
           max-width: 250px;
         }
       }

--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.scss
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.scss
@@ -98,7 +98,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .spinner {
@@ -112,7 +112,7 @@
 
 .loader-text {
   color: #fff;
-  font-size: 1.1rem;
+  font-size: 0.9625rem;
   margin: 0;
   font-weight: 500;
 }
@@ -128,7 +128,7 @@ foliate-view::part(head) {
   justify-content: space-between;
   align-items: center;
   padding: 8px 16px;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--reader-text-secondary, #666);
   border-bottom: 1px solid var(--reader-border-color, #e0e0e0);
   font-family: inherit;
@@ -141,7 +141,7 @@ foliate-view::part(foot) {
   justify-content: space-between;
   align-items: center;
   padding: 8px 16px;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--reader-text-secondary, #666);
   border-top: 1px solid var(--reader-border-color, #e0e0e0);
   font-family: inherit;

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
@@ -520,7 +520,7 @@ $transition-fast: 150ms ease;
     background: $chrome-control-bg;
     color: $text-secondary;
     cursor: pointer;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     font-weight: 500;
     transition: background 0.2s, border-color 0.2s, color 0.2s;
     height: 30px;
@@ -564,7 +564,7 @@ $transition-fast: 150ms ease;
   align-items: center;
   gap: 8px;
   font-weight: 500;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   box-shadow: 0 4px 6px rgb(0 0 0 / 10%);
   pointer-events: none;
 

--- a/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
+++ b/frontend/src/app/features/readers/pdf-reader/pdf-reader.component.scss
@@ -520,7 +520,7 @@ $transition-fast: 150ms ease;
     background: $chrome-control-bg;
     color: $text-secondary;
     cursor: pointer;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     font-weight: 500;
     transition: background 0.2s, border-color 0.2s, color 0.2s;
     height: 30px;
@@ -564,12 +564,12 @@ $transition-fast: 150ms ease;
   align-items: center;
   gap: 8px;
   font-weight: 500;
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   box-shadow: 0 4px 6px rgb(0 0 0 / 10%);
   pointer-events: none;
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     color: $active-color;
   }
 }

--- a/frontend/src/app/features/series-browser/components/series-browser/series-browser.component.scss
+++ b/frontend/src/app/features/series-browser/components/series-browser/series-browser.component.scss
@@ -7,7 +7,7 @@
   flex-direction: column;
   height: 100%;
   min-height: 0;
-  padding: 1.1rem 0 0;
+  padding: 0.9625rem 0 0;
 }
 
 .loading-state {
@@ -20,13 +20,13 @@
 
 // Browse Header
 .browse-header {
-  padding: 0.75rem var(--browser-gutter-inline) 0;
+  padding: 0.65625rem var(--browser-gutter-inline) 0;
 }
 
 .browse-title {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   font-weight: 800;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
   background: linear-gradient(135deg, var(--color-text-strong), var(--color-text-secondary), var(--color-primary));
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -36,8 +36,8 @@
 .browse-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.4375rem;
   align-items: center;
 }
 
@@ -53,20 +53,20 @@
     top: 50%;
     transform: translateY(-50%);
     color: var(--color-text-muted);
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     z-index: 1;
   }
 
   .search-input {
     width: 100%;
-    padding-left: 2.25rem;
-    font-size: 0.9rem;
+    padding-left: 1.96875rem;
+    font-size: 0.7875rem;
   }
 }
 
 .filter-sort-wrapper {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
   align-items: center;
 }
@@ -100,12 +100,12 @@
 .display-settings-content {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   min-width: 180px;
 }
 
 .display-settings-label {
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   font-weight: 600;
   color: var(--color-text);
 }
@@ -115,13 +115,13 @@
   flex: 1 1 auto;
   width: 100%;
   min-height: 0;
-  padding: 1rem var(--browser-gutter-inline);
+  padding: 0.875rem var(--browser-gutter-inline);
   box-sizing: border-box;
   overflow: hidden auto;
   scrollbar-gutter: stable;
 
   @media #{variables.$mobile-shell-media-query} {
-    padding-block: 0.5rem;
+    padding-block: 0.4375rem;
   }
 }
 
@@ -131,18 +131,18 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 4rem 2rem;
+  padding: 3.5rem 1.75rem;
   text-align: center;
 
   .empty-icon {
-    font-size: 3rem;
+    font-size: 2.625rem;
     color: var(--color-text-muted);
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
   }
 
   p {
     color: var(--color-text-muted);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 500;
   }
 }
@@ -151,11 +151,11 @@
   .series-browser-page {
     --browser-gutter-inline: var(--space-4);
 
-    padding: 1.5rem 0 0;
+    padding: 1.3125rem 0 0;
   }
 
   .browse-header {
-    padding-top: 0.5rem;
+    padding-top: 0.4375rem;
   }
 
   .browse-controls {

--- a/frontend/src/app/features/series-browser/components/series-browser/series-browser.component.scss
+++ b/frontend/src/app/features/series-browser/components/series-browser/series-browser.component.scss
@@ -20,13 +20,13 @@
 
 // Browse Header
 .browse-header {
-  padding: 0.65625rem var(--browser-gutter-inline) 0;
+  padding: 0.6563rem var(--browser-gutter-inline) 0;
 }
 
 .browse-title {
   font-size: 1.3125rem;
   font-weight: 800;
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
   background: linear-gradient(135deg, var(--color-text-strong), var(--color-text-secondary), var(--color-primary));
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -36,7 +36,7 @@
 .browse-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.4375rem;
   align-items: center;
 }
@@ -59,14 +59,14 @@
 
   .search-input {
     width: 100%;
-    padding-left: 1.96875rem;
+    padding-left: 1.9688rem;
     font-size: 0.7875rem;
   }
 }
 
 .filter-sort-wrapper {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
   align-items: center;
 }
@@ -105,7 +105,7 @@
 }
 
 .display-settings-label {
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 600;
   color: var(--color-text);
 }

--- a/frontend/src/app/features/series-browser/components/series-card/series-card.component.scss
+++ b/frontend/src/app/features/series-browser/components/series-card/series-card.component.scss
@@ -147,7 +147,7 @@
 }
 
 .series-name {
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   font-weight: 700;
   color: var(--color-text);
   margin: 0;
@@ -158,7 +158,7 @@
 }
 
 .series-authors {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--color-text-muted);
   margin: 0;
   overflow: hidden;
@@ -181,8 +181,8 @@
   gap: 4px;
 
   ::ng-deep .p-button {
-    font-size: 0.75rem;
-    padding: 0.2rem 0.4rem;
+    font-size: var(--app-text-xs);
+    padding: 0.175rem 0.35rem;
   }
 }
 
@@ -206,7 +206,7 @@
 }
 
 .progress-label {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--color-text-secondary);
   white-space: nowrap;
   font-weight: 700;

--- a/frontend/src/app/features/series-browser/components/series-card/series-card.component.scss
+++ b/frontend/src/app/features/series-browser/components/series-card/series-card.component.scss
@@ -147,7 +147,7 @@
 }
 
 .series-name {
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 700;
   color: var(--color-text);
   margin: 0;

--- a/frontend/src/app/features/series-browser/components/series-scroller/series-scroller.component.scss
+++ b/frontend/src/app/features/series-browser/components/series-scroller/series-scroller.component.scss
@@ -71,7 +71,7 @@
   overflow: auto hidden;
   scroll-snap-type: x mandatory;
   padding: 0.875rem 0.4375rem;
-  gap: 1.09375rem;
+  gap: 1.0938rem;
   width: 100%;
   position: relative;
   z-index: 2;

--- a/frontend/src/app/features/series-browser/components/series-scroller/series-scroller.component.scss
+++ b/frontend/src/app/features/series-browser/components/series-scroller/series-scroller.component.scss
@@ -1,7 +1,7 @@
 .series-scroller-container {
   border-radius: 20px;
-  padding: 1rem 2rem 0;
-  margin-bottom: 2rem;
+  padding: 0.875rem 1.75rem 0;
+  margin-bottom: 1.75rem;
   position: relative;
   overflow: hidden;
   backdrop-filter: blur(20px);
@@ -10,9 +10,9 @@
 
 .series-scroller-title {
   text-align: left;
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   font-weight: 800;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   padding: 0;
   background: linear-gradient(135deg, var(--color-text-strong), var(--color-text-secondary), var(--color-primary));
   background-clip: text;
@@ -34,7 +34,7 @@
 }
 
 .series-scroller-empty {
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -48,10 +48,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 2rem;
+    margin-bottom: 1.75rem;
 
     i {
-      font-size: 2rem;
+      font-size: 1.75rem;
       color: white;
       filter: drop-shadow(0 2px 4px rgb(0 0 0 / 30%));
     }
@@ -59,7 +59,7 @@
 
   p {
     color: var(--color-text-secondary);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 500;
     max-width: 400px;
     line-height: 1.7;
@@ -70,8 +70,8 @@
   display: flex;
   overflow: auto hidden;
   scroll-snap-type: x mandatory;
-  padding: 1rem 0.5rem;
-  gap: 1.25rem;
+  padding: 0.875rem 0.4375rem;
+  gap: 1.09375rem;
   width: 100%;
   position: relative;
   z-index: 2;
@@ -83,10 +83,10 @@
 
 @media (width <= 767px) {
   .series-scroller-container {
-    padding: 1rem 1rem 0;
+    padding: 0.875rem 0.875rem 0;
   }
 
   .series-scroller-track {
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }

--- a/frontend/src/app/features/settings/audit-logs/audit-logs.component.scss
+++ b/frontend/src/app/features/settings/audit-logs/audit-logs.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -19,7 +19,7 @@
 .settings-card {
   @include settings.settings-card;
 
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .section-header {
@@ -29,7 +29,7 @@
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .section-title {
@@ -44,7 +44,7 @@
 
 .filter-controls {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   align-items: center;
   flex-wrap: wrap;
 }
@@ -65,8 +65,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 1.75rem;
+  height: 1.75rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
   background: transparent;
@@ -93,7 +93,7 @@
 
 .timestamp-cell {
   white-space: nowrap;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   cursor: default;
 }
@@ -112,24 +112,24 @@
 
 .ip-cell {
   font-family: 'SF Mono', Monaco, 'Courier New', monospace;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--p-text-muted-color);
 }
 
 .flag-emoji {
-  font-size: 1.15rem;
-  margin-right: 0.25rem;
+  font-size: 1.00625rem;
+  margin-right: 0.21875rem;
   vertical-align: middle;
 }
 
 ::ng-deep .p-datatable.p-datatable-sm .p-datatable-tbody > tr > td.empty-message {
   text-align: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   color: var(--p-text-muted-color);
 
   .pi {
     display: block;
-    font-size: 2rem;
-    margin-bottom: 0.5rem;
+    font-size: 1.75rem;
+    margin-bottom: 0.4375rem;
   }
 }

--- a/frontend/src/app/features/settings/audit-logs/audit-logs.component.scss
+++ b/frontend/src/app/features/settings/audit-logs/audit-logs.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -117,8 +117,8 @@
 }
 
 .flag-emoji {
-  font-size: 1.00625rem;
-  margin-right: 0.21875rem;
+  font-size: 1.0063rem;
+  margin-right: 0.2188rem;
   vertical-align: middle;
 }
 

--- a/frontend/src/app/features/settings/custom-fonts/custom-fonts.component.html
+++ b/frontend/src/app/features/settings/custom-fonts/custom-fonts.component.html
@@ -65,12 +65,12 @@
                   </span>
                   @if (!fontsLoadedInBrowser) {
                     <div class="font-preview-skeleton">
-                      <p-skeleton width="100%" height="1rem"></p-skeleton>
-                      <p-skeleton width="100%" height="1rem"></p-skeleton>
-                      <p-skeleton width="85%" height="1rem"></p-skeleton>
-                      <p-skeleton width="60%" height="1rem"></p-skeleton>
-                      <p-skeleton width="85%" height="1rem"></p-skeleton>
-                      <p-skeleton width="95%" height="0.875rem"></p-skeleton>
+                      <p-skeleton width="100%" height="0.875rem"></p-skeleton>
+                      <p-skeleton width="100%" height="0.875rem"></p-skeleton>
+                      <p-skeleton width="85%" height="0.875rem"></p-skeleton>
+                      <p-skeleton width="60%" height="0.875rem"></p-skeleton>
+                      <p-skeleton width="85%" height="0.875rem"></p-skeleton>
+                      <p-skeleton width="95%" height="0.76563rem"></p-skeleton>
                     </div>
                   } @else {
                     <div class="font-preview" [style.font-family]="font.fontName">

--- a/frontend/src/app/features/settings/custom-fonts/custom-fonts.component.html
+++ b/frontend/src/app/features/settings/custom-fonts/custom-fonts.component.html
@@ -70,7 +70,7 @@
                       <p-skeleton width="85%" height="0.875rem"></p-skeleton>
                       <p-skeleton width="60%" height="0.875rem"></p-skeleton>
                       <p-skeleton width="85%" height="0.875rem"></p-skeleton>
-                      <p-skeleton width="95%" height="0.76563rem"></p-skeleton>
+                      <p-skeleton width="95%" height="0.7656rem"></p-skeleton>
                     </div>
                   } @else {
                     <div class="font-preview" [style.font-family]="font.fontName">

--- a/frontend/src/app/features/settings/custom-fonts/custom-fonts.component.scss
+++ b/frontend/src/app/features/settings/custom-fonts/custom-fonts.component.scss
@@ -2,7 +2,7 @@
 
 .main-container {
   width: 100%;
-  padding: 1rem;
+  padding: 0.875rem;
   height: 100%;
   min-height: 0;
   overflow-y: auto;
@@ -15,11 +15,11 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 2rem;
+    gap: 1.75rem;
 
     @media (width <= 768px) {
       flex-direction: column;
-      gap: 1rem;
+      gap: 0.875rem;
     }
   }
 
@@ -31,21 +31,21 @@
 .settings-title {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  font-size: 1.25rem;
+  gap: 0.65625rem;
+  font-size: 1.09375rem;
   font-weight: 700;
   color: var(--p-text-color);
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.65625rem;
 
   .pi {
     color: var(--p-primary-color);
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
   }
 }
 
 .settings-description {
   color: var(--p-text-muted-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   line-height: 1.5;
   margin-bottom: 0;
 }
@@ -53,24 +53,24 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .section-header {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .section-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 1.125rem;
+  gap: 0.4375rem;
+  font-size: var(--app-text-lg);
   font-weight: 600;
   color: var(--p-text-color);
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 
   .pi {
     color: var(--p-primary-color);
@@ -78,14 +78,14 @@
 
   .font-count {
     color: var(--p-text-muted-color);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 500;
   }
 }
 
 .section-description {
   color: var(--p-text-muted-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   line-height: 1.5;
   margin: 0;
 }
@@ -94,10 +94,10 @@
   border: 1px solid var(--p-content-border-color);
   border-radius: 8px;
   background: var(--p-content-background);
-  padding: 1.5rem;
+  padding: 1.3125rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 // ==================== Empty State ====================
@@ -107,7 +107,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 3rem 1.5rem;
+  padding: 2.625rem 1.3125rem;
   min-height: 300px;
 
   .empty-icon-wrapper {
@@ -118,26 +118,26 @@
     height: 80px;
     background: color-mix(in srgb, var(--p-primary-color) 10%, transparent);
     border-radius: 50%;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.3125rem;
     border: 3px dashed var(--p-primary-color);
 
     .empty-icon {
-      font-size: 2.5rem;
+      font-size: 2.1875rem;
       color: var(--p-primary-color);
       opacity: 0.7;
     }
   }
 
   .empty-title {
-    margin: 0 0 0.75rem;
-    font-size: 1.25rem;
+    margin: 0 0 0.65625rem;
+    font-size: 1.09375rem;
     font-weight: 600;
     color: var(--p-text-color);
   }
 
   .empty-description {
-    margin: 0 0 1rem;
-    font-size: 0.9375rem;
+    margin: 0 0 0.875rem;
+    font-size: 0.82031rem;
     color: var(--p-text-muted-color);
     max-width: 500px;
     line-height: 1.6;
@@ -147,19 +147,19 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     margin: 0;
-    padding: 0.75rem 1.25rem;
+    padding: 0.65625rem 1.09375rem;
     background: color-mix(in srgb, var(--p-primary-color) 5%, transparent);
     border: 1px solid color-mix(in srgb, var(--p-primary-color) 20%, transparent);
     border-radius: 6px;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--p-text-muted-color);
     max-width: 500px;
 
     i {
       color: var(--p-primary-color);
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       flex-shrink: 0;
     }
 
@@ -170,35 +170,35 @@
   }
 
   @media (width <= 768px) {
-    padding: 2rem 1rem;
+    padding: 1.75rem 0.875rem;
     min-height: 250px;
 
     .empty-icon-wrapper {
       width: 70px;
       height: 70px;
-      margin-bottom: 1rem;
+      margin-bottom: 0.875rem;
 
       .empty-icon {
-        font-size: 2rem;
+        font-size: 1.75rem;
       }
     }
 
     .empty-title {
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
     }
 
     .empty-description {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       max-width: 100%;
     }
 
     .empty-hint {
-      font-size: 0.75rem;
-      padding: 0.625rem 1rem;
+      font-size: var(--app-text-xs);
+      padding: 0.54688rem 0.875rem;
       max-width: 100%;
       flex-direction: column;
       text-align: center;
-      gap: 0.375rem;
+      gap: 0.32813rem;
     }
   }
 }
@@ -207,7 +207,7 @@
 .fonts-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  gap: 1.5rem;
+  gap: 1.3125rem;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;
@@ -223,32 +223,32 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 1rem;
-    padding: 1rem 1rem 0.75rem;
+    gap: 0.875rem;
+    padding: 0.875rem 0.875rem 0.65625rem;
     border-bottom: 1px solid var(--p-content-border-color);
 
     .font-title-group {
       flex: 1;
       display: flex;
       align-items: center;
-      gap: 0.75rem;
+      gap: 0.65625rem;
       flex-wrap: wrap;
 
       .font-name {
         margin: 0;
-        font-size: 1rem;
+        font-size: var(--app-text-base);
         font-weight: 600;
         color: var(--p-text-color);
       }
 
       .format-tag {
         display: inline-block;
-        padding: 0.1875rem 0.5rem;
+        padding: 0.16406rem 0.4375rem;
         border-radius: 4px;
         background: transparent;
         border: 1px solid var(--p-primary-color);
         color: var(--p-primary-color);
-        font-size: 0.6875rem;
+        font-size: 0.60156rem;
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.025em;
@@ -257,37 +257,37 @@
   }
 
   .font-preview-area {
-    padding: 1rem;
+    padding: 0.875rem;
     border-bottom: 1px solid var(--p-content-border-color);
 
     .preview-label {
       display: flex;
       align-items: center;
-      gap: 0.375rem;
-      font-size: 0.75rem;
+      gap: 0.32813rem;
+      font-size: var(--app-text-xs);
       font-weight: 600;
       color: var(--p-text-muted-color);
       text-transform: uppercase;
       letter-spacing: 0.025em;
-      margin-bottom: 0.75rem;
+      margin-bottom: 0.65625rem;
 
       i {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
       }
     }
 
     .font-preview {
-      padding: 1rem;
+      padding: 0.875rem;
       border: 1px solid var(--p-content-border-color);
       border-radius: 6px;
       background: color-mix(in srgb, var(--p-surface-ground) 30%, var(--p-content-background));
       display: flex;
       flex-direction: column;
-      gap: 0.75rem;
+      gap: 0.65625rem;
 
       .preview-paragraph {
         color: var(--p-text-color);
-        font-size: 0.9375rem;
+        font-size: 0.82031rem;
         line-height: 1.7;
         margin: 0;
         text-align: justify;
@@ -296,7 +296,7 @@
 
       .preview-paragraph-small {
         color: var(--p-text-color);
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
         line-height: 1.6;
         margin: 0;
         text-align: justify;
@@ -306,13 +306,13 @@
       .preview-characters {
         display: flex;
         flex-direction: column;
-        gap: 0.25rem;
-        padding-top: 0.5rem;
-        margin-top: 0.25rem;
+        gap: 0.21875rem;
+        padding-top: 0.4375rem;
+        margin-top: 0.21875rem;
         border-top: 1px solid var(--p-content-border-color);
 
         span {
-          font-size: 0.6875rem;
+          font-size: 0.60156rem;
           color: var(--p-text-muted-color);
           letter-spacing: 0.025em;
           font-weight: 400;
@@ -321,26 +321,26 @@
     }
 
     .font-preview-skeleton {
-      padding: 1rem;
+      padding: 0.875rem;
       border: 1px solid var(--p-content-border-color);
       border-radius: 6px;
       background: color-mix(in srgb, var(--p-surface-ground) 30%, var(--p-content-background));
       display: flex;
       flex-direction: column;
-      gap: 0.75rem;
+      gap: 0.65625rem;
     }
   }
 
   .font-metadata {
-    padding: 1rem;
+    padding: 0.875rem;
     background: color-mix(in srgb, var(--p-surface-ground) 20%, var(--p-content-background));
 
     .metadata-row {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      gap: 1rem;
-      padding: 0.375rem 0;
+      gap: 0.875rem;
+      padding: 0.32813rem 0;
 
       &:not(:last-child) {
         border-bottom: 1px solid var(--p-content-border-color);
@@ -349,19 +349,19 @@
       .meta-label {
         display: flex;
         align-items: center;
-        gap: 0.5rem;
-        font-size: 0.875rem;
+        gap: 0.4375rem;
+        font-size: var(--app-text-sm);
         color: var(--p-text-muted-color);
         font-weight: 500;
 
         i {
           color: var(--p-primary-color);
-          font-size: 0.75rem;
+          font-size: var(--app-text-xs);
         }
       }
 
       .meta-value {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
         color: var(--p-text-color);
         font-weight: 500;
         text-align: right;
@@ -373,7 +373,7 @@
 
 .float-top-right {
   position: absolute;
-  top: -0.5rem;
-  right: -0.5rem;
+  top: -0.4375rem;
+  right: -0.4375rem;
   z-index: 10;
 }

--- a/frontend/src/app/features/settings/custom-fonts/custom-fonts.component.scss
+++ b/frontend/src/app/features/settings/custom-fonts/custom-fonts.component.scss
@@ -31,15 +31,15 @@
 .settings-title {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  font-size: 1.09375rem;
+  gap: 0.6563rem;
+  font-size: 1.0938rem;
   font-weight: 700;
   color: var(--p-text-color);
-  margin: 0 0 0.65625rem;
+  margin: 0 0 0.6563rem;
 
   .pi {
     color: var(--p-primary-color);
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
   }
 }
 
@@ -129,15 +129,15 @@
   }
 
   .empty-title {
-    margin: 0 0 0.65625rem;
-    font-size: 1.09375rem;
+    margin: 0 0 0.6563rem;
+    font-size: 1.0938rem;
     font-weight: 600;
     color: var(--p-text-color);
   }
 
   .empty-description {
     margin: 0 0 0.875rem;
-    font-size: 0.82031rem;
+    font-size: 0.8203rem;
     color: var(--p-text-muted-color);
     max-width: 500px;
     line-height: 1.6;
@@ -149,7 +149,7 @@
     justify-content: center;
     gap: 0.4375rem;
     margin: 0;
-    padding: 0.65625rem 1.09375rem;
+    padding: 0.6563rem 1.0938rem;
     background: color-mix(in srgb, var(--p-primary-color) 5%, transparent);
     border: 1px solid color-mix(in srgb, var(--p-primary-color) 20%, transparent);
     border-radius: 6px;
@@ -194,11 +194,11 @@
 
     .empty-hint {
       font-size: var(--app-text-xs);
-      padding: 0.54688rem 0.875rem;
+      padding: 0.5469rem 0.875rem;
       max-width: 100%;
       flex-direction: column;
       text-align: center;
-      gap: 0.32813rem;
+      gap: 0.3281rem;
     }
   }
 }
@@ -224,14 +224,14 @@
     justify-content: space-between;
     align-items: flex-start;
     gap: 0.875rem;
-    padding: 0.875rem 0.875rem 0.65625rem;
+    padding: 0.875rem 0.875rem 0.6563rem;
     border-bottom: 1px solid var(--p-content-border-color);
 
     .font-title-group {
       flex: 1;
       display: flex;
       align-items: center;
-      gap: 0.65625rem;
+      gap: 0.6563rem;
       flex-wrap: wrap;
 
       .font-name {
@@ -243,12 +243,12 @@
 
       .format-tag {
         display: inline-block;
-        padding: 0.16406rem 0.4375rem;
+        padding: 0.1641rem 0.4375rem;
         border-radius: 4px;
         background: transparent;
         border: 1px solid var(--p-primary-color);
         color: var(--p-primary-color);
-        font-size: 0.60156rem;
+        font-size: 0.6016rem;
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.025em;
@@ -263,13 +263,13 @@
     .preview-label {
       display: flex;
       align-items: center;
-      gap: 0.32813rem;
+      gap: 0.3281rem;
       font-size: var(--app-text-xs);
       font-weight: 600;
       color: var(--p-text-muted-color);
       text-transform: uppercase;
       letter-spacing: 0.025em;
-      margin-bottom: 0.65625rem;
+      margin-bottom: 0.6563rem;
 
       i {
         font-size: var(--app-text-xs);
@@ -283,11 +283,11 @@
       background: color-mix(in srgb, var(--p-surface-ground) 30%, var(--p-content-background));
       display: flex;
       flex-direction: column;
-      gap: 0.65625rem;
+      gap: 0.6563rem;
 
       .preview-paragraph {
         color: var(--p-text-color);
-        font-size: 0.82031rem;
+        font-size: 0.8203rem;
         line-height: 1.7;
         margin: 0;
         text-align: justify;
@@ -306,13 +306,13 @@
       .preview-characters {
         display: flex;
         flex-direction: column;
-        gap: 0.21875rem;
+        gap: 0.2188rem;
         padding-top: 0.4375rem;
-        margin-top: 0.21875rem;
+        margin-top: 0.2188rem;
         border-top: 1px solid var(--p-content-border-color);
 
         span {
-          font-size: 0.60156rem;
+          font-size: 0.6016rem;
           color: var(--p-text-muted-color);
           letter-spacing: 0.025em;
           font-weight: 400;
@@ -327,7 +327,7 @@
       background: color-mix(in srgb, var(--p-surface-ground) 30%, var(--p-content-background));
       display: flex;
       flex-direction: column;
-      gap: 0.65625rem;
+      gap: 0.6563rem;
     }
   }
 
@@ -340,7 +340,7 @@
       justify-content: space-between;
       align-items: center;
       gap: 0.875rem;
-      padding: 0.32813rem 0;
+      padding: 0.3281rem 0;
 
       &:not(:last-child) {
         border-bottom: 1px solid var(--p-content-border-color);

--- a/frontend/src/app/features/settings/custom-fonts/font-upload-dialog/font-upload-dialog.component.scss
+++ b/frontend/src/app/features/settings/custom-fonts/font-upload-dialog/font-upload-dialog.component.scss
@@ -21,16 +21,16 @@
 .upload-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.75rem;
+  gap: 0.875rem;
+  padding: 1.53125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 0 0 10px 10px;
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
 
   @media (width <= 480px) {
-    padding: 1rem;
-    gap: 1rem;
+    padding: 0.875rem;
+    gap: 0.875rem;
   }
 }
 
@@ -42,29 +42,29 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.625rem 0.875rem;
+    padding: 0.54688rem 0.76563rem;
     background: var(--overlay-background);
     border-radius: 6px;
 
     .section-title {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      font-size: 0.9rem;
+      gap: 0.4375rem;
+      font-size: 0.7875rem;
       font-weight: 600;
       color: var(--text-color);
 
       i {
         color: var(--primary-color);
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
     }
 
     @media (width <= 480px) {
-      padding: 0.5rem 0.625rem;
+      padding: 0.4375rem 0.54688rem;
 
       .section-title {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }
@@ -75,7 +75,7 @@
     align-items: center;
     justify-content: center;
     text-align: center;
-    padding: 1.5rem 1rem;
+    padding: 1.3125rem 0.875rem;
 
     .empty-icon-wrapper {
       display: flex;
@@ -85,26 +85,26 @@
       height: 80px;
       background: var(--overlay-background);
       border-radius: 50%;
-      margin-bottom: 1rem;
+      margin-bottom: 0.875rem;
       border: 3px dashed var(--border-color);
 
       .empty-icon {
-        font-size: 2.5rem;
+        font-size: 2.1875rem;
         color: var(--text-secondary-color);
         opacity: 0.6;
       }
     }
 
     .empty-title {
-      margin: 0 0 0.5rem;
-      font-size: 1.125rem;
+      margin: 0 0 0.4375rem;
+      font-size: var(--app-text-lg);
       font-weight: 600;
       color: var(--text-color);
     }
 
     .empty-description {
       margin: 0;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--text-secondary-color);
       max-width: 450px;
       line-height: 1.5;
@@ -115,25 +115,25 @@
     }
 
     @media (width <= 480px) {
-      padding: 1.5rem 0.75rem;
+      padding: 1.3125rem 0.65625rem;
       min-height: 180px;
 
       .empty-icon-wrapper {
         width: 70px;
         height: 70px;
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.65625rem;
 
         .empty-icon {
-          font-size: 2rem;
+          font-size: 1.75rem;
         }
       }
 
       .empty-title {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .empty-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
         max-width: 100%;
       }
     }
@@ -142,7 +142,7 @@
 
 // ==================== Upload Zone ====================
 .upload-zone {
-  padding: 2rem;
+  padding: 1.75rem;
   text-align: center;
   border: 2px dashed var(--border-color);
   border-radius: 8px;
@@ -187,7 +187,7 @@
 .file-selected {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
   width: 100%;
   max-width: 100%;
   overflow: hidden;
@@ -196,8 +196,8 @@
 .file-info-card {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 0.875rem;
+  padding: 0.875rem;
   border: 1px solid var(--border-color);
   border-radius: 6px;
   background: var(--overlay-background);
@@ -206,7 +206,7 @@
   overflow: hidden;
 
   i {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: var(--primary-color);
     flex-shrink: 0;
   }
@@ -215,20 +215,20 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 0.21875rem;
     min-width: 0;
     overflow: hidden;
 
     .file-name {
       font-weight: 600;
       color: var(--text-color);
-      font-size: 0.9375rem;
+      font-size: 0.82031rem;
       overflow-wrap: anywhere;
       overflow-wrap: break-word;
     }
 
     .file-meta {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--text-secondary-color);
     }
   }
@@ -237,7 +237,7 @@
 .preview-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   width: 100%;
   max-width: 100%;
   overflow: hidden;
@@ -245,27 +245,27 @@
   .preview-label {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
-    font-size: 0.75rem;
+    gap: 0.32813rem;
+    font-size: var(--app-text-xs);
     font-weight: 600;
     color: var(--text-secondary-color);
     text-transform: uppercase;
     letter-spacing: 0.025em;
 
     i {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--primary-color);
     }
   }
 
   .font-preview {
-    padding: 1.5rem;
+    padding: 1.3125rem;
     border: 1px solid var(--border-color);
     border-radius: 6px;
     background: var(--overlay-background);
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
     max-height: 300px;
     overflow-y: auto;
     width: 100%;
@@ -274,7 +274,7 @@
 
     .preview-paragraph {
       color: var(--text-color);
-      font-size: 1rem;
+      font-size: var(--app-text-base);
       line-height: 1.7;
       margin: 0;
       text-align: justify;
@@ -283,7 +283,7 @@
 
     .preview-paragraph-small {
       color: var(--text-color);
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       line-height: 1.6;
       margin: 0;
       text-align: justify;
@@ -293,13 +293,13 @@
     .preview-characters {
       display: flex;
       flex-direction: column;
-      gap: 0.375rem;
-      padding-top: 0.75rem;
-      margin-top: 0.5rem;
+      gap: 0.32813rem;
+      padding-top: 0.65625rem;
+      margin-top: 0.4375rem;
       border-top: 1px solid var(--border-color);
 
       span {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         color: var(--text-secondary-color);
         letter-spacing: 0.025em;
         font-weight: 400;
@@ -311,7 +311,7 @@
 .setting-item {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   padding: 0;
   width: 100%;
   max-width: 100%;
@@ -324,13 +324,13 @@
     display: block;
     font-weight: 600;
     color: var(--text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
   }
 
   .setting-description {
     color: var(--text-secondary-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     line-height: 1.5;
     margin: 0;
   }
@@ -339,7 +339,7 @@
 .setting-control {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   width: 100%;
 
   .font-name-input {

--- a/frontend/src/app/features/settings/custom-fonts/font-upload-dialog/font-upload-dialog.component.scss
+++ b/frontend/src/app/features/settings/custom-fonts/font-upload-dialog/font-upload-dialog.component.scss
@@ -22,7 +22,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
-  padding: 1.53125rem;
+  padding: 1.5313rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 0 0 10px 10px;
@@ -42,7 +42,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.54688rem 0.76563rem;
+    padding: 0.5469rem 0.7656rem;
     background: var(--overlay-background);
     border-radius: 6px;
 
@@ -61,10 +61,10 @@
     }
 
     @media (width <= 480px) {
-      padding: 0.4375rem 0.54688rem;
+      padding: 0.4375rem 0.5469rem;
 
       .section-title {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }
@@ -115,13 +115,13 @@
     }
 
     @media (width <= 480px) {
-      padding: 1.3125rem 0.65625rem;
+      padding: 1.3125rem 0.6563rem;
       min-height: 180px;
 
       .empty-icon-wrapper {
         width: 70px;
         height: 70px;
-        margin-bottom: 0.65625rem;
+        margin-bottom: 0.6563rem;
 
         .empty-icon {
           font-size: 1.75rem;
@@ -215,14 +215,14 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 0.21875rem;
+    gap: 0.2188rem;
     min-width: 0;
     overflow: hidden;
 
     .file-name {
       font-weight: 600;
       color: var(--text-color);
-      font-size: 0.82031rem;
+      font-size: 0.8203rem;
       overflow-wrap: anywhere;
       overflow-wrap: break-word;
     }
@@ -237,7 +237,7 @@
 .preview-section {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   width: 100%;
   max-width: 100%;
   overflow: hidden;
@@ -245,7 +245,7 @@
   .preview-label {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     font-size: var(--app-text-xs);
     font-weight: 600;
     color: var(--text-secondary-color);
@@ -293,8 +293,8 @@
     .preview-characters {
       display: flex;
       flex-direction: column;
-      gap: 0.32813rem;
-      padding-top: 0.65625rem;
+      gap: 0.3281rem;
+      padding-top: 0.6563rem;
       margin-top: 0.4375rem;
       border-top: 1px solid var(--border-color);
 
@@ -311,7 +311,7 @@
 .setting-item {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding: 0;
   width: 100%;
   max-width: 100%;
@@ -339,7 +339,7 @@
 .setting-control {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   width: 100%;
 
   .font-name-input {

--- a/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.scss
+++ b/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.scss
@@ -11,7 +11,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -133,7 +133,7 @@
 .token-input-group {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   width: 100%;
 
   .token-input {

--- a/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.scss
+++ b/frontend/src/app/features/settings/device-settings/component/hardcover-settings/hardcover-settings-component.scss
@@ -2,7 +2,7 @@
 
 .main-container {
   width: 100%;
-  padding: 1rem;
+  padding: 0.875rem;
   overflow-y: auto;
 }
 
@@ -11,7 +11,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -21,8 +21,8 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  margin-top: 1.5rem;
+  gap: 1.75rem;
+  margin-top: 1.3125rem;
 
   @media (width <= 768px) {
     padding-left: 0;
@@ -38,15 +38,15 @@
 .section-header {
   @include settings.settings-section-header;
 
-  margin-bottom: 1rem;
-  margin-left: 1rem;
-  margin-right: 1rem;
+  margin-bottom: 0.875rem;
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
 }
 
 .section-title {
   @include settings.settings-section-title;
 
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 }
 
 .section-description {
@@ -56,12 +56,12 @@
 .settings-card {
   @include settings.settings-card;
 
-  padding: 1rem 1.5rem 1.5rem;
-  margin-left: 1rem;
-  margin-right: 1rem;
+  padding: 0.875rem 1.3125rem 1.3125rem;
+  margin-left: 0.875rem;
+  margin-right: 0.875rem;
 
   @media (width <= 768px) {
-    padding: 1rem;
+    padding: 0.875rem;
     margin-left: 0;
     margin-right: 0;
   }
@@ -70,8 +70,8 @@
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
-  padding: 0.5rem 0;
+  gap: 1.75rem;
+  padding: 0.4375rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -80,8 +80,8 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
-    padding: 0.5rem 0;
+    gap: 0.875rem;
+    padding: 0.4375rem 0;
   }
 }
 
@@ -93,15 +93,15 @@
     display: block;
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
   }
 
   .setting-label-row {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {
@@ -133,7 +133,7 @@
 .token-input-group {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   width: 100%;
 
   .token-input {

--- a/frontend/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.scss
+++ b/frontend/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.scss
@@ -2,7 +2,7 @@
 
 .main-container {
   width: 100%;
-  padding: 1rem;
+  padding: 0.875rem;
   overflow-y: auto;
 }
 
@@ -11,7 +11,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -21,26 +21,26 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  margin-top: 1.5rem;
+  gap: 1.75rem;
+  margin-top: 1.3125rem;
 }
 
 .preferences-section {
   @media (width >= 768px) {
-    padding: 0 1rem;
+    padding: 0 0.875rem;
   }
 }
 
 .section-header {
   @include settings.settings-section-header;
 
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .section-title {
   @include settings.settings-section-title;
 
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 }
 
 .section-description {
@@ -50,17 +50,17 @@
 .settings-card {
   @include settings.settings-card;
 
-  padding: 1.75rem;
+  padding: 1.53125rem;
 }
 
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
+  gap: 1.75rem;
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
@@ -72,15 +72,15 @@
     display: block;
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
   }
 
   .setting-label-row {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {
@@ -122,7 +122,7 @@
   .setting-warning {
     @include settings.settings-warning-notice;
 
-    margin-top: 0.75rem;
+    margin-top: 0.65625rem;
   }
 }
 
@@ -130,7 +130,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   align-items: flex-end;
 
   @media (width <= 768px) {
@@ -142,7 +142,7 @@
 .token-input-group {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   width: 100%;
 
   .token-input {

--- a/frontend/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.scss
+++ b/frontend/src/app/features/settings/device-settings/component/kobo-sync-settings/kobo-sync-settings-component.scss
@@ -11,7 +11,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -50,7 +50,7 @@
 .settings-card {
   @include settings.settings-card;
 
-  padding: 1.53125rem;
+  padding: 1.5313rem;
 }
 
 .setting-item {
@@ -122,7 +122,7 @@
   .setting-warning {
     @include settings.settings-warning-notice;
 
-    margin-top: 0.65625rem;
+    margin-top: 0.6563rem;
   }
 }
 
@@ -130,7 +130,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   align-items: flex-end;
 
   @media (width <= 768px) {

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.scss
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.scss
@@ -10,7 +10,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -20,27 +20,27 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  margin-top: 1.5rem;
+  gap: 1.75rem;
+  margin-top: 1.3125rem;
 }
 
 .preferences-section {
   @media (width >= 768px) {
-    padding: 0 1rem;
+    padding: 0 0.875rem;
   }
 }
 
 .section-header {
   @include settings.settings-section-header;
 
-  margin-top: 1.25rem;
-  margin-bottom: 1rem;
+  margin-top: 1.09375rem;
+  margin-bottom: 0.875rem;
 }
 
 .section-title {
   @include settings.settings-section-title;
 
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 }
 
 .section-description {
@@ -50,14 +50,14 @@
 .settings-card {
   @include settings.settings-card;
 
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
-  padding: 0.5rem 0;
+  gap: 1.75rem;
+  padding: 0.4375rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -66,8 +66,8 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
-    padding: 0.5rem 0;
+    gap: 0.875rem;
+    padding: 0.4375rem 0;
   }
 }
 
@@ -80,14 +80,14 @@
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
     font-size: settings.$settings-label-size;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.4375rem;
   }
 
   .setting-label-row {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {
@@ -120,7 +120,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   align-items: flex-end;
   min-width: 350px;
 
@@ -134,7 +134,7 @@
 .token-input-group {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   width: 100%;
 
   .token-input {
@@ -158,8 +158,8 @@
 
 .error-message {
   color: var(--p-red-500);
-  font-size: 0.75rem;
-  margin-top: 0.25rem;
+  font-size: var(--app-text-xs);
+  margin-top: 0.21875rem;
   display: block;
 }
 

--- a/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.scss
+++ b/frontend/src/app/features/settings/device-settings/component/koreader-settings/koreader-settings-component.scss
@@ -10,7 +10,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -33,7 +33,7 @@
 .section-header {
   @include settings.settings-section-header;
 
-  margin-top: 1.09375rem;
+  margin-top: 1.0938rem;
   margin-bottom: 0.875rem;
 }
 
@@ -120,7 +120,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   align-items: flex-end;
   min-width: 350px;
 
@@ -134,7 +134,7 @@
 .token-input-group {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   width: 100%;
 
   .token-input {
@@ -159,7 +159,7 @@
 .error-message {
   color: var(--p-red-500);
   font-size: var(--app-text-xs);
-  margin-top: 0.21875rem;
+  margin-top: 0.2188rem;
   display: block;
 }
 

--- a/frontend/src/app/features/settings/device-settings/device-settings-component.scss
+++ b/frontend/src/app/features/settings/device-settings/device-settings-component.scss
@@ -7,5 +7,5 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }

--- a/frontend/src/app/features/settings/email-v2/create-email-provider-dialog/create-email-provider-dialog.component.scss
+++ b/frontend/src/app/features/settings/email-v2/create-email-provider-dialog/create-email-provider-dialog.component.scss
@@ -50,23 +50,23 @@
   gap: 0.4375rem;
 
   &.highlight-group {
-    padding: 0.76563rem;
+    padding: 0.7656rem;
   }
 
   &.checkbox-group {
-    padding: 0.65625rem 0.76563rem;
+    padding: 0.6563rem 0.7656rem;
   }
 
   @media (width <= 480px) {
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     margin-bottom: 0.875rem;
 
     &.highlight-group {
-      padding: 0.54688rem;
+      padding: 0.5469rem;
     }
 
     &.checkbox-group {
-      padding: 0.4375rem 0.54688rem;
+      padding: 0.4375rem 0.5469rem;
     }
   }
 }
@@ -74,8 +74,8 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  font-size: 0.83125rem;
+  gap: 0.3281rem;
+  font-size: 0.8313rem;
   font-weight: 600;
   color: var(--text-color);
 
@@ -85,7 +85,7 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.10938rem;
+    margin-left: 0.1094rem;
   }
 
   @media (width <= 480px) {
@@ -109,7 +109,7 @@
 
   .input-icon {
     position: absolute;
-    right: 0.65625rem;
+    right: 0.6563rem;
     top: 50%;
     transform: translateY(-50%);
     font-size: var(--app-text-base);
@@ -135,10 +135,10 @@
 .field-error {
   color: #ef4444;
   font-size: var(--app-text-sm);
-  margin-top: 0.21875rem;
+  margin-top: 0.2188rem;
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   &::before {
     content: '⚠';
@@ -149,17 +149,17 @@
 .checkbox-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   .checkbox-label {
     display: flex;
     flex-direction: column;
-    gap: 0.10938rem;
+    gap: 0.1094rem;
     cursor: pointer;
     flex: 1;
 
     .checkbox-title {
-      font-size: 0.82031rem;
+      font-size: 0.8203rem;
       font-weight: 600;
       color: var(--text-color);
     }
@@ -194,7 +194,7 @@
       var(--border-color) 80%,
       transparent
   );
-  margin: 1.09375rem 0;
+  margin: 1.0938rem 0;
 
   @media (width <= 480px) {
     margin: 0.875rem 0;

--- a/frontend/src/app/features/settings/email-v2/create-email-provider-dialog/create-email-provider-dialog.component.scss
+++ b/frontend/src/app/features/settings/email-v2/create-email-provider-dialog/create-email-provider-dialog.component.scss
@@ -1,10 +1,10 @@
 @use '../../../../shared/styles/panel-shared' as panel;
 
 .email-provider-form {
-  padding: 1.5rem;
+  padding: 1.3125rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .email-provider-creator {
@@ -25,7 +25,7 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -34,39 +34,39 @@
   overflow-y: auto;
 
   @media (width <= 480px) {
-    padding: 1rem;
+    padding: 0.875rem;
   }
 }
 
 .form-row {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   &.highlight-group {
-    padding: 0.875rem;
+    padding: 0.76563rem;
   }
 
   &.checkbox-group {
-    padding: 0.75rem 0.875rem;
+    padding: 0.65625rem 0.76563rem;
   }
 
   @media (width <= 480px) {
-    gap: 0.375rem;
-    margin-bottom: 1rem;
+    gap: 0.32813rem;
+    margin-bottom: 0.875rem;
 
     &.highlight-group {
-      padding: 0.625rem;
+      padding: 0.54688rem;
     }
 
     &.checkbox-group {
-      padding: 0.5rem 0.625rem;
+      padding: 0.4375rem 0.54688rem;
     }
   }
 }
@@ -74,8 +74,8 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.95rem;
+  gap: 0.32813rem;
+  font-size: 0.83125rem;
   font-weight: 600;
   color: var(--text-color);
 
@@ -85,17 +85,17 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.125rem;
+    margin-left: 0.10938rem;
   }
 
   @media (width <= 480px) {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
 .form-input {
   width: 100%;
-  max-width: 20rem;
+  max-width: 17.5rem;
 }
 
 .input-wrapper {
@@ -103,16 +103,16 @@
 
   .input-full {
     width: 100%;
-    padding-right: 2.5rem;
+    padding-right: 2.1875rem;
     box-sizing: border-box;
   }
 
   .input-icon {
     position: absolute;
-    right: 0.75rem;
+    right: 0.65625rem;
     top: 50%;
     transform: translateY(-50%);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     pointer-events: none;
 
     &.success {
@@ -128,58 +128,58 @@
 
 .form-error {
   color: #ef4444;
-  padding-left: 10rem;
-  font-size: 0.875rem;
+  padding-left: 8.75rem;
+  font-size: var(--app-text-sm);
 }
 
 .field-error {
   color: #ef4444;
-  font-size: 0.875rem;
-  margin-top: 0.25rem;
+  font-size: var(--app-text-sm);
+  margin-top: 0.21875rem;
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   &::before {
     content: '⚠';
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
 .checkbox-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   .checkbox-label {
     display: flex;
     flex-direction: column;
-    gap: 0.125rem;
+    gap: 0.10938rem;
     cursor: pointer;
     flex: 1;
 
     .checkbox-title {
-      font-size: 0.9375rem;
+      font-size: 0.82031rem;
       font-weight: 600;
       color: var(--text-color);
     }
 
     .checkbox-description {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
       color: var(--text-secondary-color);
     }
   }
 
   @media (width <= 480px) {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .checkbox-label {
       .checkbox-title {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
 
       .checkbox-description {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
       }
     }
   }
@@ -194,10 +194,10 @@
       var(--border-color) 80%,
       transparent
   );
-  margin: 1.25rem 0;
+  margin: 1.09375rem 0;
 
   @media (width <= 480px) {
-    margin: 1rem 0;
+    margin: 0.875rem 0;
   }
 }
 

--- a/frontend/src/app/features/settings/email-v2/create-email-recipient-dialog/create-email-recipient-dialog.component.scss
+++ b/frontend/src/app/features/settings/email-v2/create-email-recipient-dialog/create-email-recipient-dialog.component.scss
@@ -18,7 +18,7 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -27,32 +27,32 @@
   overflow-y: auto;
 
   @media (width <= 480px) {
-    padding: 1rem;
+    padding: 0.875rem;
   }
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   &.highlight-group {
-    padding: 0.875rem;
+    padding: 0.76563rem;
   }
 
   &.checkbox-group {
-    padding: 0.75rem 0.875rem;
+    padding: 0.65625rem 0.76563rem;
   }
 
   @media (width <= 480px) {
-    gap: 0.375rem;
+    gap: 0.32813rem;
 
     &.highlight-group {
-      padding: 0.625rem;
+      padding: 0.54688rem;
     }
 
     &.checkbox-group {
-      padding: 0.5rem 0.625rem;
+      padding: 0.4375rem 0.54688rem;
     }
   }
 }
@@ -60,8 +60,8 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.95rem;
+  gap: 0.32813rem;
+  font-size: 0.83125rem;
   font-weight: 600;
   color: var(--text-color);
 
@@ -71,11 +71,11 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.125rem;
+    margin-left: 0.10938rem;
   }
 
   @media (width <= 480px) {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -84,16 +84,16 @@
 
   .input-full {
     width: 100%;
-    padding-right: 2.5rem;
+    padding-right: 2.1875rem;
     box-sizing: border-box;
   }
 
   .input-icon {
     position: absolute;
-    right: 0.75rem;
+    right: 0.65625rem;
     top: 50%;
     transform: translateY(-50%);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     pointer-events: none;
 
     &.success {
@@ -109,52 +109,52 @@
 
 .field-error {
   color: #ef4444;
-  font-size: 0.875rem;
-  margin-top: 0.25rem;
+  font-size: var(--app-text-sm);
+  margin-top: 0.21875rem;
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   &::before {
     content: '⚠';
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
 .checkbox-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   .checkbox-label {
     display: flex;
     flex-direction: column;
-    gap: 0.125rem;
+    gap: 0.10938rem;
     cursor: pointer;
     flex: 1;
 
     .checkbox-title {
-      font-size: 0.9375rem;
+      font-size: 0.82031rem;
       font-weight: 600;
       color: var(--text-color);
     }
 
     .checkbox-description {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
       color: var(--text-secondary-color);
     }
   }
 
   @media (width <= 480px) {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .checkbox-label {
       .checkbox-title {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
 
       .checkbox-description {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
       }
     }
   }
@@ -169,10 +169,10 @@
     var(--border-color) 80%,
     transparent
   );
-  margin: 1.25rem 0;
+  margin: 1.09375rem 0;
 
   @media (width <= 480px) {
-    margin: 1rem 0;
+    margin: 0.875rem 0;
   }
 }
 

--- a/frontend/src/app/features/settings/email-v2/create-email-recipient-dialog/create-email-recipient-dialog.component.scss
+++ b/frontend/src/app/features/settings/email-v2/create-email-recipient-dialog/create-email-recipient-dialog.component.scss
@@ -37,22 +37,22 @@
   gap: 0.4375rem;
 
   &.highlight-group {
-    padding: 0.76563rem;
+    padding: 0.7656rem;
   }
 
   &.checkbox-group {
-    padding: 0.65625rem 0.76563rem;
+    padding: 0.6563rem 0.7656rem;
   }
 
   @media (width <= 480px) {
-    gap: 0.32813rem;
+    gap: 0.3281rem;
 
     &.highlight-group {
-      padding: 0.54688rem;
+      padding: 0.5469rem;
     }
 
     &.checkbox-group {
-      padding: 0.4375rem 0.54688rem;
+      padding: 0.4375rem 0.5469rem;
     }
   }
 }
@@ -60,8 +60,8 @@
 .form-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  font-size: 0.83125rem;
+  gap: 0.3281rem;
+  font-size: 0.8313rem;
   font-weight: 600;
   color: var(--text-color);
 
@@ -71,7 +71,7 @@
 
   .required-indicator {
     color: var(--p-red-500);
-    margin-left: 0.10938rem;
+    margin-left: 0.1094rem;
   }
 
   @media (width <= 480px) {
@@ -90,7 +90,7 @@
 
   .input-icon {
     position: absolute;
-    right: 0.65625rem;
+    right: 0.6563rem;
     top: 50%;
     transform: translateY(-50%);
     font-size: var(--app-text-base);
@@ -110,10 +110,10 @@
 .field-error {
   color: #ef4444;
   font-size: var(--app-text-sm);
-  margin-top: 0.21875rem;
+  margin-top: 0.2188rem;
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   &::before {
     content: '⚠';
@@ -124,17 +124,17 @@
 .checkbox-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   .checkbox-label {
     display: flex;
     flex-direction: column;
-    gap: 0.10938rem;
+    gap: 0.1094rem;
     cursor: pointer;
     flex: 1;
 
     .checkbox-title {
-      font-size: 0.82031rem;
+      font-size: 0.8203rem;
       font-weight: 600;
       color: var(--text-color);
     }
@@ -169,7 +169,7 @@
     var(--border-color) 80%,
     transparent
   );
-  margin: 1.09375rem 0;
+  margin: 1.0938rem 0;
 
   @media (width <= 480px) {
     margin: 0.875rem 0;

--- a/frontend/src/app/features/settings/email-v2/email-v2-provider/email-v2-provider.component.scss
+++ b/frontend/src/app/features/settings/email-v2/email-v2-provider/email-v2-provider.component.scss
@@ -12,7 +12,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 767px) {
     flex-direction: column;
@@ -39,7 +39,7 @@
 .section-body {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 // Empty state
@@ -48,22 +48,22 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   text-align: center;
   color: var(--p-text-muted-color);
   background: var(--color-card);
   border-radius: 6px;
 
   .pi {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   .empty-title {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     color: var(--p-text-color);
   }
 
@@ -77,7 +77,7 @@
 .providers-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .provider-item {
@@ -85,7 +85,7 @@
   border: 1px solid var(--p-content-border-color);
   border-left: 3px solid var(--p-content-border-color);
   border-radius: 6px;
-  padding: 1rem;
+  padding: 0.875rem;
   transition: border-color 0.2s ease, background 0.2s ease;
 
   &:hover {
@@ -101,15 +101,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
-  padding-bottom: 0.75rem;
+  gap: 0.875rem;
+  margin-bottom: 0.875rem;
+  padding-bottom: 0.65625rem;
   border-bottom: 1px dashed var(--p-content-border-color);
 
   @media (width <= 767px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
@@ -121,13 +121,13 @@
 .provider-name-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
 }
 
 .provider-name {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   color: var(--p-text-color);
 }
 
@@ -140,32 +140,32 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.3125rem;
+  height: 1.3125rem;
   background: color-mix(in srgb, var(--p-green-600) 20%, transparent);
   color: var(--p-green-400);
   border-radius: 4px;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
 
   .pi {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
   }
 }
 
 .default-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.125rem 0.5rem;
+  padding: 0.10938rem 0.4375rem;
   background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
   color: var(--p-primary-color);
   border-radius: 4px;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
 }
 
 .provider-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-shrink: 0;
 
   @media (width <= 767px) {
@@ -177,13 +177,13 @@
 .provider-details {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .detail-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 767px) {
     grid-template-columns: 1fr;
@@ -193,7 +193,7 @@
 .detail-item {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 
   &.detail-item-wide {
     grid-column: span 2;
@@ -211,13 +211,13 @@
 .detail-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   font-size: settings.$settings-description-size;
   font-weight: 500;
   color: var(--p-text-muted-color);
 
   .pi {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--p-primary-color);
   }
 }
@@ -238,15 +238,15 @@
 .toggle-options {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.5rem;
-  padding-top: 0.75rem;
+  gap: 1.3125rem;
+  padding-top: 0.65625rem;
   border-top: 1px dashed var(--p-content-border-color);
 }
 
 .toggle-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .toggle-label {

--- a/frontend/src/app/features/settings/email-v2/email-v2-provider/email-v2-provider.component.scss
+++ b/frontend/src/app/features/settings/email-v2/email-v2-provider/email-v2-provider.component.scss
@@ -103,13 +103,13 @@
   justify-content: space-between;
   gap: 0.875rem;
   margin-bottom: 0.875rem;
-  padding-bottom: 0.65625rem;
+  padding-bottom: 0.6563rem;
   border-bottom: 1px dashed var(--p-content-border-color);
 
   @media (width <= 767px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -121,7 +121,7 @@
 .provider-name-row {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
 }
 
@@ -155,7 +155,7 @@
 .default-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.10938rem 0.4375rem;
+  padding: 0.1094rem 0.4375rem;
   background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
   color: var(--p-primary-color);
   border-radius: 4px;
@@ -193,7 +193,7 @@
 .detail-item {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 
   &.detail-item-wide {
     grid-column: span 2;
@@ -211,7 +211,7 @@
 .detail-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   font-size: settings.$settings-description-size;
   font-weight: 500;
   color: var(--p-text-muted-color);
@@ -239,7 +239,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1.3125rem;
-  padding-top: 0.65625rem;
+  padding-top: 0.6563rem;
   border-top: 1px dashed var(--p-content-border-color);
 }
 

--- a/frontend/src/app/features/settings/email-v2/email-v2-recipient/email-v2-recipient.component.scss
+++ b/frontend/src/app/features/settings/email-v2/email-v2-recipient/email-v2-recipient.component.scss
@@ -77,7 +77,7 @@
 .recipients-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .recipient-item {
@@ -85,7 +85,7 @@
   border: 1px solid var(--p-content-border-color);
   border-left: 3px solid var(--p-content-border-color);
   border-radius: 6px;
-  padding: 0.76563rem 0.875rem;
+  padding: 0.7656rem 0.875rem;
   transition: border-color 0.2s ease, background 0.2s ease;
 
   &:hover {
@@ -105,7 +105,7 @@
   @media (width <= 767px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -125,7 +125,7 @@
 .recipient-details {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .recipient-email {
@@ -157,7 +157,7 @@
 .default-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.10938rem 0.4375rem;
+  padding: 0.1094rem 0.4375rem;
   background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
   color: var(--p-primary-color);
   border-radius: 4px;
@@ -179,7 +179,7 @@
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   flex: 1;
   min-width: 180px;
 
@@ -191,7 +191,7 @@
 .field-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   font-size: settings.$settings-description-size;
   font-weight: 500;
   color: var(--p-text-muted-color);

--- a/frontend/src/app/features/settings/email-v2/email-v2-recipient/email-v2-recipient.component.scss
+++ b/frontend/src/app/features/settings/email-v2/email-v2-recipient/email-v2-recipient.component.scss
@@ -12,7 +12,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 767px) {
     flex-direction: column;
@@ -39,7 +39,7 @@
 .section-body {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 // Empty state
@@ -48,22 +48,22 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   text-align: center;
   color: var(--p-text-muted-color);
   background: var(--color-card);
   border-radius: 6px;
 
   .pi {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   .empty-title {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     color: var(--p-text-color);
   }
 
@@ -77,7 +77,7 @@
 .recipients-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .recipient-item {
@@ -85,7 +85,7 @@
   border: 1px solid var(--p-content-border-color);
   border-left: 3px solid var(--p-content-border-color);
   border-radius: 6px;
-  padding: 0.875rem 1rem;
+  padding: 0.76563rem 0.875rem;
   transition: border-color 0.2s ease, background 0.2s ease;
 
   &:hover {
@@ -100,12 +100,12 @@
 .recipient-content {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 767px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
@@ -125,18 +125,18 @@
 .recipient-details {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .recipient-email {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-weight: 500;
   color: var(--p-text-color);
 
   .pi {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--p-primary-color);
   }
 }
@@ -144,12 +144,12 @@
 .recipient-name {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: settings.$settings-description-size;
   color: var(--p-text-muted-color);
 
   .pi {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--p-text-muted-color);
   }
 }
@@ -157,18 +157,18 @@
 .default-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.125rem 0.5rem;
+  padding: 0.10938rem 0.4375rem;
   background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
   color: var(--p-primary-color);
   border-radius: 4px;
-  font-size: 0.7rem;
+  font-size: 0.6125rem;
   font-weight: 600;
 }
 
 // Edit form
 .edit-form {
   display: flex;
-  gap: 1rem;
+  gap: 0.875rem;
   flex-wrap: wrap;
 
   @media (width <= 767px) {
@@ -179,7 +179,7 @@
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
   flex: 1;
   min-width: 180px;
 
@@ -191,20 +191,20 @@
 .field-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   font-size: settings.$settings-description-size;
   font-weight: 500;
   color: var(--p-text-muted-color);
 
   .pi {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--p-primary-color);
   }
 }
 
 .recipient-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-shrink: 0;
 
   @media (width <= 767px) {

--- a/frontend/src/app/features/settings/email-v2/email-v2.component.scss
+++ b/frontend/src/app/features/settings/email-v2/email-v2.component.scss
@@ -10,7 +10,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {

--- a/frontend/src/app/features/settings/email-v2/email-v2.component.scss
+++ b/frontend/src/app/features/settings/email-v2/email-v2.component.scss
@@ -10,7 +10,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -20,8 +20,8 @@
 .access-denied-card {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1.5rem;
+  gap: 0.875rem;
+  padding: 1.3125rem;
   border-radius: settings.$settings-card-border-radius;
   background: color-mix(in srgb, var(--ground-background) 85%, var(--p-red-600) 15%);
   border: 1px solid var(--p-content-border-color);
@@ -29,15 +29,15 @@
   max-width: 500px;
 
   > .pi {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
     flex-shrink: 0;
     color: var(--p-red-400);
   }
 
   .access-denied-content {
     h3 {
-      margin: 0 0 0.5rem;
-      font-size: 1rem;
+      margin: 0 0 0.4375rem;
+      font-size: var(--app-text-base);
       font-weight: settings.$settings-section-title-weight;
       color: var(--p-red-300);
     }

--- a/frontend/src/app/features/settings/file-naming-pattern/file-naming-pattern.component.scss
+++ b/frontend/src/app/features/settings/file-naming-pattern/file-naming-pattern.component.scss
@@ -10,7 +10,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -18,8 +18,8 @@
 }
 
 .warning-notice {
-  margin-top: -2rem;
-  margin-bottom: 1rem;
+  margin-top: -1.75rem;
+  margin-bottom: 0.875rem;
 
   @include settings.settings-warning-notice;
 }
@@ -50,22 +50,22 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   text-align: center;
   color: var(--p-text-muted-color);
   background: var(--color-card);
   border-radius: 6px;
 
   .pi {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   .empty-title {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     color: var(--p-text-color);
   }
 
@@ -81,23 +81,23 @@
   border: 1px solid var(--p-content-border-color);
   border-left: 3px solid var(--p-primary-color);
   border-radius: 6px;
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .pattern-input-container {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .pattern-input-row {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   align-items: flex-start;
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     p-button {
       align-self: flex-end;
@@ -117,26 +117,26 @@
 .preview-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.25rem;
+  gap: 0.4375rem;
+  margin-top: 0.21875rem;
 
   @media (width <= 768px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.25rem;
+    gap: 0.21875rem;
   }
 }
 
 .preview-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   color: var(--p-text-muted-color);
   font-size: settings.$settings-section-description-size;
   white-space: nowrap;
 
   .pi {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
   }
 }
 
@@ -151,7 +151,7 @@
 .libraries-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .library-item {
@@ -174,8 +174,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
+  gap: 0.875rem;
+  padding: 0.65625rem 0.875rem;
   border-bottom: 1px dashed var(--p-content-border-color);
 
   @media (width <= 600px) {
@@ -186,7 +186,7 @@
 .library-info {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex: 1;
   min-width: 0;
 }
@@ -203,24 +203,24 @@
   flex-shrink: 0;
 
   .pi {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
 .library-name {
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   color: var(--p-text-color);
 }
 
 .custom-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.125rem 0.5rem;
+  padding: 0.10938rem 0.4375rem;
   background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
   color: var(--p-primary-color);
   border-radius: 12px;
-  font-size: 0.625rem;
+  font-size: 0.54688rem;
   font-weight: 700;
   text-transform: uppercase;
 }
@@ -228,30 +228,30 @@
 .default-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.125rem 0.5rem;
+  padding: 0.10938rem 0.4375rem;
   background: color-mix(in srgb, var(--color-text-secondary) 15%, transparent);
   color: var(--color-text-secondary);
   border-radius: 12px;
-  font-size: 0.625rem;
+  font-size: 0.54688rem;
   font-weight: 700;
   text-transform: uppercase;
 }
 
 .library-body {
-  padding: 0.75rem 1rem;
+  padding: 0.65625rem 0.875rem;
 }
 
 .actions-row {
   @include settings.settings-actions-row;
 
-  margin-top: 0.5rem;
+  margin-top: 0.4375rem;
 }
 
 // Placeholders Reference Section
 .placeholders-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width >= 768px) {
     grid-template-columns: 1fr 1fr;
@@ -261,26 +261,26 @@
 .placeholder-group {
   background: var(--color-card);
   border-radius: 6px;
-  padding: 1rem;
+  padding: 0.875rem;
   border-left: 3px solid var(--p-primary-color);
 
   @media (width <= 768px) {
-    padding: 0.75rem;
+    padding: 0.65625rem;
   }
 }
 
 .group-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: settings.$settings-label-size;
   font-weight: 600;
   color: var(--p-text-color);
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.65625rem;
 
   .pi {
     color: var(--p-primary-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -288,7 +288,7 @@
   font-size: settings.$settings-section-description-size;
   line-height: 1.5;
   color: var(--p-text-muted-color);
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.65625rem;
 
   code {
     color: var(--color-primary);
@@ -299,13 +299,13 @@
 .placeholder-list {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 }
 
 .placeholder-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   font-size: settings.$settings-section-description-size;
 
   code {
@@ -321,14 +321,14 @@
 .example-block {
   background: color-mix(in srgb, var(--color-card) 30%, transparent);
   border-radius: 4px;
-  padding: 0.75rem;
+  padding: 0.65625rem;
 }
 
 .example-pattern {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: 0.4375rem;
+  margin-bottom: 0.4375rem;
 
   .pattern-prefix {
     font-size: settings.$settings-description-size;
@@ -343,13 +343,13 @@
 .example-results {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .result-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: settings.$settings-section-description-size;
 
   .result-prefix {
@@ -367,14 +367,14 @@
 .examples-container {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .metadata-reference {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
+  gap: 0.875rem;
+  margin-bottom: 0.4375rem;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;
@@ -383,7 +383,7 @@
 
 .metadata-panel {
   background: var(--color-card);
-  padding: 1rem 1.25rem;
+  padding: 0.875rem 1.09375rem;
   border-radius: 6px;
   border-left: 3px solid var(--p-content-border-color);
 
@@ -392,23 +392,23 @@
 .metadata-panel-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: settings.$settings-label-size;
   font-weight: 600;
   color: var(--p-text-color);
-  margin-bottom: 0.875rem;
-  padding-bottom: 0.625rem;
+  margin-bottom: 0.76563rem;
+  padding-bottom: 0.54688rem;
   border-bottom: 1px solid color-mix(in srgb, var(--p-content-border-color) 50%, transparent);
 
   .pi {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
 .metadata-grid {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.5rem 0.75rem;
+  gap: 0.4375rem 0.65625rem;
   font-size: settings.$settings-section-description-size;
   align-items: baseline;
 }
@@ -437,20 +437,20 @@
 .example-category {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .category-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: settings.$settings-label-size;
   font-weight: 600;
   color: var(--p-text-color);
   margin: 0;
 
   .pi {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--p-primary-color);
   }
 }
@@ -458,14 +458,14 @@
 .example-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .example-row {
   display: grid;
   grid-template-columns: 130px 1fr 1fr;
-  gap: 0.75rem;
-  padding: 0.625rem 0.75rem;
+  gap: 0.65625rem;
+  padding: 0.54688rem 0.65625rem;
   background: var(--color-card);
   border-radius: 4px;
   font-size: settings.$settings-section-description-size;
@@ -473,15 +473,15 @@
 
   @media (width <= 1024px) {
     grid-template-columns: 1fr;
-    gap: 0.375rem;
+    gap: 0.32813rem;
   }
 }
 
 .example-row-conditional {
   display: grid;
   grid-template-columns: 130px 1fr 1fr;
-  gap: 0.75rem;
-  padding: 0.625rem 0.75rem;
+  gap: 0.65625rem;
+  padding: 0.54688rem 0.65625rem;
   background: var(--color-card);
   border-radius: 4px;
   font-size: settings.$settings-section-description-size;
@@ -489,7 +489,7 @@
 
   @media (width <= 1024px) {
     grid-template-columns: 1fr;
-    gap: 0.375rem;
+    gap: 0.32813rem;
   }
 }
 
@@ -511,7 +511,7 @@
   }
 
   @media (width <= 1024px) {
-    padding-left: 0.5rem;
+    padding-left: 0.4375rem;
   }
 }
 
@@ -522,7 +522,7 @@
   }
 
   @media (width <= 1024px) {
-    padding-left: 0.5rem;
+    padding-left: 0.4375rem;
     border-left: 2px solid currentcolor;
   }
 }
@@ -530,7 +530,7 @@
 .result-col-dual {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 
   code {
     font-size: settings.$settings-description-size;
@@ -538,7 +538,7 @@
   }
 
   .pi {
-    font-size: 0.625rem;
-    margin-right: 0.25rem;
+    font-size: 0.54688rem;
+    margin-right: 0.21875rem;
   }
 }

--- a/frontend/src/app/features/settings/file-naming-pattern/file-naming-pattern.component.scss
+++ b/frontend/src/app/features/settings/file-naming-pattern/file-naming-pattern.component.scss
@@ -10,7 +10,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -92,7 +92,7 @@
 
 .pattern-input-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   align-items: flex-start;
 
   @media (width <= 768px) {
@@ -118,19 +118,19 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  margin-top: 0.21875rem;
+  margin-top: 0.2188rem;
 
   @media (width <= 768px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.21875rem;
+    gap: 0.2188rem;
   }
 }
 
 .preview-label {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   color: var(--p-text-muted-color);
   font-size: settings.$settings-section-description-size;
   white-space: nowrap;
@@ -151,7 +151,7 @@
 .libraries-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .library-item {
@@ -175,7 +175,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.875rem;
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   border-bottom: 1px dashed var(--p-content-border-color);
 
   @media (width <= 600px) {
@@ -186,7 +186,7 @@
 .library-info {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex: 1;
   min-width: 0;
 }
@@ -209,18 +209,18 @@
 
 .library-name {
   font-weight: 600;
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   color: var(--p-text-color);
 }
 
 .custom-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.10938rem 0.4375rem;
+  padding: 0.1094rem 0.4375rem;
   background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
   color: var(--p-primary-color);
   border-radius: 12px;
-  font-size: 0.54688rem;
+  font-size: 0.5469rem;
   font-weight: 700;
   text-transform: uppercase;
 }
@@ -228,17 +228,17 @@
 .default-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.10938rem 0.4375rem;
+  padding: 0.1094rem 0.4375rem;
   background: color-mix(in srgb, var(--color-text-secondary) 15%, transparent);
   color: var(--color-text-secondary);
   border-radius: 12px;
-  font-size: 0.54688rem;
+  font-size: 0.5469rem;
   font-weight: 700;
   text-transform: uppercase;
 }
 
 .library-body {
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
 }
 
 .actions-row {
@@ -265,7 +265,7 @@
   border-left: 3px solid var(--p-primary-color);
 
   @media (width <= 768px) {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
   }
 }
 
@@ -276,7 +276,7 @@
   font-size: settings.$settings-label-size;
   font-weight: 600;
   color: var(--p-text-color);
-  margin: 0 0 0.65625rem;
+  margin: 0 0 0.6563rem;
 
   .pi {
     color: var(--p-primary-color);
@@ -288,7 +288,7 @@
   font-size: settings.$settings-section-description-size;
   line-height: 1.5;
   color: var(--p-text-muted-color);
-  margin: 0 0 0.65625rem;
+  margin: 0 0 0.6563rem;
 
   code {
     color: var(--color-primary);
@@ -299,13 +299,13 @@
 .placeholder-list {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 }
 
 .placeholder-item {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   font-size: settings.$settings-section-description-size;
 
   code {
@@ -321,7 +321,7 @@
 .example-block {
   background: color-mix(in srgb, var(--color-card) 30%, transparent);
   border-radius: 4px;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
 }
 
 .example-pattern {
@@ -343,7 +343,7 @@
 .example-results {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .result-item {
@@ -383,7 +383,7 @@
 
 .metadata-panel {
   background: var(--color-card);
-  padding: 0.875rem 1.09375rem;
+  padding: 0.875rem 1.0938rem;
   border-radius: 6px;
   border-left: 3px solid var(--p-content-border-color);
 
@@ -396,8 +396,8 @@
   font-size: settings.$settings-label-size;
   font-weight: 600;
   color: var(--p-text-color);
-  margin-bottom: 0.76563rem;
-  padding-bottom: 0.54688rem;
+  margin-bottom: 0.7656rem;
+  padding-bottom: 0.5469rem;
   border-bottom: 1px solid color-mix(in srgb, var(--p-content-border-color) 50%, transparent);
 
   .pi {
@@ -408,7 +408,7 @@
 .metadata-grid {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.4375rem 0.65625rem;
+  gap: 0.4375rem 0.6563rem;
   font-size: settings.$settings-section-description-size;
   align-items: baseline;
 }
@@ -437,7 +437,7 @@
 .example-category {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .category-title {
@@ -464,8 +464,8 @@
 .example-row {
   display: grid;
   grid-template-columns: 130px 1fr 1fr;
-  gap: 0.65625rem;
-  padding: 0.54688rem 0.65625rem;
+  gap: 0.6563rem;
+  padding: 0.5469rem 0.6563rem;
   background: var(--color-card);
   border-radius: 4px;
   font-size: settings.$settings-section-description-size;
@@ -473,15 +473,15 @@
 
   @media (width <= 1024px) {
     grid-template-columns: 1fr;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
   }
 }
 
 .example-row-conditional {
   display: grid;
   grid-template-columns: 130px 1fr 1fr;
-  gap: 0.65625rem;
-  padding: 0.54688rem 0.65625rem;
+  gap: 0.6563rem;
+  padding: 0.5469rem 0.6563rem;
   background: var(--color-card);
   border-radius: 4px;
   font-size: settings.$settings-section-description-size;
@@ -489,7 +489,7 @@
 
   @media (width <= 1024px) {
     grid-template-columns: 1fr;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
   }
 }
 
@@ -530,7 +530,7 @@
 .result-col-dual {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 
   code {
     font-size: settings.$settings-description-size;
@@ -538,7 +538,7 @@
   }
 
   .pi {
-    font-size: 0.54688rem;
-    margin-right: 0.21875rem;
+    font-size: 0.5469rem;
+    margin-right: 0.2188rem;
   }
 }

--- a/frontend/src/app/features/settings/global-preferences/global-preferences.component.scss
+++ b/frontend/src/app/features/settings/global-preferences/global-preferences.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -88,7 +88,7 @@
     .input-group {
       display: flex;
       align-items: center;
-      gap: 0.65625rem;
+      gap: 0.6563rem;
 
       @media (width <= 768px) {
         flex-direction: column;
@@ -109,7 +109,7 @@
 
     .pi {
       color: var(--p-primary-color);
-      margin-top: 0.10938rem;
+      margin-top: 0.1094rem;
       flex-shrink: 0;
     }
   }
@@ -119,7 +119,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   align-items: flex-end;
 
   @media (width <= 768px) {
@@ -131,7 +131,7 @@
 .input-group {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 768px) {
     flex-direction: column;
@@ -152,7 +152,7 @@
 
   .unit {
     position: absolute;
-    right: 0.65625rem;
+    right: 0.6563rem;
     color: var(--p-text-muted-color);
     font-size: settings.$settings-section-description-size;
     pointer-events: none;

--- a/frontend/src/app/features/settings/global-preferences/global-preferences.component.scss
+++ b/frontend/src/app/features/settings/global-preferences/global-preferences.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -19,19 +19,19 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .preferences-section {
   @media (width >= 768px) {
-    padding: 0 1rem;
+    padding: 0 0.875rem;
   }
 }
 
 .section-header {
   @include settings.settings-section-header;
 
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .section-title {
@@ -47,7 +47,7 @@
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
+  gap: 1.75rem;
 
   &:last-child {
     border-bottom: none;
@@ -56,7 +56,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
@@ -68,15 +68,15 @@
     display: block;
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
   }
 
   .setting-label-row {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {
@@ -88,12 +88,12 @@
     .input-group {
       display: flex;
       align-items: center;
-      gap: 0.75rem;
+      gap: 0.65625rem;
 
       @media (width <= 768px) {
         flex-direction: column;
         align-items: flex-start;
-        gap: 0.5rem;
+        gap: 0.4375rem;
       }
     }
   }
@@ -101,7 +101,7 @@
   .setting-description {
     display: flex;
     align-items: flex-start;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     color: var(--p-text-muted-color);
     font-size: settings.$settings-section-description-size;
     line-height: 1.5;
@@ -109,7 +109,7 @@
 
     .pi {
       color: var(--p-primary-color);
-      margin-top: 0.125rem;
+      margin-top: 0.10938rem;
       flex-shrink: 0;
     }
   }
@@ -119,7 +119,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   align-items: flex-end;
 
   @media (width <= 768px) {
@@ -131,12 +131,12 @@
 .input-group {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 768px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 }
 
@@ -146,13 +146,13 @@
   align-items: center;
 
   input {
-    padding-right: 2.5rem;
+    padding-right: 2.1875rem;
     width: 120px;
   }
 
   .unit {
     position: absolute;
-    right: 0.75rem;
+    right: 0.65625rem;
     color: var(--p-text-muted-color);
     font-size: settings.$settings-section-description-size;
     pointer-events: none;
@@ -162,10 +162,10 @@
 .warning-message {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
+  gap: 0.4375rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
-  margin-top: 0.5rem;
+  margin-top: 0.4375rem;
 
   .pi {
     color: var(--p-orange-500);
@@ -173,7 +173,7 @@
   }
 
   @media (width <= 768px) {
-    margin-top: 0.5rem;
+    margin-top: 0.4375rem;
   }
 }
 

--- a/frontend/src/app/features/settings/global-preferences/metadata-match-weights/metadata-match-weights-component.scss
+++ b/frontend/src/app/features/settings/global-preferences/metadata-match-weights/metadata-match-weights-component.scss
@@ -1,7 +1,7 @@
 .settings-card {
   display: flex;
   flex-direction: column;
-  gap: 1.09375rem;
+  gap: 1.0938rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 8px;
@@ -14,14 +14,14 @@
 }
 
 .section-header {
-  margin-bottom: 0.21875rem;
+  margin-bottom: 0.2188rem;
 }
 
 .section-title {
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  font-size: 1.09375rem;
+  font-size: 1.0938rem;
   font-weight: 600;
   color: var(--color-text);
   margin: 0 0 0.4375rem;
@@ -51,13 +51,13 @@
 }
 
 .setting-item {
-  padding: 0.76563rem 0.875rem;
+  padding: 0.7656rem 0.875rem;
   border-radius: 6px;
   border-left: 3px solid var(--color-primary);
   background: var(--color-card);
 
   @media (width <= 768px) {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
   }
 }
 
@@ -70,18 +70,18 @@
   @media (width <= 768px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
 .action-info {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
 }
 
 .action-label {
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   font-weight: 500;
   color: var(--color-text);
 }
@@ -96,7 +96,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .weights-icon {
@@ -106,7 +106,7 @@
 }
 
 .weights-label {
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   font-weight: 500;
   color: var(--color-text);
   margin: 0;
@@ -115,13 +115,13 @@
 .weights-form {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .weights-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 0.54688rem;
+  gap: 0.5469rem;
   padding-top: 0.4375rem;
   border-top: 1px dashed var(--p-content-border-color);
 
@@ -140,7 +140,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.4375rem;
-  padding: 0.4375rem 0.54688rem;
+  padding: 0.4375rem 0.5469rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
@@ -160,7 +160,7 @@
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  padding-top: 0.65625rem;
+  padding-top: 0.6563rem;
   border-top: 1px dashed var(--p-content-border-color);
 
   @media (width <= 768px) {

--- a/frontend/src/app/features/settings/global-preferences/metadata-match-weights/metadata-match-weights-component.scss
+++ b/frontend/src/app/features/settings/global-preferences/metadata-match-weights/metadata-match-weights-component.scss
@@ -1,39 +1,39 @@
 .settings-card {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.09375rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 8px;
-  padding: 1.5rem;
+  padding: 1.3125rem;
 
   @media (width <= 768px) {
-    padding: 1rem;
-    gap: 1rem;
+    padding: 0.875rem;
+    gap: 0.875rem;
   }
 }
 
 .section-header {
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.21875rem;
 }
 
 .section-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 1.25rem;
+  gap: 0.4375rem;
+  font-size: 1.09375rem;
   font-weight: 600;
   color: var(--color-text);
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 
   .pi {
     color: var(--color-primary);
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
   }
 }
 
 .section-description {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   line-height: 1.5;
   color: var(--p-text-muted-color);
   margin: 0;
@@ -42,22 +42,22 @@
 .section-body {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  padding-left: 1rem;
+  gap: 1.75rem;
+  padding-left: 0.875rem;
 
   @media (width <= 768px) {
-    padding-left: 0.5rem;
+    padding-left: 0.4375rem;
   }
 }
 
 .setting-item {
-  padding: 0.875rem 1rem;
+  padding: 0.76563rem 0.875rem;
   border-radius: 6px;
   border-left: 3px solid var(--color-primary);
   background: var(--color-card);
 
   @media (width <= 768px) {
-    padding: 0.75rem;
+    padding: 0.65625rem;
   }
 }
 
@@ -65,29 +65,29 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 768px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .action-info {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.10938rem;
 }
 
 .action-label {
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   font-weight: 500;
   color: var(--color-text);
 }
 
 .action-description {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   line-height: 1.4;
 }
@@ -95,18 +95,18 @@
 .weights-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  gap: 0.4375rem;
+  margin-bottom: 0.65625rem;
 }
 
 .weights-icon {
   color: var(--color-primary);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   flex-shrink: 0;
 }
 
 .weights-label {
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   font-weight: 500;
   color: var(--color-text);
   margin: 0;
@@ -115,19 +115,19 @@
 .weights-form {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .weights-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 0.625rem;
-  padding-top: 0.5rem;
+  gap: 0.54688rem;
+  padding-top: 0.4375rem;
   border-top: 1px dashed var(--p-content-border-color);
 
   @media (width <= 768px) {
     grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   @media (width <= 400px) {
@@ -139,28 +139,28 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.5rem 0.625rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0.54688rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
 
   .field-label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
     color: var(--color-text);
     text-transform: capitalize;
   }
 
   ::ng-deep p-inputnumber {
-    width: 6rem;
+    width: 5.25rem;
   }
 }
 
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  padding-top: 0.75rem;
+  padding-top: 0.65625rem;
   border-top: 1px dashed var(--p-content-border-color);
 
   @media (width <= 768px) {

--- a/frontend/src/app/features/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.scss
+++ b/frontend/src/app/features/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.scss
@@ -3,7 +3,7 @@
 .metadata-settings {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .settings-card {
@@ -25,25 +25,25 @@
 .section-body {
   @include settings.settings-section-body;
 
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .configurable-providers-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .configurable-providers-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .simple-providers-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .provider-group-title {
@@ -52,7 +52,7 @@
   color: var(--p-text-muted-color);
   text-transform: uppercase;
   letter-spacing: 0.025em;
-  margin: 0 0 0.25rem;
+  margin: 0 0 0.21875rem;
 }
 
 .setting-item {
@@ -72,13 +72,13 @@
 
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .config-field {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 }
 
 .config-label {
@@ -90,7 +90,7 @@
 .config-label-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .config-description {
@@ -102,13 +102,13 @@
 
 ::ng-deep .config-select {
   width: 100%;
-  max-width: 20rem;
+  max-width: 17.5rem;
 }
 
 .config-input {
   width: 100%;
-  max-width: 40rem;
-  padding: 0.375rem 0.625rem;
+  max-width: 35rem;
+  padding: 0.32813rem 0.54688rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
   background: var(--ground-background);
@@ -133,11 +133,11 @@
 .simple-providers-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   @media (width <= 480px) {
@@ -146,16 +146,16 @@
 }
 
 .simple-provider {
-  padding: 0.625rem 0.875rem;
+  padding: 0.54688rem 0.76563rem;
 
   @media (width <= 768px) {
-    padding: 0.5rem 0.75rem;
+    padding: 0.4375rem 0.65625rem;
   }
 }
 
 .setting-actions {
   display: flex;
   justify-content: flex-end;
-  padding-top: 0.5rem;
+  padding-top: 0.4375rem;
   border-top: 1px solid var(--p-content-border-color);
 }

--- a/frontend/src/app/features/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.scss
+++ b/frontend/src/app/features/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.scss
@@ -37,7 +37,7 @@
 .configurable-providers-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .simple-providers-section {
@@ -52,7 +52,7 @@
   color: var(--p-text-muted-color);
   text-transform: uppercase;
   letter-spacing: 0.025em;
-  margin: 0 0 0.21875rem;
+  margin: 0 0 0.2188rem;
 }
 
 .setting-item {
@@ -78,7 +78,7 @@
 .config-field {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 }
 
 .config-label {
@@ -108,7 +108,7 @@
 .config-input {
   width: 100%;
   max-width: 35rem;
-  padding: 0.32813rem 0.54688rem;
+  padding: 0.3281rem 0.5469rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
   background: var(--ground-background);
@@ -133,7 +133,7 @@
 .simple-providers-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr 1fr;
@@ -146,10 +146,10 @@
 }
 
 .simple-provider {
-  padding: 0.54688rem 0.76563rem;
+  padding: 0.5469rem 0.7656rem;
 
   @media (width <= 768px) {
-    padding: 0.4375rem 0.65625rem;
+    padding: 0.4375rem 0.6563rem;
   }
 }
 

--- a/frontend/src/app/features/settings/library-metadata-settings/library-metadata-settings.component.scss
+++ b/frontend/src/app/features/settings/library-metadata-settings/library-metadata-settings.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -19,31 +19,31 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .preferences-section {
   @media (width >= 768px) {
-    padding: 0 1rem;
+    padding: 0 0.875rem;
   }
 }
 
 .section-header {
   @include settings.settings-section-header;
 
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 
   .section-description {
     @include settings.settings-section-description;
 
-    margin: 0.5rem 0 0;
+    margin: 0.4375rem 0 0;
     display: flex;
     align-items: flex-start;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .pi {
       color: var(--p-primary-color);
-      margin-top: 0.125rem;
+      margin-top: 0.10938rem;
       flex-shrink: 0;
     }
   }
@@ -52,7 +52,7 @@
 .section-title {
   @include settings.settings-section-title;
 
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 }
 
 .settings-card {
@@ -78,7 +78,7 @@
 :host ::ng-deep {
   .p-accordion {
     .p-accordion-panel {
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
       border: 1px solid var(--p-content-border-color);
       border-radius: 6px;
       overflow: hidden;
@@ -99,7 +99,7 @@
 
       .p-accordion-header-content {
         width: 100%;
-        padding: 1rem 1.25rem;
+        padding: 0.875rem 1.09375rem;
         display: flex;
         align-items: center;
       }
@@ -121,19 +121,19 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 768px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .sidecar-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   margin-left: auto;
 
   @media (width <= 768px) {
@@ -145,10 +145,10 @@
 .library-info {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   .library-icon {
-    font-size: 1.2rem;
+    font-size: 1.05rem;
     color: var(--p-primary-color);
   }
 
@@ -161,7 +161,7 @@
     color: var(--p-text-muted-color);
     font-weight: bold;
     font-size: settings.$settings-section-description-size;
-    margin: 0 0.25rem;
+    margin: 0 0.21875rem;
     opacity: 0.6;
   }
 
@@ -169,7 +169,7 @@
   .default-indicator {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
     font-size: settings.$settings-section-description-size;
     font-weight: settings.$settings-label-weight;
 
@@ -188,7 +188,7 @@
 }
 
 .accordion-content-wrapper {
-  padding: 1.5rem;
+  padding: 1.3125rem;
 
   app-metadata-advanced-fetch-options {
     display: block;

--- a/frontend/src/app/features/settings/library-metadata-settings/library-metadata-settings.component.scss
+++ b/frontend/src/app/features/settings/library-metadata-settings/library-metadata-settings.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -43,7 +43,7 @@
 
     .pi {
       color: var(--p-primary-color);
-      margin-top: 0.10938rem;
+      margin-top: 0.1094rem;
       flex-shrink: 0;
     }
   }
@@ -99,7 +99,7 @@
 
       .p-accordion-header-content {
         width: 100%;
-        padding: 0.875rem 1.09375rem;
+        padding: 0.875rem 1.0938rem;
         display: flex;
         align-items: center;
       }
@@ -126,7 +126,7 @@
   @media (width <= 768px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -145,7 +145,7 @@
 .library-info {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   .library-icon {
     font-size: 1.05rem;
@@ -161,7 +161,7 @@
     color: var(--p-text-muted-color);
     font-weight: bold;
     font-size: settings.$settings-section-description-size;
-    margin: 0 0.21875rem;
+    margin: 0 0.2188rem;
     opacity: 0.6;
   }
 
@@ -169,7 +169,7 @@
   .default-indicator {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     font-size: settings.$settings-section-description-size;
     font-weight: settings.$settings-label-weight;
 

--- a/frontend/src/app/features/settings/metadata-settings/metadata-persistence-settings/metadata-persistence-settings-component.scss
+++ b/frontend/src/app/features/settings/metadata-settings/metadata-persistence-settings/metadata-persistence-settings-component.scss
@@ -19,7 +19,7 @@
 .section-notice {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .warning-notice {
@@ -103,7 +103,7 @@
 
 code {
   background: var(--ground-background);
-  padding: 0.10938rem 0.32813rem;
+  padding: 0.1094rem 0.3281rem;
   border-radius: 4px;
   font-family: monospace;
   font-size: var(--app-text-sm);

--- a/frontend/src/app/features/settings/metadata-settings/metadata-persistence-settings/metadata-persistence-settings-component.scss
+++ b/frontend/src/app/features/settings/metadata-settings/metadata-persistence-settings/metadata-persistence-settings-component.scss
@@ -19,7 +19,7 @@
 .section-notice {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .warning-notice {
@@ -90,21 +90,21 @@
 }
 
 .sidecar-section-header {
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
+  margin-top: 1.3125rem;
+  padding-top: 1.3125rem;
   border-top: 1px solid var(--border-color);
 }
 
 .nested-setting {
-  margin-left: 1.5rem;
-  padding-left: 1rem;
+  margin-left: 1.3125rem;
+  padding-left: 0.875rem;
   border-left: 2px solid var(--border-color);
 }
 
 code {
   background: var(--ground-background);
-  padding: 0.125rem 0.375rem;
+  padding: 0.10938rem 0.32813rem;
   border-radius: 4px;
   font-family: monospace;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
 }

--- a/frontend/src/app/features/settings/metadata-settings/metadata-settings-component.scss
+++ b/frontend/src/app/features/settings/metadata-settings/metadata-settings-component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -33,14 +33,14 @@
 .section-description {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: settings.$settings-section-description-size;
   line-height: 1.5;
   color: var(--p-text-muted-color);
   margin: 0;
 
   .pi {
-    margin-top: 0.125rem;
+    margin-top: 0.10938rem;
     flex-shrink: 0;
   }
 

--- a/frontend/src/app/features/settings/metadata-settings/metadata-settings-component.scss
+++ b/frontend/src/app/features/settings/metadata-settings/metadata-settings-component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -40,7 +40,7 @@
   margin: 0;
 
   .pi {
-    margin-top: 0.10938rem;
+    margin-top: 0.1094rem;
     flex-shrink: 0;
   }
 

--- a/frontend/src/app/features/settings/metadata-settings/public-reviews-settings/public-reviews-settings-component.scss
+++ b/frontend/src/app/features/settings/metadata-settings/public-reviews-settings/public-reviews-settings-component.scss
@@ -47,7 +47,7 @@
 .providers-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 0.54688rem;
+  gap: 0.5469rem;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr 1fr;
@@ -64,7 +64,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.4375rem;
-  padding: 0.4375rem 0.65625rem;
+  padding: 0.4375rem 0.6563rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
@@ -90,7 +90,7 @@
 .max-reviews-control {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 }
 
 .max-reviews-label {
@@ -100,7 +100,7 @@
 
 .max-reviews-input {
   width: 2.625rem;
-  padding: 0.21875rem 0.32813rem;
+  padding: 0.2188rem 0.3281rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
   background: var(--color-card);
@@ -122,7 +122,7 @@
   font-size: settings.$settings-description-size;
   font-style: italic;
   margin-top: 0.4375rem;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   background: var(--color-card);
   border-radius: 4px;
 

--- a/frontend/src/app/features/settings/metadata-settings/public-reviews-settings/public-reviews-settings-component.scss
+++ b/frontend/src/app/features/settings/metadata-settings/public-reviews-settings/public-reviews-settings-component.scss
@@ -47,11 +47,11 @@
 .providers-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 0.625rem;
+  gap: 0.54688rem;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   @media (width <= 400px) {
@@ -63,8 +63,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0.65625rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
@@ -78,7 +78,7 @@
 .provider-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .provider-label {
@@ -90,17 +90,17 @@
 .max-reviews-control {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 }
 
 .max-reviews-label {
   color: var(--p-text-muted-color);
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
 }
 
 .max-reviews-input {
-  width: 3rem;
-  padding: 0.25rem 0.375rem;
+  width: 2.625rem;
+  padding: 0.21875rem 0.32813rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
   background: var(--color-card);
@@ -117,12 +117,12 @@
 .no-providers-message {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   color: var(--p-text-muted-color);
   font-size: settings.$settings-description-size;
   font-style: italic;
-  margin-top: 0.5rem;
-  padding: 0.75rem;
+  margin-top: 0.4375rem;
+  padding: 0.65625rem;
   background: var(--color-card);
   border-radius: 4px;
 

--- a/frontend/src/app/features/settings/opds-settings/opds-settings.scss
+++ b/frontend/src/app/features/settings/opds-settings/opds-settings.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -60,7 +60,7 @@
 .toggle-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .toggle-item {
@@ -90,7 +90,7 @@
 
   @media (width <= 600px) {
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -102,7 +102,7 @@
 .toggle-header {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.4375rem;
 }
 
@@ -137,12 +137,12 @@
 .toggle-info {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
 }
 
 .toggle-label {
   font-weight: 600;
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   color: var(--p-text-color);
 }
 
@@ -156,7 +156,7 @@
   color: var(--p-text-muted-color);
   line-height: 1.5;
   margin: 0;
-  padding-left: calc(36px + 0.65625rem);
+  padding-left: calc(36px + 0.6563rem);
 
   @media (width <= 600px) {
     padding-left: 0;
@@ -167,7 +167,7 @@
 .endpoints-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .endpoint-item {
@@ -181,8 +181,8 @@
 .endpoint-header {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  margin-bottom: 0.65625rem;
+  gap: 0.6563rem;
+  margin-bottom: 0.6563rem;
 }
 
 .endpoint-icon {
@@ -204,7 +204,7 @@
 .endpoint-info {
   display: flex;
   flex-direction: column;
-  gap: 0.10938rem;
+  gap: 0.1094rem;
 }
 
 .endpoint-label {
@@ -275,7 +275,7 @@
 .users-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .user-item {
@@ -287,7 +287,7 @@
   border: 1px solid var(--p-content-border-color);
   border-left: 3px solid var(--p-primary-color);
   border-radius: 6px;
-  padding: 0.76563rem 0.875rem;
+  padding: 0.7656rem 0.875rem;
   transition: background 0.2s ease;
 
   &:hover {
@@ -297,14 +297,14 @@
   @media (width <= 600px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
 .user-info {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex: 1;
   min-width: 0;
 }
@@ -326,13 +326,13 @@
 .user-details {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
   min-width: 0;
 }
 
 .username {
   font-weight: 600;
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   color: var(--p-text-color);
 }
 
@@ -351,18 +351,18 @@
 .sort-order-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.10938rem 0.4375rem;
+  padding: 0.1094rem 0.4375rem;
   background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
   color: var(--p-primary-color);
   border-radius: 12px;
-  font-size: 0.60156rem;
+  font-size: 0.6016rem;
   font-weight: 600;
   text-transform: uppercase;
 }
 
 .user-actions {
   display: flex;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   flex-shrink: 0;
 
   @media (width <= 600px) {
@@ -384,7 +384,7 @@
 .dialog-form {
   display: flex;
   flex-direction: column;
-  gap: 1.09375rem;
+  gap: 1.0938rem;
 }
 
 .form-field {
@@ -400,7 +400,7 @@
 
   input {
     width: 100%;
-    padding: 0.65625rem;
+    padding: 0.6563rem;
     transition: border-color 0.2s;
 
     &:focus {
@@ -417,15 +417,15 @@
   .form-hint {
     display: flex;
     align-items: flex-start;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     color: var(--p-text-muted-color);
     font-size: var(--app-text-sm);
     line-height: 1.4;
-    margin-top: 0.21875rem;
+    margin-top: 0.2188rem;
 
     .pi {
-      font-size: 0.54688rem;
-      margin-top: 0.10938rem;
+      font-size: 0.5469rem;
+      margin-top: 0.1094rem;
       flex-shrink: 0;
     }
   }
@@ -434,7 +434,7 @@
 .dialog-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 // Access denied card

--- a/frontend/src/app/features/settings/opds-settings/opds-settings.scss
+++ b/frontend/src/app/features/settings/opds-settings/opds-settings.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -28,7 +28,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 767px) {
     flex-direction: column;
@@ -60,20 +60,20 @@
 .toggle-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .toggle-item {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-left-width: 3px;
   border-left-style: solid;
   border-radius: 6px;
-  padding: 1rem;
+  padding: 0.875rem;
   transition: border-color 0.2s ease, background 0.2s ease;
 
   &:hover {
@@ -81,7 +81,7 @@
   }
 
   &.sub-item {
-    margin-left: 1.5rem;
+    margin-left: 1.3125rem;
 
     @media (width <= 600px) {
       margin-left: 0;
@@ -90,7 +90,7 @@
 
   @media (width <= 600px) {
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
@@ -102,8 +102,8 @@
 .toggle-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.4375rem;
 }
 
 .toggle-icon {
@@ -118,7 +118,7 @@
   flex-shrink: 0;
 
   .pi {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   &.sub-icon {
@@ -129,7 +129,7 @@
     border-radius: 6px;
 
     .pi {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 }
@@ -137,17 +137,17 @@
 .toggle-info {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.10938rem;
 }
 
 .toggle-label {
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   color: var(--p-text-color);
 }
 
 .toggle-status {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
 }
 
@@ -156,7 +156,7 @@
   color: var(--p-text-muted-color);
   line-height: 1.5;
   margin: 0;
-  padding-left: calc(36px + 0.75rem);
+  padding-left: calc(36px + 0.65625rem);
 
   @media (width <= 600px) {
     padding-left: 0;
@@ -167,7 +167,7 @@
 .endpoints-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .endpoint-item {
@@ -175,14 +175,14 @@
   border: 1px solid var(--p-content-border-color);
   border-left: 3px solid var(--p-primary-color);
   border-radius: 6px;
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .endpoint-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.75rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.65625rem;
 }
 
 .endpoint-icon {
@@ -197,19 +197,19 @@
   flex-shrink: 0;
 
   .pi {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
 .endpoint-info {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.10938rem;
 }
 
 .endpoint-label {
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-color);
 }
 
@@ -220,7 +220,7 @@
 
 .endpoint-url-row {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   align-items: center;
 
   @media (width <= 600px) {
@@ -246,22 +246,22 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   text-align: center;
   color: var(--p-text-muted-color);
   background: var(--color-card);
   border-radius: 6px;
 
   .pi {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   .empty-title {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     color: var(--p-text-color);
   }
 
@@ -275,19 +275,19 @@
 .users-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .user-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-left: 3px solid var(--p-primary-color);
   border-radius: 6px;
-  padding: 0.875rem 1rem;
+  padding: 0.76563rem 0.875rem;
   transition: background 0.2s ease;
 
   &:hover {
@@ -297,14 +297,14 @@
   @media (width <= 600px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .user-info {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex: 1;
   min-width: 0;
 }
@@ -319,50 +319,50 @@
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   flex-shrink: 0;
 }
 
 .user-details {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
   min-width: 0;
 }
 
 .username {
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   color: var(--p-text-color);
 }
 
 .user-meta {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: settings.$settings-description-size;
   color: var(--p-text-muted-color);
 
   .pi {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
 .sort-order-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.125rem 0.5rem;
+  padding: 0.10938rem 0.4375rem;
   background: color-mix(in srgb, var(--p-primary-color) 15%, transparent);
   color: var(--p-primary-color);
   border-radius: 12px;
-  font-size: 0.6875rem;
+  font-size: 0.60156rem;
   font-weight: 600;
   text-transform: uppercase;
 }
 
 .user-actions {
   display: flex;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   flex-shrink: 0;
 
   @media (width <= 600px) {
@@ -373,24 +373,24 @@
 // Dialog styles
 .user-dialog {
   .p-dialog-content {
-    padding: 1.5rem;
+    padding: 1.3125rem;
   }
 
   .p-dialog-footer {
-    padding: 1rem 1.5rem;
+    padding: 0.875rem 1.3125rem;
   }
 }
 
 .dialog-form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.09375rem;
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   label {
     font-weight: 600;
@@ -400,7 +400,7 @@
 
   input {
     width: 100%;
-    padding: 0.75rem;
+    padding: 0.65625rem;
     transition: border-color 0.2s;
 
     &:focus {
@@ -417,15 +417,15 @@
   .form-hint {
     display: flex;
     align-items: flex-start;
-    gap: 0.375rem;
+    gap: 0.32813rem;
     color: var(--p-text-muted-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     line-height: 1.4;
-    margin-top: 0.25rem;
+    margin-top: 0.21875rem;
 
     .pi {
-      font-size: 0.625rem;
-      margin-top: 0.125rem;
+      font-size: 0.54688rem;
+      margin-top: 0.10938rem;
       flex-shrink: 0;
     }
   }
@@ -434,15 +434,15 @@
 .dialog-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 // Access denied card
 .access-denied-card {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1.5rem;
+  gap: 0.875rem;
+  padding: 1.3125rem;
   border-radius: settings.$settings-card-border-radius;
   background: color-mix(in srgb, var(--color-card) 85%, var(--p-red-600) 15%);
   border: 1px solid var(--p-content-border-color);
@@ -450,15 +450,15 @@
   max-width: 500px;
 
   > .pi {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
     flex-shrink: 0;
     color: var(--p-red-400);
   }
 
   .access-denied-content {
     h3 {
-      margin: 0 0 0.5rem;
-      font-size: 1rem;
+      margin: 0 0 0.4375rem;
+      font-size: var(--app-text-base);
       font-weight: 600;
       color: var(--p-red-300);
     }

--- a/frontend/src/app/features/settings/reader-preferences/cbx-reader-preferences/cbx-reader-preferences-component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/cbx-reader-preferences/cbx-reader-preferences-component.scss
@@ -10,7 +10,7 @@
   display: flex;
   align-items: flex-start;
   gap: 1.75rem;
-  padding: 0.21875rem 0;
+  padding: 0.2188rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -52,7 +52,7 @@
   .strip-width-control {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     flex: 1;
     min-width: 0;
 
@@ -66,7 +66,7 @@
   .strip-width-value {
     font-size: 0.7875rem;
     color: var(--p-text-muted-color);
-    min-width: 2.40625rem;
+    min-width: 2.4063rem;
   }
 
   .setting-description {
@@ -89,7 +89,7 @@
   .theme-option {
     width: 2.1875rem;
     height: 2.1875rem;
-    border-radius: 0.32813rem;
+    border-radius: 0.3281rem;
     border: 1.5px solid transparent;
     cursor: pointer;
     transition: all 0.2s ease;

--- a/frontend/src/app/features/settings/reader-preferences/cbx-reader-preferences/cbx-reader-preferences-component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/cbx-reader-preferences/cbx-reader-preferences-component.scss
@@ -3,14 +3,14 @@
 .cbx-preferences-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
-  padding: 0.25rem 0;
+  gap: 1.75rem;
+  padding: 0.21875rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -19,7 +19,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
@@ -31,15 +31,15 @@
     display: block;
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
   }
 
   .setting-label-row {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {
@@ -52,7 +52,7 @@
   .strip-width-control {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     flex: 1;
     min-width: 0;
 
@@ -64,9 +64,9 @@
   }
 
   .strip-width-value {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     color: var(--p-text-muted-color);
-    min-width: 2.75rem;
+    min-width: 2.40625rem;
   }
 
   .setting-description {
@@ -83,13 +83,13 @@
 
 .theme-selector {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
 
   .theme-option {
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 0.375rem;
+    width: 2.1875rem;
+    height: 2.1875rem;
+    border-radius: 0.32813rem;
     border: 1.5px solid transparent;
     cursor: pointer;
     transition: all 0.2s ease;

--- a/frontend/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.html
+++ b/frontend/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.html
@@ -90,7 +90,7 @@
               }
 
               @if (!customFontsReady()) {
-                <p-skeleton width="3.5rem" height="2.5rem" borderRadius="6px"></p-skeleton>
+                <p-skeleton width="3.0625rem" height="2.1875rem" borderRadius="6px"></p-skeleton>
               }
             </div>
           </div>

--- a/frontend/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.scss
@@ -11,7 +11,7 @@
   flex-direction: column;
   gap: 0.875rem;
   padding: 1.3125rem;
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
   border: 1px solid color-mix(in srgb, var(--text-color) 10%, transparent);
 
   .group-title {
@@ -19,7 +19,7 @@
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
     margin: 0 0 0.4375rem;
-    padding-bottom: 0.65625rem;
+    padding-bottom: 0.6563rem;
     border-bottom: 1px solid color-mix(in srgb, var(--text-color) 10%, transparent);
   }
 }
@@ -28,7 +28,7 @@
   display: flex;
   align-items: flex-start;
   gap: 1.75rem;
-  padding: 0.21875rem 0;
+  padding: 0.2188rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -81,7 +81,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -227,7 +227,7 @@
       font-weight: settings.$settings-section-title-weight;
       color: var(--p-text-muted-color);
       min-width: auto;
-      padding: 0.21875rem 0.4375rem;
+      padding: 0.2188rem 0.4375rem;
 
       &:hover {
         transform: none;

--- a/frontend/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/epub-reader-preferences/epub-reader-preferences-component.scss
@@ -3,23 +3,23 @@
 .epub-preferences-container {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .settings-group {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.5rem;
-  border-radius: 0.75rem;
+  gap: 0.875rem;
+  padding: 1.3125rem;
+  border-radius: 0.65625rem;
   border: 1px solid color-mix(in srgb, var(--text-color) 10%, transparent);
 
   .group-title {
     font-size: settings.$settings-section-title-size;
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
-    margin: 0 0 0.5rem;
-    padding-bottom: 0.75rem;
+    margin: 0 0 0.4375rem;
+    padding-bottom: 0.65625rem;
     border-bottom: 1px solid color-mix(in srgb, var(--text-color) 10%, transparent);
   }
 }
@@ -27,8 +27,8 @@
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
-  padding: 0.25rem 0;
+  gap: 1.75rem;
+  padding: 0.21875rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -37,7 +37,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
@@ -49,15 +49,15 @@
     display: block;
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
   }
 
   .setting-label-row {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {
@@ -77,18 +77,18 @@
 
 .radio-group {
   display: flex;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .radio-option {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   label {
     font-size: settings.$settings-section-description-size;
@@ -100,10 +100,10 @@
 .font-size-controls {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   .font-size-value {
-    min-width: 3rem;
+    min-width: 2.625rem;
     text-align: center;
     font-weight: settings.$settings-label-weight;
     color: var(--p-text-color);
@@ -112,14 +112,14 @@
 
 .theme-selector {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
 
   .theme-option {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     background: color-mix(in srgb, var(--text-color) 5%, transparent);
     color: var(--text-color);
     cursor: pointer;
@@ -131,7 +131,7 @@
       display: flex;
       gap: 0;
       padding: 0;
-      border-radius: 0.5rem;
+      border-radius: 0.4375rem;
       overflow: hidden;
       border: 2px solid color-mix(in srgb, var(--text-color) 20%, transparent);
       box-sizing: border-box;
@@ -154,7 +154,7 @@
       position: absolute;
       top: 4px;
       right: 4px;
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--primary-color);
       margin-left: 0;
       padding-left: 0;
@@ -190,7 +190,7 @@
 
   .option-button {
     &.font-button {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
 
       &[data-font="serif"] .option-text {
         font-family: Georgia, 'Times New Roman', serif;
@@ -227,7 +227,7 @@
       font-weight: settings.$settings-section-title-weight;
       color: var(--p-text-muted-color);
       min-width: auto;
-      padding: 0.25rem 0.5rem;
+      padding: 0.21875rem 0.4375rem;
 
       &:hover {
         transform: none;

--- a/frontend/src/app/features/settings/reader-preferences/local-settings/local-settings.component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/local-settings/local-settings.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -64,7 +64,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 .setting-label {

--- a/frontend/src/app/features/settings/reader-preferences/local-settings/local-settings.component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/local-settings/local-settings.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -25,7 +25,7 @@
 .section-header {
   @include settings.settings-section-header;
 
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .section-title {
@@ -48,7 +48,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 
   &.action-item {
     border-left-color: var(--p-orange-500);
@@ -64,7 +64,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 .setting-label {
@@ -78,7 +78,7 @@
 .setting-control {
   flex-shrink: 0;
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   align-items: center;
   justify-content: flex-end;
 

--- a/frontend/src/app/features/settings/reader-preferences/pdf-reader-preferences/pdf-reader-preferences-component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/pdf-reader-preferences/pdf-reader-preferences-component.scss
@@ -3,14 +3,14 @@
 .pdf-preferences-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
-  padding: 0.25rem 0;
+  gap: 1.75rem;
+  padding: 0.21875rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -19,7 +19,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
@@ -31,15 +31,15 @@
     display: block;
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
   }
 
   .setting-label-row {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {

--- a/frontend/src/app/features/settings/reader-preferences/pdf-reader-preferences/pdf-reader-preferences-component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/pdf-reader-preferences/pdf-reader-preferences-component.scss
@@ -10,7 +10,7 @@
   display: flex;
   align-items: flex-start;
   gap: 1.75rem;
-  padding: 0.21875rem 0;
+  padding: 0.2188rem 0;
 
   &:last-child {
     border-bottom: none;

--- a/frontend/src/app/features/settings/reader-preferences/reader-preferences.component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/reader-preferences.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -59,7 +59,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   align-items: flex-end;
 
   @media (width <= 768px) {
@@ -74,7 +74,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 

--- a/frontend/src/app/features/settings/reader-preferences/reader-preferences.component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/reader-preferences.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -19,25 +19,25 @@
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .preferences-section {
   @media (width >= 768px) {
-    padding: 0 1rem;
+    padding: 0 0.875rem;
   }
 }
 
 .section-header {
   @include settings.settings-section-header;
 
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .section-title {
   @include settings.settings-section-title;
 
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 }
 
 .section-description {
@@ -59,7 +59,7 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   align-items: flex-end;
 
   @media (width <= 768px) {
@@ -70,18 +70,18 @@
 
 .radio-group {
   display: flex;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .radio-option {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   label {
     font-size: settings.$settings-section-description-size;

--- a/frontend/src/app/features/settings/reader-preferences/settings-application-mode/settings-application-mode.component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/settings-application-mode/settings-application-mode.component.scss
@@ -33,7 +33,7 @@
 
   .pi {
     color: var(--p-primary-color);
-    margin-top: 0.10938rem;
+    margin-top: 0.1094rem;
     flex-shrink: 0;
   }
 }
@@ -52,7 +52,7 @@
   display: flex;
   align-items: flex-start;
   gap: 1.75rem;
-  padding: 0.21875rem 0;
+  padding: 0.2188rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -110,9 +110,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.32813rem;
-    padding: 0.4375rem 0.65625rem;
-    border-radius: 0.32813rem;
+    gap: 0.3281rem;
+    padding: 0.4375rem 0.6563rem;
+    border-radius: 0.3281rem;
     border: 1.5px solid color-mix(in srgb, var(--text-color) 20%, transparent);
     background: color-mix(in srgb, var(--text-color) 5%, transparent);
     color: var(--text-color);

--- a/frontend/src/app/features/settings/reader-preferences/settings-application-mode/settings-application-mode.component.scss
+++ b/frontend/src/app/features/settings/reader-preferences/settings-application-mode/settings-application-mode.component.scss
@@ -1,21 +1,21 @@
 .preferences-section {
   @media (width >= 768px) {
-    padding: 0 1rem;
+    padding: 0 0.875rem;
   }
 }
 
 .section-header {
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .section-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 1.125rem;
+  gap: 0.4375rem;
+  font-size: var(--app-text-lg);
   font-weight: 600;
   color: var(--p-text-color);
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 
   .pi {
     color: var(--p-primary-color);
@@ -25,15 +25,15 @@
 .section-description {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   color: var(--p-text-muted-color);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   line-height: 1.5;
   margin: 0;
 
   .pi {
     color: var(--p-primary-color);
-    margin-top: 0.125rem;
+    margin-top: 0.10938rem;
     flex-shrink: 0;
   }
 }
@@ -42,17 +42,17 @@
   border: 1px solid var(--p-content-border-color);
   border-radius: 8px;
   background: var(--p-content-background);
-  padding: 1.5rem;
+  padding: 1.3125rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
-  padding: 0.25rem 0;
+  gap: 1.75rem;
+  padding: 0.21875rem 0;
 
   &:last-child {
     border-bottom: none;
@@ -61,7 +61,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
@@ -73,8 +73,8 @@
     display: block;
     font-weight: 600;
     color: var(--p-text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
     min-width: 220px;
     flex-shrink: 0;
   }
@@ -82,8 +82,8 @@
   .setting-label-row {
     display: flex;
     align-items: flex-start;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {
@@ -95,7 +95,7 @@
 
   .setting-description {
     color: var(--p-text-muted-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     line-height: 1.5;
     margin: 0;
   }
@@ -104,26 +104,26 @@
 .button-group {
   display: flex;
   flex-flow: row wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   .option-button {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.375rem;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.375rem;
+    gap: 0.32813rem;
+    padding: 0.4375rem 0.65625rem;
+    border-radius: 0.32813rem;
     border: 1.5px solid color-mix(in srgb, var(--text-color) 20%, transparent);
     background: color-mix(in srgb, var(--text-color) 5%, transparent);
     color: var(--text-color);
     cursor: pointer;
     transition: all 0.2s ease;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
-    min-width: 4.5rem;
+    min-width: 3.9375rem;
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
 
     .option-text {

--- a/frontend/src/app/features/settings/task-management/task-management.component.scss
+++ b/frontend/src/app/features/settings/task-management/task-management.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -58,7 +58,7 @@
 
   .pi {
     font-size: 1.75rem;
-    margin-bottom: 0.65625rem;
+    margin-bottom: 0.6563rem;
   }
 
   .pi-spinner {
@@ -114,14 +114,14 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
 .task-info {
   display: flex;
   align-items: flex-start;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex: 1;
   min-width: 0;
 }
@@ -150,9 +150,9 @@
 .task-name-row {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
-  margin-bottom: 0.32813rem;
+  margin-bottom: 0.3281rem;
 }
 
 .task-name {
@@ -164,8 +164,8 @@
 .status-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.10938rem 0.4375rem;
+  gap: 0.3281rem;
+  padding: 0.1094rem 0.4375rem;
   border-radius: 12px;
   font-size: var(--app-text-xs);
   font-weight: 600;
@@ -175,7 +175,7 @@
     color: var(--p-primary-color);
 
     .pi {
-      font-size: 0.54688rem;
+      font-size: 0.5469rem;
     }
   }
 
@@ -228,7 +228,7 @@
   @media (width <= 900px) {
     flex-direction: column;
     align-items: flex-end;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
@@ -243,7 +243,7 @@
   padding: 0 0.875rem 0.875rem;
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   &:empty {
     display: none;
@@ -259,7 +259,7 @@
   color: var(--p-text-color);
   background: color-mix(in srgb, var(--p-primary-color) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--p-primary-color) 20%, transparent);
-  padding: 0.32813rem 0.65625rem;
+  padding: 0.3281rem 0.6563rem;
   border-radius: 6px;
   width: fit-content;
 
@@ -273,9 +273,9 @@
 .task-options {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
@@ -316,7 +316,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.4375rem;
-  padding: 0.21875rem 0.4375rem;
+  padding: 0.2188rem 0.4375rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
@@ -344,7 +344,7 @@
   font-size: var(--app-text-xs);
   color: var(--p-primary-color);
   background: var(--color-card);
-  padding: 0.21875rem 0.4375rem;
+  padding: 0.2188rem 0.4375rem;
   border-radius: 4px;
   border: 1px solid var(--color-border);
   white-space: nowrap;
@@ -360,7 +360,7 @@
 .cron-edit {
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 
   @media (width <= 600px) {
     flex-wrap: wrap;
@@ -374,7 +374,7 @@
   font-size: var(--app-text-xs);
   color: var(--p-text-color);
   background: var(--color-card);
-  padding: 0.21875rem 0.4375rem;
+  padding: 0.2188rem 0.4375rem;
   border-radius: 4px;
   border: 1px solid var(--color-border);
   outline: none;
@@ -400,7 +400,7 @@
   margin-top: 0.4375rem;
   font-size: var(--app-text-xs);
   color: var(--p-orange-400);
-  padding: 0.32813rem 0.4375rem;
+  padding: 0.3281rem 0.4375rem;
   background: color-mix(in srgb, var(--p-orange-500) 10%, transparent);
   border: 1px solid var(--p-orange-500);
   border-radius: 4px;
@@ -408,7 +408,7 @@
 
   .pi {
     font-size: var(--app-text-xs);
-    margin-top: 0.05469rem;
+    margin-top: 0.0547rem;
     flex-shrink: 0;
   }
 }
@@ -421,14 +421,14 @@
   border-radius: 6px;
   display: flex;
   flex-direction: column;
-  gap: 0.54688rem;
+  gap: 0.5469rem;
 }
 
 .stale-warning {
   display: flex;
   align-items: flex-start;
   gap: 0.4375rem;
-  padding: 0.54688rem 0.65625rem;
+  padding: 0.5469rem 0.6563rem;
   background: color-mix(in srgb, var(--p-orange-500) 15%, transparent);
   border: 1px solid var(--p-orange-500);
   border-radius: 4px;
@@ -437,7 +437,7 @@
 
   .pi {
     font-size: var(--app-text-base);
-    margin-top: 0.05469rem;
+    margin-top: 0.0547rem;
     flex-shrink: 0;
   }
 }
@@ -445,12 +445,12 @@
 .progress-row {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 600px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
   }
 }
 
@@ -471,7 +471,7 @@
 .progress-bar-container {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex: 1;
   min-width: 0;
 

--- a/frontend/src/app/features/settings/task-management/task-management.component.scss
+++ b/frontend/src/app/features/settings/task-management/task-management.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -52,13 +52,13 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   text-align: center;
   color: var(--p-text-muted-color);
 
   .pi {
-    font-size: 2rem;
-    margin-bottom: 0.75rem;
+    font-size: 1.75rem;
+    margin-bottom: 0.65625rem;
   }
 
   .pi-spinner {
@@ -71,7 +71,7 @@
   }
 
   .empty-title {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
     margin: 0;
     color: var(--p-text-color);
@@ -82,7 +82,7 @@
 .tasks-list {
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2.1875rem;
 }
 
 .task-item {
@@ -109,19 +109,19 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 0.875rem;
+  padding: 0.875rem;
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .task-info {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex: 1;
   min-width: 0;
 }
@@ -138,7 +138,7 @@
   flex-shrink: 0;
 
   .pi {
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
   }
 }
 
@@ -150,24 +150,24 @@
 .task-name-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
-  margin-bottom: 0.375rem;
+  margin-bottom: 0.32813rem;
 }
 
 .task-name {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   color: var(--p-text-color);
 }
 
 .status-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.125rem 0.5rem;
+  gap: 0.32813rem;
+  padding: 0.10938rem 0.4375rem;
   border-radius: 12px;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
 
   &.running {
@@ -175,7 +175,7 @@
     color: var(--p-primary-color);
 
     .pi {
-      font-size: 0.625rem;
+      font-size: 0.54688rem;
     }
   }
 
@@ -184,7 +184,7 @@
     color: var(--p-orange-500);
 
     .pi {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
     }
   }
 
@@ -213,7 +213,7 @@
 }
 
 .task-description {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   line-height: 1.5;
   margin: 0;
@@ -222,28 +222,28 @@
 .task-controls {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.875rem;
   flex-shrink: 0;
 
   @media (width <= 900px) {
     flex-direction: column;
     align-items: flex-end;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .task-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-shrink: 0;
 }
 
 // Task Body
 .task-body {
-  padding: 0 1rem 1rem;
+  padding: 0 0.875rem 0.875rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   &:empty {
     display: none;
@@ -253,19 +253,19 @@
 .task-metadata {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
+  gap: 0.4375rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
   color: var(--p-text-color);
   background: color-mix(in srgb, var(--p-primary-color) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--p-primary-color) 20%, transparent);
-  padding: 0.375rem 0.75rem;
+  padding: 0.32813rem 0.65625rem;
   border-radius: 6px;
   width: fit-content;
 
   .pi {
     color: var(--p-primary-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -273,9 +273,9 @@
 .task-options {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
-  padding: 0.75rem;
+  padding: 0.65625rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
@@ -288,13 +288,13 @@
 
 .option-label {
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-color);
   white-space: nowrap;
 }
 
 .option-hint {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   flex: 1;
 
@@ -315,8 +315,8 @@
 .cron-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.25rem 0.5rem;
+  gap: 0.4375rem;
+  padding: 0.21875rem 0.4375rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
@@ -325,12 +325,12 @@
 .cron-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: nowrap;
 
   .pi-clock {
     color: var(--p-primary-color);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     flex-shrink: 0;
   }
 
@@ -341,17 +341,17 @@
 
 .cron-value {
   font-family: 'SF Mono', Monaco, 'Courier New', monospace;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--p-primary-color);
   background: var(--color-card);
-  padding: 0.25rem 0.5rem;
+  padding: 0.21875rem 0.4375rem;
   border-radius: 4px;
   border: 1px solid var(--color-border);
   white-space: nowrap;
 }
 
 .cron-empty {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   font-style: italic;
   white-space: nowrap;
@@ -360,7 +360,7 @@
 .cron-edit {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 
   @media (width <= 600px) {
     flex-wrap: wrap;
@@ -371,10 +371,10 @@
 .cron-input {
   width: 130px;
   font-family: 'SF Mono', Monaco, 'Courier New', monospace;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--p-text-color);
   background: var(--color-card);
-  padding: 0.25rem 0.5rem;
+  padding: 0.21875rem 0.4375rem;
   border-radius: 4px;
   border: 1px solid var(--color-border);
   outline: none;
@@ -396,48 +396,48 @@
 .cron-error {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-  font-size: 0.75rem;
+  gap: 0.4375rem;
+  margin-top: 0.4375rem;
+  font-size: var(--app-text-xs);
   color: var(--p-orange-400);
-  padding: 0.375rem 0.5rem;
+  padding: 0.32813rem 0.4375rem;
   background: color-mix(in srgb, var(--p-orange-500) 10%, transparent);
   border: 1px solid var(--p-orange-500);
   border-radius: 4px;
   line-height: 1.4;
 
   .pi {
-    font-size: 0.75rem;
-    margin-top: 0.0625rem;
+    font-size: var(--app-text-xs);
+    margin-top: 0.05469rem;
     flex-shrink: 0;
   }
 }
 
 // Task Progress (Running State)
 .task-progress {
-  padding: 1rem;
+  padding: 0.875rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 0.54688rem;
 }
 
 .stale-warning {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.625rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.54688rem 0.65625rem;
   background: color-mix(in srgb, var(--p-orange-500) 15%, transparent);
   border: 1px solid var(--p-orange-500);
   border-radius: 4px;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-orange-400);
 
   .pi {
-    font-size: 1rem;
-    margin-top: 0.0625rem;
+    font-size: var(--app-text-base);
+    margin-top: 0.05469rem;
     flex-shrink: 0;
   }
 }
@@ -445,25 +445,25 @@
 .progress-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 600px) {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.375rem;
+    gap: 0.32813rem;
   }
 }
 
 .progress-label {
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-color);
   min-width: 70px;
   flex-shrink: 0;
 }
 
 .progress-value {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--p-text-muted-color);
   font-family: monospace;
 }
@@ -471,7 +471,7 @@
 .progress-bar-container {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex: 1;
   min-width: 0;
 
@@ -481,7 +481,7 @@
 }
 
 .progress-percent {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--p-text-muted-color);
   min-width: 40px;

--- a/frontend/src/app/features/settings/user-management/content-restrictions-editor/content-restrictions-editor.component.scss
+++ b/frontend/src/app/features/settings/user-management/content-restrictions-editor/content-restrictions-editor.component.scss
@@ -1,29 +1,29 @@
 .content-restrictions-editor {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .add-restriction-form {
   background: var(--ground-background);
   border-radius: 8px;
-  padding: 1rem;
+  padding: 0.875rem;
   border: 1px solid var(--border-color);
 
   .form-row {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     align-items: flex-end;
     flex-wrap: wrap;
 
     .form-field {
       display: flex;
       flex-direction: column;
-      gap: 0.25rem;
+      gap: 0.21875rem;
       min-width: 140px;
 
       label {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         font-weight: 500;
         color: var(--text-color-secondary);
         text-transform: uppercase;
@@ -47,13 +47,13 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: 1.75rem;
   text-align: center;
   color: var(--text-color-secondary);
 
   i {
-    font-size: 2rem;
-    margin-bottom: 0.5rem;
+    font-size: 1.75rem;
+    margin-bottom: 0.4375rem;
     color: var(--green-500);
   }
 
@@ -63,8 +63,8 @@
   }
 
   .empty-hint {
-    font-size: 0.85rem;
-    margin-top: 0.25rem;
+    font-size: 0.74375rem;
+    margin-top: 0.21875rem;
     opacity: 0.8;
   }
 }
@@ -72,31 +72,31 @@
 .restrictions-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .restrictions-group {
   background: var(--ground-background);
   border-radius: 8px;
-  padding: 1rem;
+  padding: 0.875rem;
   border: 1px solid var(--border-color);
 
   .group-title {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin: 0 0 0.25rem;
-    font-size: 0.9rem;
+    gap: 0.4375rem;
+    margin: 0 0 0.21875rem;
+    font-size: 0.7875rem;
     font-weight: 600;
 
     i {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
     }
   }
 
   .group-description {
-    margin: 0 0 0.75rem;
-    font-size: 0.8rem;
+    margin: 0 0 0.65625rem;
+    font-size: 0.7rem;
     color: var(--text-color-secondary);
   }
 }
@@ -104,16 +104,16 @@
 .restrictions-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .restriction-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.30625rem 0.65625rem;
   border-radius: 20px;
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   transition: all 0.2s ease;
 
   &.mode-exclude {
@@ -137,7 +137,7 @@
   }
 
   .chip-type {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
     text-transform: uppercase;
     font-weight: 600;
     letter-spacing: 0.5px;
@@ -158,11 +158,11 @@
     cursor: pointer;
     border-radius: 50%;
     padding: 0;
-    margin-left: 0.25rem;
+    margin-left: 0.21875rem;
     transition: all 0.2s ease;
 
     i {
-      font-size: 0.7rem;
+      font-size: 0.6125rem;
     }
 
     &:hover {
@@ -174,14 +174,14 @@
 .restrictions-info {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem;
   background: rgb(59 130 246 / 10%);
   border-radius: 6px;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--blue-500);
 
   i {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 }

--- a/frontend/src/app/features/settings/user-management/content-restrictions-editor/content-restrictions-editor.component.scss
+++ b/frontend/src/app/features/settings/user-management/content-restrictions-editor/content-restrictions-editor.component.scss
@@ -12,14 +12,14 @@
 
   .form-row {
     display: flex;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     align-items: flex-end;
     flex-wrap: wrap;
 
     .form-field {
       display: flex;
       flex-direction: column;
-      gap: 0.21875rem;
+      gap: 0.2188rem;
       min-width: 140px;
 
       label {
@@ -63,8 +63,8 @@
   }
 
   .empty-hint {
-    font-size: 0.74375rem;
-    margin-top: 0.21875rem;
+    font-size: 0.7438rem;
+    margin-top: 0.2188rem;
     opacity: 0.8;
   }
 }
@@ -85,7 +85,7 @@
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    margin: 0 0 0.21875rem;
+    margin: 0 0 0.2188rem;
     font-size: 0.7875rem;
     font-weight: 600;
 
@@ -95,7 +95,7 @@
   }
 
   .group-description {
-    margin: 0 0 0.65625rem;
+    margin: 0 0 0.6563rem;
     font-size: 0.7rem;
     color: var(--text-color-secondary);
   }
@@ -111,9 +111,9 @@
   display: inline-flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.30625rem 0.65625rem;
+  padding: 0.3063rem 0.6563rem;
   border-radius: 20px;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   transition: all 0.2s ease;
 
   &.mode-exclude {
@@ -158,7 +158,7 @@
     cursor: pointer;
     border-radius: 50%;
     padding: 0;
-    margin-left: 0.21875rem;
+    margin-left: 0.2188rem;
     transition: all 0.2s ease;
 
     i {
@@ -175,7 +175,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   background: rgb(59 130 246 / 10%);
   border-radius: 6px;
   font-size: 0.7rem;

--- a/frontend/src/app/features/settings/user-management/create-user-dialog/create-user-dialog.component.scss
+++ b/frontend/src/app/features/settings/user-management/create-user-dialog/create-user-dialog.component.scss
@@ -27,20 +27,20 @@
 
   @media (width <= 480px) {
     padding: 0.875rem;
-    gap: 1.09375rem;
+    gap: 1.0938rem;
   }
 }
 
 .form-section {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   .section-title {
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    margin: 0 0 0.65625rem;
+    margin: 0 0 0.6563rem;
     font-size: var(--app-text-base);
     font-weight: 600;
     color: var(--text-color);
@@ -97,10 +97,10 @@
   .field-error {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     color: #ef4444;
     font-size: var(--app-text-sm);
-    margin-top: -0.21875rem;
+    margin-top: -0.2188rem;
 
     i {
       font-size: var(--app-text-sm);
@@ -111,7 +111,7 @@
 .permissions-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   @media (width <= 640px) {
     grid-template-columns: 1fr;
@@ -131,7 +131,7 @@
 .permission-group {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding: 0.875rem;
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -167,8 +167,8 @@
 .permission-item {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.4375rem 0.83125rem;
+  gap: 0.6563rem;
+  padding: 0.4375rem 0.8313rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -215,7 +215,7 @@
     flex: 1;
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     cursor: pointer;
     min-width: 0;
 
@@ -247,11 +247,11 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.65625rem;
-    gap: 0.54688rem;
+    padding: 0.6563rem;
+    gap: 0.5469rem;
 
     .permission-label {
-      gap: 0.54688rem;
+      gap: 0.5469rem;
 
       .permission-icon-wrapper {
         width: 32px;
@@ -263,7 +263,7 @@
       }
 
       .permission-name {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }
@@ -278,7 +278,7 @@
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     color: var(--text-secondary-color);
 
     i {

--- a/frontend/src/app/features/settings/user-management/create-user-dialog/create-user-dialog.component.scss
+++ b/frontend/src/app/features/settings/user-management/create-user-dialog/create-user-dialog.component.scss
@@ -17,8 +17,8 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 2rem;
+  gap: 1.3125rem;
+  padding: 1.75rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -26,29 +26,29 @@
   max-height: 60vh;
 
   @media (width <= 480px) {
-    padding: 1rem;
-    gap: 1.25rem;
+    padding: 0.875rem;
+    gap: 1.09375rem;
   }
 }
 
 .form-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   .section-title {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin: 0 0 0.75rem;
-    font-size: 1rem;
+    gap: 0.4375rem;
+    margin: 0 0 0.65625rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
     color: var(--text-color);
-    padding-bottom: 0.5rem;
+    padding-bottom: 0.4375rem;
 
     i {
       color: var(--primary-color);
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
     }
   }
 
@@ -56,7 +56,7 @@
     .form-fields-grid {
       display: grid;
       grid-template-columns: repeat(2, 1fr);
-      gap: 1rem;
+      gap: 0.875rem;
 
       .field-full {
         grid-column: 1 / -1;
@@ -65,7 +65,7 @@
       .password-grid {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
-        gap: 1rem;
+        gap: 0.875rem;
       }
 
       @media (width <= 640px) {
@@ -82,10 +82,10 @@
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   .field-label {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     font-weight: 500;
     color: var(--text-color);
   }
@@ -97,13 +97,13 @@
   .field-error {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
     color: #ef4444;
-    font-size: 0.875rem;
-    margin-top: -0.25rem;
+    font-size: var(--app-text-sm);
+    margin-top: -0.21875rem;
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 }
@@ -111,7 +111,7 @@
 .permissions-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   @media (width <= 640px) {
     grid-template-columns: 1fr;
@@ -121,7 +121,7 @@
 .permissions-container {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;
@@ -131,32 +131,32 @@
 .permission-group {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1rem;
+  gap: 0.65625rem;
+  padding: 0.875rem;
   border: 1px solid var(--border-color);
   border-radius: 8px;
 
   .permission-group-title {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 0.875rem;
+    gap: 0.4375rem;
+    font-size: var(--app-text-sm);
     font-weight: 600;
     color: var(--text-color);
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     text-transform: uppercase;
     letter-spacing: 0.025em;
 
     i {
       color: var(--primary-color);
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 
   .permission-group-items {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   &.full-width {
@@ -167,8 +167,8 @@
 .permission-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 0.95rem;
+  gap: 0.65625rem;
+  padding: 0.4375rem 0.83125rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -215,7 +215,7 @@
     flex: 1;
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     cursor: pointer;
     min-width: 0;
 
@@ -230,14 +230,14 @@
       flex-shrink: 0;
 
       .permission-icon {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
         color: var(--text-secondary-color);
         transition: all 0.3s ease;
       }
     }
 
     .permission-name {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       color: var(--text-color);
       font-weight: 500;
       overflow: hidden;
@@ -247,23 +247,23 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.75rem;
-    gap: 0.625rem;
+    padding: 0.65625rem;
+    gap: 0.54688rem;
 
     .permission-label {
-      gap: 0.625rem;
+      gap: 0.54688rem;
 
       .permission-icon-wrapper {
         width: 32px;
         height: 32px;
 
         .permission-icon {
-          font-size: 0.9rem;
+          font-size: 0.7875rem;
         }
       }
 
       .permission-name {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }
@@ -277,8 +277,8 @@
   .footer-info {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 0.85rem;
+    gap: 0.4375rem;
+    font-size: 0.74375rem;
     color: var(--text-secondary-color);
 
     i {

--- a/frontend/src/app/features/settings/user-management/user-management.component.scss
+++ b/frontend/src/app/features/settings/user-management/user-management.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -93,7 +93,7 @@
 .users-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .user-card {
@@ -129,14 +129,14 @@
   @media (width <= 600px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 
 .user-main-info {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex: 1;
   min-width: 0;
 }
@@ -199,10 +199,10 @@
 
 .user-type-badge {
   display: inline-block;
-  padding: 0.10938rem 0.4375rem;
+  padding: 0.1094rem 0.4375rem;
   border: 1px solid;
   border-radius: 12px;
-  font-size: 0.54688rem;
+  font-size: 0.5469rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.025em;
@@ -229,23 +229,23 @@
 .admin-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.21875rem;
-  padding: 0.10938rem 0.4375rem;
+  gap: 0.2188rem;
+  padding: 0.1094rem 0.4375rem;
   border-radius: 12px;
-  font-size: 0.54688rem;
+  font-size: 0.5469rem;
   font-weight: 700;
   text-transform: uppercase;
 
   .pi {
-    font-size: 0.54688rem;
+    font-size: 0.5469rem;
   }
 }
 
 .user-meta {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  margin-top: 0.21875rem;
+  gap: 0.3281rem;
+  margin-top: 0.2188rem;
   font-size: settings.$settings-description-size;
   color: var(--p-text-muted-color);
 }
@@ -275,8 +275,8 @@
 .permission-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.21875rem 0.54688rem;
+  gap: 0.3281rem;
+  padding: 0.2188rem 0.5469rem;
   border-radius: 16px;
   font-size: var(--app-text-xs);
   font-weight: 600;
@@ -360,7 +360,7 @@
 
 .user-actions {
   display: flex;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   flex-shrink: 0;
 
   @media (width <= 600px) {
@@ -389,7 +389,7 @@
 .content-restrictions-section {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-top: 0.4375rem;
   padding-top: 0.875rem;
   border-top: 1px solid var(--p-content-border-color);
@@ -443,7 +443,7 @@
 .detail-field {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
 
   &.detail-field-wide {
     grid-column: span 2;
@@ -475,7 +475,7 @@
 .permissions-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.09375rem;
+  gap: 1.0938rem;
   padding-left: 1.3125rem;
 
   @media (width <= 600px) {
@@ -492,7 +492,7 @@
     font-size: settings.$settings-description-size;
     font-weight: 600;
     color: var(--p-text-color);
-    margin: 0 0 0.54688rem;
+    margin: 0 0 0.5469rem;
     padding-bottom: 0.4375rem;
     border-bottom: 1px solid var(--p-content-border-color);
 
@@ -512,7 +512,7 @@
 .permission-item {
   display: flex;
   align-items: center;
-  gap: 0.54688rem;
+  gap: 0.5469rem;
 
   label {
     font-size: settings.$settings-description-size;
@@ -547,7 +547,7 @@
     .p-dialog-title {
       display: flex;
       align-items: center;
-      gap: 0.65625rem;
+      gap: 0.6563rem;
       font-size: settings.$settings-section-title-size;
       font-weight: 600;
       color: var(--p-text-color);
@@ -564,7 +564,7 @@
         background: var(--p-primary-color);
         color: var(--p-primary-contrast-color);
         border-radius: 8px;
-        font-size: 1.09375rem;
+        font-size: 1.0938rem;
         box-shadow: 0 2px 6px rgb(0 0 0 / 15%);
       }
     }
@@ -605,7 +605,7 @@
 .dialog-form {
   display: flex;
   flex-direction: column;
-  gap: 1.09375rem;
+  gap: 1.0938rem;
 }
 
 .form-field {
@@ -617,7 +617,7 @@
     font-size: settings.$settings-section-description-size;
     font-weight: 600;
     color: var(--p-text-color);
-    margin-bottom: 0.21875rem;
+    margin-bottom: 0.2188rem;
   }
 
   input,
@@ -627,7 +627,7 @@
 
   ::ng-deep .p-inputtext,
   ::ng-deep .p-password-input {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
     font-size: settings.$settings-label-size;
     border: 1px solid var(--p-content-border-color);
     border-radius: 6px;
@@ -650,8 +650,8 @@
 .error-message {
   display: flex;
   align-items: flex-start;
-  gap: 0.65625rem;
-  padding: 0.76563rem 0.875rem;
+  gap: 0.6563rem;
+  padding: 0.7656rem 0.875rem;
   background: color-mix(in srgb, var(--color-red-500) 12%, var(--p-content-background));
   border: 1px solid color-mix(in srgb, var(--color-red-500) 30%, transparent);
   border-left: 3px solid var(--color-red-500);
@@ -663,7 +663,7 @@
   .pi {
     font-size: var(--app-text-base);
     flex-shrink: 0;
-    margin-top: 0.10938rem;
+    margin-top: 0.1094rem;
   }
 
   span {
@@ -676,10 +676,10 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   ::ng-deep .p-button {
-    padding: 0.65625rem 1.3125rem;
+    padding: 0.6563rem 1.3125rem;
     font-weight: 600;
     font-size: settings.$settings-label-size;
     border-radius: 6px;
@@ -738,7 +738,7 @@
     }
 
     .p-dialog-footer {
-      padding: 0.76563rem 0.875rem;
+      padding: 0.7656rem 0.875rem;
     }
   }
 

--- a/frontend/src/app/features/settings/user-management/user-management.component.scss
+++ b/frontend/src/app/features/settings/user-management/user-management.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -28,7 +28,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
 
   @media (width <= 767px) {
     flex-direction: column;
@@ -55,7 +55,7 @@
 .section-body {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 // Empty state
@@ -64,22 +64,22 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 2rem;
+  padding: 2.625rem 1.75rem;
   text-align: center;
   color: var(--p-text-muted-color);
   background: var(--color-card);
   border-radius: 6px;
 
   .pi {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   .empty-title {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     color: var(--p-text-color);
   }
 
@@ -93,7 +93,7 @@
 .users-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .user-card {
@@ -119,8 +119,8 @@
 .user-card-header {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 0.875rem;
+  padding: 0.875rem;
 
   @media (width <= 900px) {
     flex-wrap: wrap;
@@ -129,14 +129,14 @@
   @media (width <= 600px) {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .user-main-info {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex: 1;
   min-width: 0;
 }
@@ -161,7 +161,7 @@
   }
 
   .pi {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -175,7 +175,7 @@
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   flex-shrink: 0;
 }
 
@@ -187,22 +187,22 @@
 .user-name-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
 }
 
 .username {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   color: var(--p-text-color);
 }
 
 .user-type-badge {
   display: inline-block;
-  padding: 0.125rem 0.5rem;
+  padding: 0.10938rem 0.4375rem;
   border: 1px solid;
   border-radius: 12px;
-  font-size: 0.625rem;
+  font-size: 0.54688rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.025em;
@@ -229,23 +229,23 @@
 .admin-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.125rem 0.5rem;
+  gap: 0.21875rem;
+  padding: 0.10938rem 0.4375rem;
   border-radius: 12px;
-  font-size: 0.625rem;
+  font-size: 0.54688rem;
   font-weight: 700;
   text-transform: uppercase;
 
   .pi {
-    font-size: 0.625rem;
+    font-size: 0.54688rem;
   }
 }
 
 .user-meta {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  margin-top: 0.25rem;
+  gap: 0.32813rem;
+  margin-top: 0.21875rem;
   font-size: settings.$settings-description-size;
   color: var(--p-text-muted-color);
 }
@@ -264,7 +264,7 @@
 
 .permission-badges {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
 
   @media (width <= 600px) {
@@ -275,17 +275,17 @@
 .permission-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.625rem;
+  gap: 0.32813rem;
+  padding: 0.21875rem 0.54688rem;
   border-radius: 16px;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   font-weight: 600;
   border-width: 1px;
   border-style: solid;
   transition: all 0.2s;
 
   .pi {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
   }
 
   &[data-level='none'] {
@@ -360,7 +360,7 @@
 
 .user-actions {
   display: flex;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   flex-shrink: 0;
 
   @media (width <= 600px) {
@@ -370,35 +370,35 @@
 
 // Expanded card body
 .user-card-body {
-  padding: 0 1rem 1rem;
+  padding: 0 0.875rem 0.875rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
   border-top: 1px dashed var(--p-content-border-color);
   margin-top: 0;
-  padding-top: 1rem;
+  padding-top: 0.875rem;
 }
 
 .user-details-section,
 .permissions-section {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .content-restrictions-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
-  padding-top: 1rem;
+  gap: 0.65625rem;
+  margin-top: 0.4375rem;
+  padding-top: 0.875rem;
   border-top: 1px solid var(--p-content-border-color);
 
   .section-description {
     font-size: settings.$settings-description-size;
     color: var(--p-text-muted-color);
-    margin: 0 0 0.5rem;
-    padding-left: 1.5rem;
+    margin: 0 0 0.4375rem;
+    padding-left: 1.3125rem;
 
     @media (width <= 600px) {
       padding-left: 0;
@@ -406,7 +406,7 @@
   }
 
   app-content-restrictions-editor {
-    padding-left: 1.5rem;
+    padding-left: 1.3125rem;
 
     @media (width <= 600px) {
       padding-left: 0;
@@ -417,7 +417,7 @@
 .details-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: settings.$settings-label-size;
   font-weight: 600;
   color: var(--p-text-color);
@@ -425,15 +425,15 @@
 
   .pi {
     color: var(--p-primary-color);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }
 
 .details-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  padding-left: 1.5rem;
+  gap: 0.875rem;
+  padding-left: 1.3125rem;
 
   @media (width <= 600px) {
     padding-left: 0;
@@ -443,7 +443,7 @@
 .detail-field {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.32813rem;
 
   &.detail-field-wide {
     grid-column: span 2;
@@ -475,8 +475,8 @@
 .permissions-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.25rem;
-  padding-left: 1.5rem;
+  gap: 1.09375rem;
+  padding-left: 1.3125rem;
 
   @media (width <= 600px) {
     padding-left: 0;
@@ -488,17 +488,17 @@
   h5 {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     font-size: settings.$settings-description-size;
     font-weight: 600;
     color: var(--p-text-color);
-    margin: 0 0 0.625rem;
-    padding-bottom: 0.5rem;
+    margin: 0 0 0.54688rem;
+    padding-bottom: 0.4375rem;
     border-bottom: 1px solid var(--p-content-border-color);
 
     .pi {
       color: var(--p-primary-color);
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 }
@@ -506,13 +506,13 @@
 .permission-items {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .permission-item {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
+  gap: 0.54688rem;
 
   label {
     font-size: settings.$settings-description-size;
@@ -538,8 +538,8 @@
     position: relative;
     display: flex;
     align-items: center;
-    gap: 1rem;
-    padding: 1.5rem;
+    gap: 0.875rem;
+    padding: 1.3125rem;
     background: var(--p-content-background);
     border-bottom: 1px solid var(--p-content-border-color);
     border-radius: 10px 10px 0 0;
@@ -547,7 +547,7 @@
     .p-dialog-title {
       display: flex;
       align-items: center;
-      gap: 0.75rem;
+      gap: 0.65625rem;
       font-size: settings.$settings-section-title-size;
       font-weight: 600;
       color: var(--p-text-color);
@@ -564,19 +564,19 @@
         background: var(--p-primary-color);
         color: var(--p-primary-contrast-color);
         border-radius: 8px;
-        font-size: 1.25rem;
+        font-size: 1.09375rem;
         box-shadow: 0 2px 6px rgb(0 0 0 / 15%);
       }
     }
 
     .p-dialog-header-icons {
       position: absolute;
-      top: 1rem;
-      right: 1rem;
+      top: 0.875rem;
+      right: 0.875rem;
 
       .p-dialog-header-close {
-        width: 2rem;
-        height: 2rem;
+        width: 1.75rem;
+        height: 1.75rem;
         border-radius: 50%;
         transition: all 0.2s;
         color: var(--p-text-muted-color);
@@ -590,12 +590,12 @@
   }
 
   .p-dialog-content {
-    padding: 1.5rem;
+    padding: 1.3125rem;
     background: var(--p-content-background);
   }
 
   .p-dialog-footer {
-    padding: 1rem 1.5rem;
+    padding: 0.875rem 1.3125rem;
     background: var(--p-content-background);
     border-top: 1px solid var(--p-content-border-color);
     border-radius: 0 0 10px 10px;
@@ -605,19 +605,19 @@
 .dialog-form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.09375rem;
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   label {
     font-size: settings.$settings-section-description-size;
     font-weight: 600;
     color: var(--p-text-color);
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.21875rem;
   }
 
   input,
@@ -627,7 +627,7 @@
 
   ::ng-deep .p-inputtext,
   ::ng-deep .p-password-input {
-    padding: 0.75rem;
+    padding: 0.65625rem;
     font-size: settings.$settings-label-size;
     border: 1px solid var(--p-content-border-color);
     border-radius: 6px;
@@ -650,8 +650,8 @@
 .error-message {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.875rem 1rem;
+  gap: 0.65625rem;
+  padding: 0.76563rem 0.875rem;
   background: color-mix(in srgb, var(--color-red-500) 12%, var(--p-content-background));
   border: 1px solid color-mix(in srgb, var(--color-red-500) 30%, transparent);
   border-left: 3px solid var(--color-red-500);
@@ -661,9 +661,9 @@
   font-weight: 500;
 
   .pi {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     flex-shrink: 0;
-    margin-top: 0.125rem;
+    margin-top: 0.10938rem;
   }
 
   span {
@@ -676,10 +676,10 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   ::ng-deep .p-button {
-    padding: 0.75rem 1.5rem;
+    padding: 0.65625rem 1.3125rem;
     font-weight: 600;
     font-size: settings.$settings-label-size;
     border-radius: 6px;
@@ -715,37 +715,37 @@
     .p-dialog {
       width: 95vw !important;
       max-width: 95vw !important;
-      margin: 0.5rem;
+      margin: 0.4375rem;
       border-radius: 8px;
     }
 
     .p-dialog-header {
-      padding: 1rem;
+      padding: 0.875rem;
 
       .p-dialog-title {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
 
         &::before {
           width: 36px;
           height: 36px;
-          font-size: 1rem;
+          font-size: var(--app-text-base);
         }
       }
     }
 
     .p-dialog-content {
-      padding: 1rem;
+      padding: 0.875rem;
     }
 
     .p-dialog-footer {
-      padding: 0.875rem 1rem;
+      padding: 0.76563rem 0.875rem;
     }
   }
 
   .dialog-actions {
     flex-direction: column-reverse;
     width: 100%;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     ::ng-deep .p-button {
       width: 100%;

--- a/frontend/src/app/features/settings/user-profile-dialog/user-profile-dialog.component.scss
+++ b/frontend/src/app/features/settings/user-profile-dialog/user-profile-dialog.component.scss
@@ -36,7 +36,7 @@
 
   @media #{variables.$mobile-shell-media-query} {
     padding: 0.875rem;
-    gap: 1.09375rem;
+    gap: 1.0938rem;
   }
 }
 
@@ -105,7 +105,7 @@
   .field-value {
     font-size: var(--app-text-base);
     color: var(--color-text);
-    padding: 0.65625rem;
+    padding: 0.6563rem;
     background: var(--color-card);
     border: 1px solid var(--color-border);
     border-radius: 6px;
@@ -115,10 +115,10 @@
   .field-error {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
+    gap: 0.3281rem;
     color: var(--color-red-500);
     font-size: var(--app-text-sm);
-    margin-top: -0.21875rem;
+    margin-top: -0.2188rem;
 
     i {
       font-size: var(--app-text-sm);
@@ -131,7 +131,7 @@
 
   .edit-buttons {
     display: flex;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 }
 

--- a/frontend/src/app/features/settings/user-profile-dialog/user-profile-dialog.component.scss
+++ b/frontend/src/app/features/settings/user-profile-dialog/user-profile-dialog.component.scss
@@ -24,8 +24,8 @@
 .form-container {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  padding: 2rem;
+  gap: 1.75rem;
+  padding: 1.75rem;
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-top: none;
@@ -35,45 +35,45 @@
   overflow-y: auto;
 
   @media #{variables.$mobile-shell-media-query} {
-    padding: 1rem;
-    gap: 1.25rem;
+    padding: 0.875rem;
+    gap: 1.09375rem;
   }
 }
 
 .form-section {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 
   .section-title {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin: 0 0 0.5rem;
-    font-size: 1rem;
+    gap: 0.4375rem;
+    margin: 0 0 0.4375rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
     color: var(--color-text);
 
     i {
       color: var(--color-primary);
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
     }
   }
 
   form {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   .field-label {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     font-weight: 500;
     color: var(--color-text);
   }
@@ -103,9 +103,9 @@
   }
 
   .field-value {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     color: var(--color-text);
-    padding: 0.75rem;
+    padding: 0.65625rem;
     background: var(--color-card);
     border: 1px solid var(--color-border);
     border-radius: 6px;
@@ -115,28 +115,28 @@
   .field-error {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.32813rem;
     color: var(--color-red-500);
-    font-size: 0.875rem;
-    margin-top: -0.25rem;
+    font-size: var(--app-text-sm);
+    margin-top: -0.21875rem;
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 }
 
 .edit-actions {
-  margin-top: 0.5rem;
+  margin-top: 0.4375rem;
 
   .edit-buttons {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 }
 
 .password-actions {
-  margin-top: 0.5rem;
+  margin-top: 0.4375rem;
 }
 
 .loading-state {
@@ -145,15 +145,15 @@
   align-items: center;
   justify-content: center;
   min-height: 300px;
-  gap: 1rem;
+  gap: 0.875rem;
 
   .loading-icon {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: var(--color-primary);
   }
 
   p {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     color: var(--color-text-secondary);
   }
 }

--- a/frontend/src/app/features/settings/view-preferences-parent/display-preferences/display-preferences.component.html
+++ b/frontend/src/app/features/settings/view-preferences-parent/display-preferences/display-preferences.component.html
@@ -1,19 +1,19 @@
 <ng-container *transloco="let t; prefix: 'settingsView'">
-  <div class="flex flex-col gap-5 rounded-lg border border-border bg-card p-6 max-md:gap-4 max-md:p-4">
+  <div class="flex flex-col gap-4 rounded-lg border border-border bg-card p-5 max-md:gap-3.5 max-md:p-3.5">
     <div class="mb-1">
-      <h3 class="m-0 mb-2 flex items-center gap-2 text-xl font-semibold text-text">
-        <i class="pi pi-palette text-lg text-primary" aria-hidden="true"></i>
+      <h3 class="m-0 mb-2 flex items-center gap-2 text-lg font-semibold text-text">
+        <i class="pi pi-palette text-base text-primary" aria-hidden="true"></i>
         {{ t('theme.sectionTitle') }}
       </h3>
-      <p class="m-0 text-sm leading-6 text-text-secondary">{{ t('theme.sectionDesc') }}</p>
+      <p class="m-0 text-xs leading-5 text-text-secondary">{{ t('theme.sectionDesc') }}</p>
     </div>
 
-    <div class="flex flex-col gap-4 pl-4 max-md:pl-2">
-      <section class="w-full max-w-3xl rounded-md border-l-[3px] border-l-primary bg-[color-mix(in_srgb,var(--color-card)_35%,var(--color-page))] p-4 transition-[background,border-color] duration-200 hover:bg-[color-mix(in_srgb,var(--color-card)_20%,var(--color-page))] max-md:p-3">
+    <div class="flex flex-col gap-3.5 pl-3.5 max-md:pl-1.5">
+      <section class="w-full max-w-2xl rounded-md border-l-[3px] border-l-primary bg-[color-mix(in_srgb,var(--color-card)_35%,var(--color-page))] p-3.5 transition-[background,border-color] duration-200 hover:bg-[color-mix(in_srgb,var(--color-card)_20%,var(--color-page))] max-md:p-2.5">
         <div class="mb-1">
-          <label class="text-[0.9375rem] font-medium text-text" for="appearance-preference">{{ 'layout.theme.appearance' | transloco }}</label>
+          <label class="text-sm font-medium text-text" for="appearance-preference">{{ 'layout.theme.appearance' | transloco }}</label>
         </div>
-        <div class="mt-3 border-t border-dashed border-border pt-3">
+        <div class="mt-2.5 border-t border-dashed border-border pt-2.5">
           <p-select
             inputId="appearance-preference"
             [options]="appearanceOptions()"
@@ -22,27 +22,27 @@
             optionLabel="label"
             optionValue="value"
             appendTo="body"
-            class="w-80 max-w-full">
+            class="w-72 max-w-full">
           </p-select>
         </div>
 
         @if (showOledDarkModeToggle()) {
-          <div class="mt-4 flex max-w-xl items-center gap-3 border-t border-dashed border-border pt-3">
+          <div class="mt-3.5 flex max-w-lg items-center gap-2.5 border-t border-dashed border-border pt-2.5">
             <p-toggleswitch
               inputId="oled-dark-mode"
               [ngModel]="oledDarkMode()"
               (ngModelChange)="updateOledDarkMode($event)">
             </p-toggleswitch>
-            <label class="text-[0.9375rem] font-medium text-text" for="oled-dark-mode">{{ t('theme.oledDarkMode') }}</label>
+            <label class="text-sm font-medium text-text" for="oled-dark-mode">{{ t('theme.oledDarkMode') }}</label>
           </div>
         }
       </section>
 
-      <section class="w-full max-w-3xl rounded-md border-l-[3px] border-l-primary bg-[color-mix(in_srgb,var(--color-card)_35%,var(--color-page))] p-4 transition-[background,border-color] duration-200 hover:bg-[color-mix(in_srgb,var(--color-card)_20%,var(--color-page))] max-md:p-3">
+      <section class="w-full max-w-2xl rounded-md border-l-[3px] border-l-primary bg-[color-mix(in_srgb,var(--color-card)_35%,var(--color-page))] p-3.5 transition-[background,border-color] duration-200 hover:bg-[color-mix(in_srgb,var(--color-card)_20%,var(--color-page))] max-md:p-2.5">
         <div class="mb-1">
-          <label class="text-[0.9375rem] font-medium text-text" for="app-theme">{{ 'layout.theme.theme' | transloco }}</label>
+          <label class="text-sm font-medium text-text" for="app-theme">{{ 'layout.theme.theme' | transloco }}</label>
         </div>
-        <div class="mt-3 border-t border-dashed border-border pt-3">
+        <div class="mt-2.5 border-t border-dashed border-border pt-2.5">
           <p-select
             inputId="app-theme"
             [options]="themeOptions()"
@@ -51,13 +51,13 @@
             optionLabel="label"
             optionValue="value"
             appendTo="body"
-            class="w-80 max-w-full">
+            class="w-72 max-w-full">
             <ng-template #selectedItem let-option>
               @if (option) {
-                <span class="inline-flex min-w-0 items-center gap-2.5">
+                <span class="inline-flex min-w-0 items-center gap-2">
                   @if (option.value !== 'custom') {
                     <span
-                      class="h-3.5 w-3.5 shrink-0 rounded-full bg-(--color-primary-500) ring-1 ring-inset ring-black/15"
+                      class="size-3 shrink-0 rounded-full bg-(--color-primary-500) ring-1 ring-inset ring-black/15"
                       [attr.data-app-theme]="option.value"
                       aria-hidden="true">
                     </span>
@@ -67,10 +67,10 @@
               }
             </ng-template>
             <ng-template #item let-option>
-              <span class="inline-flex min-w-0 items-center gap-2.5">
+              <span class="inline-flex min-w-0 items-center gap-2">
                 @if (option.value !== 'custom') {
                   <span
-                    class="h-3.5 w-3.5 shrink-0 rounded-full bg-(--color-primary-500) ring-1 ring-inset ring-black/15"
+                    class="size-3 shrink-0 rounded-full bg-(--color-primary-500) ring-1 ring-inset ring-black/15"
                     [attr.data-app-theme]="option.value"
                     aria-hidden="true">
                   </span>
@@ -82,12 +82,12 @@
         </div>
 
         @if (selectedThemePreference() === 'custom') {
-          <div class="mt-4 max-w-xl">
-            <div class="flex flex-wrap gap-2">
+          <div class="mt-3.5 max-w-lg">
+            <div class="flex flex-wrap gap-1.5">
               @for (option of customPrimaryOptions(); track option.value) {
                 <button
                   type="button"
-                  class="size-7 cursor-pointer rounded-full border-0 p-0 shadow-[inset_0_0_0_1px_rgb(0_0_0_/_10%)] aria-pressed:ring-2 aria-pressed:ring-[var(--color-text)] aria-pressed:ring-offset-2 aria-pressed:ring-offset-[var(--color-page)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  class="size-6 cursor-pointer rounded-full border-0 p-0 shadow-[inset_0_0_0_1px_rgb(0_0_0_/_10%)] aria-pressed:ring-2 aria-pressed:ring-[var(--color-text)] aria-pressed:ring-offset-2 aria-pressed:ring-offset-[var(--color-page)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                   [style.background]="'var(--color-' + option.value + '-500)'"
                   [attr.aria-label]="option.ariaLabel"
                   [attr.aria-pressed]="option.value === selectedCustomPrimary()"
@@ -98,21 +98,21 @@
           </div>
         }
 
-        <div class="mt-4 flex max-w-xl items-center gap-3 border-t border-dashed border-border pt-3">
+        <div class="mt-3.5 flex max-w-lg items-center gap-2.5 border-t border-dashed border-border pt-2.5">
           <p-toggleswitch
             inputId="theme-sync"
             [ngModel]="selectedThemeSyncEnabled()"
             (ngModelChange)="updateThemeSyncEnabled($event)">
           </p-toggleswitch>
-          <label class="text-[0.9375rem] font-medium text-text" for="theme-sync">{{ 'layout.theme.syncAcrossDevices' | transloco }}</label>
+          <label class="text-sm font-medium text-text" for="theme-sync">{{ 'layout.theme.syncAcrossDevices' | transloco }}</label>
         </div>
       </section>
 
-      <section class="w-full max-w-3xl rounded-md border-l-[3px] border-l-primary bg-[color-mix(in_srgb,var(--color-card)_35%,var(--color-page))] p-4 transition-[background,border-color] duration-200 hover:bg-[color-mix(in_srgb,var(--color-card)_20%,var(--color-page))] max-md:p-3">
+      <section class="w-full max-w-2xl rounded-md border-l-[3px] border-l-primary bg-[color-mix(in_srgb,var(--color-card)_35%,var(--color-page))] p-3.5 transition-[background,border-color] duration-200 hover:bg-[color-mix(in_srgb,var(--color-card)_20%,var(--color-page))] max-md:p-2.5">
         <div class="mb-1">
-          <label class="text-[0.9375rem] font-medium text-text" for="interface-language">{{ t('language.label') }}</label>
+          <label class="text-sm font-medium text-text" for="interface-language">{{ t('language.label') }}</label>
         </div>
-        <div class="mt-3 border-t border-dashed border-border pt-3">
+        <div class="mt-2.5 border-t border-dashed border-border pt-2.5">
           <p-select
             inputId="interface-language"
             [options]="languageOptions"
@@ -121,7 +121,7 @@
             optionLabel="label"
             optionValue="value"
             appendTo="body"
-            class="w-80 max-w-full">
+            class="w-72 max-w-full">
           </p-select>
         </div>
       </section>

--- a/frontend/src/app/features/settings/view-preferences-parent/filter-preferences/filter-preferences.component.scss
+++ b/frontend/src/app/features/settings/view-preferences-parent/filter-preferences/filter-preferences.component.scss
@@ -56,7 +56,7 @@
 
 // Filter order editor styles
 .filter-order-editor {
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
 }
 
 .filter-order-list {
@@ -67,14 +67,14 @@
   max-height: 320px;
   max-width: 350px;
   overflow-y: auto;
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .filter-order-row {
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.4375rem 0.65625rem;
+  padding: 0.4375rem 0.6563rem;
   background-color: var(--overlay-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -90,7 +90,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.30625rem 0.65625rem;
+  padding: 0.3063rem 0.6563rem;
   background-color: var(--card-background);
   border: 1px solid var(--primary-color);
   border-radius: 6px;
@@ -121,14 +121,14 @@
   }
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 
 .filter-rank {
   font-weight: 600;
   color: var(--primary-color);
-  min-width: 1.53125rem;
+  min-width: 1.5313rem;
 }
 
 .filter-label {
@@ -141,8 +141,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.53125rem;
-  height: 1.53125rem;
+  width: 1.5313rem;
+  height: 1.5313rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -152,7 +152,7 @@
   transition: background-color 0.15s ease;
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 
   &:hover:not(:disabled) {
@@ -175,8 +175,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.53125rem;
-  height: 1.53125rem;
+  width: 1.5313rem;
+  height: 1.5313rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -186,7 +186,7 @@
   transition: background-color 0.15s ease, color 0.15s ease;
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 
   &:hover {

--- a/frontend/src/app/features/settings/view-preferences-parent/filter-preferences/filter-preferences.component.scss
+++ b/frontend/src/app/features/settings/view-preferences-parent/filter-preferences/filter-preferences.component.scss
@@ -56,25 +56,25 @@
 
 // Filter order editor styles
 .filter-order-editor {
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
 }
 
 .filter-order-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   min-height: 40px;
   max-height: 320px;
   max-width: 350px;
   overflow-y: auto;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .filter-order-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0.65625rem;
   background-color: var(--overlay-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -89,8 +89,8 @@
 .cdk-drag-preview {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.30625rem 0.65625rem;
   background-color: var(--card-background);
   border: 1px solid var(--primary-color);
   border-radius: 6px;
@@ -121,19 +121,19 @@
   }
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
 .filter-rank {
   font-weight: 600;
   color: var(--primary-color);
-  min-width: 1.75rem;
+  min-width: 1.53125rem;
 }
 
 .filter-label {
   flex: 1;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--text-color);
 }
 
@@ -141,8 +141,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 1.53125rem;
+  height: 1.53125rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -152,7 +152,7 @@
   transition: background-color 0.15s ease;
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 
   &:hover:not(:disabled) {
@@ -168,15 +168,15 @@
 .filter-actions-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .reset-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 1.53125rem;
+  height: 1.53125rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -186,7 +186,7 @@
   transition: background-color 0.15s ease, color 0.15s ease;
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 
   &:hover {

--- a/frontend/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.scss
+++ b/frontend/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .settings-description {
@@ -20,14 +20,14 @@
 
 .preferences-section {
   @media (width >= 768px) {
-    padding: 0 1rem;
+    padding: 0 0.875rem;
   }
 }
 
 .section-header {
   @include settings.settings-section-header;
 
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .section-title {
@@ -43,7 +43,7 @@
 .setting-item {
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
+  gap: 1.75rem;
 
   &:last-child {
     border-bottom: none;
@@ -52,7 +52,7 @@
 
   @media (width <= 768px) {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.875rem;
   }
 }
 
@@ -64,15 +64,15 @@
     display: block;
     font-weight: settings.$settings-section-title-weight;
     color: var(--p-text-color);
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+    font-size: var(--app-text-base);
+    margin-bottom: 0.4375rem;
   }
 
   .setting-label-row {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    gap: 0.875rem;
+    margin-bottom: 0.4375rem;
     flex-wrap: wrap;
 
     .setting-label {
@@ -85,7 +85,7 @@
   .setting-description {
     display: flex;
     align-items: flex-start;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     color: var(--p-text-muted-color);
     font-size: settings.$settings-section-description-size;
     line-height: 1.5;
@@ -93,7 +93,7 @@
 
     .pi {
       color: var(--p-primary-color);
-      margin-top: 0.125rem;
+      margin-top: 0.10938rem;
       flex-shrink: 0;
     }
   }

--- a/frontend/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.scss
+++ b/frontend/src/app/features/settings/view-preferences-parent/view-preferences-parent.component.scss
@@ -9,7 +9,7 @@
 .settings-title {
   @include settings.settings-page-title;
 
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .settings-description {
@@ -93,7 +93,7 @@
 
     .pi {
       color: var(--p-primary-color);
-      margin-top: 0.10938rem;
+      margin-top: 0.1094rem;
       flex-shrink: 0;
     }
   }

--- a/frontend/src/app/features/settings/view-preferences-parent/view-preferences/view-preferences.component.scss
+++ b/frontend/src/app/features/settings/view-preferences-parent/view-preferences/view-preferences.component.scss
@@ -55,21 +55,21 @@
 .setting-actions {
   display: flex;
   justify-content: flex-end;
-  padding-top: 0.5rem;
+  padding-top: 0.4375rem;
   border-top: 1px solid var(--border-color);
 }
 
 .multi-sort-editor {
-  margin-top: 1rem;
-  padding-top: 1rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px dashed var(--border-color);
 }
 
 .multi-sort-label {
   display: block;
   font-weight: 500;
-  font-size: 0.875rem;
-  margin-bottom: 0.5rem;
+  font-size: var(--app-text-sm);
+  margin-bottom: 0.4375rem;
   color: var(--text-color);
 }
 
@@ -80,25 +80,25 @@
 }
 
 .sort-field-order-editor {
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
 }
 
 .sort-field-order-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   min-height: 40px;
   max-height: 320px;
   max-width: 350px;
   overflow-y: auto;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65625rem;
 }
 
 .sort-field-order-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0.65625rem;
   background-color: var(--overlay-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -113,8 +113,8 @@
 .cdk-drag-preview {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.75rem;
+  gap: 0.4375rem;
+  padding: 0.30625rem 0.65625rem;
   background-color: var(--card-background);
   border: 1px solid var(--primary-color);
   border-radius: 6px;
@@ -145,19 +145,19 @@
   }
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
 .sort-field-rank {
   font-weight: 600;
   color: var(--primary-color);
-  min-width: 1.75rem;
+  min-width: 1.53125rem;
 }
 
 .sort-field-label {
   flex: 1;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--text-color);
 }
 
@@ -165,8 +165,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 1.53125rem;
+  height: 1.53125rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -176,7 +176,7 @@
   transition: background-color 0.15s ease;
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 
   &:hover:not(:disabled) {
@@ -192,15 +192,15 @@
 .sort-field-actions-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .reset-sort-fields-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 1.53125rem;
+  height: 1.53125rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -210,7 +210,7 @@
   transition: background-color 0.15s ease, color 0.15s ease;
 
   i {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 
   &:hover {

--- a/frontend/src/app/features/settings/view-preferences-parent/view-preferences/view-preferences.component.scss
+++ b/frontend/src/app/features/settings/view-preferences-parent/view-preferences/view-preferences.component.scss
@@ -80,7 +80,7 @@
 }
 
 .sort-field-order-editor {
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
 }
 
 .sort-field-order-list {
@@ -91,14 +91,14 @@
   max-height: 320px;
   max-width: 350px;
   overflow-y: auto;
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
 }
 
 .sort-field-order-row {
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.4375rem 0.65625rem;
+  padding: 0.4375rem 0.6563rem;
   background-color: var(--overlay-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -114,7 +114,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.30625rem 0.65625rem;
+  padding: 0.3063rem 0.6563rem;
   background-color: var(--card-background);
   border: 1px solid var(--primary-color);
   border-radius: 6px;
@@ -145,14 +145,14 @@
   }
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 
 .sort-field-rank {
   font-weight: 600;
   color: var(--primary-color);
-  min-width: 1.53125rem;
+  min-width: 1.5313rem;
 }
 
 .sort-field-label {
@@ -165,8 +165,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.53125rem;
-  height: 1.53125rem;
+  width: 1.5313rem;
+  height: 1.5313rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -176,7 +176,7 @@
   transition: background-color 0.15s ease;
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 
   &:hover:not(:disabled) {
@@ -199,8 +199,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.53125rem;
-  height: 1.53125rem;
+  width: 1.5313rem;
+  height: 1.5313rem;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -210,7 +210,7 @@
   transition: background-color 0.15s ease, color 0.15s ease;
 
   i {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 
   &:hover {

--- a/frontend/src/app/features/stats/component/_chart-shared.scss
+++ b/frontend/src/app/features/stats/component/_chart-shared.scss
@@ -19,7 +19,7 @@
   @include accent-text;
 
   padding: 0.35rem 0.875rem;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 500;
 }
 
@@ -43,7 +43,7 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -93,7 +93,7 @@
 
   i {
     font-size: 1.75rem;
-    margin-bottom: 0.65625rem;
+    margin-bottom: 0.6563rem;
     opacity: 0.5;
   }
 
@@ -104,7 +104,7 @@
   }
 
   small {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     opacity: 0.7;
   }
 }
@@ -117,7 +117,7 @@
       }
 
       .chart-description {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }
@@ -137,7 +137,7 @@
 
     .stats-badge {
       .badge-value {
-        font-size: 1.09375rem;
+        font-size: 1.0938rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/_chart-shared.scss
+++ b/frontend/src/app/features/stats/component/_chart-shared.scss
@@ -18,8 +18,8 @@
   @include accent-surface;
   @include accent-text;
 
-  padding: 0.4rem 1rem;
-  font-size: 0.85rem;
+  padding: 0.35rem 0.875rem;
+  font-size: 0.74375rem;
   font-weight: 500;
 }
 
@@ -33,9 +33,9 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.875rem;
 
   .chart-title {
     flex: 1;
@@ -43,17 +43,17 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--color-text-secondary);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -65,16 +65,16 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
 
     .badge-value {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
       color: var(--color-text);
     }
 
     .badge-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
@@ -87,24 +87,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: 1.75rem;
   text-align: center;
   color: var(--color-text-secondary);
 
   i {
-    font-size: 2rem;
-    margin-bottom: 0.75rem;
+    font-size: 1.75rem;
+    margin-bottom: 0.65625rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 0.9rem;
-    margin: 0 0 0.5rem;
+    font-size: 0.7875rem;
+    margin: 0 0 0.4375rem;
     color: var(--color-text);
   }
 
   small {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     opacity: 0.7;
   }
 }
@@ -113,11 +113,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .chart-description {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }
@@ -127,17 +127,17 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
 
     .stats-badge {
       .badge-value {
-        font-size: 1.25rem;
+        font-size: 1.09375rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.scss
@@ -5,7 +5,7 @@
 }
 
 .author-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: var(--color-violet-500);
 }
 
@@ -18,14 +18,14 @@
 }
 
 .chart-legend-info {
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 
   .legend-note {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 0.8rem;
-    padding: 0.5rem 0.75rem;
+    gap: 0.4375rem;
+    font-size: 0.7rem;
+    padding: 0.4375rem 0.65625rem;
     color: var(--color-text-secondary);
 
     @include chart-shared.neutral-surface(6px);
@@ -43,21 +43,21 @@
 }
 
 .insights-section {
-  margin-top: 1.25rem;
-  padding-top: 1rem;
+  margin-top: 1.09375rem;
+  padding-top: 0.875rem;
   border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .insights-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .insight-card {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.525rem;
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--color-violet-500) 10%, transparent),
@@ -65,7 +65,7 @@
   );
   border: 1px solid color-mix(in srgb, var(--color-violet-500) 20%, transparent);
   border-radius: 8px;
-  padding: 0.6rem 0.85rem;
+  padding: 0.525rem 0.74375rem;
   transition: all 0.2s ease;
 
   &:hover {
@@ -80,12 +80,12 @@
 
   .insight-icon {
     color: var(--color-amber-500);
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     flex-shrink: 0;
   }
 
   .insight-text {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     color: var(--color-text);
     line-height: 1.3;
   }
@@ -102,7 +102,7 @@
 
   .chart-legend-info {
     .legend-note {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
     }
   }
 }
@@ -113,15 +113,15 @@
   }
 
   .author-count-badge {
-    font-size: 0.8rem;
-    padding: 0.3rem 0.75rem;
+    font-size: 0.7rem;
+    padding: 0.2625rem 0.65625rem;
   }
 
   .insight-card {
-    padding: 0.5rem 0.7rem;
+    padding: 0.4375rem 0.6125rem;
 
     .insight-text {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/author-universe-chart/author-universe-chart.component.scss
@@ -25,7 +25,7 @@
     align-items: center;
     gap: 0.4375rem;
     font-size: 0.7rem;
-    padding: 0.4375rem 0.65625rem;
+    padding: 0.4375rem 0.6563rem;
     color: var(--color-text-secondary);
 
     @include chart-shared.neutral-surface(6px);
@@ -43,7 +43,7 @@
 }
 
 .insights-section {
-  margin-top: 1.09375rem;
+  margin-top: 1.0938rem;
   padding-top: 0.875rem;
   border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
@@ -51,7 +51,7 @@
 .insights-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .insight-card {
@@ -65,7 +65,7 @@
   );
   border: 1px solid color-mix(in srgb, var(--color-violet-500) 20%, transparent);
   border-radius: 8px;
-  padding: 0.525rem 0.74375rem;
+  padding: 0.525rem 0.7438rem;
   transition: all 0.2s ease;
 
   &:hover {
@@ -80,12 +80,12 @@
 
   .insight-icon {
     color: var(--color-amber-500);
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     flex-shrink: 0;
   }
 
   .insight-text {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     color: var(--color-text);
     line-height: 1.3;
   }
@@ -114,7 +114,7 @@
 
   .author-count-badge {
     font-size: 0.7rem;
-    padding: 0.2625rem 0.65625rem;
+    padding: 0.2625rem 0.6563rem;
   }
 
   .insight-card {

--- a/frontend/src/app/features/stats/component/library-stats/charts/book-formats-chart/book-formats-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/book-formats-chart/book-formats-chart.component.scss
@@ -5,7 +5,7 @@
 }
 
 .formats-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #E11D48;
 }
 

--- a/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.scss
@@ -5,7 +5,7 @@
 }
 
 .language-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #2563EB;
 }
 

--- a/frontend/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/metadata-score-chart/metadata-score-chart.component.scss
@@ -5,7 +5,7 @@
 }
 
 .score-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #16A34A;
 }
 

--- a/frontend/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/page-count-chart/page-count-chart.component.scss
@@ -5,7 +5,7 @@
 }
 
 .page-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #8B5CF6;
 }
 

--- a/frontend/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.scss
@@ -32,7 +32,7 @@
 .insights-row {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .insight-item {
@@ -40,7 +40,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
 
   @include chart-shared.neutral-surface;
 
@@ -49,7 +49,7 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--color-text-secondary);
-    margin-bottom: 0.21875rem;
+    margin-bottom: 0.2188rem;
   }
 
   .insight-value {
@@ -61,7 +61,7 @@
   .insight-detail {
     font-size: var(--app-text-xs);
     color: var(--color-text-secondary);
-    margin-top: 0.21875rem;
+    margin-top: 0.2188rem;
     max-width: 150px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -118,7 +118,7 @@
 }
 
 .insights-row + .insights-row {
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
 }
 
 @media (width <= 768px) {
@@ -135,7 +135,7 @@
     padding: 0.525rem;
 
     .insight-value {
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
     }
 
     .insight-detail {
@@ -151,7 +151,7 @@
 
   .books-count-badge {
     font-size: 0.7rem;
-    padding: 0.2625rem 0.65625rem;
+    padding: 0.2625rem 0.6563rem;
   }
 
   .insights-row {
@@ -166,7 +166,7 @@
     }
 
     .insight-label {
-      font-size: 0.56875rem;
+      font-size: 0.5687rem;
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/publication-timeline-chart/publication-timeline-chart.component.scss
@@ -5,7 +5,7 @@
 }
 
 .timeline-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: var(--color-violet-400);
 }
 
@@ -24,15 +24,15 @@
 }
 
 .insights-section {
-  margin-top: 1rem;
-  padding-top: 1rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .insights-row {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .insight-item {
@@ -40,28 +40,28 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 0.75rem;
+  padding: 0.65625rem;
 
   @include chart-shared.neutral-surface;
 
   .insight-label {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--color-text-secondary);
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.21875rem;
   }
 
   .insight-value {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
     font-weight: 600;
     color: var(--color-text);
   }
 
   .insight-detail {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--color-text-secondary);
-    margin-top: 0.25rem;
+    margin-top: 0.21875rem;
     max-width: 150px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -118,7 +118,7 @@
 }
 
 .insights-row + .insights-row {
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
 }
 
 @media (width <= 768px) {
@@ -128,14 +128,14 @@
 
   .insights-row {
     grid-template-columns: repeat(4, 1fr);
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   .insight-item {
-    padding: 0.6rem;
+    padding: 0.525rem;
 
     .insight-value {
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
     }
 
     .insight-detail {
@@ -150,8 +150,8 @@
   }
 
   .books-count-badge {
-    font-size: 0.8rem;
-    padding: 0.3rem 0.75rem;
+    font-size: 0.7rem;
+    padding: 0.2625rem 0.65625rem;
   }
 
   .insights-row {
@@ -159,14 +159,14 @@
   }
 
   .insight-item {
-    padding: 0.5rem;
+    padding: 0.4375rem;
 
     .insight-value {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
 
     .insight-label {
-      font-size: 0.65rem;
+      font-size: 0.56875rem;
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.scss
@@ -5,7 +5,7 @@
 }
 
 .trend-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: var(--color-cyan-500);
 }
 
@@ -24,15 +24,15 @@
 }
 
 .insights-section {
-  margin-top: 1rem;
-  padding-top: 1rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .insights-row {
   display: flex;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.875rem;
   flex-wrap: wrap;
 }
 
@@ -43,28 +43,28 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 0.75rem;
+  padding: 0.65625rem;
 
   @include chart-shared.neutral-surface;
 
   .insight-label {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--color-text-secondary);
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.21875rem;
   }
 
   .insight-value {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
     font-weight: 600;
     color: var(--color-text);
   }
 
   .insight-detail {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--color-text-secondary);
-    margin-top: 0.25rem;
+    margin-top: 0.21875rem;
   }
 
   &.peak {
@@ -88,7 +88,7 @@
   &.productive {
     .insight-value {
       color: var(--color-green-400);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
     }
   }
 
@@ -123,19 +123,19 @@
   }
 
   .insights-row {
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 
   .insight-item {
-    padding: 0.6rem;
+    padding: 0.525rem;
     min-width: 100px;
 
     .insight-value {
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
     }
 
     &.productive .insight-value {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
   }
 }
@@ -146,30 +146,30 @@
   }
 
   .year-range-badge {
-    font-size: 0.8rem;
-    padding: 0.3rem 0.75rem;
+    font-size: 0.7rem;
+    padding: 0.2625rem 0.65625rem;
   }
 
   .insights-row {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   .insight-item {
     min-width: unset;
-    padding: 0.5rem;
+    padding: 0.4375rem;
 
     .insight-value {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
 
     .insight-label {
-      font-size: 0.65rem;
+      font-size: 0.56875rem;
     }
 
     &.productive .insight-value {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/publication-trend-chart/publication-trend-chart.component.scss
@@ -43,7 +43,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
 
   @include chart-shared.neutral-surface;
 
@@ -52,7 +52,7 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--color-text-secondary);
-    margin-bottom: 0.21875rem;
+    margin-bottom: 0.2188rem;
   }
 
   .insight-value {
@@ -64,7 +64,7 @@
   .insight-detail {
     font-size: var(--app-text-xs);
     color: var(--color-text-secondary);
-    margin-top: 0.21875rem;
+    margin-top: 0.2188rem;
   }
 
   &.peak {
@@ -88,7 +88,7 @@
   &.productive {
     .insight-value {
       color: var(--color-green-400);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
     }
   }
 
@@ -123,7 +123,7 @@
   }
 
   .insights-row {
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 
   .insight-item {
@@ -131,7 +131,7 @@
     min-width: 100px;
 
     .insight-value {
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
     }
 
     &.productive .insight-value {
@@ -147,7 +147,7 @@
 
   .year-range-badge {
     font-size: 0.7rem;
-    padding: 0.2625rem 0.65625rem;
+    padding: 0.2625rem 0.6563rem;
   }
 
   .insights-row {
@@ -165,7 +165,7 @@
     }
 
     .insight-label {
-      font-size: 0.56875rem;
+      font-size: 0.5687rem;
     }
 
     &.productive .insight-value {

--- a/frontend/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.scss
@@ -32,7 +32,7 @@
 .insights-row {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .insight-item {
@@ -40,7 +40,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
 
   @include chart-shared.neutral-surface;
 
@@ -49,7 +49,7 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--color-text-secondary);
-    margin-bottom: 0.21875rem;
+    margin-bottom: 0.2188rem;
   }
 
   .insight-value {
@@ -61,7 +61,7 @@
   .insight-detail {
     font-size: var(--app-text-xs);
     color: var(--color-text-secondary);
-    margin-top: 0.21875rem;
+    margin-top: 0.2188rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -168,7 +168,7 @@
 
   .date-range-badge {
     font-size: var(--app-text-xs);
-    padding: 0.2625rem 0.65625rem;
+    padding: 0.2625rem 0.6563rem;
   }
 
   .insights-row {

--- a/frontend/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/reading-journey-chart/reading-journey-chart.component.scss
@@ -5,7 +5,7 @@
 }
 
 .journey-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: var(--color-emerald-500);
 }
 
@@ -24,15 +24,15 @@
 }
 
 .insights-section {
-  margin-top: 1rem;
-  padding-top: 1rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .insights-row {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .insight-item {
@@ -40,28 +40,28 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 0.75rem;
+  padding: 0.65625rem;
 
   @include chart-shared.neutral-surface;
 
   .insight-label {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--color-text-secondary);
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.21875rem;
   }
 
   .insight-value {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
     font-weight: 600;
     color: var(--color-text);
   }
 
   .insight-detail {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--color-text-secondary);
-    margin-top: 0.25rem;
+    margin-top: 0.21875rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -107,29 +107,29 @@
   &.recent {
     .insight-value {
       color: var(--color-violet-400);
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
   }
 
   &.total {
     .insight-value {
       color: var(--color-cyan-400);
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
   }
 }
 
 @media (width <= 1200px) {
   .insight-item {
-    padding: 0.6rem;
+    padding: 0.525rem;
 
     .insight-value {
-      font-size: 1.2rem;
+      font-size: 1.05rem;
     }
 
     &.recent .insight-value,
     &.total .insight-value {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 }
@@ -141,22 +141,22 @@
 
   .insights-row {
     grid-template-columns: repeat(4, 1fr);
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   .insight-item {
-    padding: 0.5rem;
+    padding: 0.4375rem;
 
     .insight-value {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
 
     .insight-label {
-      font-size: 0.6rem;
+      font-size: 0.525rem;
     }
 
     .insight-detail {
-      font-size: 0.6rem;
+      font-size: 0.525rem;
     }
   }
 }
@@ -167,8 +167,8 @@
   }
 
   .date-range-badge {
-    font-size: 0.75rem;
-    padding: 0.3rem 0.75rem;
+    font-size: var(--app-text-xs);
+    padding: 0.2625rem 0.65625rem;
   }
 
   .insights-row {
@@ -177,7 +177,7 @@
 
   .insight-item {
     .insight-value {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.scss
@@ -8,9 +8,9 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.875rem;
 
   .chart-title {
     flex: 1;
@@ -18,21 +18,21 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       i {
-        font-size: 1.5rem;
+        font-size: 1.3125rem;
       }
     }
 
     .chart-description {
       color: var(--color-text-secondary);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -41,7 +41,7 @@
   .header-controls {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     flex-shrink: 0;
   }
 }
@@ -49,10 +49,10 @@
 .select-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   i {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 }
 
@@ -60,23 +60,23 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0.5rem 0.75rem;
+  padding: 0.4375rem 0.65625rem;
 
   @include chart-shared.neutral-surface;
 
   .badge-value {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     font-weight: 600;
     color: var(--color-text);
     line-height: 1;
   }
 
   .badge-label {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
     color: var(--color-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    margin-top: 0.25rem;
+    margin-top: 0.21875rem;
   }
 }
 
@@ -89,37 +89,37 @@
 .insights-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 0.75rem;
-  margin-top: 1rem;
+  gap: 0.65625rem;
+  margin-top: 0.875rem;
 
   .insight-card {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
+    gap: 0.65625rem;
+    padding: 0.65625rem 0.875rem;
 
     @include chart-shared.neutral-surface;
 
     > i {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
       flex-shrink: 0;
     }
 
     .insight-content {
       display: flex;
       flex-direction: column;
-      gap: 0.15rem;
+      gap: 0.13125rem;
       min-width: 0;
 
       .insight-label {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         color: var(--color-text-secondary);
         text-transform: uppercase;
         letter-spacing: 0.3px;
       }
 
       .insight-value {
-        font-size: 0.9rem;
+        font-size: 0.7875rem;
         color: var(--color-text);
         font-weight: 500;
         white-space: nowrap;
@@ -146,10 +146,10 @@
 
   .insights-grid {
     grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .insight-card {
-      padding: 0.6rem 0.75rem;
+      padding: 0.525rem 0.65625rem;
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/charts/top-items-chart/top-items-chart.component.scss
@@ -18,7 +18,7 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -41,7 +41,7 @@
   .header-controls {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     flex-shrink: 0;
   }
 }
@@ -60,12 +60,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0.4375rem 0.65625rem;
+  padding: 0.4375rem 0.6563rem;
 
   @include chart-shared.neutral-surface;
 
   .badge-value {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     font-weight: 600;
     color: var(--color-text);
     line-height: 1;
@@ -76,7 +76,7 @@
     color: var(--color-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    margin-top: 0.21875rem;
+    margin-top: 0.2188rem;
   }
 }
 
@@ -89,14 +89,14 @@
 .insights-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-top: 0.875rem;
 
   .insight-card {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
-    padding: 0.65625rem 0.875rem;
+    gap: 0.6563rem;
+    padding: 0.6563rem 0.875rem;
 
     @include chart-shared.neutral-surface;
 
@@ -108,7 +108,7 @@
     .insight-content {
       display: flex;
       flex-direction: column;
-      gap: 0.13125rem;
+      gap: 0.1313rem;
       min-width: 0;
 
       .insight-label {
@@ -149,7 +149,7 @@
     gap: 0.4375rem;
 
     .insight-card {
-      padding: 0.525rem 0.65625rem;
+      padding: 0.525rem 0.6563rem;
     }
   }
 }

--- a/frontend/src/app/features/stats/component/library-stats/library-stats.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/library-stats.component.scss
@@ -48,7 +48,7 @@
       color: var(--color-text);
       font-weight: 500;
       white-space: nowrap;
-      font-size: 1.00625rem;
+      font-size: 1.0063rem;
     }
 
     .library-totals {
@@ -56,7 +56,7 @@
       gap: 12px;
       align-items: center;
       margin-top: 8px;
-      font-size: 0.83125rem;
+      font-size: 0.8313rem;
       color: var(--color-text-secondary);
       flex-wrap: wrap;
 
@@ -71,7 +71,7 @@
       }
 
       .pi {
-        font-size: 1.18125rem;
+        font-size: 1.1812rem;
         color: var(--color-primary);
       }
 
@@ -85,7 +85,7 @@
         color: var(--color-text);
         font-weight: 600;
         margin-left: 4px;
-        font-size: 1.18125rem;
+        font-size: 1.1812rem;
       }
     }
   }
@@ -225,7 +225,7 @@
       }
 
       .pi {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/library-stats/library-stats.component.scss
+++ b/frontend/src/app/features/stats/component/library-stats/library-stats.component.scss
@@ -5,7 +5,7 @@
   box-sizing: border-box;
   height: 100%;
   overflow-y: auto;
-  padding: 0.5rem;
+  padding: 0.4375rem;
 }
 
 .header-card {
@@ -27,7 +27,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1.5rem;
+    gap: 1.3125rem;
 
     .select-row {
       display: flex;
@@ -40,7 +40,7 @@
     .dropdown-row {
       display: flex;
       width: 100%;
-      gap: 0.5rem;
+      gap: 0.4375rem;
       align-items: center;
     }
 
@@ -48,7 +48,7 @@
       color: var(--color-text);
       font-weight: 500;
       white-space: nowrap;
-      font-size: 1.15rem;
+      font-size: 1.00625rem;
     }
 
     .library-totals {
@@ -56,7 +56,7 @@
       gap: 12px;
       align-items: center;
       margin-top: 8px;
-      font-size: 0.95rem;
+      font-size: 0.83125rem;
       color: var(--color-text-secondary);
       flex-wrap: wrap;
 
@@ -71,13 +71,13 @@
       }
 
       .pi {
-        font-size: 1.35rem;
+        font-size: 1.18125rem;
         color: var(--color-primary);
       }
 
       .total-label {
         color: var(--color-text-secondary);
-        font-size: 0.9rem;
+        font-size: 0.7875rem;
         white-space: nowrap;
       }
 
@@ -85,7 +85,7 @@
         color: var(--color-text);
         font-weight: 600;
         margin-left: 4px;
-        font-size: 1.35rem;
+        font-size: 1.18125rem;
       }
     }
   }
@@ -126,7 +126,7 @@
     h3 {
       color: var(--color-text);
       font-weight: 500;
-      font-size: 1.2rem;
+      font-size: 1.05rem;
       margin: 0;
       display: flex;
       align-items: center;
@@ -134,7 +134,7 @@
 
       .pi {
         color: var(--color-primary);
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
     }
 
@@ -158,7 +158,7 @@
       }
 
       .pi {
-        font-size: 0.9rem;
+        font-size: 0.7875rem;
       }
     }
   }
@@ -225,7 +225,7 @@
       }
 
       .pi {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }
@@ -243,7 +243,7 @@
       .config-category {
         h4 {
           color: var(--color-text);
-          font-size: 1rem;
+          font-size: var(--app-text-base);
           font-weight: 600;
           margin: 0 0 15px;
           padding-bottom: 8px;
@@ -279,7 +279,7 @@
 
             label {
               color: var(--color-text-secondary);
-              font-size: 0.9rem;
+              font-size: 0.7875rem;
               cursor: pointer;
               user-select: none;
               transition: color 0.2s ease;
@@ -373,7 +373,7 @@
 
   .pi {
     color: var(--color-card);
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     cursor: grab;
 
     &:hover {
@@ -446,7 +446,7 @@
   small {
     display: block;
     margin-top: 8px;
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 }
 
@@ -530,7 +530,7 @@
       padding: 15px 20px;
 
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
     }
 
@@ -578,7 +578,7 @@
     background: rgb(0 0 0 / 70%);
 
     .pi {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
     }
   }
 
@@ -608,7 +608,7 @@
       padding: 12px 15px;
 
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
     }
 
@@ -626,7 +626,7 @@
     height: 36px;
 
     .pi {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/book-flow-chart/book-flow-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/book-flow-chart/book-flow-chart.component.scss
@@ -6,24 +6,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -31,14 +31,14 @@
 }
 
 .book-flow-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #26c6da;
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
   .stat-card {
@@ -48,22 +48,22 @@
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
     flex: 1;
     min-width: 80px;
 
     .stat-value {
-      font-size: 1.3rem;
+      font-size: 1.1375rem;
       font-weight: 600;
       color: var(--text-color, #fff);
     }
 
     .stat-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--text-secondary-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
     }
     &.total .stat-value { color: #42a5f5; }
     &.quarter .stat-value { color: #26c6da; }
@@ -88,24 +88,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
   color: var(--text-secondary-color);
 
   i {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 1rem;
-    margin: 0 0 0.5rem;
+    font-size: var(--app-text-base);
+    margin: 0 0 0.4375rem;
     color: var(--text-color, #fff);
   }
 
   small {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     opacity: 0.7;
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/book-flow-chart/book-flow-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/book-flow-chart/book-flow-chart.component.scss
@@ -13,7 +13,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -37,7 +37,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
@@ -63,7 +63,7 @@
       color: var(--text-secondary-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
     }
     &.total .stat-value { color: #42a5f5; }
     &.quarter .stat-value { color: #26c6da; }
@@ -105,7 +105,7 @@
   }
 
   small {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     opacity: 0.7;
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.scss
@@ -8,9 +8,9 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.875rem;
 
   .chart-title {
     flex: 1;
@@ -18,17 +18,17 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--color-text-secondary);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -40,19 +40,19 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
 
     @include chart-shared.accent-surface(8px);
 
     .badge-value {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
 
       @include chart-shared.accent-text;
     }
 
     .badge-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
@@ -61,38 +61,38 @@
 }
 
 .book-length-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: var(--color-cyan-500);
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
   .stat-card {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
     flex: 1;
 
     @include chart-shared.neutral-surface;
 
     .stat-value-sm {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       font-weight: 500;
       color: var(--color-text);
       text-align: center;
     }
 
     .stat-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
     }
   }
 }
@@ -108,24 +108,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
   color: var(--color-text-secondary);
 
   i {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 1rem;
-    margin: 0 0 0.5rem;
+    font-size: var(--app-text-base);
+    margin: 0 0 0.4375rem;
     color: var(--color-text);
   }
 
   small {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     opacity: 0.7;
   }
 }
@@ -139,11 +139,11 @@
 @media (width <= 480px) {
   .chart-header {
     .chart-title h3 {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
 
     .stats-badge .badge-value {
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
     }
   }
 

--- a/frontend/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/book-length-chart/book-length-chart.component.scss
@@ -18,7 +18,7 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -67,7 +67,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
@@ -92,7 +92,7 @@
       color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
     }
   }
 }
@@ -125,7 +125,7 @@
   }
 
   small {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     opacity: 0.7;
   }
 }
@@ -143,7 +143,7 @@
     }
 
     .stats-badge .badge-value {
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
     }
   }
 

--- a/frontend/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.scss
@@ -6,25 +6,25 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
-  gap: 1rem;
+  margin-bottom: 0.4375rem;
+  gap: 0.875rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -32,21 +32,21 @@
 }
 
 .completion-race-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #4caf50;
 }
 
 .year-selector {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-shrink: 0;
 
   .year-nav-btn {
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 6px;
-    padding: 0.6rem;
+    padding: 0.525rem;
     color: var(--color-text);
     cursor: pointer;
     transition: all 0.3s ease;
@@ -61,23 +61,23 @@
     }
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 
   .current-year {
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
     font-weight: 600;
     color: var(--color-text);
-    min-width: 4.5rem;
+    min-width: 3.9375rem;
     text-align: center;
   }
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
   .stat-card {
@@ -87,18 +87,18 @@
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
     min-width: 80px;
     flex: 1;
 
     .stat-value {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
       color: #4caf50;
     }
 
     .stat-subtitle {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--text-secondary-color);
       text-align: center;
       line-height: 1.3;
@@ -109,11 +109,11 @@
     }
 
     .stat-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--text-secondary-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
     }
 
     &.fastest .stat-value {
@@ -137,24 +137,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
   color: var(--text-secondary-color);
 
   i {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 1rem;
-    margin: 0 0 0.5rem;
+    font-size: var(--app-text-base);
+    margin: 0 0 0.4375rem;
     color: var(--text-color, #fff);
   }
 
   small {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     opacity: 0.7;
   }
 }
@@ -179,22 +179,22 @@
 @media (width <= 480px) {
   .chart-header {
     .chart-title h3 {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
 
     .chart-description {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
     }
   }
 
   .stats-row {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .stat-card {
-      padding: 0.4rem 0.5rem;
+      padding: 0.35rem 0.4375rem;
 
       .stat-value {
-        font-size: 1.2rem;
+        font-size: 1.05rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/completion-race-chart/completion-race-chart.component.scss
@@ -14,7 +14,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -76,7 +76,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
@@ -113,7 +113,7 @@
       color: var(--text-secondary-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
     }
 
     &.fastest .stat-value {
@@ -154,7 +154,7 @@
   }
 
   small {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     opacity: 0.7;
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.scss
@@ -14,7 +14,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -95,7 +95,7 @@
       }
 
       .chart-description {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
 
@@ -114,7 +114,7 @@
       }
 
       .chart-description {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/completion-timeline-chart/completion-timeline-chart.component.scss
@@ -6,25 +6,25 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
-  gap: 1rem;
+  margin-bottom: 0.4375rem;
+  gap: 0.875rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -34,14 +34,14 @@
 .year-selector {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-shrink: 0;
 
   .year-nav-btn {
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 6px;
-    padding: 0.6rem;
+    padding: 0.525rem;
     color: var(--color-text);
     cursor: pointer;
     transition: all 0.3s ease;
@@ -60,21 +60,21 @@
     }
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 
   .current-year {
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
     font-weight: 600;
     color: var(--color-text);
-    min-width: 4.5rem;
+    min-width: 3.9375rem;
     text-align: center;
   }
 }
 
 .completion-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(251 191 36 / 100%);
 }
 
@@ -91,17 +91,17 @@
 
     .chart-title {
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .chart-description {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
 
     .year-selector {
       justify-content: center;
-      margin-top: 0.5rem;
+      margin-top: 0.4375rem;
     }
   }
 }
@@ -110,23 +110,23 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .chart-description {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }
 
   .year-selector {
     .current-year {
-      font-size: 1rem;
-      min-width: 4rem;
+      font-size: var(--app-text-base);
+      min-width: 3.5rem;
     }
 
     .year-nav-btn {
-      padding: 0.6rem;
+      padding: 0.525rem;
     }
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.scss
@@ -6,25 +6,25 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
-  gap: 1rem;
+  margin-bottom: 0.4375rem;
+  gap: 0.875rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -32,14 +32,14 @@
 
   .filter-controls {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     align-items: center;
     flex-shrink: 0;
   }
 }
 
 .favorite-days-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(139 92 246 / 100%);
 }
 
@@ -57,7 +57,7 @@
     .filter-controls {
       width: 100%;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       ::ng-deep p-select {
         width: 100%;
@@ -70,11 +70,11 @@
 
     .chart-title {
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .chart-description {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }
@@ -84,11 +84,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/favorite-days-chart/favorite-days-chart.component.scss
@@ -14,7 +14,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -32,7 +32,7 @@
 
   .filter-controls {
     display: flex;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     align-items: center;
     flex-shrink: 0;
   }
@@ -74,7 +74,7 @@
       }
 
       .chart-description {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/genre-stats-chart/genre-stats-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/genre-stats-chart/genre-stats-chart.component.scss
@@ -13,7 +13,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -49,7 +49,7 @@
       }
 
       .chart-description {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/genre-stats-chart/genre-stats-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/genre-stats-chart/genre-stats-chart.component.scss
@@ -6,24 +6,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.3125rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -31,7 +31,7 @@
 }
 
 .genre-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(34 197 94 / 100%);
 }
 
@@ -45,11 +45,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .chart-description {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.scss
@@ -6,24 +6,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -31,29 +31,29 @@
 }
 
 .page-turner-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(251 146 60 / 100%);
 }
 
 .stats-row {
   display: flex;
-  gap: 1rem;
-  margin-bottom: 0.75rem;
+  gap: 0.875rem;
+  margin-bottom: 0.65625rem;
   flex-wrap: wrap;
 
   .stat-item {
     display: flex;
     flex-direction: column;
-    gap: 0.15rem;
+    gap: 0.13125rem;
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border-radius: 8px;
-    padding: 0.5rem 0.75rem;
+    padding: 0.4375rem 0.65625rem;
     flex: 1;
     min-width: 100px;
 
     .stat-value {
       color: var(--color-text);
-      font-size: 0.95rem;
+      font-size: 0.83125rem;
       font-weight: 600;
       white-space: nowrap;
       overflow: hidden;
@@ -62,32 +62,32 @@
 
     .stat-label {
       color: var(--text-secondary-color);
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
     }
   }
 }
 
 .top-books {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 0.75rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.65625rem;
   flex-wrap: wrap;
 
   .top-book-card {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    padding: 0.5rem 0.75rem;
+    padding: 0.4375rem 0.65625rem;
     flex: 1;
     min-width: 180px;
 
     .book-rank {
       color: rgb(251 146 60 / 100%);
       font-weight: 700;
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
 
     .book-info {
@@ -96,7 +96,7 @@
 
       .book-name {
         color: var(--color-text);
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
         font-weight: 500;
         display: block;
         white-space: nowrap;
@@ -106,23 +106,23 @@
 
       .book-indicators {
         display: flex;
-        gap: 0.4rem;
-        margin-top: 0.2rem;
+        gap: 0.35rem;
+        margin-top: 0.175rem;
         flex-wrap: wrap;
 
         .indicator {
           color: var(--text-secondary-color);
-          font-size: 0.7rem;
+          font-size: 0.6125rem;
           display: flex;
           align-items: center;
-          gap: 0.2rem;
+          gap: 0.175rem;
 
           &.burst {
             color: rgb(251 146 60 / 90%);
           }
 
           i {
-            font-size: 0.65rem;
+            font-size: 0.56875rem;
           }
         }
       }
@@ -130,7 +130,7 @@
 
     .book-score {
       color: rgb(251 146 60 / 100%);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 700;
       flex-shrink: 0;
     }
@@ -155,15 +155,15 @@
 
 @media (width <= 480px) {
   .chart-header .chart-title h3 {
-    font-size: 1.1rem;
+    font-size: 0.9625rem;
   }
 
   .stats-row {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .stat-item {
       min-width: 80px;
-      padding: 0.4rem 0.5rem;
+      padding: 0.35rem 0.4375rem;
     }
   }
 

--- a/frontend/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/page-turner-chart/page-turner-chart.component.scss
@@ -13,7 +13,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -38,22 +38,22 @@
 .stats-row {
   display: flex;
   gap: 0.875rem;
-  margin-bottom: 0.65625rem;
+  margin-bottom: 0.6563rem;
   flex-wrap: wrap;
 
   .stat-item {
     display: flex;
     flex-direction: column;
-    gap: 0.13125rem;
+    gap: 0.1313rem;
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border-radius: 8px;
-    padding: 0.4375rem 0.65625rem;
+    padding: 0.4375rem 0.6563rem;
     flex: 1;
     min-width: 100px;
 
     .stat-value {
       color: var(--color-text);
-      font-size: 0.83125rem;
+      font-size: 0.8313rem;
       font-weight: 600;
       white-space: nowrap;
       overflow: hidden;
@@ -69,8 +69,8 @@
 
 .top-books {
   display: flex;
-  gap: 0.65625rem;
-  margin-bottom: 0.65625rem;
+  gap: 0.6563rem;
+  margin-bottom: 0.6563rem;
   flex-wrap: wrap;
 
   .top-book-card {
@@ -80,7 +80,7 @@
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    padding: 0.4375rem 0.65625rem;
+    padding: 0.4375rem 0.6563rem;
     flex: 1;
     min-width: 180px;
 
@@ -96,7 +96,7 @@
 
       .book-name {
         color: var(--color-text);
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
         font-weight: 500;
         display: block;
         white-space: nowrap;
@@ -122,7 +122,7 @@
           }
 
           i {
-            font-size: 0.56875rem;
+            font-size: 0.5687rem;
           }
         }
       }
@@ -130,7 +130,7 @@
 
     .book-score {
       color: rgb(251 146 60 / 100%);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 700;
       flex-shrink: 0;
     }

--- a/frontend/src/app/features/stats/component/user-stats/charts/peak-hours-chart/peak-hours-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/peak-hours-chart/peak-hours-chart.component.scss
@@ -6,25 +6,25 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
-  gap: 1rem;
+  margin-bottom: 0.4375rem;
+  gap: 0.875rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -32,14 +32,14 @@
 
   .filter-controls {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     align-items: center;
     flex-shrink: 0;
   }
 }
 
 .peak-hours-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(34 197 94 / 100%);
 }
 
@@ -57,7 +57,7 @@
     .filter-controls {
       width: 100%;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       ::ng-deep p-select {
         width: 100%;
@@ -70,11 +70,11 @@
 
     .chart-title {
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .chart-description {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }
@@ -84,11 +84,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/peak-hours-chart/peak-hours-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/peak-hours-chart/peak-hours-chart.component.scss
@@ -14,7 +14,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -32,7 +32,7 @@
 
   .filter-controls {
     display: flex;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     align-items: center;
     flex-shrink: 0;
   }
@@ -74,7 +74,7 @@
       }
 
       .chart-description {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/personal-rating-chart/personal-rating-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/personal-rating-chart/personal-rating-chart.component.scss
@@ -14,7 +14,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;

--- a/frontend/src/app/features/stats/component/user-stats/charts/personal-rating-chart/personal-rating-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/personal-rating-chart/personal-rating-chart.component.scss
@@ -7,24 +7,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -32,7 +32,7 @@
 }
 
 .personal-rating-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #FACC15;
 }
 
@@ -54,11 +54,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.scss
@@ -6,25 +6,25 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       display: flex;
-      gap: 0.5rem;
+      gap: 0.4375rem;
       align-items: center;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
     }
 
     .chart-description {
       margin: 0;
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       line-height: 1.4;
     }
   }
@@ -32,14 +32,14 @@
 
 .publication-era-icon {
   color: #673ab7;
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 
   .stat-card {
     display: flex;
@@ -47,21 +47,21 @@
     flex-direction: column;
     align-items: center;
     min-width: 80px;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
     border: 1px solid var(--color-border);
     border-radius: 8px;
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
 
     .stat-value {
       color: var(--text-color, #fff);
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
     }
 
     .stat-label {
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
       color: var(--text-secondary-color);
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       letter-spacing: 0.5px;
       text-transform: uppercase;
     }
@@ -91,25 +91,25 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   color: var(--text-secondary-color);
   text-align: center;
 
   i {
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
-    font-size: 2.5rem;
+    font-size: 2.1875rem;
   }
 
   p {
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     color: var(--text-color, #fff);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   small {
     opacity: 0.7;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
@@ -121,6 +121,6 @@
 
 @media (width <= 480px) {
   .chart-header .chart-title h3 {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/publication-era-chart/publication-era-chart.component.scss
@@ -17,7 +17,7 @@
       align-items: center;
       margin: 0 0 0.4375rem;
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
     }
 
@@ -37,7 +37,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
   margin-bottom: 0.875rem;
 
@@ -59,7 +59,7 @@
     }
 
     .stat-label {
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
       color: var(--text-secondary-color);
       font-size: var(--app-text-xs);
       letter-spacing: 0.5px;
@@ -109,7 +109,7 @@
 
   small {
     opacity: 0.7;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 

--- a/frontend/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.scss
@@ -8,9 +8,9 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.875rem;
 
   .chart-title {
     flex: 1;
@@ -18,17 +18,17 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--color-text-secondary);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -40,19 +40,19 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
 
     @include chart-shared.accent-surface(8px);
 
     .badge-value {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
 
       @include chart-shared.accent-text;
     }
 
     .badge-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.5px;
@@ -61,7 +61,7 @@
 }
 
 .rating-taste-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: var(--color-violet-600);
 }
 
@@ -69,7 +69,7 @@
   position: relative;
   height: 500px;
   width: 100%;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.3125rem;
 
   .quadrant-labels {
     position: absolute;
@@ -78,10 +78,10 @@
 
     .quadrant-label {
       position: absolute;
-      font-size: 0.7rem;
+      font-size: 0.6125rem;
       color: var(--color-text-secondary);
       font-weight: 500;
-      padding: 0.25rem 0.5rem;
+      padding: 0.21875rem 0.4375rem;
 
       @include chart-shared.neutral-surface(4px);
 
@@ -109,19 +109,19 @@
 }
 
 .taste-insights {
-  margin-top: 1.5rem;
+  margin-top: 1.3125rem;
 
   .insights-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.65625rem;
 
     h4 {
       color: var(--color-text);
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
       font-weight: 500;
       margin: 0;
     }
@@ -129,9 +129,9 @@
     .deviation-badge {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.4rem 0.75rem;
-      font-size: 0.85rem;
+      gap: 0.4375rem;
+      padding: 0.35rem 0.65625rem;
+      font-size: 0.74375rem;
 
       @include chart-shared.neutral-surface(20px);
 
@@ -146,7 +146,7 @@
 
       .deviation-desc {
         color: var(--color-text-secondary);
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
 
       &.unique {
@@ -174,11 +174,11 @@
   .quadrants-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .quadrant-card {
-    padding: 1rem;
+    padding: 0.875rem;
     position: relative;
 
     @include chart-shared.neutral-surface;
@@ -188,25 +188,25 @@
     .quadrant-header {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      margin-bottom: 0.5rem;
+      gap: 0.4375rem;
+      margin-bottom: 0.4375rem;
 
       .quadrant-icon {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .quadrant-name {
         color: var(--color-text);
         font-weight: 500;
-        font-size: 0.95rem;
+        font-size: 0.83125rem;
         flex: 1;
       }
 
       .quadrant-count {
         font-weight: 600;
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
         color: var(--color-surface-0);
-        padding: 0.15rem 0.5rem;
+        padding: 0.13125rem 0.4375rem;
         border-radius: 12px;
         min-width: 24px;
         text-align: center;
@@ -215,8 +215,8 @@
 
     .quadrant-description {
       color: var(--color-text-secondary);
-      font-size: 0.8rem;
-      margin: 0 0 0.75rem;
+      font-size: 0.7rem;
+      margin: 0 0 0.65625rem;
       line-height: 1.4;
     }
 
@@ -225,7 +225,7 @@
       background: color-mix(in srgb, var(--color-text) 8%, transparent);
       border-radius: 2px;
       overflow: hidden;
-      margin-bottom: 0.25rem;
+      margin-bottom: 0.21875rem;
 
       .bar-fill {
         height: 100%;
@@ -235,7 +235,7 @@
     }
 
     .quadrant-percentage {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
     }
   }
@@ -246,24 +246,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
   color: var(--color-text-secondary);
 
   i {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 1rem;
-    margin: 0 0 0.5rem;
+    font-size: var(--app-text-base);
+    margin: 0 0 0.4375rem;
     color: var(--color-text);
   }
 
   small {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     opacity: 0.7;
   }
 }
@@ -274,8 +274,8 @@
 
     .quadrant-labels {
       .quadrant-label {
-        font-size: 0.6rem;
-        padding: 0.15rem 0.35rem;
+        font-size: 0.525rem;
+        padding: 0.13125rem 0.30625rem;
 
         &.top-left {
           top: 50px;
@@ -311,17 +311,17 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
 
     .stats-badge {
       .badge-value {
-        font-size: 1.25rem;
+        font-size: 1.09375rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/rating-taste-chart/rating-taste-chart.component.scss
@@ -18,7 +18,7 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -81,7 +81,7 @@
       font-size: 0.6125rem;
       color: var(--color-text-secondary);
       font-weight: 500;
-      padding: 0.21875rem 0.4375rem;
+      padding: 0.2188rem 0.4375rem;
 
       @include chart-shared.neutral-surface(4px);
 
@@ -117,7 +117,7 @@
     align-items: center;
     margin-bottom: 0.875rem;
     flex-wrap: wrap;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
 
     h4 {
       color: var(--color-text);
@@ -130,8 +130,8 @@
       display: flex;
       align-items: center;
       gap: 0.4375rem;
-      padding: 0.35rem 0.65625rem;
-      font-size: 0.74375rem;
+      padding: 0.35rem 0.6563rem;
+      font-size: 0.7438rem;
 
       @include chart-shared.neutral-surface(20px);
 
@@ -198,15 +198,15 @@
       .quadrant-name {
         color: var(--color-text);
         font-weight: 500;
-        font-size: 0.83125rem;
+        font-size: 0.8313rem;
         flex: 1;
       }
 
       .quadrant-count {
         font-weight: 600;
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
         color: var(--color-surface-0);
-        padding: 0.13125rem 0.4375rem;
+        padding: 0.1313rem 0.4375rem;
         border-radius: 12px;
         min-width: 24px;
         text-align: center;
@@ -216,7 +216,7 @@
     .quadrant-description {
       color: var(--color-text-secondary);
       font-size: 0.7rem;
-      margin: 0 0 0.65625rem;
+      margin: 0 0 0.6563rem;
       line-height: 1.4;
     }
 
@@ -225,7 +225,7 @@
       background: color-mix(in srgb, var(--color-text) 8%, transparent);
       border-radius: 2px;
       overflow: hidden;
-      margin-bottom: 0.21875rem;
+      margin-bottom: 0.2188rem;
 
       .bar-fill {
         height: 100%;
@@ -263,7 +263,7 @@
   }
 
   small {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     opacity: 0.7;
   }
 }
@@ -275,7 +275,7 @@
     .quadrant-labels {
       .quadrant-label {
         font-size: 0.525rem;
-        padding: 0.13125rem 0.30625rem;
+        padding: 0.1313rem 0.3063rem;
 
         &.top-left {
           top: 50px;
@@ -321,7 +321,7 @@
 
     .stats-badge {
       .badge-value {
-        font-size: 1.09375rem;
+        font-size: 1.0938rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/read-status-chart/read-status-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/read-status-chart/read-status-chart.component.scss
@@ -14,7 +14,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;

--- a/frontend/src/app/features/stats/component/user-stats/charts/read-status-chart/read-status-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/read-status-chart/read-status-chart.component.scss
@@ -7,24 +7,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -32,7 +32,7 @@
 }
 
 .read-status-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #17a2b8;
 }
 
@@ -54,11 +54,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.scss
@@ -13,7 +13,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -37,7 +37,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
@@ -63,7 +63,7 @@
       color: var(--text-secondary-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
     }
 
     &.peak .stat-value {
@@ -109,7 +109,7 @@
   }
 
   small {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     opacity: 0.7;
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-clock-chart/reading-clock-chart.component.scss
@@ -6,24 +6,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -31,14 +31,14 @@
 }
 
 .reading-clock-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #42a5f5;
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
   .stat-card {
@@ -48,22 +48,22 @@
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
     flex: 1;
     min-width: 80px;
 
     .stat-value {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
       color: var(--text-color, #fff);
     }
 
     .stat-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--text-secondary-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
     }
 
     &.peak .stat-value {
@@ -92,24 +92,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
   color: var(--text-secondary-color);
 
   i {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 1rem;
-    margin: 0 0 0.5rem;
+    font-size: var(--app-text-base);
+    margin: 0 0 0.4375rem;
     color: var(--text-color, #fff);
   }
 
   small {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     opacity: 0.7;
   }
 }
@@ -122,17 +122,17 @@
 
 @media (width <= 480px) {
   .chart-header .chart-title h3 {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   .stats-row {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .stat-card {
-      padding: 0.4rem 0.5rem;
+      padding: 0.35rem 0.4375rem;
 
       .stat-value {
-        font-size: 1.2rem;
+        font-size: 1.05rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.scss
@@ -17,7 +17,7 @@
       align-items: center;
       margin: 0 0 0.4375rem;
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
     }
 
@@ -37,7 +37,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
   margin-bottom: 0.875rem;
 
@@ -59,7 +59,7 @@
     }
 
     .stat-label {
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
       color: var(--text-secondary-color);
       font-size: var(--app-text-xs);
       letter-spacing: 0.5px;
@@ -105,7 +105,7 @@
 
   small {
     opacity: 0.7;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-debt-chart/reading-debt-chart.component.scss
@@ -6,25 +6,25 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       display: flex;
-      gap: 0.5rem;
+      gap: 0.4375rem;
       align-items: center;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
     }
 
     .chart-description {
       margin: 0;
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       line-height: 1.4;
     }
   }
@@ -32,14 +32,14 @@
 
 .reading-debt-icon {
   color: #ef5350;
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 
   .stat-card {
     display: flex;
@@ -47,21 +47,21 @@
     flex-direction: column;
     align-items: center;
     min-width: 80px;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
     border: 1px solid var(--color-border);
     border-radius: 8px;
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
 
     .stat-value {
       color: var(--text-color, #fff);
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
     }
 
     .stat-label {
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
       color: var(--text-secondary-color);
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       letter-spacing: 0.5px;
       text-transform: uppercase;
     }
@@ -87,25 +87,25 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   color: var(--text-secondary-color);
   text-align: center;
 
   i {
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
-    font-size: 2.5rem;
+    font-size: 2.1875rem;
   }
 
   p {
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     color: var(--text-color, #fff);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   small {
     opacity: 0.7;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
@@ -117,6 +117,6 @@
 
 @media (width <= 480px) {
   .chart-header .chart-title h3 {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.scss
@@ -6,24 +6,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -31,7 +31,7 @@
 }
 
 .reading-dna-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(79 195 247 / 100%);
 }
 
@@ -39,46 +39,46 @@
   position: relative;
   height: 450px;
   width: 100%;
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
 }
 
 .personality-insights {
-  margin-top: 2rem;
+  margin-top: 1.75rem;
 
   h4 {
     color: var(--text-color, #fff);
-    font-size: 1.1rem;
+    font-size: 0.9625rem;
     font-weight: 500;
-    margin: 0 0 1rem;
+    margin: 0 0 0.875rem;
   }
 
   .insights-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .insight-card {
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border-radius: 8px;
-    padding: 1rem;
+    padding: 0.875rem;
     border: 1px solid var(--color-border);
 
     .insight-header {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
 
       .insight-trait {
         color: var(--text-color, #fff);
         font-weight: 500;
-        font-size: 0.95rem;
+        font-size: 0.83125rem;
       }
 
       .insight-score {
         font-weight: 600;
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
     }
 
@@ -87,7 +87,7 @@
       background: color-mix(in srgb, var(--color-text) 10%, transparent);
       border-radius: 3px;
       overflow: hidden;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
 
       .progress-bar {
         height: 100%;
@@ -98,7 +98,7 @@
 
     .insight-description {
       color: var(--text-secondary-color);
-      font-size: 0.85rem;
+      font-size: 0.74375rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -121,11 +121,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-dna-chart/reading-dna-chart.component.scss
@@ -13,7 +13,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -73,7 +73,7 @@
       .insight-trait {
         color: var(--text-color, #fff);
         font-weight: 500;
-        font-size: 0.83125rem;
+        font-size: 0.8313rem;
       }
 
       .insight-score {
@@ -98,7 +98,7 @@
 
     .insight-description {
       color: var(--text-secondary-color);
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
       margin: 0;
       line-height: 1.4;
     }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.scss
@@ -13,7 +13,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -73,7 +73,7 @@
       .insight-trait {
         color: var(--text-color, #fff);
         font-weight: 500;
-        font-size: 0.83125rem;
+        font-size: 0.8313rem;
       }
 
       .insight-score {
@@ -98,7 +98,7 @@
 
     .insight-description {
       color: var(--text-secondary-color);
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
       margin: 0;
       line-height: 1.4;
     }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-habits-chart/reading-habits-chart.component.scss
@@ -6,24 +6,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -31,7 +31,7 @@
 }
 
 .reading-habits-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(156 39 176 / 100%);
 }
 
@@ -39,46 +39,46 @@
   position: relative;
   height: 450px;
   width: 100%;
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
 }
 
 .habit-insights {
-  margin-top: 2rem;
+  margin-top: 1.75rem;
 
   h4 {
     color: var(--text-color, #fff);
-    font-size: 1.1rem;
+    font-size: 0.9625rem;
     font-weight: 500;
-    margin: 0 0 1rem;
+    margin: 0 0 0.875rem;
   }
 
   .insights-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .insight-card {
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border-radius: 8px;
-    padding: 1rem;
+    padding: 0.875rem;
     border: 1px solid var(--color-border);
 
     .insight-header {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
 
       .insight-trait {
         color: var(--text-color, #fff);
         font-weight: 500;
-        font-size: 0.95rem;
+        font-size: 0.83125rem;
       }
 
       .insight-score {
         font-weight: 600;
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
     }
 
@@ -87,7 +87,7 @@
       background: color-mix(in srgb, var(--color-text) 10%, transparent);
       border-radius: 3px;
       overflow: hidden;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.4375rem;
 
       .progress-bar {
         height: 100%;
@@ -98,7 +98,7 @@
 
     .insight-description {
       color: var(--text-secondary-color);
-      font-size: 0.85rem;
+      font-size: 0.74375rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -121,11 +121,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-heatmap-chart/reading-heatmap-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-heatmap-chart/reading-heatmap-chart.component.scss
@@ -14,7 +14,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-heatmap-chart/reading-heatmap-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-heatmap-chart/reading-heatmap-chart.component.scss
@@ -7,24 +7,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -32,7 +32,7 @@
 }
 
 .reading-heatmap-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(239 71 111 / 100%);
 }
 
@@ -54,11 +54,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-progress-chart/reading-progress-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-progress-chart/reading-progress-chart.component.scss
@@ -8,24 +8,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -33,7 +33,7 @@
 }
 
 .reading-progress-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #17a2b8;
 }
 
@@ -55,11 +55,11 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-progress-chart/reading-progress-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-progress-chart/reading-progress-chart.component.scss
@@ -15,7 +15,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.scss
@@ -8,23 +8,23 @@
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
-  gap: 1rem;
+  margin-bottom: 0.4375rem;
+  gap: 0.875rem;
 
   .chart-title {
     h3 {
       color: var(--color-text);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--color-text-secondary);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -33,11 +33,11 @@
   .year-selector {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     justify-self: center;
 
     .year-nav-btn {
-      padding: 0.6rem;
+      padding: 0.525rem;
       color: var(--color-text);
       cursor: pointer;
       transition: all 0.3s ease;
@@ -58,15 +58,15 @@
       }
 
       i {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
     }
 
     .current-year {
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
       font-weight: 600;
       color: var(--color-text);
-      min-width: 4.5rem;
+      min-width: 3.9375rem;
       text-align: center;
     }
   }
@@ -89,7 +89,7 @@
 }
 
 .heatmap-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: var(--color-blue-500);
   vertical-align: middle;
   margin-right: 0.25em;
@@ -100,9 +100,9 @@
   align-items: flex-start;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 1rem;
-  padding-top: 1rem;
+  gap: 0.65625rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
@@ -110,7 +110,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   &.right {
     justify-content: flex-end;
@@ -120,9 +120,9 @@
 .pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.65rem;
-  font-size: 0.85rem;
+  gap: 0.30625rem;
+  padding: 0.30625rem 0.56875rem;
+  font-size: 0.74375rem;
   color: var(--color-text);
   font-weight: 500;
   white-space: nowrap;
@@ -161,15 +161,15 @@
 @media (width <= 768px) {
   .chart-header {
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    gap: 0.65625rem;
 
     .chart-title {
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .chart-description {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
 
@@ -193,23 +193,23 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }
 
   .year-selector {
     .current-year {
-      font-size: 1rem;
-      min-width: 4rem;
+      font-size: var(--app-text-base);
+      min-width: 3.5rem;
     }
 
     .year-nav-btn {
-      padding: 0.6rem;
+      padding: 0.525rem;
     }
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-session-heatmap/reading-session-heatmap.component.scss
@@ -14,7 +14,7 @@
   .chart-title {
     h3 {
       color: var(--color-text);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -100,7 +100,7 @@
   align-items: flex-start;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-top: 0.875rem;
   padding-top: 0.875rem;
   border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
@@ -120,9 +120,9 @@
 .pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.30625rem;
-  padding: 0.30625rem 0.56875rem;
-  font-size: 0.74375rem;
+  gap: 0.3063rem;
+  padding: 0.3063rem 0.5687rem;
+  font-size: 0.7438rem;
   color: var(--color-text);
   font-weight: 500;
   white-space: nowrap;
@@ -161,7 +161,7 @@
 @media (width <= 768px) {
   .chart-header {
     grid-template-columns: 1fr;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
 
     .chart-title {
       h3 {
@@ -169,7 +169,7 @@
       }
 
       .chart-description {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
 

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.scss
@@ -13,7 +13,7 @@
   .header-title {
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
     }
@@ -84,7 +84,7 @@
 
   .filter-controls {
     display: flex;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     align-items: center;
     justify-self: end;
   }
@@ -96,7 +96,7 @@
   justify-content: center;
   gap: 0.875rem;
   margin-bottom: 0.875rem;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   background: color-mix(in srgb, var(--color-text) 5%, transparent);
   border-radius: 8px;
   border: 1px solid var(--color-border);
@@ -142,10 +142,10 @@
     }
 
     .week-dates {
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
       color: var(--text-secondary-color);
       white-space: nowrap;
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
     }
   }
 }
@@ -358,7 +358,7 @@
       }
 
       .session-duration {
-        font-size: 0.56875rem;
+        font-size: 0.5687rem;
         opacity: 0.9;
         white-space: nowrap;
         line-height: 1;
@@ -390,7 +390,7 @@
   .session-tooltip-content {
     display: flex;
     gap: 0.875rem;
-    padding: 0.65625rem;
+    padding: 0.6563rem;
   }
 
   .session-tooltip-cover {
@@ -417,8 +417,8 @@
   .session-tooltip-header {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
-    margin-bottom: 0.65625rem;
+    gap: 0.6563rem;
+    margin-bottom: 0.6563rem;
 
     i {
       font-size: 0.9625rem;
@@ -429,7 +429,7 @@
   .session-tooltip-title {
     color: #fff;
     font-weight: 600;
-    font-size: 0.83125rem;
+    font-size: 0.8313rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -441,20 +441,20 @@
       transparent 0%,
       rgb(255 255 255 / 10%) 50%,
       transparent 100%);
-    margin-bottom: 0.65625rem;
+    margin-bottom: 0.6563rem;
   }
 
   .session-tooltip-body {
     display: flex;
     flex-direction: column;
-    gap: 0.54688rem;
+    gap: 0.5469rem;
   }
 
   .session-tooltip-row {
     display: grid;
     grid-template-columns: auto auto 1fr;
     align-items: center;
-    gap: 0.54688rem;
+    gap: 0.5469rem;
     font-size: var(--app-text-sm);
 
     i {
@@ -487,7 +487,7 @@
 @media (width <= 1024px) {
   .timeline-header {
     grid-template-columns: 1fr;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
 
     .header-title {
       grid-column: 1;
@@ -525,7 +525,7 @@
       }
 
       .timeline-subtitle {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
 
@@ -545,7 +545,7 @@
       }
 
       .week-nav-btn {
-        padding: 0.30625rem 0.4375rem;
+        padding: 0.3063rem 0.4375rem;
 
         i {
           font-size: 0.7rem;
@@ -556,7 +556,7 @@
 
   .timeline-content {
     min-height: 300px;
-    padding: 0.65625rem;
+    padding: 0.6563rem;
   }
 
   .timeline-row {
@@ -581,7 +581,7 @@
 
   .session-block {
     .session-content {
-      font-size: 0.56875rem;
+      font-size: 0.5687rem;
 
       .session-duration {
         display: none;
@@ -592,10 +592,10 @@
   .session-tooltip {
     min-width: 240px;
     max-width: 280px;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
 
     .tooltip-header {
-      padding: 0.65625rem;
+      padding: 0.6563rem;
 
       .tooltip-title {
         font-size: var(--app-text-sm);
@@ -603,7 +603,7 @@
     }
 
     .tooltip-body {
-      padding: 0.65625rem;
+      padding: 0.6563rem;
     }
 
     .tooltip-row {
@@ -634,11 +634,11 @@
         min-width: 90px;
 
         .week-label {
-          font-size: 0.74375rem;
+          font-size: 0.7438rem;
         }
 
         .week-dates {
-          font-size: 0.56875rem;
+          font-size: 0.5687rem;
         }
       }
     }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-session-timeline/reading-session-timeline.component.scss
@@ -7,20 +7,20 @@
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
-  gap: 1rem;
+  margin-bottom: 0.4375rem;
+  gap: 0.875rem;
 
   .header-title {
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
     }
 
     .timeline-subtitle {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -35,7 +35,7 @@
       background: color-mix(in srgb, var(--color-text) 5%, transparent);
       border: 1px solid var(--color-border);
       border-radius: 6px;
-      padding: 0.6rem;
+      padding: 0.525rem;
       color: var(--color-text);
       cursor: pointer;
       transition: all 0.3s ease;
@@ -54,7 +54,7 @@
       }
 
       i {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
     }
 
@@ -65,7 +65,7 @@
       min-width: 120px;
 
       .week-label {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
         font-weight: 600;
         color: var(--color-text);
         white-space: nowrap;
@@ -73,10 +73,10 @@
       }
 
       .week-dates {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         color: var(--text-secondary-color);
         white-space: nowrap;
-        margin-top: 0.1rem;
+        margin-top: 0.0875rem;
         line-height: 1.2;
       }
     }
@@ -84,7 +84,7 @@
 
   .filter-controls {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     align-items: center;
     justify-self: end;
   }
@@ -94,9 +94,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
-  padding: 0.75rem;
+  gap: 0.875rem;
+  margin-bottom: 0.875rem;
+  padding: 0.65625rem;
   background: color-mix(in srgb, var(--color-text) 5%, transparent);
   border-radius: 8px;
   border: 1px solid var(--color-border);
@@ -105,7 +105,7 @@
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 6px;
-    padding: 0.6rem 6rem;
+    padding: 0.525rem 5.25rem;
     color: var(--color-text);
     cursor: pointer;
     transition: all 0.3s ease;
@@ -124,7 +124,7 @@
     }
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 
@@ -135,17 +135,17 @@
     min-width: 150px;
 
     .week-label {
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
       font-weight: 600;
       color: var(--color-text);
       white-space: nowrap;
     }
 
     .week-dates {
-      font-size: 0.85rem;
+      font-size: 0.74375rem;
       color: var(--text-secondary-color);
       white-space: nowrap;
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
     }
   }
 }
@@ -153,13 +153,13 @@
 .timeline-content {
   position: relative;
   width: 100%;
-  padding: 1rem;
+  padding: 0.875rem;
   overflow: visible;
 }
 
 .hour-markers {
   display: flex;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .day-label-spacer {
     width: 100px;
@@ -186,7 +186,7 @@
 
   .hour-label {
     display: none;
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--color-text-secondary);
     position: absolute;
     left: 0;
@@ -212,10 +212,10 @@
     flex-shrink: 0;
     display: flex;
     align-items: center;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
     color: var(--color-text);
-    padding-right: 1rem;
+    padding-right: 0.875rem;
   }
 
   .timeline-track {
@@ -343,7 +343,7 @@
       height: 100%;
       padding: 4px 8px;
       color: white;
-      font-size: 0.7rem;
+      font-size: 0.6125rem;
       font-weight: 500;
       text-align: center;
       gap: 2px;
@@ -358,7 +358,7 @@
       }
 
       .session-duration {
-        font-size: 0.65rem;
+        font-size: 0.56875rem;
         opacity: 0.9;
         white-space: nowrap;
         line-height: 1;
@@ -389,8 +389,8 @@
 
   .session-tooltip-content {
     display: flex;
-    gap: 1rem;
-    padding: 0.75rem;
+    gap: 0.875rem;
+    padding: 0.65625rem;
   }
 
   .session-tooltip-cover {
@@ -417,11 +417,11 @@
   .session-tooltip-header {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 0.75rem;
+    gap: 0.65625rem;
+    margin-bottom: 0.65625rem;
 
     i {
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
       color: rgb(239 68 68 / 100%);
     }
   }
@@ -429,7 +429,7 @@
   .session-tooltip-title {
     color: #fff;
     font-weight: 600;
-    font-size: 0.95rem;
+    font-size: 0.83125rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -441,24 +441,24 @@
       transparent 0%,
       rgb(255 255 255 / 10%) 50%,
       transparent 100%);
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.65625rem;
   }
 
   .session-tooltip-body {
     display: flex;
     flex-direction: column;
-    gap: 0.625rem;
+    gap: 0.54688rem;
   }
 
   .session-tooltip-row {
     display: grid;
     grid-template-columns: auto auto 1fr;
     align-items: center;
-    gap: 0.625rem;
-    font-size: 0.875rem;
+    gap: 0.54688rem;
+    font-size: var(--app-text-sm);
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: rgb(255 255 255 / 60%);
       width: 16px;
       text-align: center;
@@ -478,7 +478,7 @@
 }
 
 .timeline-title-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: rgb(239 68 68 / 100%);
   vertical-align: middle;
   margin-right: 0.25em;
@@ -487,7 +487,7 @@
 @media (width <= 1024px) {
   .timeline-header {
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    gap: 0.65625rem;
 
     .header-title {
       grid-column: 1;
@@ -504,7 +504,7 @@
       justify-self: stretch;
       display: grid;
       grid-template-columns: 1fr 1fr;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       ::ng-deep p-select {
         width: 100%;
@@ -521,34 +521,34 @@
   .timeline-header {
     .header-title {
       h3 {
-        font-size: 1.1rem;
+        font-size: 0.9625rem;
       }
 
       .timeline-subtitle {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
 
     .week-info {
-      padding: 0.6rem;
+      padding: 0.525rem;
 
       .week-display {
         min-width: 100px;
 
         .week-label {
-          font-size: 0.9rem;
+          font-size: 0.7875rem;
         }
 
         .week-dates {
-          font-size: 0.7rem;
+          font-size: 0.6125rem;
         }
       }
 
       .week-nav-btn {
-        padding: 0.35rem 0.5rem;
+        padding: 0.30625rem 0.4375rem;
 
         i {
-          font-size: 0.8rem;
+          font-size: 0.7rem;
         }
       }
     }
@@ -556,14 +556,14 @@
 
   .timeline-content {
     min-height: 300px;
-    padding: 0.75rem;
+    padding: 0.65625rem;
   }
 
   .timeline-row {
     .day-label {
       width: 70px;
-      font-size: 0.75rem;
-      padding-right: 0.5rem;
+      font-size: var(--app-text-xs);
+      padding-right: 0.4375rem;
     }
   }
 
@@ -575,13 +575,13 @@
 
   .hour-marker {
     .hour-label {
-      font-size: 0.6rem;
+      font-size: 0.525rem;
     }
   }
 
   .session-block {
     .session-content {
-      font-size: 0.65rem;
+      font-size: 0.56875rem;
 
       .session-duration {
         display: none;
@@ -592,23 +592,23 @@
   .session-tooltip {
     min-width: 240px;
     max-width: 280px;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
 
     .tooltip-header {
-      padding: 0.75rem;
+      padding: 0.65625rem;
 
       .tooltip-title {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
       }
     }
 
     .tooltip-body {
-      padding: 0.75rem;
+      padding: 0.65625rem;
     }
 
     .tooltip-row {
-      font-size: 0.8rem;
-      gap: 0.5rem;
+      font-size: 0.7rem;
+      gap: 0.4375rem;
     }
   }
 }
@@ -617,11 +617,11 @@
   .timeline-header {
     .header-title {
       h3 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .timeline-subtitle {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
 
@@ -634,11 +634,11 @@
         min-width: 90px;
 
         .week-label {
-          font-size: 0.85rem;
+          font-size: 0.74375rem;
         }
 
         .week-dates {
-          font-size: 0.65rem;
+          font-size: 0.56875rem;
         }
       }
     }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.scss
@@ -6,24 +6,24 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -31,14 +31,14 @@
 }
 
 .reading-survival-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: #e91e63;
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
   .stat-card {
@@ -48,28 +48,28 @@
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
     flex: 1;
     min-width: 80px;
 
     .stat-value {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
       color: #e91e63;
     }
 
     .stat-subtitle {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--text-secondary-color);
       text-align: center;
     }
 
     .stat-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--text-secondary-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
     }
 
     &.danger .stat-value {
@@ -93,24 +93,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   text-align: center;
   color: var(--text-secondary-color);
 
   i {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
+    font-size: 2.1875rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 1rem;
-    margin: 0 0 0.5rem;
+    font-size: var(--app-text-base);
+    margin: 0 0 0.4375rem;
     color: var(--text-color, #fff);
   }
 
   small {
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
     opacity: 0.7;
   }
 }
@@ -127,17 +127,17 @@
 
 @media (width <= 480px) {
   .chart-header .chart-title h3 {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   .stats-row {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .stat-card {
-      padding: 0.4rem 0.5rem;
+      padding: 0.35rem 0.4375rem;
 
       .stat-value {
-        font-size: 1.2rem;
+        font-size: 1.05rem;
       }
     }
   }

--- a/frontend/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/reading-survival-chart/reading-survival-chart.component.scss
@@ -13,7 +13,7 @@
 
     h3 {
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -37,7 +37,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
@@ -69,7 +69,7 @@
       color: var(--text-secondary-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
     }
 
     &.danger .stat-value {
@@ -110,7 +110,7 @@
   }
 
   small {
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     opacity: 0.7;
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.scss
@@ -10,7 +10,7 @@
   align-items: flex-start;
   margin-bottom: 0.875rem;
   flex-wrap: wrap;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 
   .chart-title {
     flex: 1;
@@ -18,7 +18,7 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
       margin: 0 0 0.4375rem;
       display: flex;
@@ -41,8 +41,8 @@
     .summary-item {
       display: flex;
       align-items: center;
-      gap: 0.30625rem;
-      padding: 0.30625rem 0.525rem;
+      gap: 0.3063rem;
+      padding: 0.3063rem 0.525rem;
       border-radius: 16px;
       font-size: 0.7rem;
       font-weight: 600;
@@ -81,7 +81,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
@@ -89,7 +89,7 @@
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    padding: 0.4375rem 0.74375rem;
+    padding: 0.4375rem 0.7438rem;
 
     @include chart-shared.neutral-surface(20px);
 
@@ -127,11 +127,11 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 0.65625rem;
+    margin-bottom: 0.6563rem;
 
     h4 {
       color: var(--color-text);
-      font-size: 0.83125rem;
+      font-size: 0.8313rem;
       font-weight: 500;
       margin: 0;
     }
@@ -139,7 +139,7 @@
     .series-count {
       font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
-      padding: 0.21875rem 0.4375rem;
+      padding: 0.2188rem 0.4375rem;
 
       @include chart-shared.neutral-surface(4px);
     }
@@ -147,8 +147,8 @@
 
   .controls-row {
     display: flex;
-    gap: 0.65625rem;
-    margin-bottom: 0.65625rem;
+    gap: 0.6563rem;
+    margin-bottom: 0.6563rem;
     flex-wrap: wrap;
 
     .search-box {
@@ -158,7 +158,7 @@
       display: flex;
       align-items: center;
       gap: 0.4375rem;
-      padding: 0.35rem 0.56875rem;
+      padding: 0.35rem 0.5687rem;
 
       @include chart-shared.neutral-surface(6px);
 
@@ -227,7 +227,7 @@
       gap: 0.4375rem;
       padding: 1.3125rem;
       color: var(--color-text-secondary);
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
 
       i {
         opacity: 0.5;
@@ -239,9 +239,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.65625rem;
-    margin-top: 0.65625rem;
-    padding-top: 0.65625rem;
+    gap: 0.6563rem;
+    margin-top: 0.6563rem;
+    padding-top: 0.6563rem;
     border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 
     .page-btn {
@@ -280,7 +280,7 @@
   }
 
   .series-card {
-    padding: 0.4375rem 0.65625rem;
+    padding: 0.4375rem 0.6563rem;
 
     @include chart-shared.neutral-surface;
 
@@ -306,7 +306,7 @@
       display: flex;
       align-items: flex-start;
       gap: 0.4375rem;
-      margin-bottom: 0.30625rem;
+      margin-bottom: 0.3063rem;
 
       .series-status-icon {
         font-size: 0.7875rem;
@@ -330,7 +330,7 @@
         .series-meta {
           display: flex;
           align-items: center;
-          gap: 0.65625rem;
+          gap: 0.6563rem;
           margin-top: 0.175rem;
 
           .books-count {
@@ -350,7 +350,7 @@
             color: var(--color-amber-500);
 
             i {
-              font-size: 0.56875rem;
+              font-size: 0.5687rem;
             }
           }
         }
@@ -398,14 +398,14 @@
     }
 
     .next-up {
-      margin-top: 0.30625rem;
+      margin-top: 0.3063rem;
       padding-top: 0.2625rem;
       border-top: 1px dashed color-mix(in srgb, var(--color-border) 70%, transparent);
       font-size: 0.6125rem;
 
       .next-label {
         color: var(--color-text-secondary);
-        margin-right: 0.30625rem;
+        margin-right: 0.3063rem;
       }
 
       .next-title {
@@ -427,13 +427,13 @@
 
   i {
     font-size: 1.75rem;
-    margin-bottom: 0.65625rem;
+    margin-bottom: 0.6563rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 0.83125rem;
-    margin: 0 0 0.30625rem;
+    font-size: 0.8313rem;
+    margin: 0 0 0.3063rem;
     color: var(--color-text);
   }
 
@@ -487,7 +487,7 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 0.91875rem;
+        font-size: 0.9187rem;
       }
 
       .chart-description {
@@ -497,7 +497,7 @@
 
     .series-summary {
       .summary-item {
-        padding: 0.21875rem 0.4375rem;
+        padding: 0.2188rem 0.4375rem;
         font-size: var(--app-text-xs);
       }
     }
@@ -521,12 +521,12 @@
 
   .series-details {
     .series-card {
-      padding: 0.4375rem 0.56875rem;
+      padding: 0.4375rem 0.5687rem;
 
       .series-main {
         .series-info {
           .series-name {
-            font-size: 0.74375rem;
+            font-size: 0.7438rem;
           }
         }
       }

--- a/frontend/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/series-progress-chart/series-progress-chart.component.scss
@@ -8,9 +8,9 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 
   .chart-title {
     flex: 1;
@@ -18,17 +18,17 @@
 
     h3 {
       color: var(--color-text);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
 
     .chart-description {
       color: var(--color-text-secondary);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       margin: 0;
       line-height: 1.4;
     }
@@ -36,19 +36,19 @@
 
   .series-summary {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .summary-item {
       display: flex;
       align-items: center;
-      gap: 0.35rem;
-      padding: 0.35rem 0.6rem;
+      gap: 0.30625rem;
+      padding: 0.30625rem 0.525rem;
       border-radius: 16px;
-      font-size: 0.8rem;
+      font-size: 0.7rem;
       font-weight: 600;
 
       i {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
       }
 
       &.completed {
@@ -75,32 +75,32 @@
 }
 
 .series-icon {
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
   color: var(--color-violet-700);
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.875rem;
   flex-wrap: wrap;
 
   .stat-pill {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.85rem;
+    gap: 0.4375rem;
+    padding: 0.4375rem 0.74375rem;
 
     @include chart-shared.neutral-surface(20px);
 
     .pill-value {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
       font-weight: 600;
       color: var(--color-text);
     }
 
     .pill-label {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
     }
 
@@ -119,7 +119,7 @@
 .chart-wrapper {
   height: 300px;
   width: 100%;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .series-details {
@@ -127,19 +127,19 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.65625rem;
 
     h4 {
       color: var(--color-text);
-      font-size: 0.95rem;
+      font-size: 0.83125rem;
       font-weight: 500;
       margin: 0;
     }
 
     .series-count {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
-      padding: 0.25rem 0.5rem;
+      padding: 0.21875rem 0.4375rem;
 
       @include chart-shared.neutral-surface(4px);
     }
@@ -147,8 +147,8 @@
 
   .controls-row {
     display: flex;
-    gap: 0.75rem;
-    margin-bottom: 0.75rem;
+    gap: 0.65625rem;
+    margin-bottom: 0.65625rem;
     flex-wrap: wrap;
 
     .search-box {
@@ -157,14 +157,14 @@
       max-width: 250px;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.4rem 0.65rem;
+      gap: 0.4375rem;
+      padding: 0.35rem 0.56875rem;
 
       @include chart-shared.neutral-surface(6px);
 
       i {
         color: var(--color-text-secondary);
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
 
       input {
@@ -173,7 +173,7 @@
         border: none;
         outline: none;
         color: var(--color-text);
-        font-size: 0.8rem;
+        font-size: 0.7rem;
         font-family: inherit;
 
         &::placeholder {
@@ -184,13 +184,13 @@
 
     .filter-controls {
       display: flex;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       .filter-select,
       .sort-select {
-        padding: 0.4rem 0.5rem;
+        padding: 0.35rem 0.4375rem;
         color: var(--color-text);
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         font-family: inherit;
         cursor: pointer;
         outline: none;
@@ -216,7 +216,7 @@
   .series-list {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: 0.35rem;
     max-height: 360px;
     overflow-y: auto;
 
@@ -224,10 +224,10 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 0.5rem;
-      padding: 1.5rem;
+      gap: 0.4375rem;
+      padding: 1.3125rem;
       color: var(--color-text-secondary);
-      font-size: 0.85rem;
+      font-size: 0.74375rem;
 
       i {
         opacity: 0.5;
@@ -239,9 +239,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.75rem;
-    margin-top: 0.75rem;
-    padding-top: 0.75rem;
+    gap: 0.65625rem;
+    margin-top: 0.65625rem;
+    padding-top: 0.65625rem;
     border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 
     .page-btn {
@@ -257,7 +257,7 @@
       @include chart-shared.neutral-surface(6px);
 
       i {
-        font-size: 0.7rem;
+        font-size: 0.6125rem;
       }
 
       &:hover:not(:disabled) {
@@ -272,7 +272,7 @@
     }
 
     .page-info {
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       color: var(--color-text-secondary);
       min-width: 80px;
       text-align: center;
@@ -280,7 +280,7 @@
   }
 
   .series-card {
-    padding: 0.5rem 0.75rem;
+    padding: 0.4375rem 0.65625rem;
 
     @include chart-shared.neutral-surface;
 
@@ -305,12 +305,12 @@
     .series-main {
       display: flex;
       align-items: flex-start;
-      gap: 0.5rem;
-      margin-bottom: 0.35rem;
+      gap: 0.4375rem;
+      margin-bottom: 0.30625rem;
 
       .series-status-icon {
-        font-size: 0.9rem;
-        margin-top: 0.1rem;
+        font-size: 0.7875rem;
+        margin-top: 0.0875rem;
       }
 
       .series-info {
@@ -319,7 +319,7 @@
 
         .series-name {
           display: block;
-          font-size: 0.9rem;
+          font-size: 0.7875rem;
           font-weight: 500;
           color: var(--color-text);
           white-space: nowrap;
@@ -330,11 +330,11 @@
         .series-meta {
           display: flex;
           align-items: center;
-          gap: 0.75rem;
-          margin-top: 0.2rem;
+          gap: 0.65625rem;
+          margin-top: 0.175rem;
 
           .books-count {
-            font-size: 0.75rem;
+            font-size: var(--app-text-xs);
             color: var(--color-text-secondary);
 
             .total-hint {
@@ -345,12 +345,12 @@
           .rating {
             display: flex;
             align-items: center;
-            gap: 0.2rem;
-            font-size: 0.75rem;
+            gap: 0.175rem;
+            font-size: var(--app-text-xs);
             color: var(--color-amber-500);
 
             i {
-              font-size: 0.65rem;
+              font-size: 0.56875rem;
             }
           }
         }
@@ -360,7 +360,7 @@
     .series-progress {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       .progress-bar-container {
         flex: 1;
@@ -389,7 +389,7 @@
       }
 
       .progress-text {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         font-weight: 600;
         color: var(--color-text);
         min-width: 32px;
@@ -398,14 +398,14 @@
     }
 
     .next-up {
-      margin-top: 0.35rem;
-      padding-top: 0.3rem;
+      margin-top: 0.30625rem;
+      padding-top: 0.2625rem;
       border-top: 1px dashed color-mix(in srgb, var(--color-border) 70%, transparent);
-      font-size: 0.7rem;
+      font-size: 0.6125rem;
 
       .next-label {
         color: var(--color-text-secondary);
-        margin-right: 0.35rem;
+        margin-right: 0.30625rem;
       }
 
       .next-title {
@@ -421,24 +421,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2.5rem;
+  padding: 2.1875rem;
   text-align: center;
   color: var(--color-text-secondary);
 
   i {
-    font-size: 2rem;
-    margin-bottom: 0.75rem;
+    font-size: 1.75rem;
+    margin-bottom: 0.65625rem;
     opacity: 0.5;
   }
 
   p {
-    font-size: 0.95rem;
-    margin: 0 0 0.35rem;
+    font-size: 0.83125rem;
+    margin: 0 0 0.30625rem;
     color: var(--color-text);
   }
 
   small {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     opacity: 0.7;
   }
 }
@@ -487,46 +487,46 @@
   .chart-header {
     .chart-title {
       h3 {
-        font-size: 1.05rem;
+        font-size: 0.91875rem;
       }
 
       .chart-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
 
     .series-summary {
       .summary-item {
-        padding: 0.25rem 0.5rem;
-        font-size: 0.75rem;
+        padding: 0.21875rem 0.4375rem;
+        font-size: var(--app-text-xs);
       }
     }
   }
 
   .stats-row {
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .stat-pill {
-      padding: 0.4rem 0.6rem;
+      padding: 0.35rem 0.525rem;
 
       .pill-value {
-        font-size: 0.9rem;
+        font-size: 0.7875rem;
       }
 
       .pill-label {
-        font-size: 0.7rem;
+        font-size: 0.6125rem;
       }
     }
   }
 
   .series-details {
     .series-card {
-      padding: 0.5rem 0.65rem;
+      padding: 0.4375rem 0.56875rem;
 
       .series-main {
         .series-info {
           .series-name {
-            font-size: 0.85rem;
+            font-size: 0.74375rem;
           }
         }
       }

--- a/frontend/src/app/features/stats/component/user-stats/charts/session-archetypes-chart/session-archetypes-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/session-archetypes-chart/session-archetypes-chart.component.scss
@@ -17,7 +17,7 @@
       align-items: center;
       margin: 0 0 0.4375rem;
       color: var(--text-color, #fff);
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 500;
     }
 
@@ -65,7 +65,7 @@
 
 .stats-row {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
   margin-bottom: 0.875rem;
 
@@ -87,7 +87,7 @@
     }
 
     .stat-label {
-      margin-top: 0.21875rem;
+      margin-top: 0.2188rem;
       color: var(--text-secondary-color);
       font-size: var(--app-text-xs);
       letter-spacing: 0.5px;
@@ -134,7 +134,7 @@
 
   small {
     opacity: 0.7;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
   }
 }
 

--- a/frontend/src/app/features/stats/component/user-stats/charts/session-archetypes-chart/session-archetypes-chart.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/charts/session-archetypes-chart/session-archetypes-chart.component.scss
@@ -6,36 +6,36 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 
   .chart-title {
     flex: 1;
 
     h3 {
       display: flex;
-      gap: 0.5rem;
+      gap: 0.4375rem;
       align-items: center;
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.4375rem;
       color: var(--text-color, #fff);
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 500;
     }
 
     .chart-description {
       margin: 0;
       color: var(--text-secondary-color);
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       line-height: 1.4;
     }
   }
 
   .year-nav {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     align-items: center;
 
     .nav-btn {
-      padding: 0.3rem 0.5rem;
+      padding: 0.2625rem 0.4375rem;
       border: 1px solid var(--color-border);
       border-radius: 6px;
       background: color-mix(in srgb, var(--color-text) 5%, transparent);
@@ -51,7 +51,7 @@
     .year-label {
       min-width: 50px;
       color: var(--text-color, #fff);
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
       font-weight: 600;
       text-align: center;
     }
@@ -60,14 +60,14 @@
 
 .session-archetypes-icon {
   color: #ff9800;
-  font-size: 1.5rem;
+  font-size: 1.3125rem;
 }
 
 .stats-row {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 
   .stat-card {
     display: flex;
@@ -75,21 +75,21 @@
     flex-direction: column;
     align-items: center;
     min-width: 80px;
-    padding: 0.5rem 1rem;
+    padding: 0.4375rem 0.875rem;
     border: 1px solid var(--color-border);
     border-radius: 8px;
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
 
     .stat-value {
       color: var(--text-color, #fff);
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
     }
 
     .stat-label {
-      margin-top: 0.25rem;
+      margin-top: 0.21875rem;
       color: var(--text-secondary-color);
-      font-size: 0.75rem;
+      font-size: var(--app-text-xs);
       letter-spacing: 0.5px;
       text-transform: uppercase;
     }
@@ -100,7 +100,7 @@
 
     &.archetype .stat-value {
       color: #42a5f5;
-      font-size: 1.1rem;
+      font-size: 0.9625rem;
     }
   }
 }
@@ -116,25 +116,25 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: 2.625rem;
   color: var(--text-secondary-color);
   text-align: center;
 
   i {
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
     opacity: 0.5;
-    font-size: 2.5rem;
+    font-size: 2.1875rem;
   }
 
   p {
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4375rem;
     color: var(--text-color, #fff);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 
   small {
     opacity: 0.7;
-    font-size: 0.85rem;
+    font-size: 0.74375rem;
   }
 }
 
@@ -146,6 +146,6 @@
 
 @media (width <= 480px) {
   .chart-header .chart-title h3 {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }

--- a/frontend/src/app/features/stats/component/user-stats/user-stats.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/user-stats.component.scss
@@ -33,7 +33,7 @@
   .greeting {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
@@ -67,7 +67,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem 1.09375rem;
+  padding: 0.6563rem 1.0938rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 8px;
@@ -103,7 +103,7 @@
     border-top: 1px solid var(--p-content-border-color);
     padding: 0.875rem 1.3125rem;
     display: flex;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     justify-content: flex-end;
 
     .reset-btn {
@@ -123,14 +123,14 @@
   .config-list {
     display: flex;
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 
   .config-item {
     display: flex;
     align-items: center;
     gap: 0.875rem;
-    padding: 0.4375rem 1.09375rem;
+    padding: 0.4375rem 1.0938rem;
     background: var(--color-page);
     border: 1px solid var(--p-content-border-color);
     border-radius: 8px;
@@ -156,7 +156,7 @@
     .chart-title {
       flex: 1;
       color: var(--color-text);
-      font-size: 0.83125rem;
+      font-size: 0.8313rem;
     }
 
     .visibility-toggle {
@@ -385,11 +385,11 @@
       transform: none;
 
       i {
-        font-size: 1.09375rem;
+        font-size: 1.0938rem;
       }
 
       h2 {
-        font-size: 1.09375rem;
+        font-size: 1.0938rem;
         white-space: normal;
       }
     }
@@ -436,25 +436,25 @@
 
 @media (width <= 480px) {
   .user-stats-container {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
   }
 
   .config-toggle-btn {
-    padding: 0.4375rem 0.65625rem;
+    padding: 0.4375rem 0.6563rem;
   }
 
   ::ng-deep .config-dialog {
     .p-dialog-content {
-      padding: 0.65625rem;
+      padding: 0.6563rem;
     }
   }
 
   .config-panel {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
   }
 
   .header-section {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
 
     .greeting {
       gap: 0.4375rem;
@@ -472,11 +472,11 @@
 
   .charts-container {
     grid-template-columns: 1fr;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
   }
 
   .chart-card {
-    padding: 0.65625rem;
+    padding: 0.6563rem;
 
     &.chart-small-square,
     &.chart-small,

--- a/frontend/src/app/features/stats/component/user-stats/user-stats.component.scss
+++ b/frontend/src/app/features/stats/component/user-stats/user-stats.component.scss
@@ -2,7 +2,7 @@
   max-width: 1800px;
   margin: 0 auto;
   box-sizing: border-box;
-  padding: 0.5rem;
+  padding: 0.4375rem;
   height: 100%;
   overflow-y: auto;
 }
@@ -10,11 +10,11 @@
 .header-section {
   background: var(--color-card);
   border-radius: 12px;
-  padding: 1rem;
+  padding: 0.875rem;
   backdrop-filter: blur(10px);
   border: 1px solid var(--p-content-border-color);
   box-shadow: 0 4px 6px rgb(0 0 0 / 10%);
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
   transition: all 0.3s ease;
 
   &:hover {
@@ -26,26 +26,26 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 2rem;
+    gap: 1.75rem;
     position: relative;
   }
 
   .greeting {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
 
     i {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       color: var(--color-primary);
     }
 
     h2 {
       color: var(--color-text);
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       font-weight: 600;
       margin: 0;
       white-space: nowrap;
@@ -60,21 +60,21 @@
 .config-header {
   display: flex;
   justify-content: flex-end;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .config-toggle-btn {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.25rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem 1.09375rem;
   background: var(--color-card);
   border: 1px solid var(--p-content-border-color);
   border-radius: 8px;
   color: var(--color-text);
   cursor: pointer;
   transition: all 0.3s ease;
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   white-space: nowrap;
 
   &:hover {
@@ -84,7 +84,7 @@
   }
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }
 
@@ -96,14 +96,14 @@
 
   .p-dialog-content {
     background: var(--color-card);
-    padding: 1.5rem;
+    padding: 1.3125rem;
   }
 
   .p-dialog-footer {
     border-top: 1px solid var(--p-content-border-color);
-    padding: 1rem 1.5rem;
+    padding: 0.875rem 1.3125rem;
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     justify-content: flex-end;
 
     .reset-btn {
@@ -114,7 +114,7 @@
     .show-all-btn {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
   }
 }
@@ -123,14 +123,14 @@
   .config-list {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 
   .config-item {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    padding: 0.5rem 1.25rem;
+    gap: 0.875rem;
+    padding: 0.4375rem 1.09375rem;
     background: var(--color-page);
     border: 1px solid var(--p-content-border-color);
     border-radius: 8px;
@@ -156,11 +156,11 @@
     .chart-title {
       flex: 1;
       color: var(--color-text);
-      font-size: 0.95rem;
+      font-size: 0.83125rem;
     }
 
     .visibility-toggle {
-      padding: 0.5rem;
+      padding: 0.4375rem;
       background: transparent;
       border: 1px solid var(--p-content-border-color);
       border-radius: 6px;
@@ -191,14 +191,14 @@
 .charts-container {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  gap: 1.5rem;
+  gap: 1.3125rem;
   overflow: visible;
 }
 
 .chart-card {
   background: var(--color-card);
   border-radius: 12px;
-  padding: 1.5rem;
+  padding: 1.3125rem;
   backdrop-filter: blur(10px);
   border: 1px solid var(--p-content-border-color);
   box-shadow: 0 4px 6px rgb(0 0 0 / 10%);
@@ -217,9 +217,9 @@
 
   .chart-drag-handle {
     position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    padding: 0.5rem;
+    top: 0.4375rem;
+    right: 0.4375rem;
+    padding: 0.4375rem;
     background: rgb(0 0 0 / 30%);
     border-radius: 6px;
     cursor: grab;
@@ -333,17 +333,17 @@
 
 @media (width <= 768px) {
   .user-stats-container {
-    padding: 1rem;
+    padding: 0.875rem;
   }
 
   ::ng-deep .config-dialog {
     .p-dialog-content {
-      padding: 1rem;
+      padding: 0.875rem;
     }
 
     .p-dialog-footer {
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       .reset-btn {
         margin-right: 0;
@@ -357,12 +357,12 @@
   }
 
   .config-panel {
-    padding: 1rem;
+    padding: 0.875rem;
 
     .config-panel-header {
       flex-direction: column;
       align-items: flex-start;
-      gap: 1rem;
+      gap: 0.875rem;
 
       .reset-btn {
         width: 100%;
@@ -372,11 +372,11 @@
   }
 
   .header-section {
-    padding: 1rem;
+    padding: 0.875rem;
 
     .header-content {
       flex-direction: column;
-      gap: 1rem;
+      gap: 0.875rem;
       position: static;
     }
 
@@ -385,11 +385,11 @@
       transform: none;
 
       i {
-        font-size: 1.25rem;
+        font-size: 1.09375rem;
       }
 
       h2 {
-        font-size: 1.25rem;
+        font-size: 1.09375rem;
         white-space: normal;
       }
     }
@@ -407,11 +407,11 @@
 
   .charts-container {
     grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
+    gap: 0.875rem;
   }
 
   .chart-card {
-    padding: 1rem;
+    padding: 0.875rem;
 
     .chart-drag-handle {
       opacity: 1;
@@ -436,35 +436,35 @@
 
 @media (width <= 480px) {
   .user-stats-container {
-    padding: 0.75rem;
+    padding: 0.65625rem;
   }
 
   .config-toggle-btn {
-    padding: 0.5rem 0.75rem;
+    padding: 0.4375rem 0.65625rem;
   }
 
   ::ng-deep .config-dialog {
     .p-dialog-content {
-      padding: 0.75rem;
+      padding: 0.65625rem;
     }
   }
 
   .config-panel {
-    padding: 0.75rem;
+    padding: 0.65625rem;
   }
 
   .header-section {
-    padding: 0.75rem;
+    padding: 0.65625rem;
 
     .greeting {
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       i {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       h2 {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
         white-space: normal;
       }
     }
@@ -472,11 +472,11 @@
 
   .charts-container {
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    gap: 0.65625rem;
   }
 
   .chart-card {
-    padding: 0.75rem;
+    padding: 0.65625rem;
 
     &.chart-small-square,
     &.chart-small,

--- a/frontend/src/app/shared/components/book-uploader/book-uploader.component.scss
+++ b/frontend/src/app/shared/components/book-uploader/book-uploader.component.scss
@@ -26,7 +26,7 @@
   gap: 0.875rem;
   min-height: 0;
   overflow-y: auto;
-  padding: 1.53125rem;
+  padding: 1.5313rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 0 0 10px 10px;
@@ -48,7 +48,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.54688rem 0.76563rem;
+    padding: 0.5469rem 0.7656rem;
     background: var(--overlay-background);
     border-radius: 6px;
 
@@ -67,10 +67,10 @@
     }
 
     @media (width <= 480px) {
-      padding: 0.4375rem 0.54688rem;
+      padding: 0.4375rem 0.5469rem;
 
       .section-title {
-        font-size: 0.74375rem;
+        font-size: 0.7438rem;
       }
     }
   }
@@ -84,8 +84,8 @@
 .selection-fields {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
-  padding: 0 0.65625rem 0.875rem;
+  gap: 0.6563rem;
+  padding: 0 0.6563rem 0.875rem;
 
   .field-group {
     display: flex;
@@ -96,7 +96,7 @@
       font-size: var(--app-text-sm);
       font-weight: 600;
       color: var(--text-color);
-      padding-left: 0.21875rem;
+      padding-left: 0.2188rem;
     }
   }
 }
@@ -147,13 +147,13 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     padding: 0.875rem;
     width: 100%;
 
     .action-buttons {
       display: flex;
-      gap: 0.65625rem;
+      gap: 0.6563rem;
       flex-wrap: wrap;
       justify-content: center;
     }
@@ -165,7 +165,7 @@
     }
 
     @media (width <= 480px) {
-      padding: 0.65625rem;
+      padding: 0.6563rem;
       gap: 0.4375rem;
 
       .action-buttons {
@@ -187,7 +187,7 @@
     background: var(--card-background);
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    padding: 0.54688rem 0.76563rem;
+    padding: 0.5469rem 0.7656rem;
     margin-bottom: 0.4375rem;
 
     .progress-row {
@@ -195,12 +195,12 @@
       align-items: center;
       gap: 0.875rem;
       margin-bottom: 0.4375rem;
-      font-size: 0.74375rem;
+      font-size: 0.7438rem;
 
       .progress-status {
         display: flex;
         align-items: center;
-        gap: 0.32813rem;
+        gap: 0.3281rem;
         font-weight: 600;
         color: var(--text-color);
 
@@ -248,7 +248,7 @@
     }
 
     @media (width <= 480px) {
-      padding: 0.4375rem 0.65625rem;
+      padding: 0.4375rem 0.6563rem;
 
       .progress-row {
         flex-wrap: wrap;
@@ -266,14 +266,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.4375rem;
-    padding-right: 0.21875rem;
+    padding-right: 0.2188rem;
 
     .file-item-card {
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 0.875rem;
-      padding: 0.21875rem 0.65625rem;
+      padding: 0.2188rem 0.6563rem;
       background: var(--card-background);
       border: 1px solid var(--border-color);
       border-radius: 8px;
@@ -287,7 +287,7 @@
       .file-info {
         display: flex;
         align-items: center;
-        gap: 0.65625rem;
+        gap: 0.6563rem;
         flex: 1;
         min-width: 0;
 
@@ -308,7 +308,7 @@
         }
 
         .file-progress-text {
-          font-size: 0.74375rem;
+          font-size: 0.7438rem;
           font-weight: 600;
           color: var(--primary-color);
           min-width: 40px;
@@ -323,7 +323,7 @@
         flex-shrink: 0;
 
         .status-icon {
-          font-size: 1.09375rem;
+          font-size: 1.0938rem;
           padding: 0.4375rem;
 
           &.uploading {
@@ -342,14 +342,14 @@
       }
 
       @media (width <= 480px) {
-        padding: 0.54688rem;
+        padding: 0.5469rem;
         gap: 0.4375rem;
 
         .file-info {
           gap: 0.4375rem;
 
           .file-name {
-            font-size: 0.74375rem;
+            font-size: 0.7438rem;
           }
 
           .file-size {
@@ -360,7 +360,7 @@
         .file-actions {
           .status-icon {
             font-size: var(--app-text-base);
-            padding: 0.32813rem;
+            padding: 0.3281rem;
           }
         }
       }
@@ -419,13 +419,13 @@
     }
 
     @media (width <= 480px) {
-      padding: 1.3125rem 0.65625rem;
+      padding: 1.3125rem 0.6563rem;
       min-height: 180px;
 
       .empty-icon-wrapper {
         width: 70px;
         height: 70px;
-        margin-bottom: 0.65625rem;
+        margin-bottom: 0.6563rem;
 
         .empty-icon {
           font-size: 1.75rem;

--- a/frontend/src/app/shared/components/book-uploader/book-uploader.component.scss
+++ b/frontend/src/app/shared/components/book-uploader/book-uploader.component.scss
@@ -23,18 +23,18 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
   min-height: 0;
   overflow-y: auto;
-  padding: 1.75rem;
+  padding: 1.53125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 0 0 10px 10px;
   box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
 
   @media (width <= 480px) {
-    padding: 1rem;
-    gap: 1rem;
+    padding: 0.875rem;
+    gap: 0.875rem;
   }
 }
 
@@ -48,29 +48,29 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.625rem 0.875rem;
+    padding: 0.54688rem 0.76563rem;
     background: var(--overlay-background);
     border-radius: 6px;
 
     .section-title {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      font-size: 0.9rem;
+      gap: 0.4375rem;
+      font-size: 0.7875rem;
       font-weight: 600;
       color: var(--text-color);
 
       i {
         color: var(--primary-color);
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
     }
 
     @media (width <= 480px) {
-      padding: 0.5rem 0.625rem;
+      padding: 0.4375rem 0.54688rem;
 
       .section-title {
-        font-size: 0.85rem;
+        font-size: 0.74375rem;
       }
     }
   }
@@ -84,19 +84,19 @@
 .selection-fields {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0 0.75rem 1rem;
+  gap: 0.65625rem;
+  padding: 0 0.65625rem 0.875rem;
 
   .field-group {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .field-label {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       font-weight: 600;
       color: var(--text-color);
-      padding-left: 0.25rem;
+      padding-left: 0.21875rem;
     }
   }
 }
@@ -118,7 +118,7 @@
     }
 
     .p-fileupload-content {
-      padding: 1rem;
+      padding: 0.875rem;
       background: transparent;
       border: none;
       transition: background-color 0.3s ease;
@@ -147,26 +147,26 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.75rem;
-    padding: 1rem;
+    gap: 0.65625rem;
+    padding: 0.875rem;
     width: 100%;
 
     .action-buttons {
       display: flex;
-      gap: 0.75rem;
+      gap: 0.65625rem;
       flex-wrap: wrap;
       justify-content: center;
     }
 
     .upload-hint {
       color: var(--text-secondary-color);
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       text-align: center;
     }
 
     @media (width <= 480px) {
-      padding: 0.75rem;
-      gap: 0.5rem;
+      padding: 0.65625rem;
+      gap: 0.4375rem;
 
       .action-buttons {
         width: 100%;
@@ -178,7 +178,7 @@
       }
 
       .upload-hint {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
   }
@@ -187,25 +187,25 @@
     background: var(--card-background);
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    padding: 0.625rem 0.875rem;
-    margin-bottom: 0.5rem;
+    padding: 0.54688rem 0.76563rem;
+    margin-bottom: 0.4375rem;
 
     .progress-row {
       display: flex;
       align-items: center;
-      gap: 1rem;
-      margin-bottom: 0.5rem;
-      font-size: 0.85rem;
+      gap: 0.875rem;
+      margin-bottom: 0.4375rem;
+      font-size: 0.74375rem;
 
       .progress-status {
         display: flex;
         align-items: center;
-        gap: 0.375rem;
+        gap: 0.32813rem;
         font-weight: 600;
         color: var(--text-color);
 
         i {
-          font-size: 0.9rem;
+          font-size: 0.7875rem;
           color: var(--primary-color);
         }
 
@@ -248,12 +248,12 @@
     }
 
     @media (width <= 480px) {
-      padding: 0.5rem 0.75rem;
+      padding: 0.4375rem 0.65625rem;
 
       .progress-row {
         flex-wrap: wrap;
-        gap: 0.5rem;
-        font-size: 0.8rem;
+        gap: 0.4375rem;
+        font-size: 0.7rem;
 
         .progress-bytes {
           margin-left: 0;
@@ -265,15 +265,15 @@
   .file-list-items {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
-    padding-right: 0.25rem;
+    gap: 0.4375rem;
+    padding-right: 0.21875rem;
 
     .file-item-card {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 1rem;
-      padding: 0.25rem 0.75rem;
+      gap: 0.875rem;
+      padding: 0.21875rem 0.65625rem;
       background: var(--card-background);
       border: 1px solid var(--border-color);
       border-radius: 8px;
@@ -287,7 +287,7 @@
       .file-info {
         display: flex;
         align-items: center;
-        gap: 0.75rem;
+        gap: 0.65625rem;
         flex: 1;
         min-width: 0;
 
@@ -298,17 +298,17 @@
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
-          font-size: 0.9rem;
+          font-size: 0.7875rem;
         }
 
         .file-size {
           color: var(--text-secondary-color);
-          font-size: 0.875rem;
+          font-size: var(--app-text-sm);
           flex-shrink: 0;
         }
 
         .file-progress-text {
-          font-size: 0.85rem;
+          font-size: 0.74375rem;
           font-weight: 600;
           color: var(--primary-color);
           min-width: 40px;
@@ -323,8 +323,8 @@
         flex-shrink: 0;
 
         .status-icon {
-          font-size: 1.25rem;
-          padding: 0.5rem;
+          font-size: 1.09375rem;
+          padding: 0.4375rem;
 
           &.uploading {
             color: var(--primary-color);
@@ -342,25 +342,25 @@
       }
 
       @media (width <= 480px) {
-        padding: 0.625rem;
-        gap: 0.5rem;
+        padding: 0.54688rem;
+        gap: 0.4375rem;
 
         .file-info {
-          gap: 0.5rem;
+          gap: 0.4375rem;
 
           .file-name {
-            font-size: 0.85rem;
+            font-size: 0.74375rem;
           }
 
           .file-size {
-            font-size: 0.8rem;
+            font-size: 0.7rem;
           }
         }
 
         .file-actions {
           .status-icon {
-            font-size: 1rem;
-            padding: 0.375rem;
+            font-size: var(--app-text-base);
+            padding: 0.32813rem;
           }
         }
       }
@@ -373,7 +373,7 @@
     align-items: center;
     justify-content: center;
     text-align: center;
-    padding: 1.5rem 1rem;
+    padding: 1.3125rem 0.875rem;
 
     .empty-icon-wrapper {
       display: flex;
@@ -383,12 +383,12 @@
       height: 80px;
       background: var(--overlay-background);
       border-radius: 50%;
-      margin-bottom: 1rem;
+      margin-bottom: 0.875rem;
       border: 3px dashed var(--border-color);
       transition: border-color 0.3s ease;
 
       .empty-icon {
-        font-size: 2.5rem;
+        font-size: 2.1875rem;
         color: var(--text-secondary-color);
         opacity: 0.6;
         transition: color 0.3s ease, opacity 0.3s ease, transform 0.3s ease;
@@ -400,15 +400,15 @@
     }
 
     .empty-title {
-      margin: 0 0 1.5rem;
-      font-size: 1.125rem;
+      margin: 0 0 1.3125rem;
+      font-size: var(--app-text-lg);
       font-weight: 600;
       color: var(--text-color);
     }
 
     .empty-description {
       margin: 0;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--text-secondary-color);
       max-width: 450px;
       line-height: 1.5;
@@ -419,25 +419,25 @@
     }
 
     @media (width <= 480px) {
-      padding: 1.5rem 0.75rem;
+      padding: 1.3125rem 0.65625rem;
       min-height: 180px;
 
       .empty-icon-wrapper {
         width: 70px;
         height: 70px;
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.65625rem;
 
         .empty-icon {
-          font-size: 2rem;
+          font-size: 1.75rem;
         }
       }
 
       .empty-title {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
 
       .empty-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
         max-width: 100%;
       }
     }

--- a/frontend/src/app/shared/components/cover-generator/cover-generator.component.ts
+++ b/frontend/src/app/shared/components/cover-generator/cover-generator.component.ts
@@ -56,9 +56,9 @@ export type CoverPlaceholderSize = 'sm' | 'md' | 'lg';
       overflow: hidden;
     }
 
-    .placeholder.size-sm { padding: min(0.5rem, 4cqi); }
-    .placeholder.size-md { padding: min(1rem, 6cqi); }
-    .placeholder.size-lg { padding: min(1.5rem, 8cqi); }
+    .placeholder.size-sm { padding: min(0.4375rem, 4cqi); }
+    .placeholder.size-md { padding: min(0.875rem, 6cqi); }
+    .placeholder.size-lg { padding: min(1.3125rem, 8cqi); }
 
     .placeholder-title {
       color: rgba(255, 255, 255, 0.9);

--- a/frontend/src/app/shared/components/directory-picker/directory-picker.component.scss
+++ b/frontend/src/app/shared/components/directory-picker/directory-picker.component.scss
@@ -1,7 +1,7 @@
 @use '../../styles/panel-shared' as panel;
 
 .responsive-table {
-  min-width: 50rem;
+  min-width: 43.75rem;
 
   @media (width <= 768px) {
     min-width: 100% !important;
@@ -31,8 +31,8 @@
 .picker-controls {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1rem 2rem;
+  gap: 0.875rem;
+  padding: 0.875rem 1.75rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -40,18 +40,18 @@
   .current-path {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 0.625rem;
+    gap: 0.65625rem;
+    padding: 0.54688rem;
     background: var(--overlay-background);
     border-radius: 6px;
 
     .path-label {
       display: flex;
       align-items: center;
-      gap: 0.375rem;
+      gap: 0.32813rem;
       color: var(--text-secondary-color);
       font-weight: 600;
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       white-space: nowrap;
 
       i {
@@ -63,7 +63,7 @@
       flex: 1;
       color: var(--text-color);
       font-family: monospace;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -72,7 +72,7 @@
 
   .controls-row {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65625rem;
 
     .search-input-wrapper {
       position: relative;
@@ -86,7 +86,7 @@
 
       .clear-icon {
         position: absolute;
-        right: 1rem;
+        right: 0.875rem;
         top: 50%;
         transform: translateY(-50%);
         color: var(--text-secondary-color);
@@ -103,7 +103,7 @@
 
   .selection-actions {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     align-items: center;
 
     @media (width <= 640px) {
@@ -120,27 +120,27 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.875rem;
+    gap: 0.4375rem;
+    padding: 0.4375rem 0.76563rem;
     background: var(--primary-color);
     color: var(--primary-contrast-color);
     border-radius: 6px;
     font-weight: 600;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 
   @media (width <= 480px) {
-    padding: 1rem;
-    gap: 0.5rem;
+    padding: 0.875rem;
+    gap: 0.4375rem;
 
     .current-path {
       flex-direction: column;
       align-items: flex-start;
-      gap: 0.5rem;
+      gap: 0.4375rem;
 
       .path-value {
         width: 100%;
@@ -149,7 +149,7 @@
 
     .controls-row {
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
   }
 }
@@ -157,8 +157,8 @@
 .directories-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1rem 2rem;
+  gap: 0.875rem;
+  padding: 0.875rem 1.75rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -168,7 +168,7 @@
   overflow: hidden;
 
   @media (width <= 480px) {
-    padding: 1rem;
+    padding: 0.875rem;
   }
 }
 
@@ -188,7 +188,7 @@
 }
 
 .loading-text {
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
   color: var(--text-secondary-color);
 }
 
@@ -198,7 +198,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 2rem 1rem;
+  padding: 1.75rem 0.875rem;
   flex: 1;
 
   .empty-icon-wrapper {
@@ -209,48 +209,48 @@
     height: 80px;
     background: var(--overlay-background);
     border-radius: 50%;
-    margin-bottom: 1rem;
+    margin-bottom: 0.875rem;
 
     .empty-icon {
-      font-size: 2.5rem;
+      font-size: 2.1875rem;
       color: var(--text-secondary-color);
       opacity: 0.5;
     }
   }
 
   .empty-title {
-    margin: 0 0 0.5rem;
-    font-size: 1.125rem;
+    margin: 0 0 0.4375rem;
+    font-size: var(--app-text-lg);
     font-weight: 600;
     color: var(--text-color);
   }
 
   .empty-description {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     color: var(--text-secondary-color);
     max-width: 350px;
     line-height: 1.5;
   }
 
   @media (width <= 480px) {
-    padding: 1.5rem 0.75rem;
+    padding: 1.3125rem 0.65625rem;
 
     .empty-icon-wrapper {
       width: 60px;
       height: 60px;
 
       .empty-icon {
-        font-size: 2rem;
+        font-size: 1.75rem;
       }
     }
 
     .empty-title {
-      font-size: 1rem;
+      font-size: var(--app-text-base);
     }
 
     .empty-description {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
       max-width: 100%;
     }
   }
@@ -259,7 +259,7 @@
 .directories-list {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 0.54688rem;
   height: 100%;
   overflow: hidden;
 }
@@ -268,15 +268,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.875rem;
+  padding: 0.4375rem 0.76563rem;
   background: var(--overlay-background);
   border-radius: 6px;
 
   .folder-count {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
-    font-size: 0.85rem;
+    gap: 0.32813rem;
+    font-size: 0.74375rem;
     font-weight: 600;
     color: var(--text-color);
 
@@ -286,10 +286,10 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.5rem 0.625rem;
+    padding: 0.4375rem 0.54688rem;
 
     .folder-count {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
     }
   }
 }
@@ -297,10 +297,10 @@
 .directories-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 0.54688rem;
   overflow: hidden auto;
   flex: 1;
-  padding-right: 0.25rem;
+  padding-right: 0.21875rem;
   min-height: 0;
   opacity: 1;
   transition: opacity 0.3s ease-in-out;
@@ -330,8 +330,8 @@
 .directory-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem 0.875rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -391,7 +391,7 @@
     flex: 1;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     cursor: pointer;
     min-width: 0;
 
@@ -406,7 +406,7 @@
       flex-shrink: 0;
 
       .directory-icon {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
         color: var(--text-secondary-color);
         transition: all 0.3s ease;
       }
@@ -416,12 +416,12 @@
       flex: 1;
       display: flex;
       flex-direction: column;
-      gap: 0.1875rem;
+      gap: 0.16406rem;
       min-width: 0;
       overflow: hidden;
 
       .directory-name {
-        font-size: 0.875rem;
+        font-size: var(--app-text-sm);
         color: var(--text-color);
         font-weight: 500;
         overflow: hidden;
@@ -432,7 +432,7 @@
       }
 
       .directory-path {
-        font-size: 0.75rem;
+        font-size: var(--app-text-xs);
         color: var(--text-secondary-color);
         font-family: monospace;
         overflow: hidden;
@@ -452,24 +452,24 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.5rem 0.625rem;
-    gap: 0.375rem;
+    padding: 0.4375rem 0.54688rem;
+    gap: 0.32813rem;
 
     .directory-label {
-      gap: 0.375rem;
+      gap: 0.32813rem;
 
       .directory-icon-wrapper {
         width: 26px;
         height: 26px;
 
         .directory-icon {
-          font-size: 0.875rem;
+          font-size: var(--app-text-sm);
         }
       }
 
       .directory-info {
         .directory-name {
-          font-size: 0.875rem;
+          font-size: var(--app-text-sm);
         }
 
         .directory-path {
@@ -493,7 +493,7 @@
 }
 
 .selection-note {
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
   color: var(--text-secondary-color);
 }
 
@@ -505,9 +505,9 @@ border-top: 1px solid var(--border-color);
   .selection-info {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4375rem;
     color: var(--text-secondary-color);
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
 
     i {
       color: var(--primary-color);
@@ -531,8 +531,8 @@ border-top: 1px solid var(--border-color);
   .current-path,
   .directory-list,
   .picker-footer {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-left: 0.875rem;
+    padding-right: 0.875rem;
   }
 
   .folder-item {
@@ -546,7 +546,7 @@ border-top: 1px solid var(--border-color);
   .current-path {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.5rem;
+    gap: 0.4375rem;
 
     .path-value {
       width: 100%;

--- a/frontend/src/app/shared/components/directory-picker/directory-picker.component.scss
+++ b/frontend/src/app/shared/components/directory-picker/directory-picker.component.scss
@@ -40,15 +40,15 @@
   .current-path {
     display: flex;
     align-items: center;
-    gap: 0.65625rem;
-    padding: 0.54688rem;
+    gap: 0.6563rem;
+    padding: 0.5469rem;
     background: var(--overlay-background);
     border-radius: 6px;
 
     .path-label {
       display: flex;
       align-items: center;
-      gap: 0.32813rem;
+      gap: 0.3281rem;
       color: var(--text-secondary-color);
       font-weight: 600;
       font-size: 0.7875rem;
@@ -72,7 +72,7 @@
 
   .controls-row {
     display: flex;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
 
     .search-input-wrapper {
       position: relative;
@@ -121,7 +121,7 @@
     align-items: center;
     justify-content: center;
     gap: 0.4375rem;
-    padding: 0.4375rem 0.76563rem;
+    padding: 0.4375rem 0.7656rem;
     background: var(--primary-color);
     color: var(--primary-contrast-color);
     border-radius: 6px;
@@ -188,7 +188,7 @@
 }
 
 .loading-text {
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
   color: var(--text-secondary-color);
 }
 
@@ -234,7 +234,7 @@
   }
 
   @media (width <= 480px) {
-    padding: 1.3125rem 0.65625rem;
+    padding: 1.3125rem 0.6563rem;
 
     .empty-icon-wrapper {
       width: 60px;
@@ -259,7 +259,7 @@
 .directories-list {
   display: flex;
   flex-direction: column;
-  gap: 0.54688rem;
+  gap: 0.5469rem;
   height: 100%;
   overflow: hidden;
 }
@@ -268,15 +268,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.4375rem 0.76563rem;
+  padding: 0.4375rem 0.7656rem;
   background: var(--overlay-background);
   border-radius: 6px;
 
   .folder-count {
     display: flex;
     align-items: center;
-    gap: 0.32813rem;
-    font-size: 0.74375rem;
+    gap: 0.3281rem;
+    font-size: 0.7438rem;
     font-weight: 600;
     color: var(--text-color);
 
@@ -286,7 +286,7 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.4375rem 0.54688rem;
+    padding: 0.4375rem 0.5469rem;
 
     .folder-count {
       font-size: 0.7rem;
@@ -297,10 +297,10 @@
 .directories-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.54688rem;
+  gap: 0.5469rem;
   overflow: hidden auto;
   flex: 1;
-  padding-right: 0.21875rem;
+  padding-right: 0.2188rem;
   min-height: 0;
   opacity: 1;
   transition: opacity 0.3s ease-in-out;
@@ -331,7 +331,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -416,7 +416,7 @@
       flex: 1;
       display: flex;
       flex-direction: column;
-      gap: 0.16406rem;
+      gap: 0.1641rem;
       min-width: 0;
       overflow: hidden;
 
@@ -452,11 +452,11 @@
   }
 
   @media (width <= 480px) {
-    padding: 0.4375rem 0.54688rem;
-    gap: 0.32813rem;
+    padding: 0.4375rem 0.5469rem;
+    gap: 0.3281rem;
 
     .directory-label {
-      gap: 0.32813rem;
+      gap: 0.3281rem;
 
       .directory-icon-wrapper {
         width: 26px;
@@ -493,7 +493,7 @@
 }
 
 .selection-note {
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
   color: var(--text-secondary-color);
 }
 

--- a/frontend/src/app/shared/components/file-mover/file-mover-component.scss
+++ b/frontend/src/app/shared/components/file-mover/file-mover-component.scss
@@ -26,8 +26,8 @@
   flex-direction: column;
   overflow-y: auto;
   min-height: 0;
-  padding: 1.09375rem;
-  gap: 1.09375rem;
+  padding: 1.0938rem;
+  gap: 1.0938rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -50,8 +50,8 @@
 .banner-main {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 0.76563rem 0.875rem;
+  gap: 0.6563rem;
+  padding: 0.7656rem 0.875rem;
 }
 
 .banner-icon {
@@ -75,7 +75,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.32813rem 0.875rem;
+  gap: 0.3281rem 0.875rem;
   min-width: 0;
 }
 
@@ -92,7 +92,7 @@
 .banner-warning {
   display: inline-flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   font-size: 0.7rem;
   font-weight: 500;
   color: var(--p-orange-400);
@@ -105,8 +105,8 @@
 .banner-toggle {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.35rem 0.65625rem;
+  gap: 0.3281rem;
+  padding: 0.35rem 0.6563rem;
   background: transparent;
   border: 1px solid var(--p-blue-400);
   border-radius: 5px;
@@ -129,8 +129,8 @@
 .banner-details {
   display: flex;
   flex-direction: column;
-  gap: 0.54688rem;
-  padding: 0.76563rem 0.875rem;
+  gap: 0.5469rem;
+  padding: 0.7656rem 0.875rem;
   border-top: 1px solid var(--border-color);
 }
 
@@ -138,13 +138,13 @@
   display: flex;
   align-items: flex-start;
   gap: 0.4375rem;
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   line-height: 1.4;
   color: var(--text-secondary-color);
 
   i {
-    font-size: 0.74375rem;
-    margin-top: 0.10938rem;
+    font-size: 0.7438rem;
+    margin-top: 0.1094rem;
     color: var(--p-green-400);
     flex-shrink: 0;
   }
@@ -174,7 +174,7 @@
 .patterns-section {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .patterns-toggle {
@@ -182,7 +182,7 @@
   align-items: center;
   gap: 0.4375rem;
   width: fit-content;
-  padding: 0.4375rem 0.65625rem;
+  padding: 0.4375rem 0.6563rem;
   background: transparent;
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -197,7 +197,7 @@
     display: flex;
     align-items: center;
     gap: 0.4375rem;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     font-weight: 500;
     color: var(--text-color);
 
@@ -212,7 +212,7 @@
     justify-content: center;
     min-width: 20px;
     height: 20px;
-    padding: 0 0.32813rem;
+    padding: 0 0.3281rem;
     background: var(--primary-color);
     color: var(--primary-contrast-color);
     border-radius: 10px;
@@ -235,8 +235,8 @@
 .pattern-card {
   display: flex;
   flex-direction: column;
-  gap: 0.32813rem;
-  padding: 0.65625rem;
+  gap: 0.3281rem;
+  padding: 0.6563rem;
   border: 1px solid var(--border-color);
   border-radius: 6px;
 }
@@ -256,11 +256,11 @@
 .pattern-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.10938rem 0.4375rem;
+  padding: 0.1094rem 0.4375rem;
   background: var(--p-blue-500);
   color: white;
   border-radius: 10px;
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   font-weight: 600;
 }
 
@@ -269,7 +269,7 @@
   font-size: 0.7rem;
   color: var(--primary-color);
   background: var(--ground-background);
-  padding: 0.32813rem 0.4375rem;
+  padding: 0.3281rem 0.4375rem;
   border-radius: 4px;
   border: 1px solid var(--border-color);
 }
@@ -291,8 +291,8 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  margin-bottom: 0.65625rem;
-  font-size: 0.74375rem;
+  margin-bottom: 0.6563rem;
+  font-size: 0.7438rem;
   font-weight: 500;
   color: var(--text-color);
 
@@ -304,7 +304,7 @@
 .bulk-controls {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   flex-wrap: wrap;
 }
 
@@ -329,10 +329,10 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   background: var(--overlay-background);
   border-bottom: 1px solid var(--border-color);
-  font-size: 0.74375rem;
+  font-size: 0.7438rem;
   font-weight: 500;
   color: var(--text-color);
 
@@ -360,7 +360,7 @@
 
 :host ::ng-deep {
   .p-datatable-tbody > tr > td {
-    padding: 0.4375rem 0.65625rem !important;
+    padding: 0.4375rem 0.6563rem !important;
   }
 
   .p-datatable-thead > tr > th:first-child,
@@ -499,7 +499,7 @@
 
   .dialog-footer {
     flex-direction: column;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
 
     .footer-actions {
       width: 100%;

--- a/frontend/src/app/shared/components/file-mover/file-mover-component.scss
+++ b/frontend/src/app/shared/components/file-mover/file-mover-component.scss
@@ -26,8 +26,8 @@
   flex-direction: column;
   overflow-y: auto;
   min-height: 0;
-  padding: 1.25rem;
-  gap: 1.25rem;
+  padding: 1.09375rem;
+  gap: 1.09375rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -50,8 +50,8 @@
 .banner-main {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.875rem 1rem;
+  gap: 0.65625rem;
+  padding: 0.76563rem 0.875rem;
 }
 
 .banner-icon {
@@ -65,7 +65,7 @@
   flex-shrink: 0;
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     color: var(--primary-contrast-color);
   }
 }
@@ -75,12 +75,12 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.375rem 1rem;
+  gap: 0.32813rem 0.875rem;
   min-width: 0;
 }
 
 .banner-text {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--text-secondary-color);
   line-height: 1.4;
 
@@ -92,26 +92,26 @@
 .banner-warning {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.8rem;
+  gap: 0.32813rem;
+  font-size: 0.7rem;
   font-weight: 500;
   color: var(--p-orange-400);
 
   i {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
   }
 }
 
 .banner-toggle {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.4rem 0.75rem;
+  gap: 0.32813rem;
+  padding: 0.35rem 0.65625rem;
   background: transparent;
   border: 1px solid var(--p-blue-400);
   border-radius: 5px;
   color: var(--p-blue-400);
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   cursor: pointer;
   transition: all 0.2s ease;
   flex-shrink: 0;
@@ -122,29 +122,29 @@
   }
 
   i {
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
   }
 }
 
 .banner-details {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
-  padding: 0.875rem 1rem;
+  gap: 0.54688rem;
+  padding: 0.76563rem 0.875rem;
   border-top: 1px solid var(--border-color);
 }
 
 .detail-item {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  font-size: 0.85rem;
+  gap: 0.4375rem;
+  font-size: 0.74375rem;
   line-height: 1.4;
   color: var(--text-secondary-color);
 
   i {
-    font-size: 0.85rem;
-    margin-top: 0.125rem;
+    font-size: 0.74375rem;
+    margin-top: 0.10938rem;
     color: var(--p-green-400);
     flex-shrink: 0;
   }
@@ -174,15 +174,15 @@
 .patterns-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .patterns-toggle {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   width: fit-content;
-  padding: 0.5rem 0.75rem;
+  padding: 0.4375rem 0.65625rem;
   background: transparent;
   border: 1px solid var(--border-color);
   border-radius: 6px;
@@ -196,8 +196,8 @@
   .toggle-content {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 0.85rem;
+    gap: 0.4375rem;
+    font-size: 0.74375rem;
     font-weight: 500;
     color: var(--text-color);
 
@@ -212,16 +212,16 @@
     justify-content: center;
     min-width: 20px;
     height: 20px;
-    padding: 0 0.375rem;
+    padding: 0 0.32813rem;
     background: var(--primary-color);
     color: var(--primary-contrast-color);
     border-radius: 10px;
-    font-size: 0.7rem;
+    font-size: 0.6125rem;
     font-weight: 600;
   }
 
   > i {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--text-secondary-color);
   }
 }
@@ -229,14 +229,14 @@
 .patterns-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .pattern-card {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
-  padding: 0.75rem;
+  gap: 0.32813rem;
+  padding: 0.65625rem;
   border: 1px solid var(--border-color);
   border-radius: 6px;
 }
@@ -248,7 +248,7 @@
 }
 
 .pattern-library {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   font-weight: 600;
   color: var(--text-color);
 }
@@ -256,26 +256,26 @@
 .pattern-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.125rem 0.5rem;
+  padding: 0.10938rem 0.4375rem;
   background: var(--p-blue-500);
   color: white;
   border-radius: 10px;
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   font-weight: 600;
 }
 
 .pattern-code {
   font-family: 'SF Mono', 'Fira Code', monospace;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--primary-color);
   background: var(--ground-background);
-  padding: 0.375rem 0.5rem;
+  padding: 0.32813rem 0.4375rem;
   border-radius: 4px;
   border: 1px solid var(--border-color);
 }
 
 .pattern-source {
-  font-size: 0.7rem;
+  font-size: 0.6125rem;
   color: var(--text-secondary-color);
 }
 
@@ -284,15 +284,15 @@
   background: var(--ground-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .bulk-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
-  font-size: 0.85rem;
+  gap: 0.4375rem;
+  margin-bottom: 0.65625rem;
+  font-size: 0.74375rem;
   font-weight: 500;
   color: var(--text-color);
 
@@ -304,12 +304,12 @@
 .bulk-controls {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   flex-wrap: wrap;
 }
 
 .bulk-label {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--text-secondary-color);
 }
 
@@ -328,11 +328,11 @@
 .table-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem 0.875rem;
   background: var(--overlay-background);
   border-bottom: 1px solid var(--border-color);
-  font-size: 0.85rem;
+  font-size: 0.74375rem;
   font-weight: 500;
   color: var(--text-color);
 
@@ -360,12 +360,12 @@
 
 :host ::ng-deep {
   .p-datatable-tbody > tr > td {
-    padding: 0.5rem 0.75rem !important;
+    padding: 0.4375rem 0.65625rem !important;
   }
 
   .p-datatable-thead > tr > th:first-child,
   .p-datatable-tbody > tr > td.status-cell {
-    padding-left: 1.5rem !important;
+    padding-left: 1.3125rem !important;
   }
 
   .select-library {
@@ -383,7 +383,7 @@
 
 .id-cell {
   font-family: monospace;
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--text-secondary-color);
 }
 
@@ -391,7 +391,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
 }
 
 .path-library {
@@ -403,7 +403,7 @@
 }
 
 .no-paths {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--p-red-400);
   font-style: italic;
 }
@@ -412,7 +412,7 @@
   text-align: center;
 
   i {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     color: var(--primary-color);
   }
 }
@@ -423,12 +423,12 @@
 
 .status-success {
   color: var(--p-green-500);
-  font-size: 1rem;
+  font-size: var(--app-text-base);
 }
 
 .status-pending {
   color: var(--p-orange-400);
-  font-size: 1rem;
+  font-size: var(--app-text-base);
 }
 
 .row-moved {
@@ -439,13 +439,13 @@
 .success-indicator {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   color: var(--p-green-500);
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
 
   i {
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
     animation: pulse 2s infinite;
   }
 }
@@ -453,7 +453,7 @@
 .footer-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 @keyframes pulse {
@@ -469,13 +469,13 @@
 // Responsive
 @media (width <= 768px) {
   .dialog-content {
-    padding: 1rem;
-    gap: 1rem;
+    padding: 0.875rem;
+    gap: 0.875rem;
   }
 
   .banner-main {
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.4375rem;
   }
 
   .banner-content {
@@ -499,7 +499,7 @@
 
   .dialog-footer {
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65625rem;
 
     .footer-actions {
       width: 100%;

--- a/frontend/src/app/shared/components/icon-picker/icon-picker-component.scss
+++ b/frontend/src/app/shared/components/icon-picker/icon-picker-component.scss
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.09375rem 1.3125rem;
+  padding: 1.0938rem 1.3125rem;
   background: var(--color-page);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
@@ -21,7 +21,7 @@
   .header-content {
     display: flex;
     align-items: center;
-    gap: 0.76563rem;
+    gap: 0.7656rem;
   }
 
   .header-icon {
@@ -34,7 +34,7 @@
     border-radius: 10px;
 
     i {
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       color: var(--color-primary-contrast);
     }
   }
@@ -42,13 +42,13 @@
   .header-text {
     h1 {
       margin: 0;
-      font-size: 1.09375rem;
+      font-size: 1.0938rem;
       font-weight: 600;
       color: var(--color-text);
     }
 
     p {
-      margin: 0.10938rem 0 0;
+      margin: 0.1094rem 0 0;
       font-size: var(--app-text-sm);
       color: var(--color-text-secondary);
     }
@@ -80,7 +80,7 @@
       display: flex;
       align-items: center;
       gap: 0.4375rem;
-      padding: 0.76563rem 0.875rem;
+      padding: 0.7656rem 0.875rem;
       font-size: var(--app-text-sm);
       font-weight: 500;
 
@@ -107,9 +107,9 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 1.09375rem 1.3125rem;
+  padding: 1.0938rem 1.3125rem;
   overflow-y: auto;
-  gap: 1.09375rem;
+  gap: 1.0938rem;
 
   &::-webkit-scrollbar {
     width: 6px;
@@ -136,7 +136,7 @@
 
   .search-icon {
     position: absolute;
-    left: 0.76563rem;
+    left: 0.7656rem;
     top: 50%;
     transform: translateY(-50%);
     font-size: 0.7875rem;
@@ -147,7 +147,7 @@
 
   .search-input {
     width: 100%;
-    padding: 0.65625rem 0.875rem 0.65625rem 2.1875rem;
+    padding: 0.6563rem 0.875rem 0.6563rem 2.1875rem;
   }
 }
 
@@ -173,7 +173,7 @@
   transition: all 0.15s ease;
 
   > i {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
     color: var(--color-text);
     transition: color 0.15s ease;
   }
@@ -219,7 +219,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   padding: 2.625rem;
   color: var(--color-text-secondary);
   font-size: 0.7875rem;
@@ -245,8 +245,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.54688rem;
-  padding: 0.76563rem 1.09375rem;
+  gap: 0.5469rem;
+  padding: 0.7656rem 1.0938rem;
   background: var(--color-page);
   border: 2px dashed var(--color-border);
   border-radius: 8px;
@@ -271,14 +271,14 @@
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  padding: 1.09375rem;
+  padding: 1.0938rem;
 
   .section-header {
     display: flex;
     align-items: center;
     gap: 0.4375rem;
     margin-bottom: 0.875rem;
-    font-size: 0.74375rem;
+    font-size: 0.7438rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
@@ -295,7 +295,7 @@
       justify-content: center;
       min-width: 20px;
       height: 20px;
-      padding: 0 0.32813rem;
+      padding: 0 0.3281rem;
       background: var(--color-primary);
       color: var(--color-primary-contrast);
       border-radius: 10px;
@@ -333,12 +333,12 @@
 
   .input-full {
     width: 100%;
-    padding: 0.65625rem 0.875rem;
+    padding: 0.6563rem 0.875rem;
   }
 
   .code-textarea {
     width: 100%;
-    padding: 0.65625rem 0.875rem;
+    padding: 0.6563rem 0.875rem;
     font-family: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', monospace;
     font-size: var(--app-text-sm);
     resize: vertical;
@@ -354,7 +354,7 @@
   overflow: hidden;
 
   .preview-label {
-    padding: 0.4375rem 0.65625rem;
+    padding: 0.4375rem 0.6563rem;
     font-size: var(--app-text-xs);
     font-weight: 600;
     text-transform: uppercase;
@@ -385,7 +385,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   background: rgb(239 68 68 / 10%);
   border: 1px solid rgb(239 68 68 / 20%);
   border-radius: 6px;
@@ -411,10 +411,10 @@
 .queue-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   max-height: 280px;
   overflow-y: auto;
-  padding: 0.21875rem;
+  padding: 0.2188rem;
 }
 
 .queue-item {
@@ -436,7 +436,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.4375rem 0.54688rem;
+    padding: 0.4375rem 0.5469rem;
     background: var(--color-page);
     border-bottom: 1px solid var(--color-border);
   }
@@ -469,7 +469,7 @@
     }
 
     i {
-      font-size: 0.54688rem;
+      font-size: 0.5469rem;
     }
   }
 
@@ -477,7 +477,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.65625rem;
+    padding: 0.6563rem;
     min-height: 60px;
 
     ::ng-deep svg {
@@ -489,8 +489,8 @@
   }
 
   .queue-item-error {
-    padding: 0.4375rem 0.54688rem;
-    font-size: 0.60156rem;
+    padding: 0.4375rem 0.5469rem;
+    font-size: 0.6016rem;
     color: var(--p-red-400);
     background: rgb(239 68 68 / 8%);
     border-top: 1px solid rgb(239 68 68 / 15%);
@@ -527,7 +527,7 @@
 
   .icon-grid {
     grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
-    gap: 0.32813rem;
+    gap: 0.3281rem;
   }
 
   .icon-item {

--- a/frontend/src/app/shared/components/icon-picker/icon-picker-component.scss
+++ b/frontend/src/app/shared/components/icon-picker/icon-picker-component.scss
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.25rem 1.5rem;
+  padding: 1.09375rem 1.3125rem;
   background: var(--color-page);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
@@ -21,7 +21,7 @@
   .header-content {
     display: flex;
     align-items: center;
-    gap: 0.875rem;
+    gap: 0.76563rem;
   }
 
   .header-icon {
@@ -34,7 +34,7 @@
     border-radius: 10px;
 
     i {
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       color: var(--color-primary-contrast);
     }
   }
@@ -42,14 +42,14 @@
   .header-text {
     h1 {
       margin: 0;
-      font-size: 1.25rem;
+      font-size: 1.09375rem;
       font-weight: 600;
       color: var(--color-text);
     }
 
     p {
-      margin: 0.125rem 0 0;
-      font-size: 0.875rem;
+      margin: 0.10938rem 0 0;
+      font-size: var(--app-text-sm);
       color: var(--color-text-secondary);
     }
   }
@@ -73,19 +73,19 @@
     .p-tablist {
       background: var(--color-page);
       border-bottom: 1px solid var(--color-border);
-      padding: 0 1rem;
+      padding: 0 0.875rem;
     }
 
     .p-tab {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.875rem 1rem;
-      font-size: 0.875rem;
+      gap: 0.4375rem;
+      padding: 0.76563rem 0.875rem;
+      font-size: var(--app-text-sm);
       font-weight: 500;
 
       i {
-        font-size: 0.9rem;
+        font-size: 0.7875rem;
       }
     }
 
@@ -107,9 +107,9 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 1.25rem 1.5rem;
+  padding: 1.09375rem 1.3125rem;
   overflow-y: auto;
-  gap: 1.25rem;
+  gap: 1.09375rem;
 
   &::-webkit-scrollbar {
     width: 6px;
@@ -136,10 +136,10 @@
 
   .search-icon {
     position: absolute;
-    left: 0.875rem;
+    left: 0.76563rem;
     top: 50%;
     transform: translateY(-50%);
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
     color: var(--color-text-secondary);
     pointer-events: none;
     z-index: 1;
@@ -147,7 +147,7 @@
 
   .search-input {
     width: 100%;
-    padding: 0.75rem 1rem 0.75rem 2.5rem;
+    padding: 0.65625rem 0.875rem 0.65625rem 2.1875rem;
   }
 }
 
@@ -155,7 +155,7 @@
 .icon-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex: 1;
   align-content: start;
 }
@@ -173,7 +173,7 @@
   transition: all 0.15s ease;
 
   > i {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
     color: var(--color-text);
     transition: color 0.15s ease;
   }
@@ -219,13 +219,13 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
-  padding: 3rem;
+  gap: 0.65625rem;
+  padding: 2.625rem;
   color: var(--color-text-secondary);
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
 
   i {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
   }
 }
 
@@ -237,7 +237,7 @@
 .trash-zone-container {
   position: sticky;
   bottom: 0;
-  padding-top: 1rem;
+  padding-top: 0.875rem;
   margin-top: auto;
 }
 
@@ -245,17 +245,17 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.625rem;
-  padding: 0.875rem 1.25rem;
+  gap: 0.54688rem;
+  padding: 0.76563rem 1.09375rem;
   background: var(--color-page);
   border: 2px dashed var(--color-border);
   border-radius: 8px;
   color: var(--color-text-secondary);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   transition: all 0.2s ease;
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
     color: var(--p-red-400);
   }
 
@@ -271,21 +271,21 @@
   background: var(--color-page);
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  padding: 1.25rem;
+  padding: 1.09375rem;
 
   .section-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-    font-size: 0.85rem;
+    gap: 0.4375rem;
+    margin-bottom: 0.875rem;
+    font-size: 0.74375rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
     color: var(--color-text-secondary);
 
     > i {
-      font-size: 0.9rem;
+      font-size: 0.7875rem;
       color: var(--color-primary);
     }
 
@@ -295,11 +295,11 @@
       justify-content: center;
       min-width: 20px;
       height: 20px;
-      padding: 0 0.375rem;
+      padding: 0 0.32813rem;
       background: var(--color-primary);
       color: var(--color-primary-contrast);
       border-radius: 10px;
-      font-size: 0.7rem;
+      font-size: 0.6125rem;
       font-weight: 600;
     }
 
@@ -309,7 +309,7 @@
   }
 
   &.queue-section {
-    margin-top: 1rem;
+    margin-top: 0.875rem;
   }
 }
 
@@ -317,30 +317,30 @@
 .form-fields {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   label {
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     font-weight: 500;
     color: var(--color-text);
   }
 
   .input-full {
     width: 100%;
-    padding: 0.75rem 1rem;
+    padding: 0.65625rem 0.875rem;
   }
 
   .code-textarea {
     width: 100%;
-    padding: 0.75rem 1rem;
+    padding: 0.65625rem 0.875rem;
     font-family: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', monospace;
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
     resize: vertical;
     line-height: 1.5;
   }
@@ -354,8 +354,8 @@
   overflow: hidden;
 
   .preview-label {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.75rem;
+    padding: 0.4375rem 0.65625rem;
+    font-size: var(--app-text-xs);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
@@ -368,7 +368,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1.5rem;
+    padding: 1.3125rem;
     min-height: 120px;
 
     ::ng-deep svg {
@@ -384,17 +384,17 @@
 .error-message {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  gap: 0.4375rem;
+  padding: 0.65625rem 0.875rem;
   background: rgb(239 68 68 / 10%);
   border: 1px solid rgb(239 68 68 / 20%);
   border-radius: 6px;
   color: var(--p-red-400);
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
 
   i {
-    font-size: 0.9rem;
+    font-size: 0.7875rem;
   }
 }
 
@@ -402,8 +402,8 @@
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  margin-top: 1rem;
-  padding-top: 1rem;
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
   border-top: 1px solid var(--color-border);
 }
 
@@ -411,10 +411,10 @@
 .queue-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65625rem;
   max-height: 280px;
   overflow-y: auto;
-  padding: 0.25rem;
+  padding: 0.21875rem;
 }
 
 .queue-item {
@@ -436,13 +436,13 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.5rem 0.625rem;
+    padding: 0.4375rem 0.54688rem;
     background: var(--color-page);
     border-bottom: 1px solid var(--color-border);
   }
 
   .queue-item-name {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
     font-weight: 600;
     color: var(--color-text);
     overflow: hidden;
@@ -469,7 +469,7 @@
     }
 
     i {
-      font-size: 0.625rem;
+      font-size: 0.54688rem;
     }
   }
 
@@ -477,7 +477,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.75rem;
+    padding: 0.65625rem;
     min-height: 60px;
 
     ::ng-deep svg {
@@ -489,8 +489,8 @@
   }
 
   .queue-item-error {
-    padding: 0.5rem 0.625rem;
-    font-size: 0.6875rem;
+    padding: 0.4375rem 0.54688rem;
+    font-size: 0.60156rem;
     color: var(--p-red-400);
     background: rgb(239 68 68 / 8%);
     border-top: 1px solid rgb(239 68 68 / 15%);
@@ -505,29 +505,29 @@
   }
 
   .dialog-header {
-    padding: 1rem;
+    padding: 0.875rem;
 
     .header-icon {
       width: 36px;
       height: 36px;
 
       i {
-        font-size: 1rem;
+        font-size: var(--app-text-base);
       }
     }
 
     .header-text h1 {
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
     }
   }
 
   .tab-content {
-    padding: 1rem;
+    padding: 0.875rem;
   }
 
   .icon-grid {
     grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
-    gap: 0.375rem;
+    gap: 0.32813rem;
   }
 
   .icon-item {

--- a/frontend/src/app/shared/components/library-import-progress-widget/library-import-progress-widget-component.html
+++ b/frontend/src/app/shared/components/library-import-progress-widget/library-import-progress-widget-component.html
@@ -1,11 +1,11 @@
 <ng-container *transloco="let t">
   @if (progressService.state(); as progress) {
     @if (progress.active) {
-    <div class="rounded-lg border border-[var(--primary-color)] bg-[var(--card-background)] p-4">
-      <div class="mb-2 flex items-center justify-between gap-3">
-        <div class="flex min-w-0 items-center gap-2 text-[var(--primary-color)]">
+    <div class="rounded-lg border border-[var(--primary-color)] bg-[var(--card-background)] p-3.5">
+      <div class="mb-1.5 flex items-center justify-between gap-2.5">
+        <div class="flex min-w-0 items-center gap-1.5 text-[var(--primary-color)]">
           <i class="pi pi-book" aria-hidden="true"></i>
-          <p class="m-0 text-sm font-semibold">{{ t('libraryCreator.loading.title') }}</p>
+          <p class="m-0 text-xs font-semibold">{{ t('libraryCreator.loading.title') }}</p>
         </div>
         <p-tag
           [value]="t(getStatusLabelKey(progress.status))"
@@ -13,7 +13,7 @@
         </p-tag>
       </div>
 
-      <div class="mb-2 break-words text-base text-zinc-200">
+      <div class="mb-1.5 break-words text-sm text-zinc-200">
         @if (progress.status === 'COMPLETED') {
           {{ t('libraryCreator.loading.complete') }}
         } @else if (progress.status === 'ERROR') {
@@ -23,7 +23,7 @@
         }
       </div>
 
-      <div class="mb-2 text-sm text-zinc-300 tabular-nums">
+      <div class="mb-1.5 text-xs text-zinc-300 tabular-nums">
         <span [innerHTML]="t('shared.metadataProgress.bookProgress', { current: getCurrentCount(progress), total: progress.expectedCount })"></span>
       </div>
 
@@ -34,7 +34,7 @@
       </p-progressBar>
 
       @if (progress.status !== 'IN_PROGRESS') {
-        <div class="mt-4 flex flex-wrap justify-end gap-2">
+        <div class="mt-3.5 flex flex-wrap justify-end gap-1.5">
           @if (progress.libraryId !== undefined) {
             <button
               pButton

--- a/frontend/src/app/shared/components/live-notification-box/live-notification-box.component.scss
+++ b/frontend/src/app/shared/components/live-notification-box/live-notification-box.component.scss
@@ -1,21 +1,21 @@
 .live-border {
   background: var(--color-card);
   border: 1px solid var(--color-primary);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
 }
 
 .notification-container {
   display: flex;
   flex-direction: column;
-  padding: 1rem;
-  gap: 0.5rem;
+  padding: 0.875rem;
+  gap: 0.4375rem;
 }
 
 .notification-header {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .tag-centered {
@@ -23,7 +23,7 @@
 }
 
 .notification-timestamp {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
   color: var(--color-text-secondary);
   align-self: center;
 }

--- a/frontend/src/app/shared/components/login/login.component.html
+++ b/frontend/src/app/shared/components/login/login.component.html
@@ -26,13 +26,13 @@
           </div>
 
           @if (infoMessage) {
-            <div class="info-message" style="margin-bottom: 1rem;">
+            <div class="info-message" style="margin-bottom: 0.875rem;">
               <p-message severity="info">{{ infoMessage }}</p-message>
             </div>
           }
 
           @if (errorMessage) {
-            <div class="error-message" style="margin-bottom: 1rem;">
+            <div class="error-message" style="margin-bottom: 0.875rem;">
               <p-message severity="error">{{ errorMessage }}</p-message>
             </div>
           }

--- a/frontend/src/app/shared/components/login/login.component.scss
+++ b/frontend/src/app/shared/components/login/login.component.scss
@@ -35,13 +35,13 @@
 .login-subtitle {
   @include auth.auth-subtitle;
 
-  font-size: 1rem;
+  font-size: var(--app-text-base);
 }
 
 .oidc-warning {
-  margin-bottom: 1.5rem;
-  padding: 1rem;
-  border-radius: 0.75rem;
+  margin-bottom: 1.3125rem;
+  padding: 0.875rem;
+  border-radius: 0.65625rem;
   background: rgb(245 158 11 / 10%);
   border: 1px solid rgb(245 158 11 / 30%);
   animation: fadeIn 0.3s ease-out;
@@ -50,24 +50,24 @@
 .warning-content {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65625rem;
 }
 
 .warning-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   color: #fbbf24;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
 
   i {
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }
 
 .warning-message {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: #fcd34d;
   line-height: 1.5;
   margin: 0;
@@ -75,7 +75,7 @@
 
 .warning-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   justify-content: center;
 }
 
@@ -94,7 +94,7 @@
 .login-button {
   @include auth.auth-button;
 
-  margin-top: 0.5rem;
+  margin-top: 0.4375rem;
 }
 
 .error-message {
@@ -105,7 +105,7 @@
   display: flex;
   align-items: center;
   text-align: center;
-  margin: 1.5rem 0;
+  margin: 1.3125rem 0;
 
   &::before,
   &::after {
@@ -115,8 +115,8 @@
   }
 
   span {
-    padding: 0 1rem;
-    font-size: 0.875rem;
+    padding: 0 0.875rem;
+    font-size: var(--app-text-sm);
     color: rgb(255 255 255 / 50%);
     font-weight: 500;
   }
@@ -124,7 +124,7 @@
 
 .oidc-button {
   ::ng-deep button {
-    height: 2.75rem;
+    height: 2.40625rem;
     background: rgb(255 255 255 / 5%);
     border: 1px solid rgb(255 255 255 / 15%);
     color: rgb(255 255 255 / 90%);
@@ -140,13 +140,13 @@
 
 .help-text {
   text-align: center;
-  margin-top: 0.5rem;
+  margin-top: 0.4375rem;
 }
 
 .text-link {
   background: none;
   border: none;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: rgb(255 255 255 / 50%);
   text-decoration: underline;
   cursor: pointer;

--- a/frontend/src/app/shared/components/login/login.component.scss
+++ b/frontend/src/app/shared/components/login/login.component.scss
@@ -41,7 +41,7 @@
 .oidc-warning {
   margin-bottom: 1.3125rem;
   padding: 0.875rem;
-  border-radius: 0.65625rem;
+  border-radius: 0.6563rem;
   background: rgb(245 158 11 / 10%);
   border: 1px solid rgb(245 158 11 / 30%);
   animation: fadeIn 0.3s ease-out;
@@ -50,7 +50,7 @@
 .warning-content {
   display: flex;
   flex-direction: column;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
 }
 
 .warning-header {
@@ -75,7 +75,7 @@
 
 .warning-actions {
   display: flex;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   justify-content: center;
 }
 
@@ -124,7 +124,7 @@
 
 .oidc-button {
   ::ng-deep button {
-    height: 2.40625rem;
+    height: 2.4063rem;
     background: rgb(255 255 255 / 5%);
     border: 1px solid rgb(255 255 255 / 15%);
     color: rgb(255 255 255 / 90%);

--- a/frontend/src/app/shared/components/metadata-progress-widget/metadata-progress-widget-component.scss
+++ b/frontend/src/app/shared/components/metadata-progress-widget/metadata-progress-widget-component.scss
@@ -32,7 +32,7 @@
 .task-tags {
   display: flex;
   align-items: center;
-  gap: 0.21875rem;
+  gap: 0.2188rem;
 }
 
 :host ::ng-deep .task-tag {
@@ -66,7 +66,7 @@
 
 .review-button {
   text-align: right;
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
 }
 
 .review-indicator {

--- a/frontend/src/app/shared/components/metadata-progress-widget/metadata-progress-widget-component.scss
+++ b/frontend/src/app/shared/components/metadata-progress-widget/metadata-progress-widget-component.scss
@@ -1,29 +1,29 @@
 .task-border {
-  margin-top: 1rem;
+  margin-top: 0.875rem;
   background: var(--color-card);
   border: 1px solid var(--color-primary);
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
 }
 
 .task-card {
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .task-header-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 }
 
 .task-title-group {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .task-title {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   font-weight: 600;
   color: var(--color-primary);
   margin: 0;
@@ -32,45 +32,45 @@
 .task-tags {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.21875rem;
 }
 
 :host ::ng-deep .task-tag {
-  font-size: 0.75rem;
+  font-size: var(--app-text-xs);
 }
 
 .task-header {
   display: flex;
   justify-content: flex-end;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 }
 
 .task-message {
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   color: var(--color-text);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 }
 
 .task-progress-info {
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 }
 
 .action-buttons {
-  margin-top: 1rem;
+  margin-top: 0.875rem;
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .review-button {
   text-align: right;
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
 }
 
 .review-indicator {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }

--- a/frontend/src/app/shared/components/rating/rating.component.scss
+++ b/frontend/src/app/shared/components/rating/rating.component.scss
@@ -5,7 +5,7 @@
 
   --app-rating-color: var(--p-rating-icon-active-color, var(--p-primary-color));
   --app-rating-empty-color: var(--p-rating-icon-color, var(--p-text-muted-color));
-  --app-rating-gap: var(--p-rating-gap, 0.25rem);
+  --app-rating-gap: var(--p-rating-gap, 0.21875rem);
   --app-rating-size: 18px;
 }
 

--- a/frontend/src/app/shared/components/rating/rating.component.scss
+++ b/frontend/src/app/shared/components/rating/rating.component.scss
@@ -5,7 +5,7 @@
 
   --app-rating-color: var(--p-rating-icon-active-color, var(--p-primary-color));
   --app-rating-empty-color: var(--p-rating-icon-color, var(--p-text-muted-color));
-  --app-rating-gap: var(--p-rating-gap, 0.21875rem);
+  --app-rating-gap: var(--p-rating-gap, 0.2188rem);
   --app-rating-size: 18px;
 }
 

--- a/frontend/src/app/shared/components/tag/tag.component.scss
+++ b/frontend/src/app/shared/components/tag/tag.component.scss
@@ -2,107 +2,107 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.375rem;
-  padding: 0.1875rem 0.4375rem;
-  font-size: 0.875rem;
+  gap: 0.32813rem;
+  padding: 0.16406rem 0.38281rem;
+  font-size: var(--app-text-sm);
   font-weight: 500;
-  line-height: 1.25rem;
-  border-radius: 0.375rem;
+  line-height: 1.09375rem;
+  border-radius: 0.32813rem;
   white-space: nowrap;
 
   &-5xs {
-    padding: 0.0938rem 0.3125rem;
-    font-size: 0.625rem;
-    line-height: 0.875rem;
-    gap: 0.25rem;
+    padding: 0.08207rem 0.27344rem;
+    font-size: 0.54688rem;
+    line-height: 0.76563rem;
+    gap: 0.21875rem;
   }
 
   &-4xs {
-    padding: 0.1094rem 0.3281rem;
-    font-size: 0.6875rem;
-    line-height: 0.9375rem;
-    gap: 0.2813rem;
+    padding: 0.09573rem 0.28709rem;
+    font-size: 0.60156rem;
+    line-height: 0.82031rem;
+    gap: 0.24614rem;
   }
 
   &-3xs {
-    padding: 0.125rem 0.375rem;
-    font-size: 0.75rem;
-    line-height: 1rem;
-    gap: 0.3125rem;
+    padding: 0.10938rem 0.32813rem;
+    font-size: var(--app-text-xs);
+    line-height: 0.875rem;
+    gap: 0.27344rem;
   }
 
   &-2xs {
-    padding: 0.1406rem 0.3906rem;
-    font-size: 0.7813rem;
-    line-height: 1.0625rem;
-    gap: 0.3281rem;
+    padding: 0.12302rem 0.34177rem;
+    font-size: 0.68364rem;
+    line-height: 0.92969rem;
+    gap: 0.28709rem;
   }
 
   &-xs {
-    padding: 0.1563rem 0.4063rem;
-    font-size: 0.8125rem;
-    line-height: 1.125rem;
-    gap: 0.3438rem;
+    padding: 0.13676rem 0.35551rem;
+    font-size: 0.71094rem;
+    line-height: 0.98438rem;
+    gap: 0.30083rem;
   }
 
   &-s {
-    padding: 0.1719rem 0.4219rem;
-    font-size: 0.8438rem;
-    line-height: 1.1875rem;
-    gap: 0.3594rem;
+    padding: 0.15041rem 0.36916rem;
+    font-size: 0.73833rem;
+    line-height: 1.03906rem;
+    gap: 0.31448rem;
   }
 
   &-m {
-    padding: 0.1875rem 0.4375rem;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    gap: 0.375rem;
+    padding: 0.16406rem 0.38281rem;
+    font-size: var(--app-text-sm);
+    line-height: 1.09375rem;
+    gap: 0.32813rem;
   }
 
   &-l {
-    padding: 0.2031rem 0.4531rem;
-    font-size: 0.9063rem;
-    line-height: 1.3125rem;
-    gap: 0.3906rem;
+    padding: 0.17771rem 0.39646rem;
+    font-size: 0.79301rem;
+    line-height: 1.14844rem;
+    gap: 0.34177rem;
   }
 
   &-xl {
-    padding: 0.2188rem 0.4688rem;
-    font-size: 0.9375rem;
-    line-height: 1.375rem;
-    gap: 0.4063rem;
+    padding: 0.19145rem 0.4102rem;
+    font-size: 0.82031rem;
+    line-height: 1.20313rem;
+    gap: 0.35551rem;
   }
 
   &-2xl {
-    padding: 0.2344rem 0.4844rem;
-    font-size: 0.9688rem;
-    line-height: 1.4375rem;
-    gap: 0.4219rem;
+    padding: 0.2051rem 0.42385rem;
+    font-size: 0.8477rem;
+    line-height: 1.25781rem;
+    gap: 0.36916rem;
   }
 
   &-3xl {
-    padding: 0.25rem 0.5rem;
-    font-size: 1rem;
-    line-height: 1.5rem;
-    gap: 0.4375rem;
+    padding: 0.21875rem 0.4375rem;
+    font-size: var(--app-text-base);
+    line-height: 1.3125rem;
+    gap: 0.38281rem;
   }
 
   &-4xl {
-    padding: 0.2813rem 0.5313rem;
-    font-size: 1.0625rem;
-    line-height: 1.5625rem;
-    gap: 0.4688rem;
+    padding: 0.24614rem 0.46489rem;
+    font-size: 0.92969rem;
+    line-height: 1.36719rem;
+    gap: 0.4102rem;
   }
 
   &-5xl {
-    padding: 0.3125rem 0.5625rem;
-    font-size: 1.125rem;
-    line-height: 1.625rem;
-    gap: 0.5rem;
+    padding: 0.27344rem 0.49219rem;
+    font-size: var(--app-text-lg);
+    line-height: 1.42188rem;
+    gap: 0.4375rem;
   }
 
   &-rounded {
-    border-radius: 0.5rem;
+    border-radius: 0.4375rem;
   }
 
   &-pill {
@@ -187,7 +187,7 @@
 
   &-variant-pill {
     border-radius: 9999px;
-    padding: 0.125rem 0.375rem;
+    padding: 0.10938rem 0.32813rem;
 
     &.app-tag-primary {
       background-color: var(--color-primary-600);

--- a/frontend/src/app/shared/components/tag/tag.component.scss
+++ b/frontend/src/app/shared/components/tag/tag.component.scss
@@ -2,102 +2,102 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.32813rem;
-  padding: 0.16406rem 0.38281rem;
+  gap: 0.3281rem;
+  padding: 0.1641rem 0.3828rem;
   font-size: var(--app-text-sm);
   font-weight: 500;
-  line-height: 1.09375rem;
-  border-radius: 0.32813rem;
+  line-height: 1.0938rem;
+  border-radius: 0.3281rem;
   white-space: nowrap;
 
   &-5xs {
-    padding: 0.08207rem 0.27344rem;
-    font-size: 0.54688rem;
-    line-height: 0.76563rem;
-    gap: 0.21875rem;
+    padding: 0.0821rem 0.2734rem;
+    font-size: 0.5469rem;
+    line-height: 0.7656rem;
+    gap: 0.2188rem;
   }
 
   &-4xs {
-    padding: 0.09573rem 0.28709rem;
-    font-size: 0.60156rem;
-    line-height: 0.82031rem;
-    gap: 0.24614rem;
+    padding: 0.0957rem 0.2871rem;
+    font-size: 0.6016rem;
+    line-height: 0.8203rem;
+    gap: 0.2461rem;
   }
 
   &-3xs {
-    padding: 0.10938rem 0.32813rem;
+    padding: 0.1094rem 0.3281rem;
     font-size: var(--app-text-xs);
     line-height: 0.875rem;
-    gap: 0.27344rem;
+    gap: 0.2734rem;
   }
 
   &-2xs {
-    padding: 0.12302rem 0.34177rem;
-    font-size: 0.68364rem;
-    line-height: 0.92969rem;
-    gap: 0.28709rem;
+    padding: 0.123rem 0.3418rem;
+    font-size: 0.6836rem;
+    line-height: 0.9297rem;
+    gap: 0.2871rem;
   }
 
   &-xs {
-    padding: 0.13676rem 0.35551rem;
-    font-size: 0.71094rem;
-    line-height: 0.98438rem;
-    gap: 0.30083rem;
+    padding: 0.1368rem 0.3555rem;
+    font-size: 0.7109rem;
+    line-height: 0.9844rem;
+    gap: 0.3008rem;
   }
 
   &-s {
-    padding: 0.15041rem 0.36916rem;
-    font-size: 0.73833rem;
-    line-height: 1.03906rem;
-    gap: 0.31448rem;
+    padding: 0.1504rem 0.3692rem;
+    font-size: 0.7383rem;
+    line-height: 1.0391rem;
+    gap: 0.3145rem;
   }
 
   &-m {
-    padding: 0.16406rem 0.38281rem;
+    padding: 0.1641rem 0.3828rem;
     font-size: var(--app-text-sm);
-    line-height: 1.09375rem;
-    gap: 0.32813rem;
+    line-height: 1.0938rem;
+    gap: 0.3281rem;
   }
 
   &-l {
-    padding: 0.17771rem 0.39646rem;
-    font-size: 0.79301rem;
-    line-height: 1.14844rem;
-    gap: 0.34177rem;
+    padding: 0.1777rem 0.3965rem;
+    font-size: 0.793rem;
+    line-height: 1.1484rem;
+    gap: 0.3418rem;
   }
 
   &-xl {
-    padding: 0.19145rem 0.4102rem;
-    font-size: 0.82031rem;
-    line-height: 1.20313rem;
-    gap: 0.35551rem;
+    padding: 0.1915rem 0.4102rem;
+    font-size: 0.8203rem;
+    line-height: 1.2031rem;
+    gap: 0.3555rem;
   }
 
   &-2xl {
-    padding: 0.2051rem 0.42385rem;
+    padding: 0.2051rem 0.4239rem;
     font-size: 0.8477rem;
-    line-height: 1.25781rem;
-    gap: 0.36916rem;
+    line-height: 1.2578rem;
+    gap: 0.3692rem;
   }
 
   &-3xl {
-    padding: 0.21875rem 0.4375rem;
+    padding: 0.2188rem 0.4375rem;
     font-size: var(--app-text-base);
     line-height: 1.3125rem;
-    gap: 0.38281rem;
+    gap: 0.3828rem;
   }
 
   &-4xl {
-    padding: 0.24614rem 0.46489rem;
-    font-size: 0.92969rem;
-    line-height: 1.36719rem;
+    padding: 0.2461rem 0.4649rem;
+    font-size: 0.9297rem;
+    line-height: 1.3672rem;
     gap: 0.4102rem;
   }
 
   &-5xl {
-    padding: 0.27344rem 0.49219rem;
+    padding: 0.2734rem 0.4922rem;
     font-size: var(--app-text-lg);
-    line-height: 1.42188rem;
+    line-height: 1.4219rem;
     gap: 0.4375rem;
   }
 
@@ -187,7 +187,7 @@
 
   &-variant-pill {
     border-radius: 9999px;
-    padding: 0.10938rem 0.32813rem;
+    padding: 0.1094rem 0.3281rem;
 
     &.app-tag-primary {
       background-color: var(--color-primary-600);

--- a/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.scss
+++ b/frontend/src/app/shared/components/unified-notification-popover/unified-notification-popover-component.scss
@@ -1,12 +1,12 @@
 .metadata-progress-box {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  width: 25rem;
+  gap: 0.875rem;
+  width: 21.875rem;
   max-width: 100%;
   max-height: 60vh;
   overflow-y: auto;
-  border-radius: 0.5rem;
+  border-radius: 0.4375rem;
 }
 
 ::ng-deep .p-divider-horizontal {
@@ -16,7 +16,7 @@
 
 @media (width <= 991px) {
   .metadata-progress-box {
-    width: min(25rem, calc(100vw - 1.5rem));
-    max-height: calc(100dvh - 1rem);
+    width: min(21.875rem, calc(100vw - 1.3125rem));
+    max-height: calc(100dvh - 0.875rem);
   }
 }

--- a/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.scss
+++ b/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.scss
@@ -11,19 +11,19 @@
   left: 0;
   right: 0;
   box-sizing: border-box;
-  height: 3.5rem;
+  height: 3.0625rem;
   z-index: 100;
   background-color: var(--color-app);
   color: var(--color-text);
   border-bottom: 1px solid var(--color-border);
   padding:
     0
-    calc(0.75rem + env(safe-area-inset-right))
+    calc(0.65625rem + env(safe-area-inset-right))
     0
-    calc(0.75rem + env(safe-area-inset-left));
+    calc(0.65625rem + env(safe-area-inset-left));
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .mobile-topbar-brand {
@@ -32,18 +32,18 @@
   justify-content: center;
   flex: 1 1 auto;
   min-width: 0;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .mobile-topbar-brand-icon {
   width: auto;
-  height: 1.75rem;
+  height: 1.53125rem;
   flex-shrink: 0;
   transform: translateY(1px);
 }
 
 .mobile-topbar-brand-text {
-  font-size: 1.25rem;
+  font-size: 1.09375rem;
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
@@ -57,8 +57,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.1875rem;
+  height: 2.1875rem;
   padding: 0;
   border: 0;
   background: none;
@@ -76,7 +76,7 @@
   }
 
   i {
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
   }
 }
 

--- a/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.scss
+++ b/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.scss
@@ -18,9 +18,9 @@
   border-bottom: 1px solid var(--color-border);
   padding:
     0
-    calc(0.65625rem + env(safe-area-inset-right))
+    calc(0.6563rem + env(safe-area-inset-right))
     0
-    calc(0.65625rem + env(safe-area-inset-left));
+    calc(0.6563rem + env(safe-area-inset-left));
   align-items: center;
   justify-content: space-between;
   gap: 0.4375rem;
@@ -37,13 +37,13 @@
 
 .mobile-topbar-brand-icon {
   width: auto;
-  height: 1.53125rem;
+  height: 1.5313rem;
   flex-shrink: 0;
   transform: translateY(1px);
 }
 
 .mobile-topbar-brand-text {
-  font-size: 1.09375rem;
+  font-size: 1.0938rem;
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
@@ -76,7 +76,7 @@
   }
 
   i {
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
   }
 }
 

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.scss
@@ -151,7 +151,7 @@ a.sidebar-item-link.active-route {
   align-items: center;
   justify-content: center;
   min-width: 1.75rem;
-  height: 1.64063rem;
+  height: 1.6406rem;
   padding: 0 var(--space-2);
   border: 0;
   border-radius: var(--radius-pill);
@@ -269,7 +269,7 @@ a.sidebar-item-link.active-route {
   }
 
   .entity-menu-button {
-    margin-right: -0.21875rem;
+    margin-right: -0.2188rem;
   }
 }
 

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.scss
@@ -95,7 +95,7 @@ a.sidebar-item-link.active-route {
 }
 
 .sidebar-item-chevron {
-  font-size: var(--text-sm);
+  font-size: var(--app-text-sm);
   color: var(--color-text-secondary);
   padding-right: var(--space-3);
   transition: color var(--transition-fast);
@@ -111,7 +111,7 @@ a.sidebar-item-link.active-route {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
 }
 
 .sidebar-item-label {
@@ -150,8 +150,8 @@ a.sidebar-item-link.active-route {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 2rem;
-  height: 1.875rem;
+  min-width: 1.75rem;
+  height: 1.64063rem;
   padding: 0 var(--space-2);
   border: 0;
   border-radius: var(--radius-pill);
@@ -159,7 +159,7 @@ a.sidebar-item-link.active-route {
   color: var(--color-text-secondary);
   cursor: pointer;
   font: inherit;
-  font-size: var(--text-sm);
+  font-size: var(--app-text-sm);
   transition: color var(--transition-base);
 }
 
@@ -198,7 +198,7 @@ a.sidebar-item-link.active-route {
 
 .book-count {
   color: var(--color-text-secondary);
-  font-size: var(--text-sm);
+  font-size: var(--app-text-sm);
   font-variant-numeric: tabular-nums;
 }
 
@@ -269,7 +269,7 @@ a.sidebar-item-link.active-route {
   }
 
   .entity-menu-button {
-    margin-right: -0.25rem;
+    margin-right: -0.21875rem;
   }
 }
 

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-section.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-section.component.scss
@@ -109,13 +109,13 @@
 @media #{variables.$mobile-shell-media-query} {
   .expand-icon-button {
     opacity: 1;
-    width: 2rem;
-    height: 2rem;
-    margin-right: -0.25rem;
+    width: 1.75rem;
+    height: 1.75rem;
+    margin-right: -0.21875rem;
   }
 
   .expand-icon {
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
     color: var(--color-text-secondary);
   }
 }

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-section.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-section.component.scss
@@ -111,7 +111,7 @@
     opacity: 1;
     width: 1.75rem;
     height: 1.75rem;
-    margin-right: -0.21875rem;
+    margin-right: -0.2188rem;
   }
 
   .expand-icon {

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.html
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.html
@@ -415,9 +415,9 @@
               >
                 <i class="pi pi-palette" aria-hidden="true"></i>
                 <span>{{ 'layout.theme.appearance' | transloco }}</span>
-                <span class="ml-auto mr-2 min-w-0 max-w-[5.5rem] overflow-hidden text-ellipsis whitespace-nowrap text-xs text-text-secondary">{{ selectedAppearanceLabel() }}</span>
+                <span class="ml-auto mr-1.5 min-w-0 max-w-[4.75rem] overflow-hidden text-ellipsis whitespace-nowrap text-xs text-text-secondary">{{ selectedAppearanceLabel() }}</span>
                 <i
-                  class="pi pi-chevron-down size-3 shrink-0 text-[0.6875rem] text-text-secondary! transition-transform duration-150"
+                  class="pi pi-chevron-down size-2.5 shrink-0 text-[0.6875rem] text-text-secondary! transition-transform duration-150"
                   [class.rotate-180]="appearanceMenuOpen()"
                   aria-hidden="true">
                 </i>
@@ -425,14 +425,14 @@
 
               <div
                 id="user-account-appearance-menu"
-                class="pointer-events-none grid origin-bottom grid-rows-[0fr] translate-y-1 opacity-0 transition-[grid-template-rows,opacity,transform] duration-150 ease-out data-[open=true]:pointer-events-auto data-[open=true]:mt-1 data-[open=true]:border-t data-[open=true]:border-border data-[open=true]:pt-1 data-[open=true]:grid-rows-[1fr] data-[open=true]:translate-y-0 data-[open=true]:opacity-100 motion-reduce:transition-none"
+                class="pointer-events-none grid origin-bottom grid-rows-[0fr] translate-y-0.5 opacity-0 transition-[grid-template-rows,opacity,transform] duration-150 ease-out data-[open=true]:pointer-events-auto data-[open=true]:mt-0.5 data-[open=true]:border-t data-[open=true]:border-border data-[open=true]:pt-0.5 data-[open=true]:grid-rows-[1fr] data-[open=true]:translate-y-0 data-[open=true]:opacity-100 motion-reduce:transition-none"
                 [attr.aria-label]="'layout.theme.appearance' | transloco"
                 [attr.aria-hidden]="!appearanceMenuOpen()"
                 [attr.data-open]="appearanceMenuOpen()"
                 [attr.inert]="appearanceMenuOpen() ? null : ''"
               >
                 <div class="min-h-0 overflow-hidden">
-                  <div class="flex flex-col gap-0.5 pb-1 pl-[calc(var(--control-icon-size)+var(--menu-item-gap))]">
+                  <div class="flex flex-col gap-0.5 pb-0.5 pl-[calc(var(--control-icon-size)+var(--menu-item-gap))]">
                     @for (option of appearanceOptions; track option.value) {
                       <button
                         type="button"

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.scss
@@ -24,7 +24,7 @@
   /* Shared rendered-height for both SVGs — derived from wordmark's width × aspect
      at default sidebar width. Keeps the wordmark and G-only mark the same pixel
      size so they visually align across the collapse/expand toggle. */
-  --brand-content-height: calc((225px - 2.5rem) * 350 / 2500);
+  --brand-content-height: calc((225px - 2.1875rem) * 350 / 2500);
   --sidebar-brand-optical-nudge: -1px;
 
   display: grid;
@@ -80,7 +80,7 @@
      expand animation. Width = min(default-sidebar-content, stored-content): fills
      exactly at default 225px, scales down when the user resizes narrower. Height
      is pinned alongside width so the wordmark and G-only icon are the same size. */
-  --wordmark-width: calc(min(225px, var(--sidebar-stored-width, 225px)) - 2.5rem);
+  --wordmark-width: calc(min(225px, var(--sidebar-stored-width, 225px)) - 2.1875rem);
 
   display: block;
   width: var(--wordmark-width);
@@ -144,7 +144,7 @@
   }
 
   i {
-    font-size: var(--text-base);
+    font-size: var(--app-text-base);
   }
 }
 
@@ -164,17 +164,17 @@
 
 .sidebar-notification-badge {
   position: absolute;
-  top: -0.3rem;
-  right: -0.35rem;
-  min-width: 1rem;
-  height: 1rem;
-  padding: 0 0.25rem;
+  top: -0.2625rem;
+  right: -0.30625rem;
+  min-width: 0.875rem;
+  height: 0.875rem;
+  padding: 0 0.21875rem;
   border-radius: var(--radius-pill);
   background: var(--color-primary);
   color: var(--color-primary-contrast);
-  font-size: 0.65rem;
+  font-size: 0.56875rem;
   font-weight: 700;
-  line-height: 1rem;
+  line-height: 0.875rem;
   text-align: center;
   pointer-events: none;
   z-index: 1;
@@ -220,7 +220,7 @@
   border-radius: var(--sidebar-row-radius);
   color: var(--color-text);
   font: inherit;
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
   text-align: left;
   text-decoration: none;
   cursor: pointer;
@@ -243,7 +243,7 @@
   i {
     width: var(--sidebar-row-icon-size);
     height: var(--sidebar-row-icon-size);
-    font-size: var(--text-base);
+    font-size: var(--app-text-base);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -269,8 +269,8 @@
   flex: 1 1 0;
   width: auto;
   min-width: 0;
-  height: calc(var(--sidebar-row-min-height) + 0.25rem);
-  min-height: calc(var(--sidebar-row-min-height) + 0.25rem);
+  height: calc(var(--sidebar-row-min-height) + 0.21875rem);
+  min-height: calc(var(--sidebar-row-min-height) + 0.21875rem);
   justify-content: center;
   padding-left: 0;
   padding-right: 0;
@@ -305,7 +305,7 @@
   margin-left: auto;
   color: var(--color-text-secondary);
   font-family: inherit;
-  font-size: var(--text-xs);
+  font-size: var(--app-text-xs);
   line-height: 1;
   white-space: nowrap;
   flex-shrink: 0;
@@ -318,8 +318,8 @@
   gap: var(--sidebar-row-gap);
   width: 100%;
   min-width: 0;
-  height: 2.75rem;
-  min-height: 2.75rem;
+  height: 2.40625rem;
+  min-height: 2.40625rem;
   padding: 0 var(--sidebar-row-padding-inline-end) 0 var(--sidebar-row-padding-inline-start);
   border: 0;
   background: none;
@@ -346,8 +346,8 @@
 }
 
 .sidebar-collapse-button {
-  width: 2.75rem;
-  height: 2.75rem;
+  width: 2.40625rem;
+  height: 2.40625rem;
   margin-left: auto;
 }
 
@@ -356,12 +356,12 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 1.53125rem;
+  height: 1.53125rem;
   border-radius: var(--radius-pill);
   background-color: color-mix(in srgb, var(--color-primary) 18%, transparent);
   color: var(--color-primary);
-  font-size: var(--text-xs);
+  font-size: var(--app-text-xs);
   font-weight: 600;
   letter-spacing: 0.02em;
   line-height: 1;
@@ -370,7 +370,7 @@
 
 /* Align the circle's center with the sidebar icon column (18px icons vs 28px avatar). */
 .sidebar-user-trigger .sidebar-user-avatar {
-  margin-left: calc((var(--sidebar-row-icon-size) - 1.75rem) / 2);
+  margin-left: calc((var(--sidebar-row-icon-size) - 1.53125rem) / 2);
 }
 
 .sidebar-user-meta {
@@ -382,7 +382,7 @@
 }
 
 .sidebar-user-name {
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
   font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -390,7 +390,7 @@
 }
 
 .sidebar-user-handle {
-  font-size: var(--text-xs);
+  font-size: var(--app-text-xs);
   color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -401,9 +401,9 @@
   .sidebar-header {
     box-sizing: border-box;
     align-items: center;
-    min-height: 3.5rem;
-    height: 3.5rem;
-    gap: 0.5rem;
+    min-height: 3.0625rem;
+    height: 3.0625rem;
+    gap: 0.4375rem;
     padding:
       0
       calc(var(--sidebar-shell-padding-inline-end) + env(safe-area-inset-right))
@@ -419,15 +419,15 @@
   .sidebar-brand {
     width: auto;
     flex: 1 1 auto;
-    min-height: 3.5rem;
+    min-height: 3.0625rem;
     padding: 0 var(--space-3);
     align-self: stretch;
   }
 
   .sidebar-icon-button.sidebar-mobile-close-button {
     display: inline-flex;
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 2.1875rem;
+    height: 2.1875rem;
     border-radius: var(--radius-pill);
     background-color: var(--color-card);
     color: var(--color-text);
@@ -471,9 +471,9 @@
   .sidebar-footer-action {
     container-type: inline-size;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.30625rem;
     height: auto;
-    min-height: 4.75rem;
+    min-height: 4.15625rem;
     padding: var(--space-2) var(--space-1);
     border-radius: var(--radius-lg);
     background-color: var(--color-card);
@@ -486,7 +486,7 @@
   .sidebar-footer-action .sidebar-footer-action-label {
     display: inline-flex;
     margin-left: 0;
-    font-size: var(--text-sm);
+    font-size: var(--app-text-sm);
     line-height: 1.15;
     white-space: normal;
     text-align: center;
@@ -497,12 +497,12 @@
 
   @container (width <= 6.25rem) {
     .sidebar-footer-action span {
-      font-size: var(--text-xs);
+      font-size: var(--app-text-xs);
     }
   }
 
   .sidebar-footer-action i {
-    font-size: 1.125rem;
+    font-size: var(--app-text-lg);
   }
 
   .sidebar-collapse-button {
@@ -511,9 +511,9 @@
 
   @media (orientation: landscape) {
     .sidebar-header {
-      gap: 0.5rem;
-      min-height: 4rem;
-      height: 4rem;
+      gap: 0.4375rem;
+      min-height: 3.5rem;
+      height: 3.5rem;
       padding:
         var(--space-2)
         var(--sidebar-shell-padding-inline-end)
@@ -529,7 +529,7 @@
     .sidebar-brand {
       flex: 0 0 auto;
       grid-template-columns: var(--sidebar-row-icon-size);
-      min-height: 4rem;
+      min-height: 3.5rem;
     }
 
     .sidebar-brand-mark {
@@ -553,8 +553,8 @@
     }
 
     .sidebar-icon-button.sidebar-mobile-close-button {
-      width: 3rem;
-      height: 3rem;
+      width: 2.625rem;
+      height: 2.625rem;
       background: none;
 
       &:hover {
@@ -564,8 +564,8 @@
 
     .sidebar-icon-button.sidebar-mobile-user-button {
       display: inline-flex;
-      width: 3rem;
-      height: 3rem;
+      width: 2.625rem;
+      height: 2.625rem;
       border-radius: var(--radius-pill);
       background: none;
 
@@ -578,17 +578,17 @@
       }
 
       .sidebar-user-avatar {
-        width: 2rem;
-        height: 2rem;
+        width: 1.75rem;
+        height: 1.75rem;
         margin-left: 0;
-        font-size: var(--text-sm);
+        font-size: var(--app-text-sm);
       }
     }
 
     .sidebar-icon-button.sidebar-mobile-landscape-action {
       display: inline-flex;
-      width: 3rem;
-      height: 3rem;
+      width: 2.625rem;
+      height: 2.625rem;
       border-radius: var(--radius-pill);
       background: none;
       color: var(--color-text);

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.scss
@@ -165,14 +165,14 @@
 .sidebar-notification-badge {
   position: absolute;
   top: -0.2625rem;
-  right: -0.30625rem;
+  right: -0.3063rem;
   min-width: 0.875rem;
   height: 0.875rem;
-  padding: 0 0.21875rem;
+  padding: 0 0.2188rem;
   border-radius: var(--radius-pill);
   background: var(--color-primary);
   color: var(--color-primary-contrast);
-  font-size: 0.56875rem;
+  font-size: 0.5687rem;
   font-weight: 700;
   line-height: 0.875rem;
   text-align: center;
@@ -269,8 +269,8 @@
   flex: 1 1 0;
   width: auto;
   min-width: 0;
-  height: calc(var(--sidebar-row-min-height) + 0.21875rem);
-  min-height: calc(var(--sidebar-row-min-height) + 0.21875rem);
+  height: calc(var(--sidebar-row-min-height) + 0.2188rem);
+  min-height: calc(var(--sidebar-row-min-height) + 0.2188rem);
   justify-content: center;
   padding-left: 0;
   padding-right: 0;
@@ -318,8 +318,8 @@
   gap: var(--sidebar-row-gap);
   width: 100%;
   min-width: 0;
-  height: 2.40625rem;
-  min-height: 2.40625rem;
+  height: 2.4063rem;
+  min-height: 2.4063rem;
   padding: 0 var(--sidebar-row-padding-inline-end) 0 var(--sidebar-row-padding-inline-start);
   border: 0;
   background: none;
@@ -346,8 +346,8 @@
 }
 
 .sidebar-collapse-button {
-  width: 2.40625rem;
-  height: 2.40625rem;
+  width: 2.4063rem;
+  height: 2.4063rem;
   margin-left: auto;
 }
 
@@ -356,8 +356,8 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 1.53125rem;
-  height: 1.53125rem;
+  width: 1.5313rem;
+  height: 1.5313rem;
   border-radius: var(--radius-pill);
   background-color: color-mix(in srgb, var(--color-primary) 18%, transparent);
   color: var(--color-primary);
@@ -370,7 +370,7 @@
 
 /* Align the circle's center with the sidebar icon column (18px icons vs 28px avatar). */
 .sidebar-user-trigger .sidebar-user-avatar {
-  margin-left: calc((var(--sidebar-row-icon-size) - 1.53125rem) / 2);
+  margin-left: calc((var(--sidebar-row-icon-size) - 1.5313rem) / 2);
 }
 
 .sidebar-user-meta {
@@ -471,9 +471,9 @@
   .sidebar-footer-action {
     container-type: inline-size;
     flex-direction: column;
-    gap: 0.30625rem;
+    gap: 0.3063rem;
     height: auto;
-    min-height: 4.15625rem;
+    min-height: 4.1563rem;
     padding: var(--space-2) var(--space-1);
     border-radius: var(--radius-lg);
     background-color: var(--color-card);

--- a/frontend/src/app/shared/layout/layout-sidebar/version-changelog-dialog/version-changelog-dialog.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/version-changelog-dialog/version-changelog-dialog.component.scss
@@ -11,7 +11,7 @@
 }
 
 .dialog-content {
-  padding: 1.5rem;
+  padding: 1.3125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -23,7 +23,7 @@
 
 .loading-state,
 .empty-state {
-  padding: 1rem;
+  padding: 0.875rem;
   text-align: center;
   color: var(--text-secondary-color);
 }
@@ -31,11 +31,11 @@
 .changelog-list {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
 }
 
 .release-item {
-  padding-bottom: 1rem;
+  padding-bottom: 0.875rem;
   border-bottom: 1px solid var(--border-color);
 
   &:last-child {
@@ -45,8 +45,8 @@
 
 .release-title {
   font-weight: 700;
-  font-size: 1.25rem;
-  padding-bottom: 0.5rem;
+  font-size: 1.09375rem;
+  padding-bottom: 0.4375rem;
   margin: 0;
 }
 
@@ -67,8 +67,8 @@
 
   :host ::ng-deep & {
     h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.5rem;
-      margin-bottom: 0.75rem;
+      margin-top: 1.3125rem;
+      margin-bottom: 0.65625rem;
       font-weight: 600;
       line-height: 1.25;
       color: var(--text-color);
@@ -80,38 +80,38 @@
 
     h3 {
       margin-top: 0;
-      font-size: 1.125rem;
+      font-size: var(--app-text-lg);
     }
 
     p {
-      margin-top: 0.75rem;
-      margin-bottom: 0.75rem;
+      margin-top: 0.65625rem;
+      margin-bottom: 0.65625rem;
     }
 
     ul, ol {
-      margin-top: 0.75rem;
-      margin-bottom: 0.75rem;
-      padding-left: 1.5rem;
+      margin-top: 0.65625rem;
+      margin-bottom: 0.65625rem;
+      padding-left: 1.3125rem;
     }
 
     li {
-      margin-top: 0.25rem;
-      margin-bottom: 0.25rem;
+      margin-top: 0.21875rem;
+      margin-bottom: 0.21875rem;
     }
 
     code {
       font-size: 0.875em;
       background: var(--ground-background);
-      padding: 0.125rem 0.375rem;
-      border-radius: 0.25rem;
+      padding: 0.10938rem 0.32813rem;
+      border-radius: 0.21875rem;
     }
 
     pre {
-      margin-top: 1rem;
-      margin-bottom: 1rem;
-      padding: 1rem;
+      margin-top: 0.875rem;
+      margin-bottom: 0.875rem;
+      padding: 0.875rem;
       background: var(--ground-background);
-      border-radius: 0.5rem;
+      border-radius: 0.4375rem;
       overflow-x: auto;
 
       code {
@@ -130,8 +130,8 @@
     }
 
     blockquote {
-      margin: 1rem 0;
-      padding-left: 1rem;
+      margin: 0.875rem 0;
+      padding-left: 0.875rem;
       border-left: 3px solid var(--border-color);
       color: var(--text-secondary-color);
     }

--- a/frontend/src/app/shared/layout/layout-sidebar/version-changelog-dialog/version-changelog-dialog.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/version-changelog-dialog/version-changelog-dialog.component.scss
@@ -45,7 +45,7 @@
 
 .release-title {
   font-weight: 700;
-  font-size: 1.09375rem;
+  font-size: 1.0938rem;
   padding-bottom: 0.4375rem;
   margin: 0;
 }
@@ -68,7 +68,7 @@
   :host ::ng-deep & {
     h1, h2, h3, h4, h5, h6 {
       margin-top: 1.3125rem;
-      margin-bottom: 0.65625rem;
+      margin-bottom: 0.6563rem;
       font-weight: 600;
       line-height: 1.25;
       color: var(--text-color);
@@ -84,26 +84,26 @@
     }
 
     p {
-      margin-top: 0.65625rem;
-      margin-bottom: 0.65625rem;
+      margin-top: 0.6563rem;
+      margin-bottom: 0.6563rem;
     }
 
     ul, ol {
-      margin-top: 0.65625rem;
-      margin-bottom: 0.65625rem;
+      margin-top: 0.6563rem;
+      margin-bottom: 0.6563rem;
       padding-left: 1.3125rem;
     }
 
     li {
-      margin-top: 0.21875rem;
-      margin-bottom: 0.21875rem;
+      margin-top: 0.2188rem;
+      margin-bottom: 0.2188rem;
     }
 
     code {
       font-size: 0.875em;
       background: var(--ground-background);
-      padding: 0.10938rem 0.32813rem;
-      border-radius: 0.21875rem;
+      padding: 0.1094rem 0.3281rem;
+      border-radius: 0.2188rem;
     }
 
     pre {

--- a/frontend/src/app/shared/layout/layout.service.spec.ts
+++ b/frontend/src/app/shared/layout/layout.service.spec.ts
@@ -117,13 +117,6 @@ describe('LayoutService', () => {
     expect(service.mobileDrawerOpen()).toBe(false);
   });
 
-  it('updates the document root font size when the scale changes', () => {
-    service.scale.set(18);
-    TestBed.flushEffects();
-
-    expect(document.documentElement.style.fontSize).toBe('18px');
-  });
-
   it('persists the collapsed state when toggled', () => {
     expect(service.sidebarCollapsed()).toBe(false);
 

--- a/frontend/src/app/shared/layout/layout.service.ts
+++ b/frontend/src/app/shared/layout/layout.service.ts
@@ -45,7 +45,6 @@ export class LayoutService {
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
 
-  readonly scale = signal(14);
   readonly currentPath = signal(this.router.url.split('?')[0]);
   readonly sidebarVisible = signal(true);
   readonly mobileDrawerOpen = signal(false);
@@ -67,10 +66,6 @@ export class LayoutService {
   private sidebarTransitionTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
   constructor() {
-    effect(() => {
-      this.changeScale(this.scale());
-    });
-
     effect(() => {
       const settings = this.userService?.currentUser()?.userSettings;
       this._librarySort.set(normalizeSortPref(settings?.sidebarLibrarySorting, DEFAULT_LIBRARY_SORT));
@@ -185,10 +180,6 @@ export class LayoutService {
       this._sidebarTransitioning.set(false);
       this.sidebarTransitionTimeoutId = undefined;
     }, SIDEBAR_TRANSITION_MS);
-  }
-
-  private changeScale(value: number): void {
-    this.document.documentElement.style.fontSize = `${value}px`;
   }
 
   private updateSidebarSort(

--- a/frontend/src/app/shared/layout/theme/theme-palette-extend.ts
+++ b/frontend/src/app/shared/layout/theme/theme-palette-extend.ts
@@ -93,12 +93,66 @@ const compactPrimeFontCss = `
 }
 `;
 
+const PRIME_REM_SCALE = 0.875;
+
+function isDigit(value: string): boolean {
+  return value >= '0' && value <= '9';
+}
+
+function findRemNumberStart(value: string, remIndex: number): number | undefined {
+  let start = remIndex;
+  let digitCount = 0;
+
+  while (start > 0 && isDigit(value[start - 1])) {
+    start -= 1;
+    digitCount += 1;
+  }
+
+  if (start > 0 && value[start - 1] === '.') {
+    start -= 1;
+    while (start > 0 && isDigit(value[start - 1])) {
+      start -= 1;
+      digitCount += 1;
+    }
+  }
+
+  if (start > 0 && value[start - 1] === '-') {
+    start -= 1;
+  }
+
+  return digitCount > 0 ? start : undefined;
+}
+
+function scaleRemString(value: string): string {
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    const remIndex = value.indexOf('rem', cursor);
+    if (remIndex === -1) {
+      return result + value.slice(cursor);
+    }
+
+    const numberStart = findRemNumberStart(value, remIndex);
+    if (numberStart === undefined) {
+      result += value.slice(cursor, remIndex + 3);
+      cursor = remIndex + 3;
+      continue;
+    }
+
+    const scaled = Number.parseFloat(
+      (Number(value.slice(numberStart, remIndex)) * PRIME_REM_SCALE).toFixed(6)
+    ).toString();
+    result += `${value.slice(cursor, numberStart)}${scaled}rem`;
+    cursor = remIndex + 3;
+  }
+
+  return result;
+}
+
 function scalePrimeRems<T>(value: T): T {
   if (typeof value === 'string') {
-    return value.replace(/(-?\d*\.?\d+)rem/g, (_, remValue: string) => {
-      const scaled = Number.parseFloat((Number(remValue) * 0.875).toFixed(6)).toString();
-      return `${scaled}rem`;
-    }) as T;
+    return scaleRemString(value) as T;
   }
   if (Array.isArray(value)) {
     return value.map(scalePrimeRems) as T;

--- a/frontend/src/app/shared/layout/theme/theme-palette-extend.ts
+++ b/frontend/src/app/shared/layout/theme/theme-palette-extend.ts
@@ -74,6 +74,45 @@ const overlaySurface = {
   color: 'var(--color-text)',
 };
 
+const compactPrimeFontCss = `
+.p-button:not(.p-button-sm):not(.p-button-lg),
+.p-inputtext:not(.p-inputtext-sm):not(.p-inputtext-lg),
+.p-textarea:not(.p-textarea-sm):not(.p-textarea-lg),
+.p-select:not(.p-select-sm):not(.p-select-lg) .p-select-label,
+.p-multiselect:not(.p-multiselect-sm):not(.p-multiselect-lg) .p-multiselect-label,
+.p-cascadeselect:not(.p-cascadeselect-sm):not(.p-cascadeselect-lg) .p-cascadeselect-label,
+.p-treeselect:not(.p-treeselect-sm):not(.p-treeselect-lg) .p-treeselect-label,
+.p-autocomplete-input,
+.p-autocomplete-input-multiple,
+.p-togglebutton:not(.p-togglebutton-sm):not(.p-togglebutton-lg),
+.p-inputchips-input-item input,
+.p-terminal-prompt-value,
+.p-datepicker-day-view,
+.p-datepicker-time-picker span {
+  font-size: var(--app-text-base);
+}
+`;
+
+function scalePrimeRems<T>(value: T): T {
+  if (typeof value === 'string') {
+    return value.replace(/(-?\d*\.?\d+)rem/g, (_, remValue: string) => {
+      const scaled = Number.parseFloat((Number(remValue) * 0.875).toFixed(6)).toString();
+      return `${scaled}rem`;
+    }) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map(scalePrimeRems) as T;
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, scalePrimeRems(entry)])
+    ) as T;
+  }
+  return value;
+}
+
+const AppPrimeBasePreset = scalePrimeRems(Aura);
+
 function buildAppTokenPalette(prefix: 'primary' | 'surface', stops: readonly string[]): ColorPalette {
   return Object.fromEntries(
     stops.map((stop) => [stop, `var(--color-${prefix}-${stop})`])
@@ -107,7 +146,8 @@ function buildPrimePalettePreset(theme: ResolvedThemePalettes): object {
   };
 }
 
-const AppPrimePreset = definePreset(Aura, {
+const AppPrimePreset = definePreset(AppPrimeBasePreset, {
+  css: compactPrimeFontCss,
   semantic: {
     colorScheme: {
       light: {

--- a/frontend/src/app/shared/layout/theme/theme-palette-extend.ts
+++ b/frontend/src/app/shared/layout/theme/theme-palette-extend.ts
@@ -141,7 +141,7 @@ function scaleRemString(value: string): string {
     }
 
     const scaled = Number.parseFloat(
-      (Number(value.slice(numberStart, remIndex)) * PRIME_REM_SCALE).toFixed(6)
+      (Number(value.slice(numberStart, remIndex)) * PRIME_REM_SCALE).toFixed(4)
     ).toString();
     result += `${value.slice(cursor, numberStart)}${scaled}rem`;
     cursor = remIndex + 3;

--- a/frontend/src/app/shared/styles/_auth-shared.scss
+++ b/frontend/src/app/shared/styles/_auth-shared.scss
@@ -100,7 +100,7 @@
   transition: transform 0.3s ease;
 
   i {
-    font-size: 1.53125rem;
+    font-size: 1.5313rem;
     color: white;
   }
 
@@ -118,12 +118,12 @@
   -webkit-text-fill-color: transparent;
 
   @media (width <= 640px) {
-    font-size: 1.53125rem;
+    font-size: 1.5313rem;
   }
 }
 
 @mixin auth-subtitle {
-  font-size: 0.83125rem;
+  font-size: 0.8313rem;
   color: var(--color-text-secondary);
   font-weight: 400;
   line-height: 1.5;
@@ -147,7 +147,7 @@
   display: flex;
   align-items: center;
   gap: 0.4375rem;
-  font-size: 0.83125rem;
+  font-size: 0.8313rem;
   font-weight: 600;
   color: var(--color-text);
 
@@ -168,10 +168,10 @@
 @mixin field-error {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
+  gap: 0.3281rem;
   color: var(--color-danger);
   font-size: 0.7rem;
-  margin-top: -0.21875rem;
+  margin-top: -0.2188rem;
   animation: fade-in 0.3s ease-out;
 
   i {
@@ -180,7 +180,7 @@
 }
 
 @mixin auth-button {
-  margin-top: 0.65625rem;
+  margin-top: 0.6563rem;
 
   ::ng-deep button {
     height: 2.625rem;

--- a/frontend/src/app/shared/styles/_auth-shared.scss
+++ b/frontend/src/app/shared/styles/_auth-shared.scss
@@ -40,7 +40,7 @@
 
 @mixin auth-card-border {
   width: 100%;
-  border-radius: 2rem;
+  border-radius: 1.75rem;
   padding: 2px;
   background: linear-gradient(135deg, color-mix(in srgb, var(--color-primary) 70%, transparent) 0%, color-mix(in srgb, var(--color-primary) 30%, transparent) 50%, transparent 100%);
   box-shadow: 0 20px 60px rgb(0 0 0 / 40%);
@@ -56,27 +56,27 @@
   width: 100%;
   background: var(--color-card);
   backdrop-filter: blur(20px);
-  border-radius: calc(2rem - 2px);
-  padding: 3rem 2.5rem;
+  border-radius: calc(1.75rem - 2px);
+  padding: 2.625rem 2.1875rem;
 
   @media (width <= 640px) {
-    padding: 2rem 1.5rem;
+    padding: 1.75rem 1.3125rem;
   }
 }
 
 @mixin auth-header {
   text-align: center;
-  margin-bottom: 2.5rem;
+  margin-bottom: 2.1875rem;
 }
 
 @mixin auth-logo {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.3125rem;
   animation: pulse 2s ease-in-out infinite;
 }
 
 @mixin auth-logo-icon {
   width: auto;
-  height: 4rem;
+  height: 3.5rem;
   margin: 0 auto;
   display: block;
   filter: drop-shadow(0 4px 12px rgb(0 0 0 / 30%));
@@ -88,8 +88,8 @@
 }
 
 @mixin auth-icon-circle {
-  width: 4rem;
-  height: 4rem;
+  width: 3.5rem;
+  height: 3.5rem;
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -100,7 +100,7 @@
   transition: transform 0.3s ease;
 
   i {
-    font-size: 1.75rem;
+    font-size: 1.53125rem;
     color: white;
   }
 
@@ -110,20 +110,20 @@
 }
 
 @mixin auth-title {
-  font-size: 2rem;
+  font-size: 1.75rem;
   font-weight: 700;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
   background: linear-gradient(135deg, var(--color-text-strong) 0%, var(--color-primary) 100%);
   background-clip: text;
   -webkit-text-fill-color: transparent;
 
   @media (width <= 640px) {
-    font-size: 1.75rem;
+    font-size: 1.53125rem;
   }
 }
 
 @mixin auth-subtitle {
-  font-size: 0.95rem;
+  font-size: 0.83125rem;
   color: var(--color-text-secondary);
   font-weight: 400;
   line-height: 1.5;
@@ -140,20 +140,20 @@
 @mixin form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 @mixin form-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.95rem;
+  gap: 0.4375rem;
+  font-size: 0.83125rem;
   font-weight: 600;
   color: var(--color-text);
 
   i {
     color: var(--color-primary);
-    font-size: 0.875rem;
+    font-size: var(--app-text-sm);
   }
 }
 
@@ -168,23 +168,23 @@
 @mixin field-error {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.32813rem;
   color: var(--color-danger);
-  font-size: 0.8rem;
-  margin-top: -0.25rem;
+  font-size: 0.7rem;
+  margin-top: -0.21875rem;
   animation: fade-in 0.3s ease-out;
 
   i {
-    font-size: 0.75rem;
+    font-size: var(--app-text-xs);
   }
 }
 
 @mixin auth-button {
-  margin-top: 0.75rem;
+  margin-top: 0.65625rem;
 
   ::ng-deep button {
-    height: 3rem;
-    font-size: 1rem;
+    height: 2.625rem;
+    font-size: var(--app-text-base);
     font-weight: 600;
     transition: box-shadow 0.3s ease, transform 0.3s ease;
     background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-hover) 100%);

--- a/frontend/src/app/shared/styles/_panel-shared.scss
+++ b/frontend/src/app/shared/styles/_panel-shared.scss
@@ -5,8 +5,8 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1.5rem 1.5rem 1.25rem;
+  gap: 0.875rem;
+  padding: 1.3125rem 1.3125rem 1.09375rem;
   border-radius: 10px 10px 0 0;
   border: 1px solid var(--border-color);
   background: var(--color-card);
@@ -23,7 +23,7 @@
     flex-shrink: 0;
 
     .header-icon {
-      font-size: 1.5rem;
+      font-size: 1.3125rem;
       color: var(--primary-contrast-color);
     }
   }
@@ -32,15 +32,15 @@
     flex: 1;
 
     .panel-title {
-      margin: 0 0 0.25rem;
-      font-size: 1.25rem;
+      margin: 0 0 0.21875rem;
+      font-size: 1.09375rem;
       font-weight: 600;
       color: var(--text-color);
     }
 
     .panel-description {
       margin: 0;
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
       color: var(--text-secondary-color);
     }
   }
@@ -48,36 +48,36 @@
   .close-button,
   ::ng-deep .close-button {
     position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
+    top: 0.65625rem;
+    right: 0.65625rem;
   }
 
   @media (width <= 480px) {
-    padding: 1rem;
+    padding: 0.875rem;
 
     .header-icon-wrapper {
       width: 40px;
       height: 40px;
 
       .header-icon {
-        font-size: 1.25rem;
+        font-size: 1.09375rem;
       }
     }
 
     .header-text {
       .panel-title {
-        font-size: 1.125rem;
+        font-size: var(--app-text-lg);
       }
 
       .panel-description {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
       }
     }
 
     .close-button,
     ::ng-deep .close-button {
-      top: 0.5rem;
-      right: 0.5rem;
+      top: 0.4375rem;
+      right: 0.4375rem;
     }
   }
 }
@@ -86,8 +86,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1.25rem 1.5rem;
+  gap: 0.65625rem;
+  padding: 1.09375rem 1.3125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 0 0 10px 10px;
@@ -102,15 +102,15 @@
   .footer-actions,
   .footer-right {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65625rem;
     flex-shrink: 0;
   }
 
   @media (width <= 640px) {
     flex-direction: column;
     align-items: stretch;
-    padding: 1rem;
-    gap: 0.75rem;
+    padding: 0.875rem;
+    gap: 0.65625rem;
 
     .footer-info,
     .validation-status {
@@ -121,7 +121,7 @@
     .footer-right {
       width: 100%;
       justify-content: flex-end;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
   }
 }
@@ -133,13 +133,13 @@
   justify-content: flex-end;
 
   @media (width <= 480px) {
-    padding: 1rem;
-    gap: 0.5rem;
+    padding: 0.875rem;
+    gap: 0.4375rem;
 
     .footer-actions {
       width: 100%;
       justify-content: flex-end;
-      gap: 0.5rem;
+      gap: 0.4375rem;
     }
   }
 }
@@ -148,16 +148,16 @@
 @mixin validation-message {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.5rem;
+  gap: 0.32813rem;
+  padding: 0.21875rem 0.4375rem;
   font-weight: 500;
   border-radius: 6px;
-  font-size: 0.875rem;
+  font-size: var(--app-text-sm);
   width: fit-content;
   max-width: 100%;
 
   i {
-    font-size: 0.95rem;
+    font-size: 0.83125rem;
   }
 
   &.error {
@@ -181,12 +181,12 @@
   }
 
   @media (width <= 640px) {
-    font-size: 0.8rem;
-    padding: 0.375rem 0.5rem;
+    font-size: 0.7rem;
+    padding: 0.32813rem 0.4375rem;
     width: 100%;
 
     i {
-      font-size: 0.875rem;
+      font-size: var(--app-text-sm);
     }
   }
 }

--- a/frontend/src/app/shared/styles/_panel-shared.scss
+++ b/frontend/src/app/shared/styles/_panel-shared.scss
@@ -6,7 +6,7 @@
   display: flex;
   align-items: center;
   gap: 0.875rem;
-  padding: 1.3125rem 1.3125rem 1.09375rem;
+  padding: 1.3125rem 1.3125rem 1.0938rem;
   border-radius: 10px 10px 0 0;
   border: 1px solid var(--border-color);
   background: var(--color-card);
@@ -32,8 +32,8 @@
     flex: 1;
 
     .panel-title {
-      margin: 0 0 0.21875rem;
-      font-size: 1.09375rem;
+      margin: 0 0 0.2188rem;
+      font-size: 1.0938rem;
       font-weight: 600;
       color: var(--text-color);
     }
@@ -48,8 +48,8 @@
   .close-button,
   ::ng-deep .close-button {
     position: absolute;
-    top: 0.65625rem;
-    right: 0.65625rem;
+    top: 0.6563rem;
+    right: 0.6563rem;
   }
 
   @media (width <= 480px) {
@@ -60,7 +60,7 @@
       height: 40px;
 
       .header-icon {
-        font-size: 1.09375rem;
+        font-size: 1.0938rem;
       }
     }
 
@@ -86,8 +86,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.65625rem;
-  padding: 1.09375rem 1.3125rem;
+  gap: 0.6563rem;
+  padding: 1.0938rem 1.3125rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: 0 0 10px 10px;
@@ -102,7 +102,7 @@
   .footer-actions,
   .footer-right {
     display: flex;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
     flex-shrink: 0;
   }
 
@@ -110,7 +110,7 @@
     flex-direction: column;
     align-items: stretch;
     padding: 0.875rem;
-    gap: 0.65625rem;
+    gap: 0.6563rem;
 
     .footer-info,
     .validation-status {
@@ -148,8 +148,8 @@
 @mixin validation-message {
   display: flex;
   align-items: center;
-  gap: 0.32813rem;
-  padding: 0.21875rem 0.4375rem;
+  gap: 0.3281rem;
+  padding: 0.2188rem 0.4375rem;
   font-weight: 500;
   border-radius: 6px;
   font-size: var(--app-text-sm);
@@ -157,7 +157,7 @@
   max-width: 100%;
 
   i {
-    font-size: 0.83125rem;
+    font-size: 0.8313rem;
   }
 
   &.error {
@@ -182,7 +182,7 @@
 
   @media (width <= 640px) {
     font-size: 0.7rem;
-    padding: 0.32813rem 0.4375rem;
+    padding: 0.3281rem 0.4375rem;
     width: 100%;
 
     i {

--- a/frontend/src/app/shared/styles/_settings-shared.scss
+++ b/frontend/src/app/shared/styles/_settings-shared.scss
@@ -5,30 +5,30 @@
 // ============================================================================
 // TYPOGRAPHY VARIABLES
 // ============================================================================
-$settings-page-title-size: 1.20313rem;
+$settings-page-title-size: 1.2031rem;
 $settings-page-title-weight: 700;
-$settings-page-description-size: 0.76563rem;
-$settings-section-title-size: 1.09375rem;
+$settings-page-description-size: 0.7656rem;
+$settings-section-title-size: 1.0938rem;
 $settings-section-title-weight: 600;
-$settings-section-title-icon-size: 0.98438rem;
-$settings-section-description-size: 0.76563rem;
-$settings-label-size: 0.82031rem;
+$settings-section-title-icon-size: 0.9844rem;
+$settings-section-description-size: 0.7656rem;
+$settings-label-size: 0.8203rem;
 $settings-label-weight: 500;
-$settings-description-size: 0.76563rem;
+$settings-description-size: 0.7656rem;
 
 // ============================================================================
 // SPACING VARIABLES
 // ============================================================================
 $settings-card-padding: 1.3125rem;
 $settings-card-padding-mobile: 0.875rem;
-$settings-card-gap: 1.09375rem;
+$settings-card-gap: 1.0938rem;
 $settings-card-gap-mobile: 0.875rem;
 $settings-card-border-radius: 8px;
 $settings-section-body-padding-left: 0.875rem;
 $settings-section-body-padding-left-mobile: 0.4375rem;
 $settings-section-body-gap: 0.875rem;
-$settings-item-padding: 0.76563rem 0.875rem;
-$settings-item-padding-mobile: 0.65625rem;
+$settings-item-padding: 0.7656rem 0.875rem;
+$settings-item-padding-mobile: 0.6563rem;
 $settings-item-border-radius: 6px;
 $settings-item-border-left-width: 3px;
 
@@ -70,7 +70,7 @@ $settings-item-border-left-width: 3px;
 
   .pi {
     color: var(--color-primary);
-    font-size: 1.09375rem;
+    font-size: 1.0938rem;
   }
 }
 
@@ -105,7 +105,7 @@ $settings-item-border-left-width: 3px;
 // For section headers inside cards (with icon and description)
 // ============================================================================
 @mixin settings-section-header {
-  margin-bottom: 0.21875rem;
+  margin-bottom: 0.2188rem;
 }
 
 @mixin settings-section-title {
@@ -172,8 +172,8 @@ $settings-item-border-left-width: 3px;
 @mixin settings-item-header {
   display: flex;
   align-items: center;
-  gap: 0.65625rem;
-  margin-bottom: 0.21875rem;
+  gap: 0.6563rem;
+  margin-bottom: 0.2188rem;
 
   .pi {
     color: var(--color-primary);
@@ -182,7 +182,7 @@ $settings-item-border-left-width: 3px;
 }
 
 @mixin settings-item-header-standalone {
-  margin-bottom: 0.21875rem;
+  margin-bottom: 0.2188rem;
 }
 
 // ============================================================================
@@ -209,7 +209,7 @@ $settings-item-border-left-width: 3px;
 // ============================================================================
 @mixin settings-note {
   display: block;
-  margin-top: 0.21875rem;
+  margin-top: 0.2188rem;
   font-style: italic;
   opacity: 0.85;
 }
@@ -219,8 +219,8 @@ $settings-item-border-left-width: 3px;
 // Expandable options section below a setting
 // ============================================================================
 @mixin settings-options {
-  margin-top: 0.65625rem;
-  padding-top: 0.65625rem;
+  margin-top: 0.6563rem;
+  padding-top: 0.6563rem;
   border-top: 1px dashed var(--p-content-border-color);
 }
 
@@ -231,10 +231,10 @@ $settings-item-border-left-width: 3px;
 @mixin settings-notice-base {
   display: flex;
   align-items: flex-start;
-  gap: 0.65625rem;
+  gap: 0.6563rem;
   font-size: $settings-section-description-size;
   line-height: 1.5;
-  padding: 0.65625rem 0.875rem;
+  padding: 0.6563rem 0.875rem;
   border-radius: 6px;
   color: var(--color-text);
 
@@ -243,7 +243,7 @@ $settings-item-border-left-width: 3px;
   }
 
   @media (width <= 768px) {
-    padding: 0.54688rem 0.65625rem;
+    padding: 0.5469rem 0.6563rem;
     font-size: $settings-description-size;
   }
 }
@@ -256,7 +256,7 @@ $settings-item-border-left-width: 3px;
   border-left-style: solid;
 
   .pi-exclamation-triangle {
-    margin-top: 0.10938rem;
+    margin-top: 0.1094rem;
     flex-shrink: 0;
   }
 }
@@ -269,7 +269,7 @@ $settings-item-border-left-width: 3px;
 
   .pi-info-circle {
     color: var(--p-blue-400);
-    margin-top: 0.10938rem;
+    margin-top: 0.1094rem;
     flex-shrink: 0;
   }
 
@@ -328,7 +328,7 @@ $settings-item-border-left-width: 3px;
 
   .filesize-field {
     width: 70px;
-    padding: 0.32813rem 0.4375rem;
+    padding: 0.3281rem 0.4375rem;
     border: 1px solid var(--p-content-border-color);
     border-radius: 4px;
     background: var(--color-card);
@@ -402,7 +402,7 @@ $settings-item-border-left-width: 3px;
 
       .p-datatable-thead > tr > th {
         font-weight: 600;
-        padding: 0.65625rem;
+        padding: 0.6563rem;
         background: color-mix(in srgb, var(--color-text) 3%, transparent);
         border-bottom: 1px solid var(--p-content-border-color);
         font-size: $settings-description-size;
@@ -414,7 +414,7 @@ $settings-item-border-left-width: 3px;
         }
 
         > td {
-          padding: 0.54688rem;
+          padding: 0.5469rem;
           border-bottom: 1px solid color-mix(in srgb, var(--p-content-border-color) 50%, transparent);
         }
 
@@ -485,9 +485,9 @@ $settings-item-border-left-width: 3px;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.32813rem;
-    padding: 0.4375rem 0.65625rem;
-    border-radius: 0.32813rem;
+    gap: 0.3281rem;
+    padding: 0.4375rem 0.6563rem;
+    border-radius: 0.3281rem;
     border: 1.5px solid color-mix(in srgb, var(--color-text) 20%, transparent);
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     color: var(--color-text);

--- a/frontend/src/app/shared/styles/_settings-shared.scss
+++ b/frontend/src/app/shared/styles/_settings-shared.scss
@@ -5,30 +5,30 @@
 // ============================================================================
 // TYPOGRAPHY VARIABLES
 // ============================================================================
-$settings-page-title-size: 1.375rem;
+$settings-page-title-size: 1.20313rem;
 $settings-page-title-weight: 700;
-$settings-page-description-size: 0.875rem;
-$settings-section-title-size: 1.25rem;
+$settings-page-description-size: 0.76563rem;
+$settings-section-title-size: 1.09375rem;
 $settings-section-title-weight: 600;
-$settings-section-title-icon-size: 1.125rem;
-$settings-section-description-size: 0.875rem;
-$settings-label-size: 0.9375rem;
+$settings-section-title-icon-size: 0.98438rem;
+$settings-section-description-size: 0.76563rem;
+$settings-label-size: 0.82031rem;
 $settings-label-weight: 500;
-$settings-description-size: 0.875rem;
+$settings-description-size: 0.76563rem;
 
 // ============================================================================
 // SPACING VARIABLES
 // ============================================================================
-$settings-card-padding: 1.5rem;
-$settings-card-padding-mobile: 1rem;
-$settings-card-gap: 1.25rem;
-$settings-card-gap-mobile: 1rem;
+$settings-card-padding: 1.3125rem;
+$settings-card-padding-mobile: 0.875rem;
+$settings-card-gap: 1.09375rem;
+$settings-card-gap-mobile: 0.875rem;
 $settings-card-border-radius: 8px;
-$settings-section-body-padding-left: 1rem;
-$settings-section-body-padding-left-mobile: 0.5rem;
-$settings-section-body-gap: 1rem;
-$settings-item-padding: 0.875rem 1rem;
-$settings-item-padding-mobile: 0.75rem;
+$settings-section-body-padding-left: 0.875rem;
+$settings-section-body-padding-left-mobile: 0.4375rem;
+$settings-section-body-gap: 0.875rem;
+$settings-item-padding: 0.76563rem 0.875rem;
+$settings-item-padding-mobile: 0.65625rem;
 $settings-item-border-radius: 6px;
 $settings-item-border-left-width: 3px;
 
@@ -39,12 +39,12 @@ $settings-item-border-left-width: 3px;
 @mixin settings-page-container {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.3125rem;
   width: 100%;
   height: 100%;
   min-height: 0;
   overflow-y: auto;
-  padding: 0.5rem 1.5rem;
+  padding: 0.4375rem 1.3125rem;
 }
 
 // ============================================================================
@@ -53,8 +53,8 @@ $settings-item-border-left-width: 3px;
 // ============================================================================
 @mixin settings-page-header {
   .settings-header {
-    margin-top: 1rem;
-    margin-bottom: 1.5rem;
+    margin-top: 0.875rem;
+    margin-bottom: 1.3125rem;
     border-bottom: 1px solid var(--p-content-border-color);
   }
 }
@@ -62,15 +62,15 @@ $settings-item-border-left-width: 3px;
 @mixin settings-page-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: $settings-page-title-size;
   font-weight: $settings-page-title-weight;
   color: var(--color-text);
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 
   .pi {
     color: var(--color-primary);
-    font-size: 1.25rem;
+    font-size: 1.09375rem;
   }
 }
 
@@ -78,7 +78,7 @@ $settings-item-border-left-width: 3px;
   font-size: $settings-page-description-size;
   line-height: 1.5;
   color: var(--p-text-muted-color);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4375rem;
 }
 
 // ============================================================================
@@ -105,17 +105,17 @@ $settings-item-border-left-width: 3px;
 // For section headers inside cards (with icon and description)
 // ============================================================================
 @mixin settings-section-header {
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.21875rem;
 }
 
 @mixin settings-section-title {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   font-size: $settings-section-title-size;
   font-weight: $settings-section-title-weight;
   color: var(--color-text);
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.4375rem;
 
   .pi {
     color: var(--color-primary);
@@ -172,17 +172,17 @@ $settings-item-border-left-width: 3px;
 @mixin settings-item-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.25rem;
+  gap: 0.65625rem;
+  margin-bottom: 0.21875rem;
 
   .pi {
     color: var(--color-primary);
-    font-size: 1rem;
+    font-size: var(--app-text-base);
   }
 }
 
 @mixin settings-item-header-standalone {
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.21875rem;
 }
 
 // ============================================================================
@@ -209,7 +209,7 @@ $settings-item-border-left-width: 3px;
 // ============================================================================
 @mixin settings-note {
   display: block;
-  margin-top: 0.25rem;
+  margin-top: 0.21875rem;
   font-style: italic;
   opacity: 0.85;
 }
@@ -219,8 +219,8 @@ $settings-item-border-left-width: 3px;
 // Expandable options section below a setting
 // ============================================================================
 @mixin settings-options {
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
+  margin-top: 0.65625rem;
+  padding-top: 0.65625rem;
   border-top: 1px dashed var(--p-content-border-color);
 }
 
@@ -231,10 +231,10 @@ $settings-item-border-left-width: 3px;
 @mixin settings-notice-base {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: 0.65625rem;
   font-size: $settings-section-description-size;
   line-height: 1.5;
-  padding: 0.75rem 1rem;
+  padding: 0.65625rem 0.875rem;
   border-radius: 6px;
   color: var(--color-text);
 
@@ -243,7 +243,7 @@ $settings-item-border-left-width: 3px;
   }
 
   @media (width <= 768px) {
-    padding: 0.625rem 0.75rem;
+    padding: 0.54688rem 0.65625rem;
     font-size: $settings-description-size;
   }
 }
@@ -256,7 +256,7 @@ $settings-item-border-left-width: 3px;
   border-left-style: solid;
 
   .pi-exclamation-triangle {
-    margin-top: 0.125rem;
+    margin-top: 0.10938rem;
     flex-shrink: 0;
   }
 }
@@ -269,7 +269,7 @@ $settings-item-border-left-width: 3px;
 
   .pi-info-circle {
     color: var(--p-blue-400);
-    margin-top: 0.125rem;
+    margin-top: 0.10938rem;
     flex-shrink: 0;
   }
 
@@ -284,8 +284,8 @@ $settings-item-border-left-width: 3px;
 // ============================================================================
 @mixin settings-section-divider {
   .section-divider {
-    padding-top: 1.5rem;
-    padding-bottom: 0.5rem;
+    padding-top: 1.3125rem;
+    padding-bottom: 0.4375rem;
 
     hr {
       border: none;
@@ -302,7 +302,7 @@ $settings-item-border-left-width: 3px;
 @mixin settings-actions-row {
   display: flex;
   justify-content: flex-end;
-  padding-top: 0.5rem;
+  padding-top: 0.4375rem;
 
   @media (width <= 768px) {
     p-button {
@@ -318,7 +318,7 @@ $settings-item-border-left-width: 3px;
 @mixin settings-filesize-input {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 
   label {
     font-size: $settings-description-size;
@@ -328,7 +328,7 @@ $settings-item-border-left-width: 3px;
 
   .filesize-field {
     width: 70px;
-    padding: 0.375rem 0.5rem;
+    padding: 0.32813rem 0.4375rem;
     border: 1px solid var(--p-content-border-color);
     border-radius: 4px;
     background: var(--color-card);
@@ -368,7 +368,7 @@ $settings-item-border-left-width: 3px;
 @mixin settings-select-group {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
 
   p-select {
@@ -402,7 +402,7 @@ $settings-item-border-left-width: 3px;
 
       .p-datatable-thead > tr > th {
         font-weight: 600;
-        padding: 0.75rem;
+        padding: 0.65625rem;
         background: color-mix(in srgb, var(--color-text) 3%, transparent);
         border-bottom: 1px solid var(--p-content-border-color);
         font-size: $settings-description-size;
@@ -414,7 +414,7 @@ $settings-item-border-left-width: 3px;
         }
 
         > td {
-          padding: 0.625rem;
+          padding: 0.54688rem;
           border-bottom: 1px solid color-mix(in srgb, var(--p-content-border-color) 50%, transparent);
         }
 
@@ -441,8 +441,8 @@ $settings-item-border-left-width: 3px;
 @mixin settings-access-denied-card {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1.5rem;
+  gap: 0.875rem;
+  padding: 1.3125rem;
   border-radius: $settings-card-border-radius;
   background: color-mix(in srgb, var(--color-card) 85%, var(--p-red-600) 15%);
   border: 1px solid var(--p-content-border-color);
@@ -450,7 +450,7 @@ $settings-item-border-left-width: 3px;
   max-width: 500px;
 
   .pi {
-    font-size: 1.5rem;
+    font-size: 1.3125rem;
     flex-shrink: 0;
     color: var(--p-red-400);
   }
@@ -458,8 +458,8 @@ $settings-item-border-left-width: 3px;
 
 @mixin settings-access-denied-content {
   h3 {
-    margin: 0 0 0.5rem;
-    font-size: 1rem;
+    margin: 0 0 0.4375rem;
+    font-size: var(--app-text-base);
     font-weight: $settings-section-title-weight;
     color: var(--p-red-300);
   }
@@ -478,16 +478,16 @@ $settings-item-border-left-width: 3px;
 // ============================================================================
 @mixin settings-button-group {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   flex-wrap: wrap;
 
   .option-button {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.375rem;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.375rem;
+    gap: 0.32813rem;
+    padding: 0.4375rem 0.65625rem;
+    border-radius: 0.32813rem;
     border: 1.5px solid color-mix(in srgb, var(--color-text) 20%, transparent);
     background: color-mix(in srgb, var(--color-text) 5%, transparent);
     color: var(--color-text);
@@ -495,7 +495,7 @@ $settings-item-border-left-width: 3px;
     transition: all 0.2s ease;
     font-size: $settings-description-size;
     font-weight: $settings-label-weight;
-    min-width: 4.5rem;
+    min-width: 3.9375rem;
 
     i {
       font-size: $settings-section-description-size;

--- a/frontend/src/assets/layout/styles/layout/_responsive.scss
+++ b/frontend/src/assets/layout/styles/layout/_responsive.scss
@@ -26,7 +26,7 @@
     background-color: var(--surface-page);
 
     .layout-main {
-      --mobile-topbar-height: 3.5rem;
+      --mobile-topbar-height: 3.0625rem;
 
       box-sizing: border-box;
       padding:
@@ -42,7 +42,7 @@
       --sidebar-shell-padding-inline-end: var(--space-4);
       --sidebar-header-padding-block: var(--space-2);
       --sidebar-header-gap-after: var(--space-3);
-      --sidebar-row-min-height: 3rem;
+      --sidebar-row-min-height: 2.625rem;
       --sidebar-row-padding-block: var(--space-3);
       --sidebar-row-padding-inline-start: var(--space-3);
       --sidebar-row-padding-inline-end: var(--space-3);
@@ -52,10 +52,10 @@
       --sidebar-group-gap: var(--space-4);
       --sidebar-section-spacing-before: var(--space-4);
       --sidebar-section-spacing-after: var(--space-1);
-      --sidebar-section-min-height: 2rem;
+      --sidebar-section-min-height: 1.75rem;
       --sidebar-section-inline-start: var(--space-3);
       --sidebar-section-inline-end: var(--space-3);
-      --sidebar-section-font-size: var(--text-base);
+      --sidebar-section-font-size: var(--app-text-base);
       --sidebar-section-font-weight: 600;
 
       position: fixed;
@@ -125,7 +125,7 @@
     .layout-wrapper {
       .layout-sidebar {
         width: fit-content;
-        max-width: calc(100dvw - 1rem);
+        max-width: calc(100dvw - 0.875rem);
         border-right: 1px solid var(--border-color);
         padding:
           calc(var(--space-3) + env(safe-area-inset-top))

--- a/frontend/src/assets/layout/styles/layout/_sidebar.scss
+++ b/frontend/src/assets/layout/styles/layout/_sidebar.scss
@@ -14,7 +14,7 @@
   --sidebar-header-padding-inline-start: var(--space-2);
   --sidebar-header-padding-inline-end: var(--space-1);
   --sidebar-header-gap-after: var(--space-2);
-  --sidebar-row-min-height: 1.96875rem;
+  --sidebar-row-min-height: 1.9688rem;
   --sidebar-row-padding-block: var(--space-2);
   --sidebar-row-padding-inline-start: var(--space-2);
   --sidebar-row-padding-inline-end: var(--space-1);
@@ -25,7 +25,7 @@
   --sidebar-group-gap: var(--space-3);
   --sidebar-section-spacing-before: var(--space-3);
   --sidebar-section-spacing-after: var(--space-1);
-  --sidebar-section-min-height: 1.09375rem;
+  --sidebar-section-min-height: 1.0938rem;
   --sidebar-section-inline-start: var(--space-2);
   --sidebar-section-inline-end: var(--space-3);
   --sidebar-section-font-size: var(--app-text-xs);

--- a/frontend/src/assets/layout/styles/layout/_sidebar.scss
+++ b/frontend/src/assets/layout/styles/layout/_sidebar.scss
@@ -14,7 +14,7 @@
   --sidebar-header-padding-inline-start: var(--space-2);
   --sidebar-header-padding-inline-end: var(--space-1);
   --sidebar-header-gap-after: var(--space-2);
-  --sidebar-row-min-height: 2.25rem;
+  --sidebar-row-min-height: 1.96875rem;
   --sidebar-row-padding-block: var(--space-2);
   --sidebar-row-padding-inline-start: var(--space-2);
   --sidebar-row-padding-inline-end: var(--space-1);
@@ -25,10 +25,10 @@
   --sidebar-group-gap: var(--space-3);
   --sidebar-section-spacing-before: var(--space-3);
   --sidebar-section-spacing-after: var(--space-1);
-  --sidebar-section-min-height: 1.25rem;
+  --sidebar-section-min-height: 1.09375rem;
   --sidebar-section-inline-start: var(--space-2);
   --sidebar-section-inline-end: var(--space-3);
-  --sidebar-section-font-size: var(--text-xs);
+  --sidebar-section-font-size: var(--app-text-xs);
   --sidebar-section-font-weight: 500;
   --sidebar-focus-ring: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 50%, transparent);
 
@@ -98,7 +98,7 @@ body.layout-resizing-cursor {
     padding: var(--space-2) var(--space-3);
     border-radius: var(--radius-sm);
     color: var(--color-text);
-    font-size: var(--text-base);
+    font-size: var(--app-text-base);
     cursor: pointer;
 
     &:hover {
@@ -157,7 +157,7 @@ body.layout-resizing-cursor {
     display: block;
     width: 100%;
     height: 1px;
-    margin: 0 0.4rem;
+    margin: 0 0.35rem;
     background-color: var(--color-border);
   }
 

--- a/frontend/src/assets/styles/base.scss
+++ b/frontend/src/assets/styles/base.scss
@@ -20,6 +20,7 @@ body {
   background-color: var(--color-app);
   color: var(--color-text);
   font-family: var(--font-family), serif;
+  font-size: var(--app-text-base);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -62,7 +63,7 @@ h3,
 h4,
 h5,
 h6 {
-  margin: 1.5rem 0 1rem;
+  margin: 1.3125rem 0 0.875rem;
   color: var(--color-text-strong);
   font-weight: 500;
   line-height: 1.2;
@@ -74,31 +75,31 @@ h6 {
 }
 
 h1 {
-  font-size: 2.5rem;
+  font-size: var(--text-4xl);
 }
 
 h2 {
-  font-size: 2rem;
+  font-size: var(--text-3xl);
 }
 
 h3 {
-  font-size: 1.75rem;
+  font-size: var(--text-2xl);
 }
 
 h4 {
-  font-size: 1.5rem;
+  font-size: var(--text-xl);
 }
 
 h5 {
-  font-size: 1.25rem;
+  font-size: var(--text-lg);
 }
 
 h6 {
-  font-size: 1rem;
+  font-size: var(--text-sm);
 }
 
 p {
-  margin: 0 0 1rem;
+  margin: 0 0 0.875rem;
   color: var(--color-text);
   line-height: 1.5;
   overflow-wrap: break-word;
@@ -113,20 +114,20 @@ p.p-secondary {
 }
 
 mark {
-  padding: 0.25rem 0.4rem;
+  padding: 0.21875rem 0.35rem;
   border-radius: var(--radius-lg);
   background: #fff8e1;
   font-family: monospace;
 }
 
 blockquote {
-  margin: 1rem 0;
-  padding: 0 2rem;
+  margin: 0.875rem 0;
+  padding: 0 1.75rem;
   border-left: 4px solid #90a4ae;
 }
 
 hr {
-  margin: 1rem 0;
+  margin: 0.875rem 0;
   border-top: solid var(--color-border);
   border-width: 1px 0 0;
 }

--- a/frontend/src/assets/styles/base.scss
+++ b/frontend/src/assets/styles/base.scss
@@ -114,7 +114,7 @@ p.p-secondary {
 }
 
 mark {
-  padding: 0.21875rem 0.35rem;
+  padding: 0.2188rem 0.35rem;
   border-radius: var(--radius-lg);
   background: #fff8e1;
   font-family: monospace;

--- a/frontend/src/assets/styles/buttons.scss
+++ b/frontend/src/assets/styles/buttons.scss
@@ -25,7 +25,7 @@
   background-clip: padding-box;
   color: var(--app-button-color);
   font: inherit;
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
   font-weight: 500;
   line-height: 1;
   text-decoration: none;
@@ -91,7 +91,7 @@
   --app-button-padding-x: var(--control-padding-x-sm);
   --app-button-icon-size: var(--control-icon-size-sm);
 
-  font-size: var(--text-sm);
+  font-size: var(--app-text-sm);
 }
 
 .app-button-icon {

--- a/frontend/src/assets/styles/compat.scss
+++ b/frontend/src/assets/styles/compat.scss
@@ -32,22 +32,21 @@
   --control-primary-border-hover: color-mix(in srgb, var(--primary-color) 45%, var(--control-primary-bg));
   --control-focus-border: color-mix(in srgb, var(--primary-color) 50%, var(--control-bg));
   --control-focus-ring-color: color-mix(in srgb, var(--primary-color) 50%, transparent);
-  --control-height: 2.625rem;
-  --control-height-sm: 2.25rem;
-  --control-padding-x: 0.75rem;
-  --control-padding-x-sm: 0.875rem;
-  --control-icon-size: 1rem;
-  --control-icon-size-sm: 0.875rem;
-  --control-gap: 0.5rem;
+  --control-height: 2.29688rem;
+  --control-height-sm: 1.96875rem;
+  --control-padding-x: 0.65625rem;
+  --control-padding-x-sm: 0.76563rem;
+  --control-icon-size: 0.875rem;
+  --control-icon-size-sm: 0.76563rem;
+  --control-gap: 0.4375rem;
   --control-radius: var(--radius-md);
   --control-disabled-opacity: 0.5;
   --danger-color: var(--color-danger);
   --danger-hover-color: var(--color-danger-hover);
   --warning-color: var(--color-warning);
   --info-color: var(--color-info);
-  --focus-ring: 0 0 0 0.2rem color-mix(in srgb, var(--primary-color) 40%, transparent);
-  --font-family: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif;
-  --font-size-root: 14px;
+  --focus-ring: 0 0 0 0.175rem color-mix(in srgb, var(--primary-color) 40%, transparent);
+  --font-family: var(--font-sans);
   --page-content-gap: var(--space-4);
   --page-gutter-block: var(--space-5);
   --page-gutter-inline: var(--space-5);
@@ -58,16 +57,12 @@
   --radius-sm: 4px;
   --shadow-overlay: 0 30px 80px -20px rgb(0 0 0 / 70%), 0 10px 30px -10px rgb(0 0 0 / 50%);
   --shadow-sm: 0 2px 4px rgb(0 0 0 / 25%);
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.25rem;
-  --space-6: 1.5rem;
-  --text-base: 1rem;
-  --text-lg: 1.125rem;
-  --text-sm: 0.875rem;
-  --text-xs: 0.75rem;
+  --space-1: 0.21875rem;
+  --space-2: 0.4375rem;
+  --space-3: 0.65625rem;
+  --space-4: 0.875rem;
+  --space-5: 1.09375rem;
+  --space-6: 1.3125rem;
   --transition-base: 0.2s ease;
   --transition-fast: 0.15s ease;
   --book-type-pdf-color: var(--color-red-600);
@@ -93,10 +88,10 @@
 
 @mixin sidebar-fixed-overlay {
   position: fixed !important;
-  top: var(--sidebar-popover-top, 0.75rem) !important;
+  top: var(--sidebar-popover-top, 0.65625rem) !important;
   bottom: auto !important;
-  left: var(--sidebar-popover-left, calc(var(--sidebar-width, 225px) + 0.5rem)) !important;
-  max-height: var(--sidebar-popover-max-height, calc(100vh - 1rem)) !important;
+  left: var(--sidebar-popover-left, calc(var(--sidebar-width, 225px) + 0.4375rem)) !important;
+  max-height: var(--sidebar-popover-max-height, calc(100vh - 0.875rem)) !important;
   margin: 0 !important;
   overflow: auto !important;
   transform: none !important;
@@ -174,7 +169,7 @@
 }
 
 .p-toast {
-  top: 4rem !important;
+  top: 3.5rem !important;
 }
 
 .p-inputchips,
@@ -189,7 +184,7 @@
 }
 
 .chart-info-tooltip.p-tooltip {
-  --p-tooltip-max-width: 25rem;
+  --p-tooltip-max-width: 21.875rem;
 }
 
 .progress-incomplete .p-progressbar-value {
@@ -221,11 +216,11 @@
 }
 
 .custom-button-padding .p-button {
-  padding-block: 0.25rem !important;
+  padding-block: 0.21875rem !important;
 }
 
 .book-details-dialog .p-dialog-header {
-  padding: 1rem 1.25rem !important;
+  padding: 0.875rem 1.09375rem !important;
 }
 
 .sidebar-flyout-popover.p-popover {
@@ -239,7 +234,7 @@
 
 @media (width <= 991px) {
   .sidebar-flyout-popover.p-popover {
-    max-width: calc(100vw - 1rem) !important;
+    max-width: calc(100vw - 0.875rem) !important;
   }
 }
 
@@ -267,7 +262,7 @@
     .p-menu-item-link,
     .p-tieredmenu-item-content > .p-tieredmenu-item-link,
     .p-tieredmenu-item-link {
-      min-height: 3rem !important;
+      min-height: 2.625rem !important;
       padding: var(--space-3) var(--space-4) !important;
       gap: var(--space-3) !important;
     }

--- a/frontend/src/assets/styles/compat.scss
+++ b/frontend/src/assets/styles/compat.scss
@@ -32,12 +32,12 @@
   --control-primary-border-hover: color-mix(in srgb, var(--primary-color) 45%, var(--control-primary-bg));
   --control-focus-border: color-mix(in srgb, var(--primary-color) 50%, var(--control-bg));
   --control-focus-ring-color: color-mix(in srgb, var(--primary-color) 50%, transparent);
-  --control-height: 2.29688rem;
-  --control-height-sm: 1.96875rem;
-  --control-padding-x: 0.65625rem;
-  --control-padding-x-sm: 0.76563rem;
+  --control-height: 2.2969rem;
+  --control-height-sm: 1.9688rem;
+  --control-padding-x: 0.6563rem;
+  --control-padding-x-sm: 0.7656rem;
   --control-icon-size: 0.875rem;
-  --control-icon-size-sm: 0.76563rem;
+  --control-icon-size-sm: 0.7656rem;
   --control-gap: 0.4375rem;
   --control-radius: var(--radius-md);
   --control-disabled-opacity: 0.5;
@@ -57,11 +57,11 @@
   --radius-sm: 4px;
   --shadow-overlay: 0 30px 80px -20px rgb(0 0 0 / 70%), 0 10px 30px -10px rgb(0 0 0 / 50%);
   --shadow-sm: 0 2px 4px rgb(0 0 0 / 25%);
-  --space-1: 0.21875rem;
+  --space-1: 0.2188rem;
   --space-2: 0.4375rem;
-  --space-3: 0.65625rem;
+  --space-3: 0.6563rem;
   --space-4: 0.875rem;
-  --space-5: 1.09375rem;
+  --space-5: 1.0938rem;
   --space-6: 1.3125rem;
   --transition-base: 0.2s ease;
   --transition-fast: 0.15s ease;
@@ -88,7 +88,7 @@
 
 @mixin sidebar-fixed-overlay {
   position: fixed !important;
-  top: var(--sidebar-popover-top, 0.65625rem) !important;
+  top: var(--sidebar-popover-top, 0.6563rem) !important;
   bottom: auto !important;
   left: var(--sidebar-popover-left, calc(var(--sidebar-width, 225px) + 0.4375rem)) !important;
   max-height: var(--sidebar-popover-max-height, calc(100vh - 0.875rem)) !important;
@@ -216,11 +216,11 @@
 }
 
 .custom-button-padding .p-button {
-  padding-block: 0.21875rem !important;
+  padding-block: 0.2188rem !important;
 }
 
 .book-details-dialog .p-dialog-header {
-  padding: 0.875rem 1.09375rem !important;
+  padding: 0.875rem 1.0938rem !important;
 }
 
 .sidebar-flyout-popover.p-popover {

--- a/frontend/src/assets/styles/control-groups.scss
+++ b/frontend/src/assets/styles/control-groups.scss
@@ -33,7 +33,7 @@
   }
 
   > .app-button-icon {
-    width: calc(var(--app-button-height) + 0.32813rem);
+    width: calc(var(--app-button-height) + 0.3281rem);
   }
 
   > .app-button-primary {

--- a/frontend/src/assets/styles/control-groups.scss
+++ b/frontend/src/assets/styles/control-groups.scss
@@ -29,11 +29,11 @@
   }
 
   > .app-button {
-    --app-button-padding-x: 1rem;
+    --app-button-padding-x: 0.875rem;
   }
 
   > .app-button-icon {
-    width: calc(var(--app-button-height) + 0.375rem);
+    width: calc(var(--app-button-height) + 0.32813rem);
   }
 
   > .app-button-primary {

--- a/frontend/src/assets/styles/overlays.scss
+++ b/frontend/src/assets/styles/overlays.scss
@@ -123,7 +123,7 @@
   gap: 0.4375rem;
   box-sizing: border-box;
   width: 100%;
-  padding: 0.65625rem;
+  padding: 0.6563rem;
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -192,8 +192,8 @@
 .user-account-popover-body {
   display: flex;
   flex-direction: column;
-  gap: 0.21875rem;
-  padding: 0.32813rem;
+  gap: 0.2188rem;
+  padding: 0.3281rem;
 }
 
 .user-account-popover .user-account-popover-action {
@@ -202,7 +202,7 @@
 }
 
 .user-account-popover-footer {
-  padding: 0.32813rem;
+  padding: 0.3281rem;
   border-top: 1px solid var(--color-border);
 }
 

--- a/frontend/src/assets/styles/overlays.scss
+++ b/frontend/src/assets/styles/overlays.scss
@@ -18,7 +18,7 @@
 
 @media #{variables.$mobile-shell-media-query} {
   .cdk-overlay-backdrop.command-palette-backdrop {
-    top: 3.5rem;
+    top: 3.0625rem;
   }
 }
 
@@ -73,7 +73,7 @@
   flex-shrink: 0;
   width: var(--control-icon-size);
   height: var(--control-icon-size);
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
   color: var(--color-surface-500);
 }
 
@@ -96,7 +96,7 @@
 
 .sidebar-notification-popover,
 .user-account-popover {
-  max-width: calc(100vw - 1rem);
+  max-width: calc(100vw - 0.875rem);
   overflow: hidden;
   border: 1px solid var(--color-border);
   border-radius: var(--control-radius);
@@ -114,16 +114,16 @@
 .user-account-popover {
   display: flex;
   flex-direction: column;
-  width: min(17.5rem, calc(100vw - 1rem));
+  width: min(15.3125rem, calc(100vw - 0.875rem));
 }
 
 .user-account-popover-header {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   box-sizing: border-box;
   width: 100%;
-  padding: 0.75rem;
+  padding: 0.65625rem;
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -131,17 +131,17 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   width: 100%;
 }
 
 .user-account-popover-header h2 {
   display: flex;
   align-items: baseline;
-  gap: 0.5rem;
+  gap: 0.4375rem;
   min-width: 0;
   margin: 0;
-  font-size: var(--text-lg);
+  font-size: var(--app-text-lg);
   font-weight: 600;
   line-height: 1.15;
   white-space: nowrap;
@@ -152,7 +152,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--color-text-secondary);
-  font-size: var(--text-xs);
+  font-size: var(--app-text-xs);
   font-weight: 500;
 }
 
@@ -161,14 +161,14 @@
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  width: 2rem;
-  height: 2rem;
+  width: 1.75rem;
+  height: 1.75rem;
   padding: 0;
   border: 0;
   border-radius: 8px;
   background: transparent;
   color: var(--color-surface-500);
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
   cursor: pointer;
   transition:
     background-color var(--transition-fast),
@@ -186,14 +186,14 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .user-account-popover-body {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.375rem;
+  gap: 0.21875rem;
+  padding: 0.32813rem;
 }
 
 .user-account-popover .user-account-popover-action {
@@ -202,7 +202,7 @@
 }
 
 .user-account-popover-footer {
-  padding: 0.375rem;
+  padding: 0.32813rem;
   border-top: 1px solid var(--color-border);
 }
 

--- a/frontend/src/assets/styles/tabs.scss
+++ b/frontend/src/assets/styles/tabs.scss
@@ -41,7 +41,7 @@ app-tabs {
   border: 0;
   background: none;
   color: var(--color-text-secondary);
-  font-size: 0.9375rem;
+  font-size: 0.82031rem;
   font-weight: 500;
   line-height: 1;
   white-space: nowrap;
@@ -83,11 +83,11 @@ app-tabs {
 app-tabs.placement-below {
   display: flex;
   align-items: flex-start;
-  height: var(--app-tabs-row-height, 3.5rem);
-  padding: 0.25rem 2rem 0;
+  height: var(--app-tabs-row-height, 3.0625rem);
+  padding: 0.21875rem 1.75rem 0;
 
   @media (width <= 767px) {
-    padding: 0.25rem 1rem 0;
+    padding: 0.21875rem 0.875rem 0;
   }
 }
 
@@ -100,29 +100,29 @@ app-tabs.variant-underline {
     align-items: stretch;
     width: 100%;
     height: 100%;
-    gap: 1.5rem;
-    padding: 0 2rem;
+    gap: 1.3125rem;
+    padding: 0 1.75rem;
 
     &::after {
       content: "";
       position: absolute;
-      right: 2rem;
+      right: 1.75rem;
       bottom: 0;
-      left: 2rem;
+      left: 1.75rem;
       height: 1px;
       background: var(--app-tabs-divider);
       pointer-events: none;
     }
 
     @media (width <= 767px) {
-      gap: 1rem;
-      padding: 0 1rem;
+      gap: 0.875rem;
+      padding: 0 0.875rem;
       overflow-x: auto;
       scrollbar-width: none;
 
       &::after {
-        right: 1rem;
-        left: 1rem;
+        right: 0.875rem;
+        left: 0.875rem;
       }
 
       &::-webkit-scrollbar {
@@ -132,13 +132,13 @@ app-tabs.variant-underline {
   }
 
   .app-tab {
-    min-width: 5rem;
-    padding: 0 1rem;
+    min-width: 4.375rem;
+    padding: 0 0.875rem;
 
     @media (width <= 767px) {
       flex: 1 1 0;
-      min-width: 4rem;
-      padding: 0 0.875rem;
+      min-width: 3.5rem;
+      padding: 0 0.76563rem;
     }
 
     &[aria-selected="true"] {
@@ -173,7 +173,7 @@ app-tabs.variant-underline {
 
 app-tabs.variant-segmented {
   .app-tabs {
-    gap: 0.125rem;
+    gap: 0.10938rem;
     padding: var(--space-1);
     border-radius: var(--radius-lg);
     background: var(--control-bg);
@@ -189,8 +189,8 @@ app-tabs.variant-segmented {
   }
 
   .app-tab {
-    height: 2rem;
-    padding: 0 1rem;
+    height: 1.75rem;
+    padding: 0 0.875rem;
     border-radius: var(--control-radius);
 
     &:hover:not([aria-selected="true"]) {

--- a/frontend/src/assets/styles/tabs.scss
+++ b/frontend/src/assets/styles/tabs.scss
@@ -41,7 +41,7 @@ app-tabs {
   border: 0;
   background: none;
   color: var(--color-text-secondary);
-  font-size: 0.82031rem;
+  font-size: 0.8203rem;
   font-weight: 500;
   line-height: 1;
   white-space: nowrap;
@@ -84,10 +84,10 @@ app-tabs.placement-below {
   display: flex;
   align-items: flex-start;
   height: var(--app-tabs-row-height, 3.0625rem);
-  padding: 0.21875rem 1.75rem 0;
+  padding: 0.2188rem 1.75rem 0;
 
   @media (width <= 767px) {
-    padding: 0.21875rem 0.875rem 0;
+    padding: 0.2188rem 0.875rem 0;
   }
 }
 
@@ -138,7 +138,7 @@ app-tabs.variant-underline {
     @media (width <= 767px) {
       flex: 1 1 0;
       min-width: 3.5rem;
-      padding: 0 0.76563rem;
+      padding: 0 0.7656rem;
     }
 
     &[aria-selected="true"] {
@@ -173,7 +173,7 @@ app-tabs.variant-underline {
 
 app-tabs.variant-segmented {
   .app-tabs {
-    gap: 0.10938rem;
+    gap: 0.1094rem;
     padding: var(--space-1);
     border-radius: var(--radius-lg);
     background: var(--control-bg);

--- a/frontend/src/assets/styles/tailwind.css
+++ b/frontend/src/assets/styles/tailwind.css
@@ -6,6 +6,13 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme static {
+  --font-sans: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif;
+
+  --text-app-xs: 0.65625rem;
+  --text-app-sm: 0.765625rem;
+  --text-app-base: 0.875rem;
+  --text-app-lg: 0.984375rem;
+
   --color-primary-50: var(--color-orange-50);
   --color-primary-100: var(--color-orange-100);
   --color-primary-200: var(--color-orange-200);
@@ -54,6 +61,14 @@
   --color-logo-start: var(--color-primary-400);
   --color-logo-end: var(--color-primary-600);
   --color-logo-bookmark: #FF2126;
+}
+
+:root {
+  --font-size-root: 16px;
+  --app-text-xs: var(--text-app-xs);
+  --app-text-sm: var(--text-app-sm);
+  --app-text-base: var(--text-app-base);
+  --app-text-lg: var(--text-app-lg);
 }
 
 [data-app-theme] {

--- a/frontend/src/assets/styles/tailwind.css
+++ b/frontend/src/assets/styles/tailwind.css
@@ -8,10 +8,10 @@
 @theme static {
   --font-sans: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif;
 
-  --text-app-xs: 0.65625rem;
-  --text-app-sm: 0.765625rem;
+  --text-app-xs: 0.6563rem;
+  --text-app-sm: 0.7656rem;
   --text-app-base: 0.875rem;
-  --text-app-lg: 0.984375rem;
+  --text-app-lg: 0.9844rem;
 
   --color-primary-50: var(--color-orange-50);
   --color-primary-100: var(--color-orange-100);

--- a/frontend/src/assets/styles/text-fields.scss
+++ b/frontend/src/assets/styles/text-fields.scss
@@ -21,7 +21,7 @@
   background-clip: padding-box;
   color: var(--app-text-field-color);
   font: inherit;
-  font-size: var(--text-base);
+  font-size: var(--app-text-base);
   line-height: 1.5;
   transition:
     background var(--transition-fast),

--- a/frontend/src/assets/styles/utilities.scss
+++ b/frontend/src/assets/styles/utilities.scss
@@ -51,13 +51,13 @@
   flex-shrink: 0;
   height: 1px;
   min-height: 1px;
-  margin: 0.25rem 0;
+  margin: 0.21875rem 0;
   background: linear-gradient(90deg, transparent, var(--color-border), transparent);
 }
 
 .chart-info-icon {
   color: var(--color-text-muted);
-  font-size: 0.9rem;
+  font-size: 0.7875rem;
   cursor: help;
   transition: color var(--transition-base);
 
@@ -96,17 +96,17 @@
 
 .browser-grid-options {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4375rem;
 }
 
 .browser-grid-option-btn {
   flex: 1;
-  padding: 0.25rem 0.5rem;
+  padding: 0.21875rem 0.4375rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
   background-color: var(--color-card);
   color: var(--color-text);
-  font-size: 1rem;
+  font-size: var(--app-text-base);
   font-weight: 600;
   cursor: pointer;
   transition: all 0.15s ease;

--- a/frontend/src/assets/styles/utilities.scss
+++ b/frontend/src/assets/styles/utilities.scss
@@ -51,7 +51,7 @@
   flex-shrink: 0;
   height: 1px;
   min-height: 1px;
-  margin: 0.21875rem 0;
+  margin: 0.2188rem 0;
   background: linear-gradient(90deg, transparent, var(--color-border), transparent);
 }
 
@@ -101,7 +101,7 @@
 
 .browser-grid-option-btn {
   flex: 1;
-  padding: 0.21875rem 0.4375rem;
+  padding: 0.2188rem 0.4375rem;
   border: 1px solid var(--p-content-border-color);
   border-radius: 6px;
   background-color: var(--color-card);


### PR DESCRIPTION
## Description

This is a slightly horrible one but it's all mechanical changes. The app's root font size was set to 14px which isn't ideal for Tailwind given it assumes a default 16px for all spacing and sizing. At 14px, basic things like incorrect breakpoints, rem calculations, external packages that assume 16px, sub-pixel computed sizes etc, all start to get messy. None of the tailwind documentation lines up with what the frontend is currently computing either. This PR fixes the root size while ensuring the existing UI is unchanged. 

## Linked Issue

N/A

## Changes

- Increase root font size to 16px
- Added app-text size tokens to maintain current text sizing. 
- Ran a script to scale down all CSS rem measurements to maintain current sizing and spacing. 
- Added PrimeNG rem and text size scaling to maintain current sizes. 

## Manual Testing Steps

Confirm the UI is unchanged despite the root change. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

There is zero user facing change from this, but allows for much cleaner work on future UI work with tailwind. This is a direct prerequisite for control component work I'm doing right now. 

## AI Disclosure

Codex wrote and executed the rem-calculation script and verified computed values were identical. 

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.
