### PR TITLE
perf(db): add missing `book_file` indices for ingestion lookups

### DIFF
--- a/backend/src/main/resources/db/migration/V142__Add_book_file_ingest_indexes.sql
+++ b/backend/src/main/resources/db/migration/V142__Add_book_file_ingest_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_book_file_current_hash ON book_file (current_hash);
+CREATE INDEX IF NOT EXISTS idx_book_file_path ON book_file (file_sub_path(255), file_name(255));


### PR DESCRIPTION
## Description

_RAM prices are too high, and I don't have the bandwidth to download any more- why don't we just add some new indices to improve performance?_

Library ingestion scans slow down linearly w/ library growth- ingesting 150K books can take over an hour, with the ingestion rate decreasing from ~240 books/s at 50K, to ~30 books/s at 150K. The cause is two missing indices on `book_file`- every ingested book runs dupe detection checks by hash + file path. Both full-scan `book_file`, so the book cost grows linearly with library size, making ingestion O(N^2).

Migration `V91` moved the file columns from `book` to `book_file` and dropped the `unique_library_file_path` index, but only indexed `alt_format_current_hash`- which `BookRepository.findByCurrentHash` & `findByLibraryPath_IdAndFileSubPathAndFileName` can't use. This change adds the two indices this flow needs.

## Linked Issue

N/A

## Changes

- New indices:
  - `idx_book_file_current_hash` on `book_file (current_hash)`
  - `idx_book_file_path` on `book_file (file_sub_path(255), file_name(255))` 

## Manual Testing Steps

1. Started the app against a fresh DB and confirmed the migration
2. Ingested a synthetic 150,000-book EPUB library (each ~2 KB, unique paths) under a 6 CPU / 8 GB container, shipped JVM defaults, with `docker stats` and MariaDB statement counters sampled throughout. Verified all 150,000 books were ingested with zero error logs
3. Ran an identical scan on `develop` w/o the indices as an A/B test
4. Confirmed the fix on a 150K book row DB via `EXPLAIN`- it changed from `type: ALL` (full scan) to an indexed lookup, isolated query times dropped from 53.3 ms → 0.22 ms (hash) and 12.3 ms → 0.26 ms (path)

### Results (150K books, 6 CPU / 8 GB, shipped JVM defaults)

| Metric | `develop` (unindexed) | This PR (indexed) | Change |
|---|---|---|---|
| Ingestion time | 84.3 min | 9.0 min | **~9× faster** |
| Throughput | ~30 books/s | ~277 books/s | ~9× |
| Books ingested | 150,000 | 150,000 | — |
| RAM peak | 740 MB | 1,248 MB | +69% |
| RAM avg (ingest) | 671 MB | 1,175 MB | +75% |
| RAM idle | 471 MB | 469 MB | ~flat |
| CPU peak | 263% | 285% | ~flat |
| CPU avg (ingest) | 22% | 100% | scan is no longer DB-blocked |
| PIDs peak | 84 | 85 | ~flat |

Higher RAM/CPU averages likely reflect the scan no longer spending most of its time blocked on full table scans, as the same work completes in ~1/9th the clock time, and idle memory is unchanged

## Additional Context

The degraded throughput curve matches what an external benchmark observed for Grimmory at scale- this likely accounts for a large part of the performance gap for ingestion. Heap memory usage can be addressed by setting a target heap size to orient the GC towards. In the future, a broad audit of cron job/task big O is worth a follow-up.

## AI Disclosure

I used an external community benchmark and Claude Code to generate a set of synthetic test data and a profiling harness that I used to generate this comparison. Investigation led by, and all changes understood and approved by me.

## Checklist

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved database query performance through indexing optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->