### PR TITLE
fix(reader): switch header/footer hover zones from static heights to dynamic

### DIFF
--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.html
@@ -2,7 +2,8 @@
   [class.rtl-reading]="readingDirection() === CbxReadingDirection.RTL"
   [class.fullscreen-mode]="isFullscreen()" [class.slideshow-active]="isSlideshowActive()">
   <app-cbx-header [isCurrentPageBookmarked]="isCurrentPageBookmarked()"
-    [currentPageHasNotes]="currentPageHasNotes()"></app-cbx-header>
+    [currentPageHasNotes]="currentPageHasNotes()"
+    (hoverChange)="onHeaderHovered($event)"></app-cbx-header>
 
   <app-cbx-sidebar></app-cbx-sidebar>
 
@@ -185,5 +186,6 @@
     }
   </div>
 
-  <app-cbx-footer></app-cbx-footer>
+  <app-cbx-footer
+    (hoverChange)="onFooterHovered($event)"></app-cbx-footer>
 </div>

--- a/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/cbx-reader.component.ts
@@ -1859,6 +1859,14 @@ export class CbxReaderComponent implements OnInit, OnDestroy {
     }
   }
 
+  onHeaderHovered(hovered: boolean): void {
+    this.visibilityManager.setHeaderHovered(hovered);
+  }
+
+  onFooterHovered(hovered: boolean): void {
+    this.visibilityManager.setFooterHovered(hovered);
+  }
+
   private handleSwipeGesture() {
     if (this.scrollMode() === CbxScrollMode.INFINITE || this.scrollMode() === CbxScrollMode.LONG_STRIP) return;
 

--- a/frontend/src/app/features/readers/cbx-reader/layout/footer/cbx-footer.component.html
+++ b/frontend/src/app/features/readers/cbx-reader/layout/footer/cbx-footer.component.html
@@ -1,4 +1,5 @@
-<div class="cbx-footer" [class.is-visible]="forceVisible()">
+<div class="cbx-footer" [class.is-visible]="forceVisible()"
+  (mouseenter)="hoverChange.emit(true)" (mouseleave)="hoverChange.emit(false)">
 
   @if (state().hasSeries) {
     <button

--- a/frontend/src/app/features/readers/cbx-reader/layout/footer/cbx-footer.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/layout/footer/cbx-footer.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject} from '@angular/core';
+import {Component, EventEmitter, inject, Output} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {TranslocoService, TranslocoPipe} from '@jsverse/transloco';
 import {Book} from '../../../../book/model/book.model';
@@ -18,6 +18,7 @@ export class CbxFooterComponent {
 
   readonly forceVisible = this.footerService.forceVisible;
   readonly state = this.footerService.state;
+  @Output() hoverChange = new EventEmitter<boolean>();
 
   goToPageInput: number | null = null;
 

--- a/frontend/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.html
+++ b/frontend/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.html
@@ -1,4 +1,5 @@
-<div class="cbx-header" [class.is-visible]="forceVisible()">
+<div class="cbx-header" [class.is-visible]="forceVisible()"
+  (mouseenter)="hoverChange.emit(true)" (mouseleave)="hoverChange.emit(false)">
   <div class="header-left">
     <button class="icon-btn" (click)="onOpenSidebar()" [title]="'readerCbx.header.contents' | transloco">
       <app-reader-icon name="menu" [size]="20" />

--- a/frontend/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.ts
+++ b/frontend/src/app/features/readers/cbx-reader/layout/header/cbx-header.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, Input} from '@angular/core';
+import {Component, EventEmitter, inject, Input, Output} from '@angular/core';
 import {TranslocoPipe} from '@jsverse/transloco';
 import {CbxHeaderService} from './cbx-header.service';
 import {ReaderIconComponent} from '../../../ebook-reader';
@@ -15,6 +15,7 @@ export class CbxHeaderComponent {
 
   @Input() isCurrentPageBookmarked = false;
   @Input() currentPageHasNotes = false;
+  @Output() hoverChange = new EventEmitter<boolean>();
 
   readonly forceVisible = this.headerService.forceVisible;
   readonly state = this.headerService.state;

--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.html
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.html
@@ -19,7 +19,8 @@
     </div>
   }
 
-  <app-reader-header></app-reader-header>
+  <app-reader-header
+    (hoverChange)="onHeaderHovered($event)"></app-reader-header>
 
   <div class="reader-content" style="position: relative;">
     @if (isCurrentCfiBookmarked()) {
@@ -36,7 +37,8 @@
     [progressData]="progressData()"
     [forceVisible]="forceNavbarVisible()"
     [sectionFractions]="sectionFractions()"
-    (progressChange)="onProgressChange($event)">
+    (progressChange)="onProgressChange($event)"
+    (hoverChange)="onFooterHovered($event)">
   </app-reader-navbar>
 
   <app-reader-sidebar></app-reader-sidebar>

--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
@@ -591,6 +591,14 @@ export class EbookReaderComponent implements OnInit {
     this.visibilityManager.handleFooterZoneEnter();
   }
 
+  onHeaderHovered(hovered: boolean): void {
+    this.visibilityManager.setHeaderHovered(hovered);
+  }
+
+  onFooterHovered(hovered: boolean): void {
+    this.visibilityManager.setFooterHovered(hovered);
+  }
+
   toggleImmersiveMode(): void {
     const newValue = !this.immersiveMode();
     this.immersiveMode.set(newValue);

--- a/frontend/src/app/features/readers/ebook-reader/layout/footer/footer.component.html
+++ b/frontend/src/app/features/readers/ebook-reader/layout/footer/footer.component.html
@@ -1,5 +1,6 @@
 <ng-container *transloco="let t; prefix: 'readerEbook.footer'">
-<div class="reader-navbar" [class.is-visible]="navbarVisible">
+<div class="reader-navbar" [class.is-visible]="navbarVisible"
+  (mouseenter)="hoverChange.emit(true)" (mouseleave)="hoverChange.emit(false)">
   <button class="icon-btn" [title]="t('previousSection')" [disabled]="!canGoPrevious" (click)="onPreviousSection()">
     <app-reader-icon name="chevron-left"></app-reader-icon>
   </button>

--- a/frontend/src/app/features/readers/ebook-reader/layout/footer/footer.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/layout/footer/footer.component.ts
@@ -23,6 +23,7 @@ export class ReaderNavbarComponent {
     return this._sectionFractions;
   }
   @Output() progressChange = new EventEmitter<number>();
+  @Output() hoverChange = new EventEmitter<boolean>();
 
   private managerService = inject(ReaderViewManagerService);
   showLocationPopover = false;

--- a/frontend/src/app/features/readers/ebook-reader/layout/header/header.component.html
+++ b/frontend/src/app/features/readers/ebook-reader/layout/header/header.component.html
@@ -1,5 +1,6 @@
 <ng-container *transloco="let t; prefix: 'readerEbook.header'">
-<div class="reader-header" [class.is-visible]="forceVisible()" [style.background]="theme().bg" [style.color]="theme().fg">
+<div class="reader-header" [class.is-visible]="forceVisible()" [style.background]="theme().bg" [style.color]="theme().fg"
+  (mouseenter)="hoverChange.emit(true)" (mouseleave)="hoverChange.emit(false)">
   <div class="header-left">
     <button class="icon-btn" (click)="onShowChapters()" [title]="t('chapters')">
       <app-reader-icon name="menu" [size]="20"></app-reader-icon>

--- a/frontend/src/app/features/readers/ebook-reader/layout/header/header.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/layout/header/header.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject} from '@angular/core';
+import {Component, EventEmitter, inject, Output} from '@angular/core';
 import {TranslocoDirective} from '@jsverse/transloco';
 import {ReaderHeaderService} from './header.service';
 import {ReaderIconComponent} from '../../shared/icon.component';
@@ -20,6 +20,7 @@ export class ReaderHeaderComponent {
   readonly isFullscreen = this.headerService.isFullscreen;
   readonly bookTitle = this.headerService.bookTitle;
   readonly theme = this.headerService.theme;
+  @Output() hoverChange = new EventEmitter<boolean>();
   overflowOpen = false;
 
   onShowChapters(): void {

--- a/frontend/src/app/features/readers/ebook-reader/shared/visibility.util.spec.ts
+++ b/frontend/src/app/features/readers/ebook-reader/shared/visibility.util.spec.ts
@@ -44,6 +44,43 @@ describe('ReaderHeaderFooterVisibilityManager', () => {
     expect(manager.getVisibilityState()).toEqual({headerVisible: true, footerVisible: true});
   });
 
+  it('keeps the header visible while the pointer is over the bar past the trigger zone', () => {
+    const manager = new ReaderHeaderFooterVisibilityManager(1000);
+
+    manager.handleMouseMove(5);
+    expect(manager.getVisibilityState().headerVisible).toBe(true);
+
+    manager.setHeaderHovered(true);
+    manager.handleMouseMove(34);
+    expect(manager.getVisibilityState().headerVisible).toBe(true);
+
+    manager.setHeaderHovered(false);
+    expect(manager.getVisibilityState().headerVisible).toBe(false);
+  });
+
+  it('keeps the footer visible while the pointer is over the bar', () => {
+    const manager = new ReaderHeaderFooterVisibilityManager(1000);
+
+    manager.handleMouseMove(995);
+    expect(manager.getVisibilityState().footerVisible).toBe(true);
+
+    manager.setFooterHovered(true);
+    manager.handleMouseMove(955);
+    expect(manager.getVisibilityState().footerVisible).toBe(true);
+
+    manager.setFooterHovered(false);
+    expect(manager.getVisibilityState().footerVisible).toBe(false);
+  });
+
+  it('ignores hover-hold while immersive', () => {
+    const manager = new ReaderHeaderFooterVisibilityManager(1000);
+    manager.setImmersive(true);
+
+    manager.setHeaderHovered(true);
+
+    expect(manager.getVisibilityState().headerVisible).toBe(false);
+  });
+
   it('uses the updated window height for the footer trigger zone', () => {
     const manager = new ReaderHeaderFooterVisibilityManager(1000);
 

--- a/frontend/src/app/features/readers/ebook-reader/shared/visibility.util.ts
+++ b/frontend/src/app/features/readers/ebook-reader/shared/visibility.util.ts
@@ -8,13 +8,14 @@ export class ReaderHeaderFooterVisibilityManager {
   private isImmersive = false;
   private mouseY: number;
 
-  private readonly HEADER_HEIGHT = 20;
-  private readonly FOOTER_HEIGHT = 40;
   private readonly HEADER_TRIGGER_ZONE = 20;
   private readonly FOOTER_TRIGGER_ZONE = 30;
 
   private headerVisible = false;
   private footerVisible = false;
+
+  private headerHovered = false;
+  private footerHovered = false;
 
   private onStateChangeCallback?: (state: HeaderFooterVisibilityState) => void;
 
@@ -38,6 +39,8 @@ export class ReaderHeaderFooterVisibilityManager {
   }
 
   handleMouseLeave(): void {
+    this.headerHovered = false;
+    this.footerHovered = false;
     if (!this.isPinned && !this.isImmersive) {
       this.setHeaderVisible(false);
       this.setFooterVisible(false);
@@ -59,6 +62,20 @@ export class ReaderHeaderFooterVisibilityManager {
     }
   }
 
+  setHeaderHovered(hovered: boolean): void {
+    this.headerHovered = hovered;
+    if (!this.isImmersive) {
+      this.updateVisibility();
+    }
+  }
+
+  setFooterHovered(hovered: boolean): void {
+    this.footerHovered = hovered;
+    if (!this.isImmersive) {
+      this.updateVisibility();
+    }
+  }
+
   togglePinned(): void {
     this.isPinned = !this.isPinned;
     this.updateVisibility();
@@ -75,6 +92,8 @@ export class ReaderHeaderFooterVisibilityManager {
     this.isImmersive = immersive;
     if (immersive) {
       this.isPinned = false;
+      this.headerHovered = false;
+      this.footerHovered = false;
       this.setHeaderVisible(false);
       this.setFooterVisible(false);
       this.notifyStateChange();
@@ -105,22 +124,21 @@ export class ReaderHeaderFooterVisibilityManager {
   private updateVisibility(): void {
     if (
       this.mouseY <= this.HEADER_TRIGGER_ZONE ||
-      (this.mouseY <= this.HEADER_HEIGHT && this.headerVisible) ||
+      this.headerHovered ||
       this.isPinned
     ) {
       this.setHeaderVisible(true);
-    } else if (this.mouseY > this.HEADER_HEIGHT) {
+    } else {
       this.setHeaderVisible(this.isPinned);
     }
 
-    const footerTop = this.windowHeight - this.FOOTER_HEIGHT;
     if (
       this.mouseY >= this.windowHeight - this.FOOTER_TRIGGER_ZONE ||
-      (this.mouseY >= footerTop && this.footerVisible) ||
+      this.footerHovered ||
       this.isPinned
     ) {
       this.setFooterVisible(true);
-    } else if (this.mouseY < footerTop) {
+    } else {
       this.setFooterVisible(this.isPinned);
     }
 


### PR DESCRIPTION
## Description

The header/footer hover zones were statically typed pixel heights. They were inconsistent with the actual heights that were live in prod, and as a result resulted in the hover disappearing only halfway across the header.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/1715

## Changes

- Switch from using hard coded height values to using event emitters for entering/exiting the header/footer
- Apply these changes to both the CBX reader and PDF reader

## Manual Testing Steps



1. Spin up Grimmory Nightly, compare the hover zones for CBX/EPUB readers
2. Spin up this branch, compare the hover zones for CBX/EPUB readers

## Screenshots (Optional)

https://github.com/user-attachments/assets/a074b0ab-49e8-4717-85b1-d77cdac7070d

## Additional Context (Optional)

I'm aware of the code duplication between the different readers- I don't love it, but it's out of scope for this and will need to be addressed in a broader refactor of the reader surfaces as per https://github.com/grimmory-tools/grimmory/issues/1005

As well, this change doesn't touch the PDF reader because it uses a completely different approach (arguably much worse) for hiding the chrome (see `frontend/src/app/features/readers/pdf-reader/pdf-reader.component.ts`). Like I said though, this should all be refactored for code reusability and visual consistency across surfaces.

## AI Disclosure

Handwritten aside from spec generation

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Header and footer visibility now responds to user hover interactions across readers
  * Enhanced visibility manager to separately track header and footer hover states
  * Immersive mode properly ignores hover inputs for consistent full-screen experience

* **Tests**
  * Added tests verifying header and footer remain visible during hovering
  * Added tests confirming immersive mode disables hover-based visibility behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->