### PR TITLE
fix(ui): remove cover timestamp check from metadata lock

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table.helpers.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table.helpers.ts
@@ -44,7 +44,6 @@ export const LOCK_FIELDS = [
   'audibleIdLocked',
   'audibleRatingLocked',
   'audibleReviewCountLocked',
-  'coverUpdatedOnLocked',
   'authorsLocked',
   'categoriesLocked',
   'moodsLocked',


### PR DESCRIPTION
## Description

Fixes an issue where the book browser's metadata lock didn't reflect the true state from the metadata editor. 

## Linked Issue

Fixes #1805

## Changes

Removes `coverUpdatedOnLocked` field from the book table's lock check. 

## Manual Testing Steps

Lock or unlock a book's metadata on the book details metadata editor. check the book in the book browser table to confirm the lock status is correct. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted book metadata locking configuration by removing an unused metadata lock field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->