### PR TITLE
fix(api): fix content restrictions for `api/v1/books/page`

### DIFF
--- a/backend/src/main/java/org/booklore/security/policy/ContentRestrictionSpecification.java
+++ b/backend/src/main/java/org/booklore/security/policy/ContentRestrictionSpecification.java
@@ -1,0 +1,129 @@
+package org.booklore.security.policy;
+
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.model.entity.UserContentRestrictionEntity;
+import org.booklore.model.enums.ContentRestrictionMode;
+import org.booklore.model.enums.ContentRestrictionType;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class ContentRestrictionSpecification {
+
+    private ContentRestrictionSpecification() {
+    }
+
+    public static Specification<BookEntity> from(List<UserContentRestrictionEntity> restrictions) {
+        if (restrictions == null || restrictions.isEmpty()) {
+            return (root, query, cb) -> cb.conjunction();
+        }
+
+        Specification<BookEntity> spec = (root, query, cb) -> cb.conjunction();
+
+        for (CollectionType type : CollectionType.values()) {
+            Set<String> excluded = values(restrictions, type.restrictionType, ContentRestrictionMode.EXCLUDE);
+            if (!excluded.isEmpty()) {
+                spec = spec.and(Specification.not(hasAnyCollectionValue(type.attribute, excluded)));
+            }
+            Set<String> allowed = values(restrictions, type.restrictionType, ContentRestrictionMode.ALLOW_ONLY);
+            if (!allowed.isEmpty()) {
+                spec = spec.and(hasAnyCollectionValue(type.attribute, allowed));
+            }
+        }
+
+        Set<String> excludedRatings = values(restrictions, ContentRestrictionType.CONTENT_RATING, ContentRestrictionMode.EXCLUDE);
+        if (!excludedRatings.isEmpty()) {
+            spec = spec.and(Specification.not(hasContentRatingIn(excludedRatings)));
+        }
+        Set<String> allowedRatings = values(restrictions, ContentRestrictionType.CONTENT_RATING, ContentRestrictionMode.ALLOW_ONLY);
+        if (!allowedRatings.isEmpty()) {
+            spec = spec.and(hasContentRatingIn(allowedRatings));
+        }
+
+        Integer maxAgeRating = maxAgeRating(restrictions);
+        if (maxAgeRating != null) {
+            spec = spec.and(Specification.not(hasAgeRatingAtLeast(maxAgeRating)));
+        }
+
+        return spec;
+    }
+
+    private enum CollectionType {
+        CATEGORY(ContentRestrictionType.CATEGORY, "categories"),
+        TAG(ContentRestrictionType.TAG, "tags"),
+        MOOD(ContentRestrictionType.MOOD, "moods");
+
+        final ContentRestrictionType restrictionType;
+        final String attribute;
+
+        CollectionType(ContentRestrictionType restrictionType, String attribute) {
+            this.restrictionType = restrictionType;
+            this.attribute = attribute;
+        }
+    }
+
+    private static Specification<BookEntity> hasAnyCollectionValue(String collectionAttribute, Set<String> loweredValues) {
+        return (root, query, cb) -> {
+            Subquery<Long> sq = query.subquery(Long.class);
+            Root<BookMetadataEntity> m = sq.from(BookMetadataEntity.class);
+            Join<Object, Object> value = m.join(collectionAttribute);
+            sq.select(m.get("bookId")).where(
+                    cb.equal(m.get("bookId"), root.get("id")),
+                    cb.lower(value.get("name")).in(loweredValues));
+            return cb.exists(sq);
+        };
+    }
+
+    private static Specification<BookEntity> hasContentRatingIn(Set<String> loweredValues) {
+        return (root, query, cb) -> {
+            Subquery<Long> sq = query.subquery(Long.class);
+            Root<BookMetadataEntity> m = sq.from(BookMetadataEntity.class);
+            sq.select(m.get("bookId")).where(
+                    cb.equal(m.get("bookId"), root.get("id")),
+                    cb.lower(m.get("contentRating")).in(loweredValues));
+            return cb.exists(sq);
+        };
+    }
+
+    private static Specification<BookEntity> hasAgeRatingAtLeast(int threshold) {
+        return (root, query, cb) -> {
+            Subquery<Long> sq = query.subquery(Long.class);
+            Root<BookMetadataEntity> m = sq.from(BookMetadataEntity.class);
+            sq.select(m.get("bookId")).where(
+                    cb.equal(m.get("bookId"), root.get("id")),
+                    cb.greaterThanOrEqualTo(m.get("ageRating"), threshold));
+            return cb.exists(sq);
+        };
+    }
+
+    private static Set<String> values(List<UserContentRestrictionEntity> restrictions,
+                                      ContentRestrictionType type, ContentRestrictionMode mode) {
+        return restrictions.stream()
+                .filter(r -> r.getRestrictionType() == type && r.getMode() == mode)
+                .map(r -> r.getValue().toLowerCase())
+                .collect(Collectors.toSet());
+    }
+
+    private static Integer maxAgeRating(List<UserContentRestrictionEntity> restrictions) {
+        return restrictions.stream()
+                .filter(r -> r.getRestrictionType() == ContentRestrictionType.AGE_RATING)
+                .filter(r -> r.getMode() == ContentRestrictionMode.EXCLUDE)
+                .map(r -> {
+                    try {
+                        return Integer.parseInt(r.getValue());
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .min(Integer::compareTo)
+                .orElse(null);
+    }
+}

--- a/backend/src/main/java/org/booklore/service/book/BookQueryService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookQueryService.java
@@ -1,6 +1,7 @@
 package org.booklore.service.book;
 
 import lombok.RequiredArgsConstructor;
+import org.booklore.app.specification.AppBookSpecification;
 import org.booklore.mapper.v2.BookMapperV2;
 import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookMetadata;
@@ -8,11 +9,14 @@ import org.booklore.model.dto.BookRecommendationLite;
 import org.booklore.model.dto.ComicMetadata;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.repository.BookRepository;
+import org.booklore.repository.UserContentRestrictionRepository;
+import org.booklore.security.policy.ContentRestrictionSpecification;
 import org.booklore.service.restriction.ContentRestrictionService;
 import org.hibernate.Hibernate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +32,7 @@ public class BookQueryService {
     private final BookRepository bookRepository;
     private final BookMapperV2 bookMapperV2;
     private final ContentRestrictionService contentRestrictionService;
+    private final UserContentRestrictionRepository restrictionRepository;
 
     public List<Book> getAllBooks(boolean includeDescription, boolean stripForListView) {
         List<BookEntity> books = bookRepository.findAllWithMetadata();
@@ -46,12 +51,27 @@ public class BookQueryService {
     }
 
     public Page<Book> getAllBooksByLibraryIdsPaged(Collection<Long> libraryIds, Long userId, Pageable pageable) {
-        Page<BookEntity> page = bookRepository.findAllWithMetadataByLibraryIdsPage(libraryIds, pageable);
-        List<BookEntity> filtered = contentRestrictionService.applyRestrictions(page.getContent(), userId);
-        List<Book> dtos = filtered.stream()
+        Page<BookEntity> page = bookRepository.findAll(visibleBooks(libraryIds, userId), pageable);
+        Map<Long, BookEntity> booksById = bookRepository
+                .findAllWithMetadataByIds(page.getContent().stream().map(BookEntity::getId).collect(Collectors.toSet()))
+                .stream()
+                .collect(Collectors.toMap(BookEntity::getId, book -> book));
+        List<Book> dtos = page.getContent().stream()
+                .map(book -> booksById.get(book.getId()))
+                .filter(Objects::nonNull)
                 .map(book -> mapBookToDto(book, false, userId, true))
                 .toList();
         return new PageImpl<>(dtos, pageable, page.getTotalElements());
+    }
+
+    private Specification<BookEntity> visibleBooks(Collection<Long> libraryIds, Long userId) {
+        Specification<BookEntity> inLibraries = (root, query, cb) ->
+                libraryIds == null || libraryIds.isEmpty()
+                        ? cb.disjunction()
+                        : root.get("library").get("id").in(libraryIds);
+        return AppBookSpecification.notDeleted()
+                .and(inLibraries)
+                .and(ContentRestrictionSpecification.from(restrictionRepository.findByUserId(userId)));
     }
 
     public List<BookEntity> getAllFullBookEntitiesBatch(Pageable pageable) {

--- a/backend/src/test/java/org/booklore/service/restriction/ContentRestrictionSpecificationTest.java
+++ b/backend/src/test/java/org/booklore/service/restriction/ContentRestrictionSpecificationTest.java
@@ -1,0 +1,334 @@
+package org.booklore.service.restriction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.booklore.BookloreApplication;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookLoreUserEntity;
+import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.model.entity.CategoryEntity;
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.entity.LibraryPathEntity;
+import org.booklore.model.entity.MoodEntity;
+import org.booklore.model.entity.TagEntity;
+import org.booklore.model.entity.UserContentRestrictionEntity;
+import org.booklore.model.enums.BookFileType;
+import org.booklore.model.enums.ContentRestrictionMode;
+import org.booklore.model.enums.ContentRestrictionType;
+import org.booklore.model.dto.Book;
+import org.booklore.repository.BookRepository;
+import org.booklore.repository.UserContentRestrictionRepository;
+import org.booklore.security.policy.ContentRestrictionSpecification;
+import org.springframework.data.jpa.domain.Specification;
+import org.booklore.service.book.BookQueryService;
+import org.booklore.service.task.TaskCronService;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest(classes = BookloreApplication.class)
+@Transactional
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.datasource.url=jdbc:h2:mem:restrictiontest;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "app.path-config=build/tmp/test-config",
+        "app.bookdrop-folder=build/tmp/test-bookdrop",
+        "spring.main.allow-bean-definition-overriding=true",
+        "spring.task.scheduling.enabled=false",
+        "app.task.scan-library-cron=*/1 * * * * *",
+        "app.task.process-bookdrop-cron=*/1 * * * * *",
+        "app.features.oidc-enabled=false"
+})
+@Import(ContentRestrictionSpecificationTest.TestConfig.class)
+class ContentRestrictionSpecificationTest {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private ContentRestrictionService contentRestrictionService;
+
+    @Autowired
+    private BookQueryService bookQueryService;
+
+    @Autowired
+    private UserContentRestrictionRepository restrictionRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private BookLoreUserEntity user;
+    private LibraryEntity library;
+    private LibraryPathEntity libraryPath;
+    private final Map<String, CategoryEntity> categories = new HashMap<>();
+    private final Map<String, TagEntity> tags = new HashMap<>();
+    private final Map<String, MoodEntity> moods = new HashMap<>();
+
+    @TestConfiguration
+    public static class TestConfig {
+        @Bean("flyway")
+        @Primary
+        public Flyway flyway() {
+            return mock(Flyway.class);
+        }
+
+        @Bean
+        @Primary
+        public TaskCronService taskCronService() {
+            return mock(TaskCronService.class);
+        }
+    }
+
+    @BeforeEach
+    void seed() {
+        user = BookLoreUserEntity.builder().username("restricted").passwordHash("x").name("Restricted").build();
+        em.persist(user);
+
+        library = LibraryEntity.builder().name("Lib").icon("book").watch(false)
+                .formatPriority(List.of(BookFileType.EPUB)).build();
+        em.persist(library);
+        libraryPath = LibraryPathEntity.builder().library(library).path("/p").build();
+        em.persist(libraryPath);
+
+        book("horror-cat", null, null, List.of("Horror"), List.of(), List.of());
+        book("romance-cat", null, null, List.of("Romance"), List.of(), List.of());
+        book("horror-and-romance", null, null, List.of("Horror", "Romance"), List.of(), List.of());
+        book("explicit-tag", null, null, List.of(), List.of("Explicit"), List.of());
+        book("dark-mood", null, null, List.of(), List.of(), List.of("Dark"));
+        book("mature-rating", "Mature", null, List.of(), List.of(), List.of());
+        book("everyone-rating", "Everyone", null, List.of(), List.of(), List.of());
+        book("age-18", null, 18, List.of(), List.of(), List.of());
+        book("age-12", null, 12, List.of(), List.of(), List.of());
+        book("age-null", null, null, List.of(), List.of(), List.of());
+        book("bare-metadata", null, null, List.of(), List.of(), List.of());
+        bookWithoutMetadata("no-metadata");
+
+        em.flush();
+    }
+
+    private BookEntity book(String title, String contentRating, Integer ageRating,
+                            List<String> categoryNames, List<String> tagNames, List<String> moodNames) {
+        BookEntity bookEntity = BookEntity.builder()
+                .library(library).libraryPath(libraryPath).addedOn(Instant.now()).deleted(false).build();
+        em.persist(bookEntity);
+
+        BookMetadataEntity metadata = BookMetadataEntity.builder()
+                .book(bookEntity).title(title).contentRating(contentRating).ageRating(ageRating).build();
+        metadata.setCategories(categoryNames.stream().map(this::category).collect(Collectors.toSet()));
+        metadata.setTags(tagNames.stream().map(this::tag).collect(Collectors.toSet()));
+        metadata.setMoods(moodNames.stream().map(this::mood).collect(Collectors.toSet()));
+        em.persist(metadata);
+        bookEntity.setMetadata(metadata);
+        return bookEntity;
+    }
+
+    private void bookWithoutMetadata(String title) {
+        BookEntity bookEntity = BookEntity.builder()
+                .library(library).libraryPath(libraryPath).addedOn(Instant.now()).deleted(false).build();
+        em.persist(bookEntity);
+    }
+
+    private CategoryEntity category(String name) {
+        return categories.computeIfAbsent(name, n -> {
+            CategoryEntity e = CategoryEntity.builder().name(n).build();
+            em.persist(e);
+            return e;
+        });
+    }
+
+    private TagEntity tag(String name) {
+        return tags.computeIfAbsent(name, n -> {
+            TagEntity e = TagEntity.builder().name(n).build();
+            em.persist(e);
+            return e;
+        });
+    }
+
+    private MoodEntity mood(String name) {
+        return moods.computeIfAbsent(name, n -> {
+            MoodEntity e = MoodEntity.builder().name(n).build();
+            em.persist(e);
+            return e;
+        });
+    }
+
+    private void restrict(ContentRestrictionType type, ContentRestrictionMode mode, String value) {
+        UserContentRestrictionEntity entity = UserContentRestrictionEntity.builder()
+                .user(user).restrictionType(type).mode(mode).value(value).build();
+        em.persist(entity);
+        em.flush();
+    }
+
+    private Specification<BookEntity> restrictionSpec() {
+        return ContentRestrictionSpecification.from(restrictionRepository.findByUserId(user.getId()));
+    }
+
+    private void assertEquivalent() {
+        List<BookEntity> all = bookRepository.findAll();
+        Set<Long> expected = contentRestrictionService.applyRestrictions(all, user.getId()).stream()
+                .map(BookEntity::getId).collect(Collectors.toSet());
+        Set<Long> actual = bookRepository.findAll(restrictionSpec()).stream()
+                .map(BookEntity::getId).collect(Collectors.toSet());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void noRestrictionsKeepsEverything() {
+        assertEquivalent();
+        assertThat(bookRepository.findAll(restrictionSpec()))
+                .hasSize(bookRepository.findAll().size());
+    }
+
+    @Test
+    void excludeCategory() {
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.EXCLUDE, "Horror");
+        assertEquivalent();
+    }
+
+    @Test
+    void excludeTag() {
+        restrict(ContentRestrictionType.TAG, ContentRestrictionMode.EXCLUDE, "Explicit");
+        assertEquivalent();
+    }
+
+    @Test
+    void excludeMood() {
+        restrict(ContentRestrictionType.MOOD, ContentRestrictionMode.EXCLUDE, "Dark");
+        assertEquivalent();
+    }
+
+    @Test
+    void excludeContentRating() {
+        restrict(ContentRestrictionType.CONTENT_RATING, ContentRestrictionMode.EXCLUDE, "Mature");
+        assertEquivalent();
+    }
+
+    @Test
+    void excludeAgeRatingThreshold() {
+        restrict(ContentRestrictionType.AGE_RATING, ContentRestrictionMode.EXCLUDE, "16");
+        assertEquivalent();
+    }
+
+    @Test
+    void allowOnlyCategory() {
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.ALLOW_ONLY, "Romance");
+        assertEquivalent();
+    }
+
+    @Test
+    void allowOnlyContentRating() {
+        restrict(ContentRestrictionType.CONTENT_RATING, ContentRestrictionMode.ALLOW_ONLY, "Everyone");
+        assertEquivalent();
+    }
+
+    @Test
+    void caseInsensitiveMatching() {
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.EXCLUDE, "horror");
+        assertEquivalent();
+    }
+
+    @Test
+    void multipleExcludeTypesCombined() {
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.EXCLUDE, "Horror");
+        restrict(ContentRestrictionType.CONTENT_RATING, ContentRestrictionMode.EXCLUDE, "Mature");
+        restrict(ContentRestrictionType.AGE_RATING, ContentRestrictionMode.EXCLUDE, "16");
+        assertEquivalent();
+    }
+
+    @Test
+    void excludeAndAllowCombined() {
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.ALLOW_ONLY, "Horror");
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.ALLOW_ONLY, "Romance");
+        restrict(ContentRestrictionType.CONTENT_RATING, ContentRestrictionMode.EXCLUDE, "Mature");
+        assertEquivalent();
+    }
+
+    @Test
+    void allowOnlyMultipleValuesWithinType() {
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.ALLOW_ONLY, "Horror");
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.ALLOW_ONLY, "Romance");
+        assertEquivalent();
+    }
+
+    @Test
+    void paginatedTotalReflectsRestrictedSet() {
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.EXCLUDE, "Horror");
+        Set<Long> permitted = permittedIds();
+
+        var page = bookQueryService.getAllBooksByLibraryIdsPaged(List.of(library.getId()), user.getId(), PageRequest.of(0, 100));
+
+        assertThat(page.getTotalElements()).isEqualTo(permitted.size());
+        assertThat(page.getContent().stream().map(Book::getId).collect(Collectors.toSet())).isEqualTo(permitted);
+    }
+
+    @Test
+    void paginatedPagesStayFullDespiteRestrictions() {
+        restrict(ContentRestrictionType.CATEGORY, ContentRestrictionMode.EXCLUDE, "Horror");
+        Set<Long> permitted = permittedIds();
+        int pageSize = 4;
+
+        var firstPage = bookQueryService.getAllBooksByLibraryIdsPaged(List.of(library.getId()), user.getId(), PageRequest.of(0, pageSize));
+
+        assertThat(firstPage.getTotalElements()).isEqualTo(permitted.size());
+        assertThat(firstPage.getContent()).hasSize(pageSize);
+
+        Set<Long> collected = new java.util.HashSet<>();
+        int pages = (int) Math.ceil((double) permitted.size() / pageSize);
+        for (int p = 0; p < pages; p++) {
+            bookQueryService.getAllBooksByLibraryIdsPaged(List.of(library.getId()), user.getId(), PageRequest.of(p, pageSize))
+                    .getContent().forEach(b -> collected.add(b.getId()));
+        }
+        assertThat(collected).isEqualTo(permitted);
+    }
+
+    private Set<Long> permittedIds() {
+        return contentRestrictionService.applyRestrictions(bookRepository.findAll(), user.getId()).stream()
+                .map(BookEntity::getId).collect(Collectors.toSet());
+    }
+    @Test
+    void emptyLibraryScopeReturnsEmptyPage() {
+        var page = bookQueryService.getAllBooksByLibraryIdsPaged(List.of(), user.getId(), PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
+    }
+
+    @Test
+    void foreignLibraryBooksAreNotReturned() {
+        LibraryEntity otherLibrary = LibraryEntity.builder().name("Other").icon("book").watch(false)
+                .formatPriority(List.of(BookFileType.EPUB)).build();
+        em.persist(otherLibrary);
+        BookEntity foreign = BookEntity.builder().library(otherLibrary).addedOn(Instant.now()).deleted(false).build();
+        em.persist(foreign);
+        em.flush();
+
+        var page = bookQueryService.getAllBooksByLibraryIdsPaged(List.of(library.getId()), user.getId(), PageRequest.of(0, 100));
+
+        assertThat(page.getContent().stream().map(Book::getId)).doesNotContain(foreign.getId());
+    }
+}


