### PR TITLE
fix(helm): add startup probe to helm chart

### DIFF
--- a/deploy/helm/grimmory/templates/deployment.yaml
+++ b/deploy/helm/grimmory/templates/deployment.yaml
@@ -141,6 +141,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
adds a missing startup probe definition to the helm deployment

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1711

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* adds startup probe to helm deployment

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. `helm template grimmory .`
2. Observe startup probe rendered

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for configurable startup probe in deployment configuration. The startup probe is now conditionally applied based on configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->