### PR TITLE
chore(ui): add warning for goodreads metadata provider

### DIFF
--- a/frontend/src/app/features/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.html
+++ b/frontend/src/app/features/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.html
@@ -145,6 +145,26 @@
                 </div>
               }
             </div>
+
+            <div class="setting-item">
+              <div class="setting-header">
+                <p-toggleswitch [(ngModel)]="goodreadsEnabled"></p-toggleswitch>
+                <span class="setting-label">Goodreads</span>
+              </div>
+              @if (goodreadsEnabled) {
+                <div class="warning-notice warning-notice-danger">
+                  <i class="pi pi-exclamation-triangle"></i>
+                  <div>
+                    <p>
+                      {{ t('goodreadsWarning') }}
+                      <a href="https://github.com/grimmory-tools/grimmory/issues/1713">
+                        {{ t('goodreadsWarningReadMore') }}
+                      </a>
+                    </p>
+                  </div>
+                </div>
+              }
+            </div>
           </div>
         </div>
 
@@ -152,12 +172,6 @@
           <h4 class="provider-group-title">{{ t('readyToUseTitle') }}</h4>
 
           <div class="simple-providers-grid">
-            <div class="setting-item simple-provider">
-              <div class="setting-header">
-                <p-toggleswitch [(ngModel)]="goodreadsEnabled"></p-toggleswitch>
-                <span class="setting-label">Goodreads</span>
-              </div>
-            </div>
 
             <div class="setting-item simple-provider">
               <div class="setting-header">

--- a/frontend/src/app/features/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.scss
+++ b/frontend/src/app/features/settings/global-preferences/metadata-provider-settings/metadata-provider-settings.component.scss
@@ -159,3 +159,32 @@
   padding-top: 0.5rem;
   border-top: 1px solid var(--p-content-border-color);
 }
+
+.warning-notice {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+
+  @include settings.settings-warning-notice;
+}
+
+.warning-notice-danger {
+  border-left-color: var(--color-red-700);
+  color: var(--color-red-700);
+
+  .pi,
+  strong {
+    color: var(--color-red-700);
+  }
+}
+
+:host-context(.dark) {
+  .warning-notice-danger {
+    border-left-color: var(--color-red-300);
+    color: var(--color-red-300);
+
+    .pi,
+    strong {
+      color: var(--color-red-300);
+    }
+  }
+}

--- a/frontend/src/i18n/en/settings-metadata.json
+++ b/frontend/src/i18n/en/settings-metadata.json
@@ -61,7 +61,9 @@
     "googleApiPlaceholder": "Enter Google Books API key",
     "apiToken": "API Token",
     "hardcoverPlaceholder": "Enter Hardcover API token",
-    "comicvinePlaceholder": "Enter Comic Vine API token"
+    "comicvinePlaceholder": "Enter Comic Vine API token",
+    "goodreadsWarning": "The Goodreads metadata provider is currently reported as degraded for most users.",
+    "goodreadsWarningReadMore": "Read more in Github Issue #1713."
   },
   "publicReviews": {
     "sectionTitle": "Public Reviews",


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
adds a warning to the goodreads metadata provider so users understand why it's not working as expected

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #1713 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
1. adds warning

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. open metadata provider
2. see warning

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/000a82c6-58cb-4a43-9d2b-f0c1909bd0fa" />


## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Goodreads entry now appears as a configurable provider and shows a prominent danger-styled warning with an external "read more" link when enabled.
* **Style**
  * Added warning notice styling, including a danger variant and dark-mode color adjustments for consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->