### PR TITLE
fix(ui): use signals for OIDC settings

### DIFF
--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -537,7 +537,8 @@
             <label for="groupSyncMode">{{ t('groupMapping.syncModeLabel') }}</label>
             <p-select
               inputId="groupSyncMode"
-              [(ngModel)]="groupSyncMode"
+              [ngModel]="groupSyncMode()"
+              (ngModelChange)="groupSyncMode.set($event)"
               [options]="groupSyncModeOptions"
               optionLabel="label"
               optionValue="value"
@@ -557,8 +558,8 @@
           </div>
         </div>
 
-        @if (groupMappings.length > 0) {
-          <p-table [value]="groupMappings" [tableStyle]="{'min-width': '100%'}" styleClass="p-datatable-sm">
+        @if (groupMappings().length > 0) {
+          <p-table [value]="groupMappings()" [tableStyle]="{'min-width': '100%'}" styleClass="p-datatable-sm">
             <ng-template #header>
               <tr>
                 <th>{{ t('groupMapping.colGroupClaim') }}</th>
@@ -602,72 +603,77 @@
     </div>
 
     <p-dialog
-      [header]="editingGroupMapping.id ? t('groupMapping.editTitle') : t('groupMapping.addTitle')"
-      [(visible)]="showGroupMappingDialog"
+      [header]="groupMappingDraft()?.id ? t('groupMapping.editTitle') : t('groupMapping.addTitle')"
+      [visible]="!!groupMappingDraft()"
+      (onHide)="groupMappingDraft.set(null)"
       [modal]="true"
       [style]="{width: '550px', maxWidth: '95vw'}"
       [dismissableMask]="true">
-      <div class="config-grid" style="gap: 0.875rem;">
-        <div class="config-item full-width">
-          <label for="gmGroupClaim">{{ t('groupMapping.groupClaimLabel') }}</label>
-          <input pInputText id="gmGroupClaim" [(ngModel)]="editingGroupMapping.oidcGroupClaim" [placeholder]="t('groupMapping.groupClaimPlaceholder')"/>
-        </div>
-        <div class="config-item full-width">
-          <label for="gmDescription">{{ t('groupMapping.descriptionLabel') }}</label>
-          <input pInputText id="gmDescription" [(ngModel)]="editingGroupMapping.description" [placeholder]="t('groupMapping.descriptionPlaceholder')"/>
-        </div>
-        <div class="config-item full-width">
-          <div class="provisioning-toggle" style="padding: 0;">
-            <div class="toggle-content">
-              <span class="toggle-label">{{ t('groupMapping.adminLabel') }}</span>
-            </div>
-            <p-toggleswitch
-              [(ngModel)]="editingGroupMapping.isAdmin"
-              (onChange)="onAdminCheckboxChange()"
-            />
+      @if (groupMappingDraft(); as draft) {
+        <div class="config-grid" style="gap: 0.875rem;">
+          <div class="config-item full-width">
+            <label for="gmGroupClaim">{{ t('groupMapping.groupClaimLabel') }}</label>
+            <input pInputText id="gmGroupClaim" [ngModel]="draft.oidcGroupClaim" (ngModelChange)="updateGroupMappingDraft({oidcGroupClaim: $event})" [placeholder]="t('groupMapping.groupClaimPlaceholder')"/>
           </div>
-        </div>
-        <div class="config-item full-width">
-          <h4 class="group-title">{{ t('groupMapping.permissionsLabel') }}</h4>
-          <div class="permissions-grid">
-            <div class="permission-item">
-              <p-checkbox [binary]="true" [disabled]="true" [ngModel]="true" inputId="gmPermRead"></p-checkbox>
-              <label for="gmPermRead">{{ t('provisioning.readBooks') }}</label>
-            </div>
-            <ng-container *transloco="let a; prefix: 'settingsUsers'">
-            @for (perm of editingGroupMappingPerms; track perm) {
-              <div class="permission-item">
-                <p-checkbox
-                  [(ngModel)]="perm.selected"
-                  [binary]="true"
-                  [inputId]="'gm_' + perm.value"
-                  [disabled]="editingGroupMapping.isAdmin"
-                />
-                <label [for]="'gm_' + perm.value">{{ a(perm.translationKey) }}</label>
+          <div class="config-item full-width">
+            <label for="gmDescription">{{ t('groupMapping.descriptionLabel') }}</label>
+            <input pInputText id="gmDescription" [ngModel]="draft.description" (ngModelChange)="updateGroupMappingDraft({description: $event})" [placeholder]="t('groupMapping.descriptionPlaceholder')"/>
+          </div>
+          <div class="config-item full-width">
+            <div class="provisioning-toggle" style="padding: 0;">
+              <div class="toggle-content">
+                <span class="toggle-label">{{ t('groupMapping.adminLabel') }}</span>
               </div>
-            }
-            </ng-container>
+              <p-toggleswitch
+                [ngModel]="draft.isAdmin"
+                (ngModelChange)="setGroupMappingAdmin($event)"
+              />
+            </div>
+          </div>
+          <div class="config-item full-width">
+            <h4 class="group-title">{{ t('groupMapping.permissionsLabel') }}</h4>
+            <div class="permissions-grid">
+              <div class="permission-item">
+                <p-checkbox [binary]="true" [disabled]="true" [ngModel]="true" inputId="gmPermRead"></p-checkbox>
+                <label for="gmPermRead">{{ t('provisioning.readBooks') }}</label>
+              </div>
+              <ng-container *transloco="let a; prefix: 'settingsUsers'">
+              @for (perm of availablePermissions; track perm.value) {
+                <div class="permission-item">
+                  <p-checkbox
+                    [ngModel]="draft.permissions.includes(perm.value)"
+                    (ngModelChange)="setGroupMappingPermission(perm.value, $event)"
+                    [binary]="true"
+                    [inputId]="'gm_' + perm.value"
+                    [disabled]="draft.isAdmin"
+                  />
+                  <label [for]="'gm_' + perm.value">{{ a(perm.translationKey) }}</label>
+                </div>
+              }
+              </ng-container>
+            </div>
+          </div>
+          <div class="config-item full-width">
+            <h4 class="group-title">{{ t('groupMapping.librariesLabel') }}</h4>
+            <p-multiSelect
+              [options]="allLibraries"
+              optionLabel="name"
+              optionValue="id"
+              [ngModel]="draft.libraryIds"
+              (ngModelChange)="updateGroupMappingDraft({libraryIds: $event})"
+              [placeholder]="t('provisioning.selectLibraries')"
+              appendTo="body"
+              class="libraries-select">
+            </p-multiSelect>
           </div>
         </div>
-        <div class="config-item full-width">
-          <h4 class="group-title">{{ t('groupMapping.librariesLabel') }}</h4>
-          <p-multiSelect
-            [options]="allLibraries"
-            optionLabel="name"
-            optionValue="id"
-            [(ngModel)]="editingGroupMappingLibraryIds"
-            [placeholder]="t('provisioning.selectLibraries')"
-            appendTo="body"
-            class="libraries-select">
-          </p-multiSelect>
-        </div>
-      </div>
+      }
       <ng-template #footer>
         <p-button
           [label]="'common.save' | transloco"
           icon="pi pi-check"
           (click)="saveGroupMapping()"
-          [disabled]="!editingGroupMapping.oidcGroupClaim">
+          [disabled]="!groupMappingDraft()?.oidcGroupClaim">
         </p-button>
       </ng-template>
     </p-dialog>

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
@@ -167,7 +167,7 @@ describe('AuthenticationSettingsComponent', () => {
     expect(component.availablePermissions.find(p => p.value === 'permissionDeleteBook')?.selected).toBe(false);
     expect(component.editingLibraryIds).toEqual([1, 2]);
     expect(component.sessionDurationHours).toBe(12);
-    expect(component.groupSyncMode).toBe('ON_LOGIN');
+    expect(component.groupSyncMode()).toBe('ON_LOGIN');
     expect(component.oidcForceOnlyMode).toBe(true);
     expect(component.oidcProvider.providerName).toBe('Example IdP');
     expect(component.oidcProvider.claimMapping).toEqual({
@@ -177,7 +177,7 @@ describe('AuthenticationSettingsComponent', () => {
       groups: 'memberOf',
     });
     expect(component.mobileRedirectUris).toEqual(['grimmory://oauth2-callback']);
-    expect(component.groupMappings).toEqual(mappings);
+    expect(component.groupMappings()).toEqual(mappings);
     expect(groupMappingService.getAll).toHaveBeenCalledOnce();
   });
 
@@ -191,31 +191,23 @@ describe('AuthenticationSettingsComponent', () => {
   });
 
   it('opens a new group mapping dialog with blank state', () => {
-    component.editingGroupMapping = {
+    component.groupMappingDraft.set({
       oidcGroupClaim: 'existing',
       isAdmin: true,
       permissions: ['permissionUpload'],
       libraryIds: [1],
       description: 'Existing',
-    };
-    component.editingGroupMappingPerms = component.availablePermissions.map(permission => ({
-      ...permission,
-      selected: true,
-    }));
-    component.editingGroupMappingLibraryIds = [1];
+    });
 
     component.openNewGroupMapping();
 
-    expect(component.showGroupMappingDialog).toBe(true);
-    expect(component.editingGroupMapping).toEqual({
+    expect(component.groupMappingDraft()).toEqual({
       oidcGroupClaim: '',
       isAdmin: false,
       permissions: [],
       libraryIds: [],
       description: '',
     });
-    expect(component.editingGroupMappingPerms.every(permission => !permission.selected)).toBe(true);
-    expect(component.editingGroupMappingLibraryIds).toEqual([]);
   });
 
   it('opens an existing group mapping dialog with cloned state and selected permissions', () => {
@@ -230,12 +222,11 @@ describe('AuthenticationSettingsComponent', () => {
 
     component.openEditGroupMapping(mapping);
 
-    expect(component.showGroupMappingDialog).toBe(true);
-    expect(component.editingGroupMapping).toEqual(mapping);
-    expect(component.editingGroupMapping).not.toBe(mapping);
-    expect(component.editingGroupMappingPerms.find(permission => permission.value === 'permissionUpload')?.selected).toBe(true);
-    expect(component.editingGroupMappingPerms.find(permission => permission.value === 'permissionDeleteBook')?.selected).toBe(false);
-    expect(component.editingGroupMappingLibraryIds).toEqual([1, 2]);
+    const draft = component.groupMappingDraft();
+    expect(draft).toEqual({...mapping, permissions: ['permissionUpload']});
+    expect(draft).not.toBe(mapping);
+    expect(draft?.permissions).not.toBe(mapping.permissions);
+    expect(draft?.libraryIds).not.toBe(mapping.libraryIds);
   });
 
   it('toggles OIDC enablement and reports persistence failures', () => {
@@ -371,7 +362,7 @@ describe('AuthenticationSettingsComponent', () => {
 
   it('saves the group sync mode and reports failures', () => {
     appSettingsService.saveSettings.mockReturnValueOnce(of(void 0));
-    component.groupSyncMode = 'ON_LOGIN_ADDITIVE';
+    component.groupSyncMode.set('ON_LOGIN_ADDITIVE');
 
     component.saveGroupSyncMode();
 
@@ -428,12 +419,13 @@ describe('AuthenticationSettingsComponent', () => {
     groupMappingService.update.mockReturnValue(of(createdMapping));
     groupMappingService.delete.mockReturnValue(of(void 0));
     groupMappingService.getAll.mockReturnValue(of([createdMapping]));
-    component.editingGroupMapping = {oidcGroupClaim: 'readers', isAdmin: false, permissions: [], libraryIds: [], description: ''};
-    component.editingGroupMappingPerms = component.availablePermissions.map(permission => ({
-      ...permission,
-      selected: permission.value === 'permissionUpload',
-    }));
-    component.editingGroupMappingLibraryIds = [1];
+    component.groupMappingDraft.set({
+      oidcGroupClaim: 'readers',
+      isAdmin: false,
+      permissions: ['permissionUpload'],
+      libraryIds: [1],
+      description: '',
+    });
 
     component.saveGroupMapping();
 
@@ -445,12 +437,7 @@ describe('AuthenticationSettingsComponent', () => {
       description: '',
     });
 
-    component.editingGroupMapping = createdMapping;
-    component.editingGroupMappingPerms = component.availablePermissions.map(permission => ({
-      ...permission,
-      selected: false,
-    }));
-    component.editingGroupMappingLibraryIds = [2];
+    component.groupMappingDraft.set({...createdMapping, permissions: [], libraryIds: [2]});
     component.saveGroupMapping();
 
     expect(groupMappingService.update).toHaveBeenCalledWith(9, {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -1,6 +1,6 @@
 import {HttpErrorResponse} from '@angular/common/http';
-import {Component, effect, inject} from '@angular/core';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {Component, effect, inject, signal} from '@angular/core';
+import {FormsModule} from '@angular/forms';
 import {InputText} from 'primeng/inputtext';
 import {Button} from 'primeng/button';
 import {Checkbox} from 'primeng/checkbox';
@@ -33,7 +33,6 @@ import {Chip} from 'primeng/chip';
     Button,
     MultiSelect,
     InputNumber,
-    ReactiveFormsModule,
     ExternalDocLinkComponent,
     TranslocoDirective,
     TranslocoPipe,
@@ -105,17 +104,14 @@ export class AuthenticationSettingsComponent {
   showTestDetails = false;
 
   // Group mapping
-  groupSyncMode: string = 'DISABLED';
+  readonly groupSyncMode = signal('DISABLED');
   groupSyncModeOptions = [
     {label: 'Disabled', value: 'DISABLED'},
     {label: 'On Login (Replace)', value: 'ON_LOGIN'},
     {label: 'On Login (Additive)', value: 'ON_LOGIN_ADDITIVE'}
   ];
-  groupMappings: OidcGroupMapping[] = [];
-  showGroupMappingDialog = false;
-  editingGroupMapping: OidcGroupMapping = this.emptyGroupMapping();
-  editingGroupMappingPerms: {label: string; value: string; selected: boolean; translationKey: string}[] = [];
-  editingGroupMappingLibraryIds: number[] = [];
+  readonly groupMappings = signal<OidcGroupMapping[]>([]);
+  readonly groupMappingDraft = signal<OidcGroupMapping | null>(null);
 
   oidcProvider: OidcProviderDetails = {
     providerName: '',
@@ -163,7 +159,7 @@ export class AuthenticationSettingsComponent {
     };
 
     this.sessionDurationHours = settings.oidcSessionDurationHours ?? null;
-    this.groupSyncMode = settings.oidcGroupSyncMode ?? 'DISABLED';
+    this.groupSyncMode.set(settings.oidcGroupSyncMode ?? 'DISABLED');
     this.oidcForceOnlyMode = settings.oidcForceOnlyMode ?? false;
     this.mobileRedirectUris = settings.oidcRedirectUris?.length
       ? [...settings.oidcRedirectUris]
@@ -340,14 +336,14 @@ export class AuthenticationSettingsComponent {
 
   // Group mapping methods
   loadGroupMappings(): void {
-    this.groupMappingService.getAll().subscribe(mappings => this.groupMappings = mappings);
+    this.groupMappingService.getAll().subscribe(mappings => this.groupMappings.set(mappings));
   }
 
   saveGroupSyncMode(): void {
     const payload = [
       {
         key: AppSettingKey.OIDC_GROUP_SYNC_MODE,
-        newValue: this.groupSyncMode
+        newValue: this.groupSyncMode()
       }
     ];
     this.appSettingsService.saveSettings(payload).subscribe({
@@ -365,34 +361,48 @@ export class AuthenticationSettingsComponent {
   }
 
   openNewGroupMapping(): void {
-    this.editingGroupMapping = this.emptyGroupMapping();
-    this.initGroupMappingPerms([]);
-    this.editingGroupMappingLibraryIds = [];
-    this.showGroupMappingDialog = true;
+    this.groupMappingDraft.set(this.emptyGroupMapping());
   }
 
   openEditGroupMapping(mapping: OidcGroupMapping): void {
-    this.editingGroupMapping = {...mapping};
-    this.initGroupMappingPerms(mapping.permissions);
-    this.editingGroupMappingLibraryIds = [...mapping.libraryIds];
-    this.showGroupMappingDialog = true;
+    this.groupMappingDraft.set({
+      ...mapping,
+      permissions: mapping.permissions.filter(permission => permission !== 'permissionRead'),
+      libraryIds: [...mapping.libraryIds],
+    });
   }
 
-  private initGroupMappingPerms(selectedPerms: string[]): void {
-    this.editingGroupMappingPerms = this.availablePermissions.map(p => ({
-      ...p,
-      selected: selectedPerms.includes(p.value)
-    }));
+  updateGroupMappingDraft(patch: Partial<OidcGroupMapping>): void {
+    this.groupMappingDraft.update(draft => draft ? {...draft, ...patch} : draft);
+  }
+
+  setGroupMappingAdmin(isAdmin: boolean): void {
+    this.updateGroupMappingDraft(isAdmin
+      ? {isAdmin, permissions: this.availablePermissions.map(p => p.value)}
+      : {isAdmin});
+  }
+
+  setGroupMappingPermission(permission: string, selected: boolean): void {
+    this.groupMappingDraft.update(draft => {
+      if (!draft) return draft;
+
+      const permissions = selected
+        ? [...draft.permissions, permission]
+        : draft.permissions.filter(value => value !== permission);
+      return {...draft, permissions: [...new Set(permissions)]};
+    });
   }
 
   saveGroupMapping(): void {
+    const draft = this.groupMappingDraft();
+    if (!draft) return;
+
     const mapping: OidcGroupMapping = {
-      ...this.editingGroupMapping,
+      ...draft,
       permissions: [
         'permissionRead',
-        ...this.editingGroupMappingPerms.filter(p => p.selected).map(p => p.value)
-      ],
-      libraryIds: this.editingGroupMappingLibraryIds
+        ...draft.permissions
+      ]
     };
 
     const obs = mapping.id
@@ -401,7 +411,7 @@ export class AuthenticationSettingsComponent {
 
     obs.subscribe({
       next: () => {
-        this.showGroupMappingDialog = false;
+        this.groupMappingDraft.set(null);
         this.loadGroupMappings();
         this.messageService.add({
           severity: 'success',
@@ -482,15 +492,6 @@ export class AuthenticationSettingsComponent {
         });
       }
     });
-  }
-
-  onAdminCheckboxChange(): void {
-    if (this.editingGroupMapping.isAdmin) {
-      this.editingGroupMappingPerms = this.availablePermissions.map(p => ({
-        ...p,
-        selected: true,
-      }));
-    }
   }
 
   private emptyGroupMapping(): OidcGroupMapping {


### PR DESCRIPTION
## Description

Fixes issues with reactivity in the authentication settings component by migrating to signals, specifically addressing an issue with the OIDC claim mappings UI specifically. 

## Linked Issue

Fixes #1549 

## Changes

- Migrates OIDC group mapping UI state to signals
- Replaces group mapping form state with draft/immutable updates using signals
- Update template to read signals directly for group sync mode, mappings, etc. 
- Update tests

## Manual Testing Steps

Open authentication settings, confirm OIDC data loads correctly and shows in the UI

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal state management architecture for OAuth2/OIDC group mapping configuration to improve code maintainability and reliability. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->