### PR TITLE
ci: ignore angular 22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,12 @@ updates:
           - "*"
     ignore:
       - dependency-name: "typescript"
+      - dependency-name: "@angular/common"
+        versions: [ ">=22.0.0" ]
+      - dependency-name: "@angular/compiler"
+        versions: [ ">=22.0.0" ]
+      - dependency-name: "@angular/core"
+        versions: [ ">=22.0.0" ]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,12 +46,34 @@ updates:
           - "*"
     ignore:
       - dependency-name: "typescript"
+      - dependency-name: "@angular/animations"
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/aria"
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/build"
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/cdk"
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/cli"
+        versions: [">=22.0.0"]
       - dependency-name: "@angular/common"
-        versions: [ ">=22.0.0" ]
+        versions: [">=22.0.0"]
       - dependency-name: "@angular/compiler"
-        versions: [ ">=22.0.0" ]
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/compiler-cli"
+        versions: [">=22.0.0"]
       - dependency-name: "@angular/core"
-        versions: [ ">=22.0.0" ]
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/forms"
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/platform-browser"
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/platform-browser-dynamic"
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/router"
+        versions: [">=22.0.0"]
+      - dependency-name: "@angular/service-worker"
+        versions: [">=22.0.0"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
we don't want to upgrade to angular 22 yet so we should tell dependabot to stop trying to upgrade

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #1758

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
adds angular 22 to ignored dependabot

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

Not well tested - CI & dependabot is difficult but this matches with the documentation

https://docs.github.com/en/enterprise-cloud@latest/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot settings to extend the ignore rules for the root npm (pnpm workspace) update job, preventing automatic updates for a broad set of Angular packages (v22+).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->