### PR TITLE
fix(ui): avoid CSS transition on page navigation

### DIFF
--- a/frontend/src/app/core/navigation-transition-guard.ts
+++ b/frontend/src/app/core/navigation-transition-guard.ts
@@ -1,0 +1,23 @@
+import { DOCUMENT } from '@angular/common';
+import { afterNextRender, inject, Injectable, Injector } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class NavigationTransitionGuard {
+  private readonly root = inject(DOCUMENT).documentElement;
+  private readonly injector = inject(Injector);
+
+  constructor() {
+    inject(Router).events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        this.root.classList.add('route-settling');
+        afterNextRender(() => this.release(), { injector: this.injector });
+      }
+    });
+  }
+
+  private release(): void {
+    getComputedStyle(this.root).getPropertyValue('opacity');
+    setTimeout(() => this.root.classList.remove('route-settling'), 1);
+  }
+}

--- a/frontend/src/assets/styles/base.scss
+++ b/frontend/src/assets/styles/base.scss
@@ -173,3 +173,9 @@ hr {
     transition-duration: 0.01ms !important;
   }
 }
+
+html.route-settling *,
+html.route-settling *::before,
+html.route-settling *::after {
+  transition: none !important;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,6 +6,7 @@ import { RxStompService } from './app/shared/websocket/rx-stomp.service';
 import { rxStompServiceFactory } from './app/shared/websocket/rx-stomp-service-factory';
 import { provideRouter, RouteReuseStrategy } from '@angular/router';
 import { CustomReuseStrategy } from './app/core/custom-reuse-strategy';
+import { NavigationTransitionGuard } from './app/core/navigation-transition-guard';
 import { providePrimeNG } from 'primeng/config';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
@@ -38,6 +39,9 @@ bootstrapApplication(AppComponent, {
       const initializeAuth = initializeAuthFactory();
       const startup = inject(StartupService);
       return Promise.resolve(initializeAuth()).then(() => startup.load());
+    }),
+    provideAppInitializer(() => {
+      inject(NavigationTransitionGuard);
     }),
     provideHttpClient(withInterceptors([AuthInterceptorService])),
     provideRouter(routes),


### PR DESCRIPTION
## Description

Fixes an issue with the new UI components and the CSS hover transition firing on page navigation, causing odd flashes. 

## Linked Issue

Fixes #1832 

## Changes

Added `navigation-transition-guard` to handle CSS variable transitions on page navigation

## Manual Testing Steps

Open design system page, navigate back and forth between form example pages and confirm buttons/fields no longer flash and transition in before settling. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

CSS transitions are normally fine, but as these are dynamic variants via typescript they have this side effect. 

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved page navigation with a brief “route settling” state during route changes to minimize distracting effects.
* **Styling**
  * Added a global settling style that temporarily disables CSS transitions (including `::before`/`::after`) while the route settles.
* **Performance/UX**
  * Ensures the settling behavior is applied early during app startup for more consistent visual transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->