### PR TITLE
fix(book-details): fall back from invalid book detail tabs

### DIFF
--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.html
@@ -21,50 +21,50 @@
   <div class="tabs-wrapper" [class.dialog-mode]="config">
     <p-tabs [(value)]="tab" lazy="true" scrollable>
     <p-tablist>
-      <p-tab value="view">
+      <p-tab [value]="BookMetadataTab.View">
         <i [class]="'pi pi-book'"></i>
         {{ t('tabView') }}
       </p-tab>
-      @if (admin() || canEditMetadata()) {
-        <p-tab value="edit">
+      @if (canOpenTab(BookMetadataTab.Edit)) {
+        <p-tab [value]="BookMetadataTab.Edit">
           <i [class]="'pi pi-pencil'"></i>
           {{ t('tabEdit') }}
         </p-tab>
       }
-      @if (admin() || canEditMetadata()) {
-        <p-tab value="match">
+      @if (canOpenTab(BookMetadataTab.Match)) {
+        <p-tab [value]="BookMetadataTab.Match">
           <i [class]="'pi pi-search'"></i>
           {{ t('tabSearch') }}
         </p-tab>
       }
-      @if (canShowSidecarTab) {
-        <p-tab value="sidecar">
+      @if (canOpenTab(BookMetadataTab.Sidecar)) {
+        <p-tab [value]="BookMetadataTab.Sidecar">
           <i [class]="'pi pi-file'"></i>
           {{ t('tabSidecar') }}
         </p-tab>
       }
     </p-tablist>
     <p-tabpanels class="tabpanels-responsive">
-      <p-tabpanel value="view">
+      <p-tabpanel [value]="BookMetadataTab.View">
         <app-metadata-viewer
           [book]="book()"
           [recommendedBooks]="recommendedBooks()">
         </app-metadata-viewer>
       </p-tabpanel>
-      @if (admin() || canEditMetadata()) {
-        <p-tabpanel value="edit">
+      @if (canOpenTab(BookMetadataTab.Edit)) {
+        <p-tabpanel [value]="BookMetadataTab.Edit">
           <app-metadata-editor
             [book]="book()">
           </app-metadata-editor>
         </p-tabpanel>
       }
-      @if (admin() || canEditMetadata()) {
-        <p-tabpanel value="match">
-          <app-metadata-searcher [book]="book()" [isActiveTab]="tab === 'match'"></app-metadata-searcher>
+      @if (canOpenTab(BookMetadataTab.Match)) {
+        <p-tabpanel [value]="BookMetadataTab.Match">
+          <app-metadata-searcher [book]="book()" [isActiveTab]="tab === BookMetadataTab.Match"></app-metadata-searcher>
         </p-tabpanel>
       }
-      @if (canShowSidecarTab) {
-        <p-tabpanel value="sidecar">
+      @if (canOpenTab(BookMetadataTab.Sidecar)) {
+        <p-tabpanel [value]="BookMetadataTab.Sidecar">
           <app-sidecar-viewer [book]="book()"></app-sidecar-viewer>
         </p-tabpanel>
       }

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.spec.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.spec.ts
@@ -1,12 +1,15 @@
 import {signal, type WritableSignal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ActivatedRoute, Router} from '@angular/router';
+import {ActivatedRoute, convertToParamMap, Router} from '@angular/router';
+import {queryOptions} from '@tanstack/angular-query-experimental';
+import {BehaviorSubject, Subject} from 'rxjs';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {createQueryClientHarness} from '../../../../core/testing/query-testing';
 import {AppSettings, type MetadataPersistenceSettings} from '../../../../shared/model/app-settings.model';
 import {AppSettingsService} from '../../../../shared/service/app-settings.service';
 import {BookMetadataHostService} from '../../../../shared/service/book-metadata-host.service';
+import {Book} from '../../../book/model/book.model';
 import {BookService} from '../../../book/service/book.service';
 import {UserService} from '../../../settings/user-management/user.service';
 import {BookMetadataCenterComponent} from './book-metadata-center.component';
@@ -14,22 +17,44 @@ import {BookMetadataCenterComponent} from './book-metadata-center.component';
 describe('BookMetadataCenterComponent', () => {
   let appSettingsSignal: WritableSignal<AppSettings | null>;
   let currentUserSignal: WritableSignal<{permissions?: {admin?: boolean; canEditMetadata?: boolean}} | null>;
+  let queryParamMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  let routerNavigate: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     const queryClientHarness = createQueryClientHarness();
 
     appSettingsSignal = signal<AppSettings | null>(null);
     currentUserSignal = signal({permissions: {admin: true, canEditMetadata: true}});
+    queryParamMapSubject = new BehaviorSubject(convertToParamMap({}));
+    routerNavigate = vi.fn();
 
     TestBed.configureTestingModule({
       providers: [
         ...queryClientHarness.providers,
-        {provide: ActivatedRoute, useValue: {}},
-        {provide: Router, useValue: {navigate: vi.fn()}},
-        {provide: BookService, useValue: {}},
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: new BehaviorSubject(convertToParamMap({bookId: '1'})),
+            queryParamMap: queryParamMapSubject.asObservable(),
+          }
+        },
+        {provide: Router, useValue: {navigate: routerNavigate}},
+        {
+          provide: BookService,
+          useValue: {
+            bookDetailQueryOptions: (bookId: number) => queryOptions({
+              queryKey: ['books', 'detail', bookId, true],
+              queryFn: async (): Promise<Book> => ({id: bookId} as Book),
+            }),
+            bookRecommendationsQueryOptions: (bookId: number) => queryOptions({
+              queryKey: ['books', 'recommendations', bookId],
+              queryFn: async () => [],
+            }),
+          }
+        },
         {provide: UserService, useValue: {currentUser: currentUserSignal}},
         {provide: AppSettingsService, useValue: {appSettings: appSettingsSignal}},
-        {provide: BookMetadataHostService, useValue: {}},
+        {provide: BookMetadataHostService, useValue: {bookSwitches$: new Subject<number>()}},
       ],
     });
   });
@@ -47,6 +72,37 @@ describe('BookMetadataCenterComponent', () => {
     appSettingsSignal.set(buildSettings({sidecarEnabled: false}));
 
     expect(component.canShowSidecarTab).toBe(false);
+  });
+
+  it('falls back to the view tab when the query param is invalid', () => {
+    const component = TestBed.runInInjectionContext(() => new BookMetadataCenterComponent());
+
+    queryParamMapSubject.next(convertToParamMap({tab: 'missing'}));
+    component.ngOnInit();
+
+    expect(component.tab).toBe('view');
+    expect(routerNavigate).toHaveBeenCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      queryParams: {tab: 'view'},
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  });
+
+  it('falls back to the view tab when the user cannot open the requested tab', () => {
+    currentUserSignal.set({permissions: {admin: false, canEditMetadata: false}});
+    const component = TestBed.runInInjectionContext(() => new BookMetadataCenterComponent());
+
+    queryParamMapSubject.next(convertToParamMap({tab: 'edit'}));
+    component.ngOnInit();
+
+    expect(component.tab).toBe('view');
+    expect(routerNavigate).toHaveBeenCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      queryParams: {tab: 'view'},
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   });
 });
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
@@ -18,6 +18,13 @@ import {SidecarViewerComponent} from './sidecar-viewer/sidecar-viewer.component'
 import {injectQuery, queryOptions} from '@tanstack/angular-query-experimental';
 import {bookRecommendationsQueryKey} from '../../../book/service/book-query-keys';
 
+enum BookMetadataTab {
+  View = 'view',
+  Edit = 'edit',
+  Match = 'match',
+  Sidecar = 'sidecar',
+}
+
 @Component({
   selector: 'app-book-metadata-center',
   standalone: true,
@@ -46,6 +53,7 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
   private metadataHostService = inject(BookMetadataHostService);
   readonly config = inject(DynamicDialogConfig, {optional: true});
   readonly ref = inject(DynamicDialogRef, {optional: true});
+  BookMetadataTab = BookMetadataTab;
   private destroy$ = new Subject<void>();
 
   private currentBookId = signal<number | null>(this.config?.data?.bookId ?? null);
@@ -84,7 +92,7 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
       (a, b) => (b.similarityScore ?? 0) - (a.similarityScore ?? 0)
     )
   );
-  private _tab: string = 'view';
+  private _tab: BookMetadataTab = BookMetadataTab.View;
   readonly canEditMetadata = computed(() => {
     const user = this.userService.currentUser();
     return user?.permissions?.canEditMetadata ?? false;
@@ -101,13 +109,13 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
 
     return (this.admin() || this.canEditMetadata()) && !this.isPhysical && this.isLocalStorage() && sidecarEnabled;
   }
-  private validTabs = ['view', 'edit', 'match', 'sidecar'];
+  private validTabs = Object.values(BookMetadataTab);
 
-  get tab(): string {
+  get tab(): BookMetadataTab {
     return this._tab;
   }
 
-  set tab(value: string) {
+  set tab(value: BookMetadataTab) {
     this._tab = value;
 
     if (!this.config) {
@@ -143,14 +151,41 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
 
     this.route.queryParamMap
       .pipe(
-        map(params => params.get('tab') ?? 'view'),
+        map(params => params.get('tab')),
         distinctUntilChanged(),
         takeUntil(this.destroy$)
       )
       .subscribe(tabParam => {
-        this._tab = this.validTabs.includes(tabParam) ? tabParam : 'view';
+        if (this.validTabs.includes(tabParam as BookMetadataTab) && this.canOpenTab(tabParam as BookMetadataTab)) {
+          this._tab = tabParam as BookMetadataTab;
+        } else {
+          const defaultTab = BookMetadataTab.View;
+          this._tab = defaultTab;
+          if (!this.config) {
+            this.router.navigate([], {
+              relativeTo: this.route,
+              queryParams: {tab: defaultTab},
+              queryParamsHandling: 'merge',
+              replaceUrl: true
+            });
+          }
+        }
       });
 
+  }
+
+  protected canOpenTab(tab: BookMetadataTab): boolean {
+    switch (tab) {
+      case BookMetadataTab.View:
+        return true;
+      case BookMetadataTab.Edit:
+      case BookMetadataTab.Match:
+        return this.admin() || this.canEditMetadata();
+      case BookMetadataTab.Sidecar:
+        return this.canShowSidecarTab;
+      default:
+        return false;
+    }
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
@@ -1,9 +1,9 @@
-import {computed, Component, inject, OnDestroy, OnInit, signal} from '@angular/core';
+import {computed, Component, DestroyRef, inject, OnInit, signal} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {ActivatedRoute, Router} from '@angular/router';
 import {UserService} from '../../../settings/user-management/user.service';
 import {Book, BookRecommendation} from '../../../book/model/book.model';
-import {Subject} from 'rxjs';
-import {distinctUntilChanged, filter, map, takeUntil,} from 'rxjs/operators';
+import {distinctUntilChanged, filter, map} from 'rxjs/operators';
 import {BookService} from '../../../book/service/book.service';
 import {AppSettingsService} from '../../../../shared/service/app-settings.service';
 import {Tab, TabList, TabPanel, TabPanels, Tabs,} from 'primeng/tabs';
@@ -44,17 +44,17 @@ enum BookMetadataTab {
   ],
   styleUrls: ['./book-metadata-center.component.scss'],
 })
-export class BookMetadataCenterComponent implements OnInit, OnDestroy {
+export class BookMetadataCenterComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private bookService = inject(BookService);
   private userService = inject(UserService);
   private appSettingsService = inject(AppSettingsService);
   private metadataHostService = inject(BookMetadataHostService);
+  private destroyRef = inject(DestroyRef);
   readonly config = inject(DynamicDialogConfig, {optional: true});
   readonly ref = inject(DynamicDialogRef, {optional: true});
   BookMetadataTab = BookMetadataTab;
-  private destroy$ = new Subject<void>();
 
   private currentBookId = signal<number | null>(this.config?.data?.bookId ?? null);
   private bookQuery = injectQuery(() => {
@@ -136,7 +136,7 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
         .pipe(
           map(params => Number(params.get('bookId'))),
           filter(bookId => !isNaN(bookId)),
-          takeUntil(this.destroy$)
+          takeUntilDestroyed(this.destroyRef)
         )
         .subscribe(bookId => this.currentBookId.set(bookId));
     }
@@ -145,7 +145,7 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
       .pipe(
         filter((bookId): bookId is number => !!bookId),
         distinctUntilChanged(),
-        takeUntil(this.destroy$)
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(bookId => this.currentBookId.set(bookId));
 
@@ -153,7 +153,7 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
       .pipe(
         map(params => params.get('tab')),
         distinctUntilChanged(),
-        takeUntil(this.destroy$)
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(tabParam => {
         if (this.validTabs.includes(tabParam as BookMetadataTab) && this.canOpenTab(tabParam as BookMetadataTab)) {
@@ -188,8 +188,4 @@ export class BookMetadataCenterComponent implements OnInit, OnDestroy {
     }
   }
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 }


### PR DESCRIPTION
## Description

How we handle the accessibility of, and routing for book metadata tabs is inconsistent with how we handle other tab accessibility within the platform. As a result, if a tab exists, but is not available for the user's permissions, when a user navigates to that tab via the URL, it shows an empty screen, instead of falling back to the default tab (like in settings).

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/813

## Changes

- Refactor the book metadata tabs to use a similar structure to the recently cleaned up settings tabs
- Add a reusable `canOpenTab(...)` helper method, and `BookMetadataTab` in book metadata, similar to what we do in settings
- Update `book-metadata-center.component.html` to use the `canOpenTab(...)` helper methods for consistency around tab permissions between routing and visibility
- Add spec coverage

## Manual Testing Steps

1. Open the book detail view for an admin in one browser, and a demo user w/o admin or edit metadata perms in another
2. Verify pre-fix that navigating to the edit tab via URL shows the edit tab for admins, and a blank view for demo users
3. Post-fix, verify the edit tab nav works for admins, and redirects to the view tab for demo users
4. Similarly, verify for admins the sidecar tab does not show when sidecar is disabled, and shows when it is enabled (and additionally does not show up when sidecar is enabled but user is not an admin, or cannot edit metadata, etc.)

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or unauthorized tab requests now reliably fall back to the View tab and update the URL to reflect the fallback.

* **Refactor**
  * Tab handling standardized to use centralized tab identifiers and persisted to the query string for consistent behavior.

* **Tests**
  * Added tests covering fallback-to-View behavior for invalid or inaccessible tabs and URL update assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->