### PR TITLE
fix(shelf): fix public shelf book visibility

### DIFF
--- a/backend/src/main/java/org/booklore/service/book/BookQueryService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookQueryService.java
@@ -12,6 +12,7 @@ import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserContentRestrictionRepository;
 import org.booklore.security.policy.ContentRestrictionSpecification;
 import org.booklore.service.restriction.ContentRestrictionService;
+import org.booklore.util.BookUtils;
 import org.hibernate.Hibernate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -154,9 +155,7 @@ public class BookQueryService {
         }
 
         if (dto.getShelves() != null && userId != null) {
-            dto.setShelves(dto.getShelves().stream()
-                    .filter(shelf -> userId.equals(shelf.getUserId()))
-                    .collect(Collectors.toSet()));
+            dto.setShelves(BookUtils.filterShelvesByUserId(dto.getShelves(), userId));
         }
 
         if (stripForListView) {

--- a/backend/src/test/java/org/booklore/service/book/BookQueryServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookQueryServiceTest.java
@@ -1,0 +1,34 @@
+package org.booklore.service.book;
+
+import org.booklore.mapper.v2.BookMapperV2;
+import org.booklore.model.dto.Book;
+import org.booklore.model.dto.Shelf;
+import org.booklore.model.entity.BookEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BookQueryServiceTest {
+
+    @Test
+    void mapEntitiesToDto_keepsPublicShelvesForUser() {
+        BookMapperV2 bookMapperV2 = mock(BookMapperV2.class);
+        BookQueryService bookQueryService = new BookQueryService(null, bookMapperV2, null, null);
+        BookEntity bookEntity = BookEntity.builder().id(1L).build();
+        Shelf ownShelf = Shelf.builder().id(1L).userId(1L).publicShelf(false).build();
+        Shelf otherPrivateShelf = Shelf.builder().id(2L).userId(2L).publicShelf(false).build();
+        Shelf otherPublicShelf = Shelf.builder().id(3L).userId(2L).publicShelf(true).build();
+        when(bookMapperV2.toDTO(bookEntity)).thenReturn(Book.builder()
+                .shelves(Set.of(ownShelf, otherPrivateShelf, otherPublicShelf))
+                .build());
+
+        List<Book> result = bookQueryService.mapEntitiesToDto(List.of(bookEntity), true, 1L);
+
+        assertEquals(Set.of(ownShelf, otherPublicShelf), result.getFirst().getShelves());
+    }
+}

--- a/backend/src/test/java/org/booklore/service/book/BookQueryServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookQueryServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +29,7 @@ class BookQueryServiceTest {
 
         List<Book> result = bookQueryService.mapEntitiesToDto(List.of(bookEntity), true, 1L);
 
-        assertEquals(Set.of(ownShelf, otherPublicShelf), result.getFirst().getShelves());
+        assertThat(result.getFirst().getShelves())
+                .containsExactlyInAnyOrder(ownShelf, otherPublicShelf);
     }
 }


### PR DESCRIPTION
## Description

Fixes an issue with public shelves where individual books weren't given the accompanying level of access, leaving public shelves empty. 

## Linked Issue

Fixes #98 

## Changes

Updates `BookQueryService` to use the shared shelf visibility helper for book DTOs. This ensures books are visible within public shelves. 

## Manual Testing Steps

Open a public shelf from multiple users and confirm all available books are visible. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

Used codex to add tests. 

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined shelf-filtering logic in book queries to improve maintainability and clarity, without changing visible behavior.

* **Tests**
  * Added unit tests ensuring users see their own shelves plus other users' public shelves (private shelves remain hidden).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->