### PR DESCRIPTION
## Description

The paginated books endpoint (`GET /api/v1/books/page`) didn't deal w/ content restrictions properly, and restricted books were onlyfiltered out after the page was fetched. This led to pages coming back partially empty, reporting wrong totals (`totalElements`/`totalPages` still counted restricted books), and it could push whitelisted books across page windows, resulting in some of them becoming unreachable. Library scoping was already applied in the query- only content restrictions had the problem. This moves content restrictions into the page query itself, so pages are full, totals are correct, and all whitelisted books are reachable.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/1705

## Changes

- `getAllBooksByLibraryIdsPaged` applies content restrictions as a query instead of filtering the fetched page in memory
- Added a new `ContentRestrictionSpecification` (in `org.booklore.security.policy`), to translate a user's restriction rules into `EXISTS`/`NOT EXISTS` predicates (in effect replicating the existing in-memory `ContentRestrictionService.applyRestrictions`)
- Added `ContentRestrictionSpecificationTest` to ensure the new content restriction spec replicates the existing in-memory behaviour that this moves away from.

## Manual Testing Steps

1. Create a library with 30 books, where 8 books have the category `Horror`
2. Create a non-admin user with access to that library, and a content restriction to exclude `Horror`
4. Log in as the non-admin, fetch the library through the paginated endpoint with a page size 20 (`GET /api/v1/books/page?size=20&page=0`)
5. Note the following:
   - The first page returns less than 20 books
   - `totalElements` still reports 30, not 22
   - Paging to the end, the total number of distinct books you can actually reach is less than 22, since some non-Horror books never appear on any page
