### PR TITLE
fix(metadata): detect retryable errors in LubimyCzytac parser

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/LubimyCzytacParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/LubimyCzytacParser.java
@@ -443,9 +443,9 @@ public class LubimyCzytacParser implements BookParser {
     private boolean isConnectivityError(Exception e) {
         Throwable cause = e;
         while (cause != null) {
-            if (e instanceof ConnectException ||
-                    e instanceof UnresolvedAddressException ||
-                    e instanceof SocketTimeoutException) {
+            if (cause instanceof ConnectException ||
+                    cause instanceof UnresolvedAddressException ||
+                    cause instanceof SocketTimeoutException) {
                 return true;
             }
             cause = cause.getCause();

--- a/backend/src/test/java/org/booklore/service/metadata/parser/LubimyCzytacParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/LubimyCzytacParserTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.net.ConnectException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -189,6 +190,99 @@ class LubimyCzytacParserTest {
         assertEquals(827, result.getDescription().length());
     }
 
+    @Test
+    void testFetchMetadata_stopsWithRegularException() throws Exception {
+        // Given
+        Book book = Book.builder()
+                .title("Sklepy cynamonowe")
+                .build();
+
+        FetchMetadataRequest request = FetchMetadataRequest.builder()
+                .title("Sklepy cynamonowe")
+                .author("Bruno Schulz")
+                .build();
+
+        // Mock enabled provider
+        AppSettings appSettings = new AppSettings();
+        MetadataProviderSettings providerSettings = new MetadataProviderSettings();
+        MetadataProviderSettings.Lubimyczytac lubimyCzytac = new MetadataProviderSettings.Lubimyczytac();
+        lubimyCzytac.setEnabled(true);
+        providerSettings.setLubimyczytac(lubimyCzytac);
+        appSettings.setMetadataProviderSettings(providerSettings);
+
+        mockResponseThrow("https://lubimyczytac.pl/szukaj/ksiazki", new IOException());
+
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+
+        // When
+        List<BookMetadata> results = parser.fetchMetadata(book, request);
+
+        assertEquals(0, results.size());
+        mockJsoup.verify(() -> Jsoup.connect(anyString()), times(1));
+    }
+
+    @Test
+    void testFetchMetadata_retriesWithConnectionException() throws Exception {
+        // Given
+        Book book = Book.builder()
+                .title("Sklepy cynamonowe")
+                .build();
+
+        FetchMetadataRequest request = FetchMetadataRequest.builder()
+                .title("Sklepy cynamonowe")
+                .author("Bruno Schulz")
+                .build();
+
+        // Mock enabled provider
+        AppSettings appSettings = new AppSettings();
+        MetadataProviderSettings providerSettings = new MetadataProviderSettings();
+        MetadataProviderSettings.Lubimyczytac lubimyCzytac = new MetadataProviderSettings.Lubimyczytac();
+        lubimyCzytac.setEnabled(true);
+        providerSettings.setLubimyczytac(lubimyCzytac);
+        appSettings.setMetadataProviderSettings(providerSettings);
+
+        mockResponseThrow("https://lubimyczytac.pl/szukaj/ksiazki", new ConnectException());
+
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+
+        // When
+        List<BookMetadata> results = parser.fetchMetadata(book, request);
+
+        assertEquals(0, results.size());
+        mockJsoup.verify(() -> Jsoup.connect(anyString()), times(3));
+    }
+
+    @Test
+    void testFetchMetadata_retriesWithWrappedConnectionException() throws Exception {
+        // Given
+        Book book = Book.builder()
+                .title("Sklepy cynamonowe")
+                .build();
+
+        FetchMetadataRequest request = FetchMetadataRequest.builder()
+                .title("Sklepy cynamonowe")
+                .author("Bruno Schulz")
+                .build();
+
+        // Mock enabled provider
+        AppSettings appSettings = new AppSettings();
+        MetadataProviderSettings providerSettings = new MetadataProviderSettings();
+        MetadataProviderSettings.Lubimyczytac lubimyCzytac = new MetadataProviderSettings.Lubimyczytac();
+        lubimyCzytac.setEnabled(true);
+        providerSettings.setLubimyczytac(lubimyCzytac);
+        appSettings.setMetadataProviderSettings(providerSettings);
+
+        mockResponseThrow("https://lubimyczytac.pl/szukaj/ksiazki", new IOException("Wrapped", new ConnectException()));
+
+        when(appSettingService.getAppSettings()).thenReturn(appSettings);
+
+        // When
+        List<BookMetadata> results = parser.fetchMetadata(book, request);
+
+        assertEquals(0, results.size());
+        mockJsoup.verify(() -> Jsoup.connect(anyString()), times(3));
+    }
+
     private String readFixture(String fixtureName) throws IOException {
         String filename = Paths.get("lubimyczytac", fixtureName + ".fixture").toString();
 
@@ -197,6 +291,17 @@ class LubimyCzytacParserTest {
 
             return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    private void mockResponseThrow(String urlPrefix, Throwable exception) throws Exception {
+        Connection mockConnection = mock(Connection.class);
+
+        when(mockConnection.userAgent(any())).thenReturn(mockConnection);
+        when(mockConnection.timeout(anyInt())).thenReturn(mockConnection);
+
+        when(mockConnection.get()).thenThrow(exception);
+
+        mockJsoup.when(() -> Jsoup.connect(startsWith(urlPrefix))).thenReturn(mockConnection);
     }
 
     private void mockResponse(String urlPrefix, String response) throws Exception {


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the LubimyCzytac parser was incorrectly checking the exception type to find connection errors
so it wasn't doing any retries as expected

this change switches the var it's testing against to allow for retries to occur

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1209

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
1. LubimyCzytac parser
2. update tests for change

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
I cannot force LubimyCzytac do have a connection timeout but I can turn off network connectivity during metadata search which did lead to the retries occurring

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry logic for metadata fetching by more reliably detecting connectivity-related failures, including when they’re wrapped inside other exceptions (e.g., connection, DNS resolution, and timeouts).
* **Tests**
  * Expanded metadata fetch tests to cover stopping on regular errors and retrying on connection-related errors, including wrapped exceptions, validating the expected number of attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->