### PR TITLE
fix(user-managment): non-admin users must be assigned atleast one lib…

### DIFF
--- a/backend/src/main/java/org/booklore/service/user/UserService.java
+++ b/backend/src/main/java/org/booklore/service/user/UserService.java
@@ -66,19 +66,23 @@ public class UserService {
         user.setName(updateRequest.getName());
         user.setEmail(updateRequest.getEmail());
 
+        boolean isTargetAdmin = updateRequest.getPermissions() == null ?
+                user.getPermissions().isPermissionAdmin() :
+                updateRequest.getPermissions().isAdmin();
+
         if (updateRequest.getPermissions() != null && getMyself().getPermissions().isAdmin()) {
             UserPermission.copyFromRequestToEntity(updateRequest.getPermissions(), user.getPermissions());
             auditService.log(AuditAction.PERMISSIONS_CHANGED, "User", id, "Changed permissions for user: " + user.getUsername());
         }
 
-        if (updateRequest.getAssignedLibraries() == null || (updateRequest.getAssignedLibraries().isEmpty() && updateRequest.getPermissions() != null && !updateRequest.getPermissions().isAdmin() )) {
+        if (updateRequest.getAssignedLibraries() == null || (updateRequest.getAssignedLibraries().isEmpty() && !isTargetAdmin)) {
             throw ApiError.GENERIC_BAD_REQUEST.createException("At least one library must be assigned.");
         }
 
         List<Long> libraryIds = updateRequest.getAssignedLibraries();
         Set<LibraryEntity> updatedLibraries = new HashSet<>(libraryRepository.findAllById(libraryIds));
 
-        if(updateRequest.getPermissions() != null && !updateRequest.getPermissions().isAdmin() && updatedLibraries.isEmpty()){
+        if(!isTargetAdmin && updatedLibraries.isEmpty()){
             throw ApiError.GENERIC_BAD_REQUEST.createException("At least one library must be assigned.");
         }
 

--- a/backend/src/main/java/org/booklore/service/user/UserService.java
+++ b/backend/src/main/java/org/booklore/service/user/UserService.java
@@ -75,12 +75,15 @@ public class UserService {
             auditService.log(AuditAction.PERMISSIONS_CHANGED, "User", id, "Changed permissions for user: " + user.getUsername());
         }
 
-        if (updateRequest.getAssignedLibraries() == null || (updateRequest.getAssignedLibraries().isEmpty() && !isTargetAdmin)) {
-            throw ApiError.GENERIC_BAD_REQUEST.createException("At least one library must be assigned.");
+        if (updateRequest.getAssignedLibraries() == null) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Assigned Libraries is missing from request.");
         }
 
-        List<Long> libraryIds = updateRequest.getAssignedLibraries();
-        Set<LibraryEntity> updatedLibraries = new HashSet<>(libraryRepository.findAllById(libraryIds));
+        Set<LibraryEntity> updatedLibraries = new HashSet<>();
+
+        if (!updateRequest.getAssignedLibraries().isEmpty()) {
+            updatedLibraries.addAll(libraryRepository.findAllById(updateRequest.getAssignedLibraries()));
+        }
 
         if(!isTargetAdmin && updatedLibraries.isEmpty()){
             throw ApiError.GENERIC_BAD_REQUEST.createException("At least one library must be assigned.");

--- a/backend/src/main/java/org/booklore/service/user/UserService.java
+++ b/backend/src/main/java/org/booklore/service/user/UserService.java
@@ -71,12 +71,19 @@ public class UserService {
             auditService.log(AuditAction.PERMISSIONS_CHANGED, "User", id, "Changed permissions for user: " + user.getUsername());
         }
 
-        if (updateRequest.getAssignedLibraries() != null && getMyself().getPermissions().isAdmin()) {
-            List<Long> libraryIds = updateRequest.getAssignedLibraries();
-            Set<LibraryEntity> updatedLibraries = new HashSet<>(libraryRepository.findAllById(libraryIds));
-            user.setLibraries(updatedLibraries);
+        if (updateRequest.getAssignedLibraries() == null || (updateRequest.getAssignedLibraries().isEmpty() && updateRequest.getPermissions() != null && !updateRequest.getPermissions().isAdmin() )) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("At least one library must be assigned.");
         }
 
+        List<Long> libraryIds = updateRequest.getAssignedLibraries();
+        Set<LibraryEntity> updatedLibraries = new HashSet<>(libraryRepository.findAllById(libraryIds));
+
+        if(updateRequest.getPermissions() != null && !updateRequest.getPermissions().isAdmin() && updatedLibraries.isEmpty()){
+            throw ApiError.GENERIC_BAD_REQUEST.createException("At least one library must be assigned.");
+        }
+
+        user.setLibraries(updatedLibraries);                  
+        
         userRepository.save(user);
         auditService.log(AuditAction.USER_UPDATED, "User", id, "Updated user: " + user.getUsername());
         return bookLoreUserTransformer.toDTO(user);

--- a/frontend/src/app/features/settings/user-management/user-management.component.html
+++ b/frontend/src/app/features/settings/user-management/user-management.component.html
@@ -163,6 +163,7 @@
                       [outlined]="true"
                       [rounded]="true"
                       (onClick)="saveUser(user)"
+                      [disabled] = "!editUserBtnEnabled(user)"
                       [pTooltip]="t('actions.saveChanges')">
                     </p-button>
                     <p-button
@@ -215,6 +216,14 @@
                             appendTo="body"
                             [disabled]="user.permissions.admin">
                           </p-multiSelect>
+                          @if (editingLibraryIds.length === 0 && !user.permissions.admin) {
+                            <div class="form-field">
+                            <small class="field-error">
+                              <i class="pi pi-exclamation-circle"></i>
+                              {{ t('createDialog.libraryRequired') }}
+                            </small>
+                            </div>
+                          }
                         } @else {
                           <span>{{ getLibraryAccessLabel(user) }}</span>
                         }

--- a/frontend/src/app/features/settings/user-management/user-management.component.scss
+++ b/frontend/src/app/features/settings/user-management/user-management.component.scss
@@ -624,6 +624,19 @@
   ::ng-deep .p-password {
     width: 100%;
   }
+  
+  .field-error {
+    display: flex;
+    align-items: center;
+    gap: 0.3281rem;
+    color: #ef4444;
+    font-size: var(--app-text-sm);
+    margin-top: -0.2188rem;
+
+    i {
+      font-size: var(--app-text-sm);
+    }
+  }
 
   ::ng-deep .p-inputtext,
   ::ng-deep .p-password-input {

--- a/frontend/src/app/features/settings/user-management/user-management.component.ts
+++ b/frontend/src/app/features/settings/user-management/user-management.component.ts
@@ -343,4 +343,8 @@ export class UserManagementComponent implements OnInit {
   isPermissionDisabled(user: UserWithEditing): boolean {
     return !user.isEditing || user.permissions.admin;
   }
+  
+  editUserBtnEnabled(user: User) : boolean {
+    return !(this.editingLibraryIds.length === 0 && !user.permissions.admin);
+  }
 }


### PR DESCRIPTION
## Description

Prevent non-admin users from being updated without any assigned libraries.

The validation is enforced on both the backend and frontend to ensure data integrity and provide immediate user feedback.

## Linked Issue

Fixes #1696

## Changes

### Backend

- Added validation in `UserService.updateUser()` to reject updates when a non-admin user has no assigned libraries.
- Return a `BadRequest` error when the validation fails.
- Removed the current-user admin check from the update logic, as authorization is already enforced by `@PreAuthorize` in the controller.

### Frontend

- Disabled the edit/save button when a non-admin user has no assigned libraries assigned.
- Added a validation error message (`libraryRequired`) to indicate that at least one library must be assigned.

## Manual Testing Steps

1. Log in as an administrator.
2. Navigate to User Management.
3. Edit a non-admin user and remove all assigned libraries.
4. Verify that the validation message is displayed.
5. Verify that the edit/save button is disabled.
6. Attempt to update a non-admin user without assigned libraries through the API and verify that a `BadRequest` error is returned.
7. Verify that updating a non-admin user with at least one assigned library succeeds.

## Screenshots (Optional)

<img width="1279" height="901" alt="image" src="https://github.com/user-attachments/assets/93d4d993-812c-41ff-885f-f8fe7ac80218" />


## Additional Context (Optional)

The backend validation serves as the source of truth, while the frontend validation provides immediate feedback and prevents invalid submissions.

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

None in coding

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Strengthened user library update validation: library assignments are now required and validated for non-admin updates, preventing unintended empty/invalid library changes.

* **UI Improvements**
  * Disabled the user edit “save” button until valid edits are complete.
  * Added inline “library required” feedback for non-admins when no libraries are selected.
  * Improved visual styling for field-level error messages for clearer, tighter feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->