### PR TITLE
fix(download): stream book downloads instead of buffering in browser

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -219,6 +219,23 @@ public class SecurityConfig {
 
     @Bean
     @Order(8)
+    public SecurityFilterChain bookDownloadSecurityChain(HttpSecurity http, QueryParameterJwtFilter queryParameterJwtFilter) throws Exception {
+        http
+                .securityMatcher("/api/v1/books/*/download", "/api/v1/books/*/download-all", "/api/v1/books/*/files/*/download")
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(queryParameterJwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(authenticationCheckFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    @Order(9)
     public SecurityFilterChain wsSecurityChain(HttpSecurity http) throws Exception {
         http
                 .securityMatcher("/ws/**")
@@ -238,7 +255,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    @Order(9)
+    @Order(10)
     public SecurityFilterChain jwtApiSecurityChain(HttpSecurity http) throws Exception {
         var parser = new PathPatternParser();
         final List<PathPattern> matchPatterns = Stream.of(
@@ -289,7 +306,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    @Order(10)
+    @Order(11)
     public SecurityFilterChain staticResourcesSecurityChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)

--- a/frontend/src/app/shared/service/file-download.service.spec.ts
+++ b/frontend/src/app/shared/service/file-download.service.spec.ts
@@ -4,21 +4,21 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {FileDownloadService} from './file-download.service';
 import {AuthService} from './auth.service';
+import {API_CONFIG} from '../../core/config/api-config';
 
 describe('FileDownloadService', () => {
+  const apiUrl = `${API_CONFIG.BASE_URL}/api/v1/books/1/download`;
   let service: FileDownloadService;
   let ensureAccessToken: ReturnType<typeof vi.fn>;
-  let getInternalAccessToken: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     ensureAccessToken = vi.fn().mockReturnValue(of('tok'));
-    getInternalAccessToken = vi.fn().mockReturnValue('stale-tok');
 
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
         FileDownloadService,
-        {provide: AuthService, useValue: {ensureAccessToken, getInternalAccessToken}},
+        {provide: AuthService, useValue: {ensureAccessToken}},
       ]
     });
 
@@ -40,10 +40,10 @@ describe('FileDownloadService', () => {
   it('navigates to the download url with a fresh access token appended', () => {
     const {anchor, click} = stubAnchor();
 
-    service.downloadFile('/files/1', 'book.epub');
+    service.downloadFile(apiUrl, 'book.epub');
 
     expect(ensureAccessToken).toHaveBeenCalledOnce();
-    expect(anchor.href).toBe('/files/1?token=tok');
+    expect(anchor.href).toBe(`${apiUrl}?token=tok`);
     expect(anchor.download).toBe('book.epub');
     expect(click).toHaveBeenCalledOnce();
   });
@@ -51,38 +51,35 @@ describe('FileDownloadService', () => {
   it('uses & as the separator when the url already has a query string', () => {
     const {anchor} = stubAnchor();
 
-    service.downloadFile('/files/1?foo=bar', 'book.epub');
+    service.downloadFile(`${apiUrl}?foo=bar`, 'book.epub');
 
-    expect(anchor.href).toBe('/files/1?foo=bar&token=tok');
+    expect(anchor.href).toBe(`${apiUrl}?foo=bar&token=tok`);
   });
 
   it('url-encodes the token', () => {
     ensureAccessToken.mockReturnValue(of('a b/c+d'));
     const {anchor} = stubAnchor();
 
-    service.downloadFile('/files/1', 'book.epub');
+    service.downloadFile(apiUrl, 'book.epub');
 
-    expect(anchor.href).toBe('/files/1?token=a%20b%2Fc%2Bd');
+    expect(anchor.href).toBe(`${apiUrl}?token=a%20b%2Fc%2Bd`);
   });
 
-  it('falls back to the stored access token when refresh fails', () => {
-    ensureAccessToken.mockReturnValue(throwError(() => new Error('refresh failed')));
+  it('does not append the token to a non-API (cross-origin) url', () => {
     const {anchor, click} = stubAnchor();
 
-    service.downloadFile('/files/1', 'book.epub');
+    service.downloadFile('https://example.com/evil', 'book.epub');
 
-    expect(anchor.href).toBe('/files/1?token=stale-tok');
+    expect(anchor.href).toBe('https://example.com/evil');
     expect(click).toHaveBeenCalledOnce();
   });
 
-  it('downloads without a token when none is available', () => {
+  it('does not start a download when the token refresh fails', () => {
     ensureAccessToken.mockReturnValue(throwError(() => new Error('refresh failed')));
-    getInternalAccessToken.mockReturnValue(null);
-    const {anchor, click} = stubAnchor();
+    const createElement = vi.spyOn(document, 'createElement');
 
-    service.downloadFile('/files/1', 'book.epub');
+    service.downloadFile(apiUrl, 'book.epub');
 
-    expect(anchor.href).toBe('/files/1');
-    expect(click).toHaveBeenCalledOnce();
+    expect(createElement).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/shared/service/file-download.service.spec.ts
+++ b/frontend/src/app/shared/service/file-download.service.spec.ts
@@ -1,135 +1,88 @@
-import {HttpHeaders, provideHttpClient} from '@angular/common/http';
-import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
 import {TestBed} from '@angular/core/testing';
+import {of, throwError} from 'rxjs';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {FileDownloadService} from './file-download.service';
+import {AuthService} from './auth.service';
 
 describe('FileDownloadService', () => {
   let service: FileDownloadService;
-  let httpTestingController: HttpTestingController;
+  let ensureAccessToken: ReturnType<typeof vi.fn>;
+  let getInternalAccessToken: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    ensureAccessToken = vi.fn().mockReturnValue(of('tok'));
+    getInternalAccessToken = vi.fn().mockReturnValue('stale-tok');
+
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
-        provideHttpClient(),
-        provideHttpClientTesting(),
         FileDownloadService,
+        {provide: AuthService, useValue: {ensureAccessToken, getInternalAccessToken}},
       ]
     });
 
     service = TestBed.inject(FileDownloadService);
-    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
-    httpTestingController.verify();
+    vi.restoreAllMocks();
     TestBed.resetTestingModule();
   });
 
-  it('downloads a blob', () => {
+  function stubAnchor() {
     const click = vi.fn();
     const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
-    const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue(anchor);
-    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:download');
-    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+    return {anchor, click};
+  }
 
-    service.downloadFile('/files/1', 'fallback.epub');
+  it('navigates to the download url with a fresh access token appended', () => {
+    const {anchor, click} = stubAnchor();
 
-    const request = httpTestingController.expectOne('/files/1');
-    expect(request.request.method).toBe('GET');
-    expect(request.request.responseType).toBe('blob');
-    request.flush(new Blob(['content']), {
-      headers: new HttpHeaders({
-        'Content-Disposition': "attachment; filename*=UTF-8''server%20name.epub",
-      }),
-    });
+    service.downloadFile('/files/1', 'book.epub');
 
-    expect(createElementSpy).toHaveBeenCalledWith('a');
-    expect(createObjectUrlSpy).toHaveBeenCalled();
+    expect(ensureAccessToken).toHaveBeenCalledOnce();
+    expect(anchor.href).toBe('/files/1?token=tok');
+    expect(anchor.download).toBe('book.epub');
     expect(click).toHaveBeenCalledOnce();
-    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:download');
   });
 
-  it('downloads using the utf-8-only filename from the response header', () => {
-    const click = vi.fn();
-    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
-    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+  it('uses & as the separator when the url already has a query string', () => {
+    const {anchor} = stubAnchor();
 
-    service.downloadFile('/files/1', 'fallback.epub');
+    service.downloadFile('/files/1?foo=bar', 'book.epub');
 
-    const request = httpTestingController.expectOne('/files/1');
-    request.flush(new Blob(['content']), {
-      headers: new HttpHeaders({
-        'Content-Disposition': "attachment; filename*=UTF-8''server%20name.epub",
-      }),
-    });
-
-    expect(anchor.download).toBe('server name.epub');
+    expect(anchor.href).toBe('/files/1?foo=bar&token=tok');
   });
 
-  it('downloads a blob using the ascii filename from the response header', () => {
-    const click = vi.fn();
-    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
-    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+  it('url-encodes the token', () => {
+    ensureAccessToken.mockReturnValue(of('a b/c+d'));
+    const {anchor} = stubAnchor();
 
-    service.downloadFile('/files/1', 'fallback.epub');
+    service.downloadFile('/files/1', 'book.epub');
 
-    const request = httpTestingController.expectOne('/files/1');
-    request.flush(new Blob(['content']), {
-      headers: new HttpHeaders({
-        'Content-Disposition': "attachment; filename=\"server name.epub\"",
-      }),
-    });
-
-    expect(anchor.download).toBe('server name.epub');
+    expect(anchor.href).toBe('/files/1?token=a%20b%2Fc%2Bd');
   });
 
-  it('downloads a blob using the unquoted ascii filename from the response header', () => {
-    const click = vi.fn();
-    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
-    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+  it('falls back to the stored access token when refresh fails', () => {
+    ensureAccessToken.mockReturnValue(throwError(() => new Error('refresh failed')));
+    const {anchor, click} = stubAnchor();
 
-    service.downloadFile('/files/1', 'fallback.epub');
+    service.downloadFile('/files/1', 'book.epub');
 
-    const request = httpTestingController.expectOne('/files/1');
-    request.flush(new Blob(['content']), {
-      headers: new HttpHeaders({
-        'Content-Disposition': "attachment; filename=server_name.epub",
-      }),
-    });
-
-    expect(anchor.download).toBe('server_name.epub');
+    expect(anchor.href).toBe('/files/1?token=stale-tok');
+    expect(click).toHaveBeenCalledOnce();
   });
 
-  it('downloads a blob using the both utf-8 and ascii from the response header', () => {
-    const click = vi.fn();
-    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
-    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+  it('downloads without a token when none is available', () => {
+    ensureAccessToken.mockReturnValue(throwError(() => new Error('refresh failed')));
+    getInternalAccessToken.mockReturnValue(null);
+    const {anchor, click} = stubAnchor();
 
-    service.downloadFile('/files/1', 'fallback.epub');
+    service.downloadFile('/files/1', 'book.epub');
 
-    const request = httpTestingController.expectOne('/files/1');
-    request.flush(new Blob(['content']), {
-      headers: new HttpHeaders({
-        'Content-Disposition': "attachment; filename=\"server name.epub\"; filename*=UTF-8''server%20name.epub",
-      }),
-    });
-
-    expect(anchor.download).toBe('server name.epub');
-  });
-
-  it('falls back to the provided filename when the response has no content-disposition header', () => {
-    const click = vi.fn();
-    const anchor = {href: '', download: '', click} as unknown as HTMLAnchorElement;
-    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
-
-    service.downloadFile('/files/2', 'fallback.epub');
-
-    const request = httpTestingController.expectOne('/files/2');
-    request.flush(new Blob(['content']));
-
-    expect(anchor.download).toBe('fallback.epub');
+    expect(anchor.href).toBe('/files/1');
+    expect(click).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/app/shared/service/file-download.service.ts
+++ b/frontend/src/app/shared/service/file-download.service.ts
@@ -1,26 +1,33 @@
 import {inject, Injectable} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
 import {AuthService} from './auth.service';
+import {API_CONFIG} from '../../core/config/api-config';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FileDownloadService {
+  private readonly document = inject(DOCUMENT);
   private authService = inject(AuthService);
 
   downloadFile(url: string, filename: string): void {
     this.authService.ensureAccessToken().subscribe({
       next: token => this.triggerDownload(url, filename, token),
-      error: () => this.triggerDownload(url, filename, this.authService.getInternalAccessToken())
+      error: () => undefined
     });
   }
 
-  private triggerDownload(url: string, filename: string, token: string | null): void {
-    const href = token
-      ? `${url}${url.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`
-      : url;
-    const link = document.createElement('a');
-    link.href = href;
+  private triggerDownload(url: string, filename: string, token: string): void {
+    const link = this.document.createElement('a');
+    link.href = this.appendToken(url, token);
     link.download = filename;
     link.click();
+  }
+
+  private appendToken(url: string, token: string): string {
+    if (!url.startsWith(`${API_CONFIG.BASE_URL}/api/`)) {
+      return url;
+    }
+    return `${url}${url.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`;
   }
 }

--- a/frontend/src/app/shared/service/file-download.service.ts
+++ b/frontend/src/app/shared/service/file-download.service.ts
@@ -1,41 +1,26 @@
 import {inject, Injectable} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {AuthService} from './auth.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FileDownloadService {
-  private http = inject(HttpClient);
+  private authService = inject(AuthService);
 
   downloadFile(url: string, filename: string): void {
-    this.http.get(url, {responseType: 'blob', observe: 'response'}).subscribe(response => {
-      const blob = response.body;
-      if (!blob) return;
-
-      const resolvedFilename = this.extractFilename(response.headers.get('Content-Disposition')) ?? filename;
-      const objectUrl = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = objectUrl;
-      link.download = resolvedFilename;
-      link.click();
-      URL.revokeObjectURL(objectUrl);
+    this.authService.ensureAccessToken().subscribe({
+      next: token => this.triggerDownload(url, filename, token),
+      error: () => this.triggerDownload(url, filename, this.authService.getInternalAccessToken())
     });
   }
 
-  private extractFilename(contentDisposition: string | null): string | null {
-    if (!contentDisposition) return null;
-    const utf8Match = contentDisposition.match(/filename\*=UTF-8''([\w%\-.]+)/i);
-    if (utf8Match) {
-      try {
-        return decodeURIComponent(utf8Match[1]);
-      } catch {
-        // Do nothing in this case and fall back to the ascii filename.
-      }
-    }
-    const match = contentDisposition.match(/filename=(?:"([^"]+)"|([^"; ]+))/i)
-    if (match) {
-      return match[1] ?? match[2];
-    }
-    return null;
+  private triggerDownload(url: string, filename: string, token: string | null): void {
+    const href = token
+      ? `${url}${url.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`
+      : url;
+    const link = document.createElement('a');
+    link.href = href;
+    link.download = filename;
+    link.click();
   }
 }


### PR DESCRIPTION
## Description

Book file downloads previously fetched the entire response file as a blob w/ an `HttpClient` before triggering a save- this resulted in an experience where when trying to download a large file, no download UI/feedback was provided until the download was complete. This made downloads feel broken, and if download speeds were slow, the user might not even realize it had worked

## Linked Issue

Fix https://github.com/grimmory-tools/grimmory/issues/1006

## Changes

- Adds a security filter chain that accepts the JWT as a `token` query
param on download routes (same auth flow as the existing epub/audiobook chains)
- Update `FileDownloadService` to triger an anchor nav w/ the token

## Manual Testing Steps

1. Try downloading a large file (either via book detail action button, or book file tab download buttons)
2. Verify downloads happen via API blobs before writing the entire file to downloads
3. Test this branch and verify on all file types (epub, multi-file audiobook, etc.) that it properly bundles the files as expected and downloads via the browser instead

## Screenshots (Optional)

N/A

## Additional Context (Optional)

I don't love how much business logic is solely defined in security config, and how much code duplication there is. I've got another ticket (https://github.com/grimmory-tools/grimmory/issues/290) to evaluate refactoring the security config. I'll explore that after this.

As well, this doesn't enable streamed downloads for content where it needs to be packaged as a ZIP first. Follow up issue created: https://github.com/grimmory-tools/grimmory/issues/1719

## AI Disclosure

N/A

## Checklist

- [ ] This PR links and implements an accepted issue.
- [ ] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [ ] I have disclosed any AI usage as per the organization AI Policy above.
- [ ] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted security handling for book download endpoints and reordered security checks to ensure correct access behavior.
* **New Features**
  * File downloads now use token-authenticated direct browser downloads for API-hosted files (token appended to URL).
* **Bug Fixes / Reliability**
  * If token acquisition fails, downloads are not initiated to prevent unauthorized attempts.
* **Tests**
  * Download behavior tests rewritten to validate token URL construction and browser-triggered downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->