### PR TITLE
fix(ui): no libraries assigned label

### DIFF
--- a/frontend/src/app/features/settings/user-management/user-management.component.html
+++ b/frontend/src/app/features/settings/user-management/user-management.component.html
@@ -216,7 +216,7 @@
                             [disabled]="user.permissions.admin">
                           </p-multiSelect>
                         } @else {
-                          <span>{{ user.libraryNames || t('userInfo.allLibrariesAdmin') }}</span>
+                          <span>{{ getLibraryAccessLabel(user) }}</span>
                         }
                       </div>
                     </div>

--- a/frontend/src/app/features/settings/user-management/user-management.component.ts
+++ b/frontend/src/app/features/settings/user-management/user-management.component.ts
@@ -121,6 +121,18 @@ export class UserManagementComponent implements OnInit {
     }
   }
 
+  getLibraryAccessLabel(user: UserWithEditing): string {
+    if (user.libraryNames) {
+      return user.libraryNames;
+    }
+
+    return this.t.translate(
+      user.permissions.admin
+        ? 'settingsUsers.userInfo.allLibrariesAdmin'
+        : 'settingsUsers.userInfo.noLibrariesAssigned'
+    );
+  }
+
   saveUser(user: UserWithEditing) {
     user.selectedLibraryIds = [...this.editingLibraryIds];
     const updateRequest: UserUpdateRequest = {

--- a/frontend/src/i18n/en/settings-users.json
+++ b/frontend/src/i18n/en/settings-users.json
@@ -32,6 +32,7 @@
     "libraries": "Libraries",
     "notSet": "Not set",
     "allLibrariesAdmin": "All libraries (Admin)",
+    "noLibrariesAssigned": "No libraries assigned",
     "selectLibraries": "Select Libraries",
     "enterFullName": "Enter full name",
     "enterEmail": "Enter email"


### PR DESCRIPTION
## Description

Added a string to correctly show "No Libraries Assigned" instead of the misleading "All Libraries (admin)" string for non-admin users when a library has not been assigned to them. 

## Linked Issue

Fixes #1697 

## Changes

Added `noLibrariesAssigned` string and added english variant. 

## Manual Testing Steps

Check user permissions list to confirm string changed from "All Libraries (admin)" to "No libraries assigned". 

## Screenshots (Optional)
<img width="253" height="307" alt="Screenshot 2026-06-13 at 15 32 54" src="https://github.com/user-attachments/assets/1ee00d16-a77d-48ca-a519-38a9f2350b0d" />

## Additional Context (Optional)

Added the string for English only, but should get picked up by weblate. 

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of library access information in user details view with clearer labels based on user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->