### PR TITLE
fix: handle multiple book files with the same checksum

### DIFF
--- a/backend/src/main/java/org/booklore/repository/BookRepository.java
+++ b/backend/src/main/java/org/booklore/repository/BookRepository.java
@@ -55,10 +55,10 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
     List<BookEntity> findAllForSummaryByIds(@Param("bookIds") Collection<Long> bookIds);
 
     @EntityGraph(attributePaths = {"bookFiles", "metadata", "library", "libraryPath"})
-    @Query("SELECT b FROM BookEntity b JOIN b.bookFiles bf WHERE bf.currentHash = :currentHash AND bf.isBookFormat = true AND (b.deleted IS NULL OR b.deleted = false)")
+    @Query("SELECT b FROM BookEntity b JOIN b.bookFiles bf WHERE bf.currentHash = :currentHash AND bf.isBookFormat = true AND (b.deleted IS NULL OR b.deleted = false) ORDER BY b.id DESC LIMIT 1")
     Optional<BookEntity> findByCurrentHash(@Param("currentHash") String currentHash);
 
-    @Query("SELECT b FROM BookEntity b JOIN FETCH b.bookFiles bf WHERE bf.currentHash = :currentHash AND bf.isBookFormat = true AND (b.deleted IS NULL OR b.deleted = false OR b.deletedAt > :cutoff)")
+    @Query("SELECT b FROM BookEntity b JOIN FETCH b.bookFiles bf WHERE bf.currentHash = :currentHash AND bf.isBookFormat = true AND (b.deleted IS NULL OR b.deleted = false OR b.deletedAt > :cutoff) ORDER BY b.id DESC LIMIT 1")
     Optional<BookEntity> findByCurrentHashIncludingRecentlyDeleted(@Param("currentHash") String currentHash, @Param("cutoff") Instant cutoff);
 
     Optional<BookEntity> findByBookCoverHash(String bookCoverHash);


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
in some cases - like when the same book has been uploaded multiple times - the koreader sync will fail with the mesasge `Query did not return a unique result`.

this limits the query to the most recent book to allow for a slightly more consistent behavior

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1723

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* Adds order/limit to the koreader checksum lookup

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Upload the same book 5 times
2. Try to sync one of them
3. Observe that only the most recent version receives progress

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed book retrieval queries to consistently return the most recent version of a book when searching by identifier, ensuring accurate results when accessing book data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->