6. Switch to this branch, and perform step 4 again
7. Note the following:
   - The first page returns 20 books
   - `totalElements` reports 22
   - Paging to the second page, there are 2 results, as would be expected
8. Edit the non-admin user to an admin, and note that the API response now contains all books from all libraries, regardless of content restrictions

## Screenshots (Optional)

N/A

## Additional Context (Optional)

- I placed the new content restriction. spec in `security.policy`, as it'll be the new home in the future for this type of policy scope refactoring.

- Adding the net-new content spec while leaving the old memory based approach is intentional. In a follow up PR, we can then refactor the remaining in-memory instances of content restriction, and eventually delete `ContentRestrictionService.applyRestrictions`.
  - When the code from the `ContentRestrictionService` is deprecated and removed, not counting specs, it will be a net-negative line difference- this PR adds lines for now, but long term this shift will reduce the complexity of the codebase
  - Before this is done we will need to agree in practice upon a new app-wide pattern for query-based scoping. I will be opening a proposal for that up shortly today

## AI Disclosure

Used Fable to convert the existing memory approach to a predicate based approach, manually guided, tested, and verified everything myself

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced content filtering supporting exclusion and allow-only modes for categories, tags, moods, content ratings, and age ratings with improved pagination handling.

* **Tests**
  * Added comprehensive test coverage for content filtering across various restriction scenarios, multiple restriction types, and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->