### PR TITLE
fix(metadata-refresh): add audible to metadata refresh

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/MetadataRefreshService.java
@@ -365,6 +365,9 @@ public class MetadataRefreshService {
             addProviderToSet(fieldOptions.getLubimyczytacRating(), uniqueProviders, appSettings);
             addProviderToSet(fieldOptions.getRanobedbId(), uniqueProviders, appSettings);
             addProviderToSet(fieldOptions.getRanobedbRating(), uniqueProviders, appSettings);
+            addProviderToSet(fieldOptions.getAudibleId(), uniqueProviders, appSettings);
+            addProviderToSet(fieldOptions.getAudibleRating(), uniqueProviders, appSettings);
+            addProviderToSet(fieldOptions.getAudibleReviewCount(), uniqueProviders, appSettings);
             addProviderToSet(fieldOptions.getMoods(), uniqueProviders, appSettings);
             addProviderToSet(fieldOptions.getTags(), uniqueProviders, appSettings);
         }
@@ -396,6 +399,7 @@ public class MetadataRefreshService {
             case Ranobedb -> settings.getRanobedb() != null && settings.getRanobedb().isEnabled();
             case Douban -> settings.getDouban() != null && settings.getDouban().isEnabled();
             case Lubimyczytac -> settings.getLubimyczytac() != null && settings.getLubimyczytac().isEnabled();
+            case Audible -> settings.getAudible() != null && settings.getAudible().isEnabled();
             default -> true;
         };
     }
@@ -654,6 +658,30 @@ public class MetadataRefreshService {
             }
         } else if (isReplaceAll && existingMetadata != null) {
             metadata.setRanobedbRating(existingMetadata.getRanobedbRating());
+        }
+
+        if (enabledFields.isAudibleId()) {
+            if (metadataMap.containsKey(Audible)) {
+                metadata.setAudibleId(metadataMap.get(Audible).getAudibleId());
+            }
+        } else if (isReplaceAll && existingMetadata != null) {
+            metadata.setAudibleId(existingMetadata.getAudibleId());
+        }
+
+        if (enabledFields.isAudibleRating()) {
+            if (metadataMap.containsKey(Audible)) {
+                metadata.setAudibleRating(metadataMap.get(Audible).getAudibleRating());
+            }
+        } else if (isReplaceAll && existingMetadata != null) {
+            metadata.setAudibleRating(existingMetadata.getAudibleRating());
+        }
+
+        if (enabledFields.isAudibleReviewCount()) {
+            if (metadataMap.containsKey(Audible)) {
+                metadata.setAudibleReviewCount(metadataMap.get(Audible).getAudibleReviewCount());
+            }
+        } else if (isReplaceAll && existingMetadata != null) {
+            metadata.setAudibleReviewCount(existingMetadata.getAudibleReviewCount());
         }
 
         if (enabledFields.isMoods()) {

--- a/backend/src/test/java/org/booklore/service/metadata/MetadataRefreshServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/MetadataRefreshServiceTest.java
@@ -822,11 +822,25 @@ class MetadataRefreshServiceTest {
         }
 
         @Test
-        void audible_defaultCase_returnsTrue() {
+        void audible_enabled() {
             MetadataProviderSettings ps = new MetadataProviderSettings();
+            MetadataProviderSettings.Audible audible = new MetadataProviderSettings.Audible();
+            audible.setEnabled(true);
+            ps.setAudible(audible);
             AppSettings settings = AppSettings.builder().metadataProviderSettings(ps).build();
 
             assertThat(service.isProviderEnabled(MetadataProvider.Audible, settings)).isTrue();
+        }
+
+        @Test
+        void audible_disabled() {
+            MetadataProviderSettings ps = new MetadataProviderSettings();
+            MetadataProviderSettings.Audible audible = new MetadataProviderSettings.Audible();
+            audible.setEnabled(false);
+            ps.setAudible(audible);
+            AppSettings settings = AppSettings.builder().metadataProviderSettings(ps).build();
+
+            assertThat(service.isProviderEnabled(MetadataProvider.Audible, settings)).isFalse();
         }
     }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the metadata refresh service was missing audible from multiple flows and this adds them

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1778

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
adds audible fields to provider fields
adds proper testing of audible provider enabled check
properly sets up build fetch metadata flags for audible

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Enabled audible provider
2. Run metadata refresh
3. Check logs for running audible

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
Some work was done in this from #1408 

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded metadata refresh pipeline to include Audible metadata enrichment
  * Metadata refresh now populates Audible IDs, ratings, and review counts when the provider is enabled
  * Audible metadata provider integrates with application settings configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->