### PR TITLE
fix(bookdrop): directly copy instead of move between filesystems

### DIFF
--- a/backend/src/main/java/org/booklore/service/bookdrop/BookDropService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookDropService.java
@@ -420,8 +420,7 @@ public class BookDropService {
             // that caused moves between filesystems to end up with a file at the target
             // with 0 bytes.
             //
-            // Instead, we are using `Files.copy` directly instead of copying to `tmp` and
-            // then moving.
+            // Instead, we are using `Files.copy` directly
             Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
 
             log.info("Copied file id={}, name={} from '{}' to '{}'", bookdropFile.getId(), bookdropFile.getFileName(), source, target);

--- a/backend/src/main/java/org/booklore/service/bookdrop/BookDropService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookDropService.java
@@ -412,21 +412,19 @@ public class BookDropService {
     }
 
     private BookdropFileResult performFileMove(BookdropFileEntity bookdropFile, Path source, Path target, LibraryEntity library, LibraryPathEntity path, BookMetadata metadata) {
-        Path tempPath = null;
         try {
-            String suffix = "";
-            String fileName = bookdropFile.getFileName();
-            int lastDotIndex = fileName.lastIndexOf('.');
-            if (lastDotIndex >= 0) {
-                suffix = fileName.substring(lastDotIndex);
-            }
-            tempPath = Files.createTempFile("bookdrop-finalize-", suffix);
-            Files.copy(source, tempPath, StandardCopyOption.REPLACE_EXISTING);
-
             Files.createDirectories(target.getParent());
-            Files.move(tempPath, target, StandardCopyOption.REPLACE_EXISTING);
 
-            log.info("Moved file id={}, name={} from '{}' to '{}'", bookdropFile.getId(), bookdropFile.getFileName(), source, target);
+            // We used to use `Files.copy` to copy from `/bookdrop` to tmp, then used `Files.move`
+            // to get the file to its target destination.  However, there seemed to be a bug
+            // that caused moves between filesystems to end up with a file at the target
+            // with 0 bytes.
+            //
+            // Instead, we are using `Files.copy` directly instead of copying to `tmp` and
+            // then moving.
+            Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+
+            log.info("Copied file id={}, name={} from '{}' to '{}'", bookdropFile.getId(), bookdropFile.getFileName(), source, target);
 
             BookdropFileResult result;
             try {
@@ -453,8 +451,6 @@ public class BookDropService {
             log.error("Failed to move file id={}, name={} from '{}' to '{}': {}", bookdropFile.getId(), bookdropFile.getFileName(), source, target, e.getMessage(), e);
             cleanupFailedMove(target);
             return failureResult(bookdropFile.getFileName(), "Failed to move file: " + e.getMessage());
-        } finally {
-            cleanupTempFile(tempPath);
         }
     }
 
@@ -529,16 +525,6 @@ public class BookDropService {
             }
         } catch (IOException e) {
             log.warn("Failed to cleanup partially created target file: {}: {}", target, e.getMessage());
-        }
-    }
-
-    private void cleanupTempFile(Path tempPath) {
-        if (tempPath != null) {
-            try {
-                Files.deleteIfExists(tempPath);
-            } catch (Exception e) {
-                log.warn("Failed to cleanup temp file: {}", tempPath, e);
-            }
         }
     }
 

--- a/backend/src/test/java/org/booklore/service/bookdrop/BookDropServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/bookdrop/BookDropServiceTest.java
@@ -18,7 +18,6 @@ import org.booklore.repository.BookdropFileRepository;
 import org.booklore.repository.LibraryPathRepository;
 import org.booklore.repository.LibraryRepository;
 import org.booklore.service.NotificationService;
-import org.booklore.service.event.BookAddedEvent;
 import org.booklore.service.file.FileMovingHelper;
 import org.booklore.service.fileprocessor.BookFileProcessor;
 import org.booklore.service.fileprocessor.BookFileProcessorRegistry;
@@ -268,10 +267,8 @@ class BookDropServiceTest {
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class, withSettings().lenient())) {
             filesMock.when(() -> Files.exists(any(Path.class))).thenReturn(true);
-            filesMock.when(() -> Files.createTempFile(anyString(), anyString())).thenReturn(tempDir.resolve("temp-file"));
             filesMock.when(() -> Files.copy(any(Path.class), any(Path.class), any())).thenReturn(1024L);
             filesMock.when(() -> Files.createDirectories(any(Path.class))).thenReturn(tempDir);
-            filesMock.when(() -> Files.move(any(Path.class), any(Path.class), any())).thenReturn(tempDir);
             filesMock.when(() -> Files.deleteIfExists(any(Path.class))).thenReturn(true);
 
             BookdropFinalizeResult result = bookDropService.finalizeImport(request);
@@ -435,7 +432,7 @@ class BookDropServiceTest {
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class, withSettings().lenient())) {
             filesMock.when(() -> Files.exists(any(Path.class))).thenReturn(true);
-            filesMock.when(() -> Files.createTempFile(anyString(), anyString()))
+            filesMock.when(() -> Files.copy(any(Path.class), any(Path.class), any()))
                     .thenThrow(new IOException("Disk full"));
 
             BookdropFinalizeResult result = bookDropService.finalizeImport(request);
@@ -490,16 +487,13 @@ class BookDropServiceTest {
         when(appProperties.getPathConfig()).thenReturn(tempDir.toString());
 
         Path sourcePath = Path.of(bookdropFileEntity.getFilePath());
-        Path tempPath = tempDir.resolve("temp-file");
         Path targetPath = tempDir.resolve("moved-book.pdf");
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             filesMock.when(() -> Files.exists(any(Path.class))).thenReturn(true);
-            filesMock.when(() -> Files.createTempFile(anyString(), anyString())).thenReturn(tempPath);
-            filesMock.when(() -> Files.copy(any(Path.class), any(Path.class), any())).thenReturn(tempPath);
+            filesMock.when(() -> Files.copy(any(Path.class), any(Path.class), any())).thenReturn(targetPath);
             filesMock.when(() -> Files.createDirectories(any(Path.class))).thenReturn(tempDir);
-            filesMock.when(() -> Files.move(any(Path.class), any(Path.class), any())).thenReturn(targetPath);
-            
+
             BookdropFinalizeResult result = bookDropService.finalizeImport(request);
 
             assertNotNull(result);
@@ -536,16 +530,13 @@ class BookDropServiceTest {
         when(processor.processFile(any())).thenThrow(new RuntimeException("Processing failed"));
 
         Path sourcePath = Path.of(bookdropFileEntity.getFilePath());
-        Path tempPath = tempDir.resolve("temp-file");
         Path targetPath = tempDir.resolve("moved-book.pdf");
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
             filesMock.when(() -> Files.exists(any(Path.class))).thenReturn(true);
-            filesMock.when(() -> Files.createTempFile(anyString(), anyString())).thenReturn(tempPath);
-            filesMock.when(() -> Files.copy(any(Path.class), any(Path.class), any())).thenReturn(tempPath);
+            filesMock.when(() -> Files.copy(any(Path.class), any(Path.class), any())).thenReturn(targetPath);
             filesMock.when(() -> Files.createDirectories(any(Path.class))).thenReturn(tempDir);
-            filesMock.when(() -> Files.move(any(Path.class), any(Path.class), any())).thenReturn(targetPath);
-            
+
             filesMock.when(() -> Files.deleteIfExists(targetPath)).thenReturn(true);
 
             BookdropFinalizeResult result = bookDropService.finalizeImport(request);


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
for some reason on devices such as QNAP the `Files.move()` fails to actually move the bytes.  instead, we can skip the middle man and copy directly to the target path

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1578

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
replaces `Files.copy`/`Files.move` with just `Files.copy`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. uploaded file to bookdrop
2. ran through bookdrop processing
3. viewed book had content afterwards

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
I could not reproduce this anywhere but QNAP devices.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the dropped-file placement flow to use a direct copy approach and ensure the destination directory exists before writing.
* **Bug Fixes**
  * Refined success messaging to match the new copy-based behavior and improved cleanup of partially created destinations on failures.
* **Tests**
  * Updated book drop service tests to reflect the new file operation expectations (copy vs move) and adjusted mocks accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->