### PR TITLE
refactor(ui): migrate controls to lucide

### DIFF
--- a/frontend/src/app/features/design-system/design-system.component.html
+++ b/frontend/src/app/features/design-system/design-system.component.html
@@ -2,9 +2,9 @@
   <header class="page-header flex flex-wrap items-center justify-between gap-3">
     <h1>Design System</h1>
     <div class="flex flex-wrap items-center gap-2">
-      <app-button variant="soft" size="sm" icon="pi pi-folder" label="Create library" (clicked)="openExample('library')" />
-      <app-button variant="soft" size="sm" icon="pi pi-mobile" label="Device settings" (clicked)="openExample('device')" />
-      <app-button variant="soft" size="sm" icon="pi pi-list" label="Everything" (clicked)="openExample('everything')" />
+      <app-button variant="soft" size="sm" label="Create library" (clicked)="openExample('library')"><svg lucideFolder></svg></app-button>
+      <app-button variant="soft" size="sm" label="Device settings" (clicked)="openExample('device')"><svg lucideSmartphone></svg></app-button>
+      <app-button variant="soft" size="sm" label="Everything" (clicked)="openExample('everything')"><svg lucideList></svg></app-button>
     </div>
   </header>
 
@@ -21,8 +21,7 @@
                 [tone]="example.tone"
                 [variant]="example.variant"
                 [size]="size"
-                icon="pi pi-bolt"
-                [label]="size" />
+                [label]="size"><svg lucideZap></svg></app-button>
             }
           </div>
         </div>
@@ -30,9 +29,9 @@
     </div>
 
     <div class="sample-row">
-      <app-button iconOnly icon="pi pi-chevron-left" ariaLabel="Previous" />
-      <app-button iconOnly rounded icon="pi pi-heart" ariaLabel="Favourite" />
-      <app-button label="Loading" icon="pi pi-save" loading />
+      <app-button iconOnly ariaLabel="Previous"><svg lucideChevronLeft></svg></app-button>
+      <app-button iconOnly rounded ariaLabel="Favourite"><svg lucideHeart></svg></app-button>
+      <app-button label="Loading" loading><svg lucideSave></svg></app-button>
       <app-button label="Disabled" disabled />
       <app-button fluid label="Full width" />
     </div>
@@ -45,18 +44,15 @@
       <app-split-button
         tone="primary"
         label="Open"
-        icon="pi pi-folder-open"
-        [model]="menuItems" />
+        [model]="menuItems"><svg lucideFolderOpen></svg></app-split-button>
       <app-split-button
         label="Download"
-        icon="pi pi-download"
-        [model]="menuItems" />
+        [model]="menuItems"><svg lucideDownload></svg></app-split-button>
       <app-split-button
         tone="danger"
         variant="soft"
         label="Delete"
-        icon="pi pi-trash"
-        [model]="menuItems" />
+        [model]="menuItems"><svg lucideTrash2></svg></app-split-button>
     </div>
   </section>
 
@@ -90,20 +86,20 @@
       </div>
       <div class="field">
         <span>Trailing Action</span>
-        <app-input value="Search text" trailingIcon="pi pi-times" trailingAriaLabel="Clear text" />
+        <app-input value="Search text"><svg lucideX appInputTrailing></svg></app-input>
       </div>
       <div class="field">
         <span>Leading Icon</span>
-        <app-input type="search" leadingIcon="pi pi-search" placeholder="Search..." />
+        <app-input type="search" placeholder="Search..."><svg lucideSearch appInputLeading></svg></app-input>
       </div>
       <div class="field">
         <span>Leading + Trailing</span>
         <app-input
           type="search"
-          value="Search text"
-          leadingIcon="pi pi-search"
-          trailingIcon="pi pi-times"
-          trailingAriaLabel="Clear search" />
+          value="Search text">
+          <svg lucideSearch appInputLeading></svg>
+          <svg lucideX appInputTrailing></svg>
+        </app-input>
       </div>
     </div>
   </section>
@@ -481,7 +477,7 @@
       <app-accordion [items]="accordionItems" [(value)]="accordionValue">
         <ng-template appAccordionHeader let-item>{{ item.title }}</ng-template>
         <ng-template appAccordionActions>
-          <app-button size="sm" variant="ghost" icon="pi pi-cog" iconOnly ariaLabel="Configure" />
+          <app-button size="sm" variant="ghost" iconOnly ariaLabel="Configure"><svg lucideSettings></svg></app-button>
         </ng-template>
         <ng-template appAccordionContent let-item>{{ item.body }}</ng-template>
       </app-accordion>
@@ -491,7 +487,7 @@
     <div class="max-w-md">
       <app-accordion multiple [items]="accordionItems" [(value)]="accordionMultiValue">
         <ng-template appAccordionHeader let-item>
-          <span class="inline-flex items-center gap-2"><i class="pi pi-folder text-text-muted" aria-hidden="true"></i>{{ item.title }}</span>
+          <span class="inline-flex items-center gap-2"><svg lucideFolder class="size-4 text-text-muted" aria-hidden="true"></svg>{{ item.title }}</span>
         </ng-template>
         <ng-template appAccordionContent let-item>{{ item.body }}</ng-template>
       </app-accordion>
@@ -515,7 +511,7 @@
   <section class="showcase-section">
     <h2>Menus</h2>
 
-    <app-button label="Open menu" icon="pi pi-ellipsis-v" (clicked)="debugMenu.toggle($event)" />
+    <app-button label="Open menu" (clicked)="debugMenu.toggle($event)"><svg lucideEllipsisVertical></svg></app-button>
     <app-menu #debugMenu [model]="menuItems" />
   </section>
 
@@ -550,7 +546,7 @@
     <div class="flex flex-wrap items-center gap-2">
       <app-tag size="sm" color="green" label="Small" />
       <app-tag size="md" color="green" label="Medium" />
-      <app-tag color="amber" icon="pi pi-exclamation-triangle" label="With icon" />
+      <app-tag color="amber" label="With icon"><svg lucideTriangleAlert></svg></app-tag>
       <app-tag color="sky">Projected content</app-tag>
     </div>
 

--- a/frontend/src/app/features/design-system/design-system.component.ts
+++ b/frontend/src/app/features/design-system/design-system.component.ts
@@ -3,6 +3,25 @@ import { CdkScrollable } from '@angular/cdk/scrolling';
 import { Router } from '@angular/router';
 import { email, form, FormField, minLength, required, validate } from '@angular/forms/signals';
 import { MenuItem } from 'primeng/api';
+import {
+  LucideChevronLeft,
+  LucideDownload,
+  LucideEllipsisVertical,
+  LucideFile,
+  LucideFolder,
+  LucideFolderOpen,
+  LucideHeart,
+  LucideList,
+  LucideSave,
+  LucideSearch,
+  LucideSettings,
+  LucideSmartphone,
+  LucideTag,
+  LucideTrash2,
+  LucideTriangleAlert,
+  LucideX,
+  LucideZap,
+} from '@lucide/angular';
 import { AppAccordionComponent } from '../../shared/ui/accordion/app-accordion.component';
 import {
   AppAccordionActionsDirective,
@@ -76,6 +95,21 @@ interface ButtonExample {
     AppTagComponent,
     AppTextareaComponent,
     AppTooltipDirective,
+    LucideFolder,
+    LucideSmartphone,
+    LucideList,
+    LucideZap,
+    LucideChevronLeft,
+    LucideHeart,
+    LucideSave,
+    LucideSettings,
+    LucideEllipsisVertical,
+    LucideFolderOpen,
+    LucideDownload,
+    LucideTrash2,
+    LucideSearch,
+    LucideX,
+    LucideTriangleAlert,
     FormField,
   ],
   templateUrl: './design-system.component.html',
@@ -137,9 +171,9 @@ export class DesignSystemComponent {
   ];
 
   readonly settingsTabs: TabItem[] = [
-    { id: 'general', label: 'General', icon: 'pi pi-cog' },
-    { id: 'metadata', label: 'Metadata', icon: 'pi pi-tag' },
-    { id: 'formats', label: 'Formats', icon: 'pi pi-file' },
+    { id: 'general', label: 'General', icon: LucideSettings.icon },
+    { id: 'metadata', label: 'Metadata', icon: LucideTag.icon },
+    { id: 'formats', label: 'Formats', icon: LucideFile.icon },
   ];
   readonly manyTabs: TabItem[] = [
     { id: 'general', label: 'General' },

--- a/frontend/src/app/features/design-system/forms/device-form.component.html
+++ b/frontend/src/app/features/design-system/forms/device-form.component.html
@@ -4,10 +4,9 @@
       <app-button
         variant="ghost"
         size="sm"
-        icon="pi pi-chevron-left"
         label="Back to design system"
         styleClass="self-start"
-        (clicked)="back()" />
+        (clicked)="back()"><svg lucideChevronLeft></svg></app-button>
       <div class="flex flex-col gap-1">
         <h1 class="text-2xl font-extrabold text-text-strong">Device settings</h1>
       </div>
@@ -18,7 +17,7 @@
       <app-tag [color]="deviceForm().dirty() ? 'amber' : 'neutral'" [label]="deviceForm().dirty() ? 'dirty' : 'pristine'" />
       <app-tag [color]="deviceForm().touched() ? 'sky' : 'neutral'" [label]="deviceForm().touched() ? 'touched' : 'untouched'" />
       @if (deviceForm().submitting()) {
-        <app-tag color="primary" icon="pi pi-spin pi-spinner" label="submitting" />
+        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle></svg></app-tag>
       }
     </div>
 
@@ -27,7 +26,7 @@
         <div class="flex flex-col gap-1">
           <div class="flex items-center justify-between gap-4">
             <h2 class="m-0 inline-flex items-center gap-2 text-base font-bold text-text-strong">
-              <i class="pi pi-book text-text-muted" aria-hidden="true"></i> Hardcover
+              <svg lucideBook class="size-4 text-text-muted" aria-hidden="true"></svg> Hardcover
             </h2>
             <app-switch [formField]="deviceForm.hardcover.enabled" ariaLabel="Enable Hardcover sync" />
           </div>
@@ -44,7 +43,7 @@
         <div class="flex flex-col gap-1">
           <div class="flex items-center justify-between gap-4">
             <h2 class="m-0 inline-flex items-center gap-2 text-base font-bold text-text-strong">
-              <i class="pi pi-tablet text-text-muted" aria-hidden="true"></i> Kobo
+              <svg lucideTablet class="size-4 text-text-muted" aria-hidden="true"></svg> Kobo
             </h2>
             <app-switch [formField]="deviceForm.kobo.enabled" ariaLabel="Enable Kobo sync" />
           </div>
@@ -77,7 +76,7 @@
         <div class="flex flex-col gap-1">
           <div class="flex items-center justify-between gap-4">
             <h2 class="m-0 inline-flex items-center gap-2 text-base font-bold text-text-strong">
-              <i class="pi pi-mobile text-text-muted" aria-hidden="true"></i> KOReader
+              <svg lucideSmartphone class="size-4 text-text-muted" aria-hidden="true"></svg> KOReader
             </h2>
             <app-switch [formField]="deviceForm.koreader.enabled" ariaLabel="Enable KOReader sync" />
           </div>
@@ -103,9 +102,8 @@
           type="submit"
           tone="primary"
           label="Save settings"
-          icon="pi pi-save"
           [loading]="deviceForm().submitting()"
-          [disabled]="deviceForm().submitting()" />
+          [disabled]="deviceForm().submitting()"><svg lucideSave></svg></app-button>
         <app-button variant="soft" label="Validate" (clicked)="validateAll()" />
         <app-button variant="ghost" label="Reset" (clicked)="reset()" />
         @if (submitState() === 'saved') {

--- a/frontend/src/app/features/design-system/forms/device-form.component.html
+++ b/frontend/src/app/features/design-system/forms/device-form.component.html
@@ -17,7 +17,7 @@
       <app-tag [color]="deviceForm().dirty() ? 'amber' : 'neutral'" [label]="deviceForm().dirty() ? 'dirty' : 'pristine'" />
       <app-tag [color]="deviceForm().touched() ? 'sky' : 'neutral'" [label]="deviceForm().touched() ? 'touched' : 'untouched'" />
       @if (deviceForm().submitting()) {
-        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle></svg></app-tag>
+        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle class="animate-spin"></svg></app-tag>
       }
     </div>
 

--- a/frontend/src/app/features/design-system/forms/device-form.component.ts
+++ b/frontend/src/app/features/design-system/forms/device-form.component.ts
@@ -11,6 +11,7 @@ import { AppNumberInputComponent } from '../../../shared/ui/number-input/app-num
 import { AppSliderComponent } from '../../../shared/ui/slider/app-slider.component';
 import { AppSwitchComponent } from '../../../shared/ui/switch/app-switch.component';
 import { AppTagComponent } from '../../../shared/ui/tag/app-tag.component';
+import { LucideBook, LucideChevronLeft, LucideLoaderCircle, LucideSave, LucideSmartphone, LucideTablet } from '@lucide/angular';
 
 interface DeviceFormModel {
   hardcover: { enabled: boolean; apiKey: string };
@@ -57,6 +58,12 @@ function createInitialModel(): DeviceFormModel {
     AppSliderComponent,
     AppSwitchComponent,
     AppTagComponent,
+    LucideBook,
+    LucideSmartphone,
+    LucideTablet,
+    LucideChevronLeft,
+    LucideSave,
+    LucideLoaderCircle,
   ],
   templateUrl: './device-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/features/design-system/forms/everything-form.component.html
+++ b/frontend/src/app/features/design-system/forms/everything-form.component.html
@@ -4,10 +4,9 @@
       <app-button
         variant="ghost"
         size="sm"
-        icon="pi pi-chevron-left"
         label="Back to design system"
         styleClass="self-start"
-        (clicked)="back()" />
+        (clicked)="back()"><svg lucideChevronLeft></svg></app-button>
       <div class="flex flex-col gap-1">
         <h1 class="text-2xl font-extrabold text-text-strong">Everything</h1>
       </div>
@@ -18,7 +17,7 @@
       <app-tag [color]="everythingForm().dirty() ? 'amber' : 'neutral'" [label]="everythingForm().dirty() ? 'dirty' : 'pristine'" />
       <app-tag [color]="everythingForm().touched() ? 'sky' : 'neutral'" [label]="everythingForm().touched() ? 'touched' : 'untouched'" />
       @if (everythingForm().submitting()) {
-        <app-tag color="primary" icon="pi pi-spin pi-spinner" label="submitting" />
+        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle></svg></app-tag>
       }
     </div>
 
@@ -95,9 +94,8 @@
           type="submit"
           tone="primary"
           label="Save"
-          icon="pi pi-save"
           [loading]="everythingForm().submitting()"
-          [disabled]="everythingForm().submitting()" />
+          [disabled]="everythingForm().submitting()"><svg lucideSave></svg></app-button>
         <app-button variant="soft" label="Validate" (clicked)="validateAll()" />
         <app-button variant="ghost" label="Reset" (clicked)="reset()" />
         @if (submitState() === 'saved') {

--- a/frontend/src/app/features/design-system/forms/everything-form.component.html
+++ b/frontend/src/app/features/design-system/forms/everything-form.component.html
@@ -17,7 +17,7 @@
       <app-tag [color]="everythingForm().dirty() ? 'amber' : 'neutral'" [label]="everythingForm().dirty() ? 'dirty' : 'pristine'" />
       <app-tag [color]="everythingForm().touched() ? 'sky' : 'neutral'" [label]="everythingForm().touched() ? 'touched' : 'untouched'" />
       @if (everythingForm().submitting()) {
-        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle></svg></app-tag>
+        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle class="animate-spin"></svg></app-tag>
       }
     </div>
 

--- a/frontend/src/app/features/design-system/forms/everything-form.component.ts
+++ b/frontend/src/app/features/design-system/forms/everything-form.component.ts
@@ -22,6 +22,7 @@ import { AppDateRangePickerComponent, type DatePickerRange } from '../../../shar
 import { AppMessageComponent } from '../../../shared/ui/message/app-message.component';
 import { AppTagComponent } from '../../../shared/ui/tag/app-tag.component';
 import { type SelectOption } from '../../../shared/ui/select/app-select.options';
+import { LucideChevronLeft, LucideLoaderCircle, LucideSave } from '@lucide/angular';
 
 interface EverythingFormModel {
   text: string;
@@ -86,6 +87,9 @@ function createInitialModel(): EverythingFormModel {
     AppDateRangePickerComponent,
     AppMessageComponent,
     AppTagComponent,
+    LucideChevronLeft,
+    LucideSave,
+    LucideLoaderCircle,
   ],
   templateUrl: './everything-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/features/design-system/forms/library-form.component.html
+++ b/frontend/src/app/features/design-system/forms/library-form.component.html
@@ -4,10 +4,9 @@
       <app-button
         variant="ghost"
         size="sm"
-        icon="pi pi-chevron-left"
         label="Back to design system"
         styleClass="self-start"
-        (clicked)="back()" />
+        (clicked)="back()"><svg lucideChevronLeft></svg></app-button>
       <div class="flex flex-col gap-1">
         <h1 class="text-2xl font-extrabold text-text-strong">Create library</h1>
       </div>
@@ -18,7 +17,7 @@
       <app-tag [color]="libraryForm().dirty() ? 'amber' : 'neutral'" [label]="libraryForm().dirty() ? 'dirty' : 'pristine'" />
       <app-tag [color]="libraryForm().touched() ? 'sky' : 'neutral'" [label]="libraryForm().touched() ? 'touched' : 'untouched'" />
       @if (libraryForm().submitting()) {
-        <app-tag color="primary" icon="pi pi-spin pi-spinner" label="submitting" />
+        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle></svg></app-tag>
       }
     </div>
 
@@ -63,9 +62,8 @@
           type="submit"
           tone="primary"
           label="Save library"
-          icon="pi pi-save"
           [loading]="libraryForm().submitting()"
-          [disabled]="libraryForm().submitting()" />
+          [disabled]="libraryForm().submitting()"><svg lucideSave></svg></app-button>
         <app-button variant="soft" label="Validate" (clicked)="validateAll()" />
         <app-button variant="ghost" label="Reset" (clicked)="reset()" />
         @if (submitState() === 'saved') {

--- a/frontend/src/app/features/design-system/forms/library-form.component.html
+++ b/frontend/src/app/features/design-system/forms/library-form.component.html
@@ -17,7 +17,7 @@
       <app-tag [color]="libraryForm().dirty() ? 'amber' : 'neutral'" [label]="libraryForm().dirty() ? 'dirty' : 'pristine'" />
       <app-tag [color]="libraryForm().touched() ? 'sky' : 'neutral'" [label]="libraryForm().touched() ? 'touched' : 'untouched'" />
       @if (libraryForm().submitting()) {
-        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle></svg></app-tag>
+        <app-tag color="primary" label="submitting"><svg lucideLoaderCircle class="animate-spin"></svg></app-tag>
       }
     </div>
 

--- a/frontend/src/app/features/design-system/forms/library-form.component.ts
+++ b/frontend/src/app/features/design-system/forms/library-form.component.ts
@@ -14,6 +14,7 @@ import { AppSelectComponent } from '../../../shared/ui/select/app-select.compone
 import { AppSwitchComponent } from '../../../shared/ui/switch/app-switch.component';
 import { AppTagComponent } from '../../../shared/ui/tag/app-tag.component';
 import { type SelectOption } from '../../../shared/ui/select/app-select.options';
+import { LucideChevronLeft, LucideLoaderCircle, LucideSave } from '@lucide/angular';
 
 type OrganizationMode = 'BOOK_PER_FILE' | 'BOOK_PER_FOLDER';
 type MetadataSource = 'EMBEDDED' | 'SIDECAR' | 'PREFER_SIDECAR' | 'PREFER_EMBEDDED' | 'NONE';
@@ -61,6 +62,9 @@ function createInitialModel(): LibraryFormModel {
     AppSelectComponent,
     AppSwitchComponent,
     AppTagComponent,
+    LucideChevronLeft,
+    LucideSave,
+    LucideLoaderCircle,
   ],
   templateUrl: './library-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/shared/ui/accordion/app-accordion.component.ts
+++ b/frontend/src/app/shared/ui/accordion/app-accordion.component.ts
@@ -9,6 +9,7 @@ import {
   numberAttribute,
 } from '@angular/core';
 import { AccordionContent, AccordionGroup, AccordionPanel, AccordionTrigger } from '@angular/aria/accordion';
+import { LucideChevronDown } from '@lucide/angular';
 
 import {
   AppAccordionActionsDirective,
@@ -20,7 +21,7 @@ import { neutralControlBorderClass } from '../control.styles';
 @Component({
   selector: 'app-accordion',
   standalone: true,
-  imports: [NgTemplateOutlet, AccordionGroup, AccordionPanel, AccordionTrigger, AccordionContent],
+  imports: [NgTemplateOutlet, AccordionGroup, AccordionPanel, AccordionTrigger, AccordionContent, LucideChevronDown],
   host: { class: 'block' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -46,7 +47,7 @@ import { neutralControlBorderClass } from '../control.styles';
                     {{ item }}
                   }
                 </span>
-                <i [class]="chevronClass" [class.rotate-180]="trigger.expanded()" aria-hidden="true"></i>
+                <svg lucideChevronDown [class]="chevronClass" [class.rotate-180]="trigger.expanded()" aria-hidden="true"></svg>
               </button>
             </div>
             @if (actionsTemplate(); as tpl) {
@@ -104,7 +105,7 @@ export class AppAccordionComponent {
   protected readonly labelClass = 'min-w-0 flex-1 pr-7 text-left';
   protected readonly labelWithActionsClass = 'min-w-0 flex-1 pr-24 text-left';
   protected readonly chevronClass =
-    'pi pi-chevron-down pointer-events-none absolute right-3 top-1/2 shrink-0 -translate-y-1/2 text-xs text-text-muted transition-transform duration-200';
+    'pointer-events-none absolute right-3 top-1/2 size-4 shrink-0 -translate-y-1/2 text-text-muted transition-transform duration-200';
   protected readonly actionsOverlayClass = 'pointer-events-none absolute inset-y-0 right-8 flex items-center';
   protected readonly actionsClass = 'pointer-events-auto flex shrink-0 items-center gap-1';
   protected readonly contentClass = 'surface-page border-t border-border px-3 py-3 text-sm text-text';

--- a/frontend/src/app/shared/ui/autocomplete/app-autocomplete.component.ts
+++ b/frontend/src/app/shared/ui/autocomplete/app-autocomplete.component.ts
@@ -4,6 +4,7 @@ import { Combobox, ComboboxInput, ComboboxPopupContainer } from '@angular/aria/c
 import { Listbox, Option } from '@angular/aria/listbox';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { LucideLoaderCircle } from '@lucide/angular';
 
 import { AppAutocompleteBaseDirective } from './app-autocomplete-base.directive';
 
@@ -18,6 +19,7 @@ import { AppAutocompleteBaseDirective } from './app-autocomplete-base.directive'
     Listbox,
     Option,
     TranslocoPipe,
+    LucideLoaderCircle,
   ],
   host: { class: 'block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -55,7 +57,7 @@ import { AppAutocompleteBaseDirective } from './app-autocomplete-base.directive'
           (blur)="onInputBlur()"
           [class]="innerInputClass" />
         @if (pending()) {
-          <i class="pi pi-spinner pi-spin shrink-0 text-xs text-text-muted" aria-hidden="true"></i>
+          <svg lucideLoaderCircle class="size-4 shrink-0 animate-spin text-text-muted" aria-hidden="true"></svg>
         }
       </div>
 

--- a/frontend/src/app/shared/ui/autocomplete/app-multi-autocomplete.component.ts
+++ b/frontend/src/app/shared/ui/autocomplete/app-multi-autocomplete.component.ts
@@ -13,6 +13,7 @@ import { Combobox, ComboboxInput, ComboboxPopupContainer } from '@angular/aria/c
 import { Listbox, Option } from '@angular/aria/listbox';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { LucideLoaderCircle } from '@lucide/angular';
 
 import { AppTagComponent } from '../tag/app-tag.component';
 import { AppAutocompleteBaseDirective } from './app-autocomplete-base.directive';
@@ -29,6 +30,7 @@ import { AppAutocompleteBaseDirective } from './app-autocomplete-base.directive'
     Option,
     AppTagComponent,
     TranslocoPipe,
+    LucideLoaderCircle,
   ],
   host: { class: 'block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -76,7 +78,7 @@ import { AppAutocompleteBaseDirective } from './app-autocomplete-base.directive'
           (blur)="touched.set(true)"
           [class]="innerInputClass" />
         @if (pending()) {
-          <i class="pi pi-spinner pi-spin shrink-0 text-xs text-text-muted" aria-hidden="true"></i>
+          <svg lucideLoaderCircle class="size-4 shrink-0 animate-spin text-text-muted" aria-hidden="true"></svg>
         }
       </div>
 

--- a/frontend/src/app/shared/ui/button/app-button.component.ts
+++ b/frontend/src/app/shared/ui/button/app-button.component.ts
@@ -31,15 +31,15 @@ import { buttonVariants, type ButtonSize, type ButtonTone, type ButtonVariant } 
       (click)="clicked.emit($event)">
       @if (loading()) {
         <span [class]="loadingRingClass" aria-hidden="true"></span>
-      } @else if (icon() && iconPos() === 'left') {
-        <i [class]="iconClass()" aria-hidden="true"></i>
       }
+      <span
+        class="inline-flex shrink-0 empty:hidden [&>svg]:size-[1em] [&>svg]:shrink-0"
+        [class.hidden]="loading()"
+        [class.order-last]="iconPos() === 'right'">
+        <ng-content />
+      </span>
       @if (label()) {
         <span class="leading-none">{{ label() }}</span>
-      }
-      <ng-content />
-      @if (!loading() && icon() && iconPos() === 'right') {
-        <i [class]="iconClass()" aria-hidden="true"></i>
       }
     </button>
   `,
@@ -64,7 +64,6 @@ export class AppButtonComponent {
   readonly ariaExpanded = input<boolean | string | null>(null);
   readonly ariaHasPopup = input<boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | null>(null);
   readonly ariaPressed = input<boolean | 'false' | 'true' | 'mixed' | null>(null);
-  readonly icon = input('');
   readonly iconPos = input<'left' | 'right'>('left');
   readonly loading = input(false, { transform: booleanAttribute });
   readonly disabled = input(false, { transform: booleanAttribute });
@@ -85,6 +84,5 @@ export class AppButtonComponent {
       this.styleClass(),
     ),
   );
-  protected readonly iconClass = computed(() => cn(this.icon(), 'shrink-0 m-0 leading-none'));
   protected readonly loadingRingClass = cn(SPINNER_RING, 'size-[1em] border-2 shrink-0');
 }

--- a/frontend/src/app/shared/ui/date-picker/app-date-picker-base.directive.ts
+++ b/frontend/src/app/shared/ui/date-picker/app-date-picker-base.directive.ts
@@ -122,9 +122,9 @@ export const DATE_PICKER_TEMPLATE = `
       <span
         class="pointer-events-none absolute inset-y-0 right-0 inline-flex w-10 items-center justify-center text-text-muted">
         @if (pending()) {
-          <i class="pi pi-spinner pi-spin text-xs" aria-hidden="true"></i>
+          <svg lucideLoaderCircle class="size-4 animate-spin" aria-hidden="true"></svg>
         } @else {
-          <i class="pi pi-calendar text-sm" aria-hidden="true"></i>
+          <svg lucideCalendar class="size-4" aria-hidden="true"></svg>
         }
       </span>
     </div>
@@ -150,11 +150,11 @@ export const DATE_PICKER_TEMPLATE = `
         (focusout)="onPopupFocusOut($event)">
         <div class="mb-2 flex items-center justify-between gap-1">
           <button type="button" [class]="navButtonClass" [attr.aria-label]="'shared.ui.datePicker.previousMonth' | transloco" (click)="shiftMonth(-1)">
-            <i class="pi pi-chevron-left text-xs" aria-hidden="true"></i>
+            <svg lucideChevronLeft class="size-4" aria-hidden="true"></svg>
           </button>
           <span aria-live="polite" class="text-sm font-semibold text-text-strong">{{ monthYearLabel() }}</span>
           <button type="button" [class]="navButtonClass" [attr.aria-label]="'shared.ui.datePicker.nextMonth' | transloco" (click)="shiftMonth(1)">
-            <i class="pi pi-chevron-right text-xs" aria-hidden="true"></i>
+            <svg lucideChevronRight class="size-4" aria-hidden="true"></svg>
           </button>
         </div>
 

--- a/frontend/src/app/shared/ui/date-picker/app-date-picker.component.ts
+++ b/frontend/src/app/shared/ui/date-picker/app-date-picker.component.ts
@@ -3,6 +3,7 @@ import { type FormValueControl } from '@angular/forms/signals';
 import { Grid, GridCell, GridCellWidget, GridRow } from '@angular/aria/grid';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { LucideCalendar, LucideChevronLeft, LucideChevronRight, LucideLoaderCircle } from '@lucide/angular';
 
 import {
   AppDatePickerBaseDirective,
@@ -16,7 +17,7 @@ const NO_SELECTION: DaySelectionFlags = { point: false, spanStart: false, spanEn
 @Component({
   selector: 'app-date-picker',
   standalone: true,
-  imports: [OverlayModule, Grid, GridRow, GridCell, GridCellWidget, TranslocoPipe],
+  imports: [OverlayModule, Grid, GridRow, GridCell, GridCellWidget, TranslocoPipe, LucideCalendar, LucideChevronLeft, LucideChevronRight, LucideLoaderCircle],
   host: { class: 'block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: DATE_PICKER_TEMPLATE,

--- a/frontend/src/app/shared/ui/date-picker/app-date-range-picker.component.ts
+++ b/frontend/src/app/shared/ui/date-picker/app-date-range-picker.component.ts
@@ -3,6 +3,7 @@ import { type FormValueControl } from '@angular/forms/signals';
 import { Grid, GridCell, GridCellWidget, GridRow } from '@angular/aria/grid';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { LucideCalendar, LucideChevronLeft, LucideChevronRight, LucideLoaderCircle } from '@lucide/angular';
 
 import {
   AppDatePickerBaseDirective,
@@ -22,7 +23,7 @@ const NO_SELECTION: DaySelectionFlags = { point: false, spanStart: false, spanEn
 @Component({
   selector: 'app-date-range-picker',
   standalone: true,
-  imports: [OverlayModule, Grid, GridRow, GridCell, GridCellWidget, TranslocoPipe],
+  imports: [OverlayModule, Grid, GridRow, GridCell, GridCellWidget, TranslocoPipe, LucideCalendar, LucideChevronLeft, LucideChevronRight, LucideLoaderCircle],
   host: { class: 'block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: DATE_PICKER_TEMPLATE,

--- a/frontend/src/app/shared/ui/input/app-input.component.ts
+++ b/frontend/src/app/shared/ui/input/app-input.component.ts
@@ -13,14 +13,16 @@ import {
 } from '@angular/core';
 import { type FormValueControl } from '@angular/forms/signals';
 import { translateSignal } from '@jsverse/transloco';
+import { LucideEye, LucideEyeOff, LucideLoaderCircle } from '@lucide/angular';
 import { cn } from '../cn';
 import { APP_FIELD } from '../field/app-field.context';
 import { appInputVariants, type AppInputSize, type AppInputVariant } from './app-input.variants';
 
 type AppInputType = 'text' | 'email' | 'password' | 'search' | 'tel' | 'url';
 
-const TRAILING_ACTION_BUTTON_CLASS =
-  'absolute inset-y-0 right-0 inline-flex w-10 items-center justify-center rounded-r-md text-text-muted ' +
+const ADORNMENT_CLASS = 'inline-flex shrink-0 items-center text-text-muted empty:hidden [&>svg]:size-4';
+const REVEAL_TOGGLE_CLASS =
+  'inline-flex size-7 shrink-0 items-center justify-center rounded-md text-text-muted ' +
   'transition-colors hover:text-text-strong ' +
   'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary ' +
   'disabled:pointer-events-none disabled:opacity-50';
@@ -28,56 +30,55 @@ const TRAILING_ACTION_BUTTON_CLASS =
 @Component({
   selector: 'app-input',
   standalone: true,
-  host: { class: 'relative block w-full' },
+  imports: [LucideEye, LucideEyeOff, LucideLoaderCircle],
+  host: { class: 'block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    @if (leadingIcon()) {
-      <span class="pointer-events-none absolute inset-y-0 left-0 inline-flex w-10 items-center justify-center text-text-muted">
-        <i [class]="leadingIcon()" aria-hidden="true"></i>
-      </span>
-    }
-    <input
-      #input
-      [class]="inputClass()"
-      [type]="resolvedType()"
-      [attr.id]="resolvedInputId()"
-      [attr.name]="name() || null"
-      [attr.placeholder]="placeholder() || null"
-      [attr.autocomplete]="autocomplete() || null"
-      [attr.aria-label]="ariaLabel() || null"
-      [attr.aria-describedby]="resolvedDescribedBy()"
-      [attr.aria-invalid]="showInvalid() ? 'true' : null"
-      [attr.aria-busy]="pending() ? 'true' : null"
-      [attr.maxlength]="maxLength()"
-      [attr.minlength]="minLength()"
-      [attr.pattern]="patternAttr()"
-      [value]="value()"
-      [disabled]="disabled()"
-      [readonly]="readonly()"
-      [required]="required()"
-      (input)="onInput(input)"
-      (blur)="touched.set(true)"
-      (keydown)="keyedDown.emit($event)"
-      (keyup.enter)="onEnterKeyup($event)" />
-    @if (pending()) {
-      <span
-        class="pointer-events-none absolute inset-y-0 inline-flex w-10 items-center justify-center text-text-muted"
-        [class.right-10]="showTrailingAction()"
-        [class.right-0]="!showTrailingAction()">
-        <i class="pi pi-spinner pi-spin text-xs" aria-hidden="true"></i>
-      </span>
-    }
-    @if (showTrailingAction()) {
-      <button
-        type="button"
-        [class]="trailingActionButtonClass"
+    <div [class]="boxClass()" [attr.aria-invalid]="showInvalid() ? 'true' : null">
+      <span [class]="adornmentClass"><ng-content select="[appInputLeading]" /></span>
+      <input
+        #input
+        [class]="inputClass"
+        [type]="resolvedType()"
+        [attr.id]="resolvedInputId()"
+        [attr.name]="name() || null"
+        [attr.placeholder]="placeholder() || null"
+        [attr.autocomplete]="autocomplete() || null"
+        [attr.aria-label]="ariaLabel() || null"
+        [attr.aria-describedby]="resolvedDescribedBy()"
+        [attr.aria-invalid]="showInvalid() ? 'true' : null"
+        [attr.aria-busy]="pending() ? 'true' : null"
+        [attr.maxlength]="maxLength()"
+        [attr.minlength]="minLength()"
+        [attr.pattern]="patternAttr()"
+        [value]="value()"
         [disabled]="disabled()"
-        [attr.aria-label]="trailingActionAriaLabel()"
-        [attr.aria-pressed]="trailingActionPressed()"
-        (click)="onTrailingActionClick($event)">
-        <i [class]="trailingActionIcon()" aria-hidden="true"></i>
-      </button>
-    }
+        [readonly]="readonly()"
+        [required]="required()"
+        (input)="onInput(input)"
+        (blur)="touched.set(true)"
+        (keydown)="keyedDown.emit($event)"
+        (keyup.enter)="onEnterKeyup($event)" />
+      @if (pending()) {
+        <svg lucideLoaderCircle class="size-4 shrink-0 animate-spin text-text-muted" aria-hidden="true"></svg>
+      }
+      @if (showRevealToggle()) {
+        <button
+          type="button"
+          [class]="revealToggleClass"
+          [disabled]="disabled()"
+          [attr.aria-label]="revealAriaLabel()"
+          [attr.aria-pressed]="passwordVisible()"
+          (click)="passwordVisible.set(!passwordVisible())">
+          @if (passwordVisible()) {
+            <svg lucideEyeOff class="size-4" aria-hidden="true"></svg>
+          } @else {
+            <svg lucideEye class="size-4" aria-hidden="true"></svg>
+          }
+        </button>
+      }
+      <span [class]="adornmentClass"><ng-content select="[appInputTrailing]" /></span>
+    </div>
   `,
 })
 export class AppInputComponent implements FormValueControl<string> {
@@ -103,17 +104,13 @@ export class AppInputComponent implements FormValueControl<string> {
   readonly minLength = input<number | undefined>(undefined);
   readonly pattern = input<readonly RegExp[]>([]);
   readonly revealToggle = input(false, { transform: booleanAttribute });
-  readonly leadingIcon = input('');
-  readonly trailingIcon = input('');
-  readonly trailingAriaLabel = input('');
-  readonly trailingPressed = input<boolean | 'false' | 'true' | 'mixed' | null>(null);
 
   readonly keyedDown = output<KeyboardEvent>();
   readonly enterPressed = output<KeyboardEvent>();
-  readonly trailingClicked = output<MouseEvent>();
 
   private readonly fieldContext = inject(APP_FIELD, { optional: true });
-  protected readonly trailingActionButtonClass = TRAILING_ACTION_BUTTON_CLASS;
+  protected readonly adornmentClass = ADORNMENT_CLASS;
+  protected readonly revealToggleClass = REVEAL_TOGGLE_CLASS;
   protected readonly resolvedInputId = computed(() => this.inputId() || this.fieldContext?.controlId() || null);
   protected readonly resolvedDescribedBy = computed(
     () => this.ariaDescribedBy() || this.fieldContext?.describedById() || null,
@@ -123,47 +120,22 @@ export class AppInputComponent implements FormValueControl<string> {
 
   protected readonly passwordVisible = signal(false);
   protected readonly showRevealToggle = computed(() => this.type() === 'password' && this.revealToggle());
-  protected readonly showTrailingAction = computed(() => this.showRevealToggle() || this.trailingIcon() !== '');
   private readonly showPasswordLabel = translateSignal('shared.ui.input.showPassword');
   private readonly hidePasswordLabel = translateSignal('shared.ui.input.hidePassword');
-  private readonly trailingActionDefaultLabel = translateSignal('shared.ui.input.trailingAction');
   protected readonly resolvedType = computed(() =>
     this.showRevealToggle() && this.passwordVisible() ? 'text' : this.type(),
   );
-  protected readonly trailingActionIcon = computed(() => {
-    if (this.showRevealToggle()) {
-      return this.passwordVisible() ? 'pi pi-eye-slash' : 'pi pi-eye';
-    }
-
-    return this.trailingIcon();
-  });
-  protected readonly trailingActionAriaLabel = computed(() => {
-    if (this.showRevealToggle()) {
-      return this.passwordVisible() ? this.hidePasswordLabel() : this.showPasswordLabel();
-    }
-
-    return this.trailingAriaLabel() || this.trailingActionDefaultLabel();
-  });
-  protected readonly trailingActionPressed = computed(() => {
-    if (this.showRevealToggle()) {
-      return this.passwordVisible();
-    }
-
-    return this.trailingPressed();
-  });
-  protected readonly trailingPaddingClass = computed(() => {
-    const hasTrailingAction = this.showTrailingAction();
-    const pending = this.pending();
-
-    if (hasTrailingAction && pending) return 'pr-20';
-    if (hasTrailingAction || pending) return 'pr-10';
-    return '';
-  });
-  protected readonly inputClass = computed(() =>
+  protected readonly revealAriaLabel = computed(() =>
+    this.passwordVisible() ? this.hidePasswordLabel() : this.showPasswordLabel(),
+  );
+  protected readonly inputClass =
+    'min-w-0 flex-1 border-0 bg-transparent p-0 text-text-strong outline-hidden placeholder:text-text-muted ' +
+    '[&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden disabled:cursor-default';
+  protected readonly boxClass = computed(() =>
     cn(
       appInputVariants({ size: this.size(), variant: this.variant() }),
-      this.leadingIcon() && 'pl-10',
-      this.trailingPaddingClass(),
+      'flex items-center gap-2',
+      this.disabled() && 'pointer-events-none opacity-50',
       this.styleClass(),
     ),
   );
@@ -180,15 +152,6 @@ export class AppInputComponent implements FormValueControl<string> {
 
   protected onEnterKeyup(event: Event): void {
     this.enterPressed.emit(event as KeyboardEvent);
-  }
-
-  protected onTrailingActionClick(event: MouseEvent): void {
-    if (this.showRevealToggle()) {
-      this.passwordVisible.update(visible => !visible);
-      return;
-    }
-
-    this.trailingClicked.emit(event);
   }
 
   focus(options?: FocusOptions): void {

--- a/frontend/src/app/shared/ui/input/app-input.variants.ts
+++ b/frontend/src/app/shared/ui/input/app-input.variants.ts
@@ -19,8 +19,8 @@ export const appInputVariants = cva(
       variant: {
         outlined:
           `rounded-md border ${neutralControlBorderClass} bg-card shadow-control ` +
-          'focus:border-primary/60 focus:outline-1 focus:outline-offset-0 focus:outline-primary/60 ' +
-          'aria-invalid:border-danger aria-invalid:focus:border-danger aria-invalid:focus:outline-danger',
+          'focus-within:border-primary/60 focus-within:outline-1 focus-within:outline-offset-0 focus-within:outline-primary/60 ' +
+          'aria-invalid:border-danger aria-invalid:focus-within:border-danger aria-invalid:focus-within:outline-danger',
         bare: 'rounded-none border-0 bg-transparent shadow-none aria-invalid:text-danger',
       },
     },

--- a/frontend/src/app/shared/ui/message/app-message.component.ts
+++ b/frontend/src/app/shared/ui/message/app-message.component.ts
@@ -3,6 +3,7 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject,
 import { toSignal } from '@angular/core/rxjs-interop';
 import { type FieldState, type ValidationError } from '@angular/forms/signals';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { LucideChevronDown, LucideChevronUp, LucideDynamicIcon } from '@lucide/angular';
 import { AppButtonComponent } from '../button/app-button.component';
 import { cn } from '../cn';
 import {
@@ -18,7 +19,7 @@ type SummaryLayout = 'list' | 'inline';
 @Component({
   selector: 'app-message',
   standalone: true,
-  imports: [AppButtonComponent, TranslocoPipe],
+  imports: [AppButtonComponent, TranslocoPipe, LucideDynamicIcon, LucideChevronUp, LucideChevronDown],
   host: {
     '[class.block]': '!inline()',
     '[class.inline-block]': 'inline()',
@@ -28,7 +29,7 @@ type SummaryLayout = 'list' | 'inline';
   template: `
     @if (visible()) {
       <div [class]="rootClass()" [attr.role]="role()">
-        <i [class]="iconClass()" aria-hidden="true"></i>
+        <svg [lucideIcon]="messageIcon()" [class]="iconClass()" aria-hidden="true"></svg>
         <div class="min-w-0 flex-1">
           @if (field() && summary()) {
             @if (summaryLayout() === 'inline') {
@@ -46,17 +47,15 @@ type SummaryLayout = 'list' | 'inline';
                       variant="ghost"
                       size="sm"
                       iconOnly
-                      icon="pi pi-chevron-up"
                       [ariaLabel]="'shared.ui.message.previousIssue' | transloco"
-                      (clicked)="focusAdjacentSummaryIssue(-1)" />
+                      (clicked)="focusAdjacentSummaryIssue(-1)"><svg lucideChevronUp aria-hidden="true"></svg></app-button>
                     <app-button
                       tone="danger"
                       variant="ghost"
                       size="sm"
                       iconOnly
-                      icon="pi pi-chevron-down"
                       [ariaLabel]="'shared.ui.message.nextIssue' | transloco"
-                      (clicked)="focusAdjacentSummaryIssue(1)" />
+                      (clicked)="focusAdjacentSummaryIssue(1)"><svg lucideChevronDown aria-hidden="true"></svg></app-button>
                   </div>
                 </div>
               } @else {
@@ -141,9 +140,8 @@ export class AppMessageComponent {
   });
   protected readonly resolvedColor = computed<MessageColor>(() => (this.field() ? 'red' : this.color()));
   protected readonly role = computed(() => (this.resolvedColor() === 'red' ? 'alert' : 'status'));
-  protected readonly iconClass = computed(() =>
-    cn(MESSAGE_ICONS[this.resolvedColor()], 'mt-0.5 shrink-0 text-[1.05em] leading-none'),
-  );
+  protected readonly messageIcon = computed(() => MESSAGE_ICONS[this.resolvedColor()]);
+  protected readonly iconClass = computed(() => cn('mt-0.5 size-4 shrink-0 leading-none'));
   protected readonly rootClass = computed(() =>
     cn(messageVariants({ color: this.resolvedColor() }), this.inline() && 'inline-flex align-middle', this.styleClass()),
   );

--- a/frontend/src/app/shared/ui/message/app-message.variants.ts
+++ b/frontend/src/app/shared/ui/message/app-message.variants.ts
@@ -1,4 +1,5 @@
 import { cva } from 'class-variance-authority';
+import { LucideCircleAlert, LucideCircleCheck, LucideInfo, LucideTriangleAlert, type LucideIconData } from '@lucide/angular';
 import { neutralControlBorderClass } from '../control.styles';
 
 export type MessageColor = 'neutral' | 'primary' | 'green' | 'amber' | 'red';
@@ -16,10 +17,10 @@ export const messageVariants = cva('flex min-h-9 items-center gap-2 rounded-md b
   defaultVariants: { color: 'neutral' },
 });
 
-export const MESSAGE_ICONS: Record<MessageColor, string> = {
-  neutral: 'pi pi-info-circle',
-  primary: 'pi pi-info-circle',
-  green: 'pi pi-check-circle',
-  amber: 'pi pi-exclamation-triangle',
-  red: 'pi pi-exclamation-circle',
+export const MESSAGE_ICONS: Record<MessageColor, LucideIconData> = {
+  neutral: LucideInfo.icon,
+  primary: LucideInfo.icon,
+  green: LucideCircleCheck.icon,
+  amber: LucideTriangleAlert.icon,
+  red: LucideCircleAlert.icon,
 };

--- a/frontend/src/app/shared/ui/number-input/app-number-input.component.ts
+++ b/frontend/src/app/shared/ui/number-input/app-number-input.component.ts
@@ -11,6 +11,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { transformedValue, type FormValueControl, type ParseResult } from '@angular/forms/signals';
+import { LucideChevronDown, LucideChevronUp } from '@lucide/angular';
 
 import { cn } from '../cn';
 import { APP_FIELD } from '../field/app-field.context';
@@ -19,6 +20,7 @@ import { appInputVariants, type AppInputSize } from '../input/app-input.variants
 @Component({
   selector: 'app-number-input',
   standalone: true,
+  imports: [LucideChevronDown, LucideChevronUp],
   host: { class: 'relative block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -59,7 +61,7 @@ import { appInputVariants, type AppInputSize } from '../input/app-input.variants
               [class]="stepButtonClass"
               [disabled]="disabled() || atMax()"
               (click)="nudge(1)">
-              <i class="pi pi-chevron-up text-xs leading-none" aria-hidden="true"></i>
+              <svg lucideChevronUp class="size-3" aria-hidden="true"></svg>
             </button>
             <button
               type="button"
@@ -68,7 +70,7 @@ import { appInputVariants, type AppInputSize } from '../input/app-input.variants
               [class]="stepButtonClass + ' border-t border-border'"
               [disabled]="disabled() || atMin()"
               (click)="nudge(-1)">
-              <i class="pi pi-chevron-down text-xs leading-none" aria-hidden="true"></i>
+              <svg lucideChevronDown class="size-3" aria-hidden="true"></svg>
             </button>
           </span>
         }

--- a/frontend/src/app/shared/ui/rating/app-rating.component.ts
+++ b/frontend/src/app/shared/ui/rating/app-rating.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { type FormValueControl } from '@angular/forms/signals';
 import { TranslocoPipe, translateSignal } from '@jsverse/transloco';
+import { LucideLoaderCircle } from '@lucide/angular';
 
 import { APP_FIELD } from '../field/app-field.context';
 
@@ -30,7 +31,7 @@ interface Star {
 @Component({
   selector: 'app-rating',
   standalone: true,
-  imports: [TranslocoPipe],
+  imports: [TranslocoPipe, LucideLoaderCircle],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'inline-flex' },
   template: `
@@ -57,7 +58,7 @@ interface Star {
           <span class="rating-label">{{ valueLabel() }}</span>
         }
         @if (pending()) {
-          <i class="pi pi-spinner pi-spin ml-1 text-xs text-text-muted" aria-hidden="true"></i>
+          <svg lucideLoaderCircle class="ml-1 size-4 animate-spin text-text-muted" aria-hidden="true"></svg>
         }
       </span>
     } @else {
@@ -109,7 +110,7 @@ interface Star {
           <span class="rating-label">{{ valueLabel() }}</span>
         }
         @if (pending()) {
-          <i class="pi pi-spinner pi-spin ml-1 text-xs text-text-muted" aria-hidden="true"></i>
+          <svg lucideLoaderCircle class="ml-1 size-4 animate-spin text-text-muted" aria-hidden="true"></svg>
         }
       </div>
     }

--- a/frontend/src/app/shared/ui/select/app-multi-select.component.ts
+++ b/frontend/src/app/shared/ui/select/app-multi-select.component.ts
@@ -10,6 +10,7 @@ import { Combobox, ComboboxInput, ComboboxPopupContainer } from '@angular/aria/c
 import { Listbox, Option } from '@angular/aria/listbox';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { TranslocoPipe, translateSignal } from '@jsverse/transloco';
+import { LucideCheck, LucideChevronDown, LucideLoaderCircle, LucideSearch, LucideX } from '@lucide/angular';
 
 import { cn } from '../cn';
 import { AppSelectBaseDirective } from './app-select-base.directive';
@@ -27,6 +28,11 @@ import { type SelectOption } from './app-select.options';
     Listbox,
     Option,
     TranslocoPipe,
+    LucideCheck,
+    LucideChevronDown,
+    LucideLoaderCircle,
+    LucideSearch,
+    LucideX,
   ],
   host: { class: 'block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -70,7 +76,7 @@ import { type SelectOption } from './app-select.options';
             [class.w-9]="variant() !== 'bare'"
             [class.w-7]="variant() === 'bare'"
             (click)="clear($event)">
-            <i class="pi pi-times text-xs" aria-hidden="true"></i>
+            <svg lucideX class="size-4" aria-hidden="true"></svg>
           </button>
         }
 
@@ -79,9 +85,9 @@ import { type SelectOption } from './app-select.options';
           [class.w-9]="variant() !== 'bare'"
           [class.w-7]="variant() === 'bare'">
           @if (pending()) {
-            <i class="pi pi-spinner pi-spin text-xs" aria-hidden="true"></i>
+            <svg lucideLoaderCircle class="size-4 animate-spin" aria-hidden="true"></svg>
           } @else {
-            <i class="pi pi-chevron-down text-xs transition-transform" [class.rotate-180]="cb.expanded()" aria-hidden="true"></i>
+            <svg lucideChevronDown class="size-4 transition-transform" [class.rotate-180]="cb.expanded()" aria-hidden="true"></svg>
           }
         </span>
       </div>
@@ -111,7 +117,7 @@ import { type SelectOption } from './app-select.options';
                   [placeholder]="filterPlaceholder() || ('shared.ui.select.search' | transloco)"
                   [readonly]="readonly()"
                   class="h-full min-w-0 flex-1 border-0 bg-transparent px-0 pr-2 text-sm text-text-strong outline-hidden placeholder:text-text-muted focus:outline-hidden" />
-                <i class="pi pi-search shrink-0 text-xs" aria-hidden="true"></i>
+                <svg lucideSearch class="size-4 shrink-0" aria-hidden="true"></svg>
               </div>
             }
 
@@ -142,7 +148,7 @@ import { type SelectOption } from './app-select.options';
                     [disabled]="option.disabled === true"
                     [class]="optionClass">
                     <span [class]="checkboxClass(isSelected(option))">
-                      @if (isSelected(option)) { <i class="pi pi-check text-[0.625rem] text-white" aria-hidden="true"></i> }
+                      @if (isSelected(option)) { <svg lucideCheck class="size-3 text-white" aria-hidden="true"></svg> }
                     </span>
                     @if (optionTemplate(); as tpl) {
                       <ng-container [ngTemplateOutlet]="tpl.template" [ngTemplateOutletContext]="{ $implicit: option }" />

--- a/frontend/src/app/shared/ui/select/app-select.component.ts
+++ b/frontend/src/app/shared/ui/select/app-select.component.ts
@@ -11,6 +11,7 @@ import { Combobox, ComboboxInput, ComboboxPopupContainer } from '@angular/aria/c
 import { Listbox, Option } from '@angular/aria/listbox';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { LucideCheck, LucideChevronDown, LucideLoaderCircle, LucideSearch, LucideX } from '@lucide/angular';
 
 import { AppSelectBaseDirective } from './app-select-base.directive';
 import { AppSelectSelectedTemplateDirective } from './app-select.templates';
@@ -28,6 +29,11 @@ import { type SelectOption } from './app-select.options';
     Listbox,
     Option,
     TranslocoPipe,
+    LucideCheck,
+    LucideChevronDown,
+    LucideLoaderCircle,
+    LucideSearch,
+    LucideX,
   ],
   host: { class: 'block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -79,7 +85,7 @@ import { type SelectOption } from './app-select.options';
             [class.w-9]="variant() !== 'bare'"
             [class.w-7]="variant() === 'bare'"
             (click)="clear($event)">
-            <i class="pi pi-times text-xs" aria-hidden="true"></i>
+            <svg lucideX class="size-4" aria-hidden="true"></svg>
           </button>
         }
 
@@ -88,9 +94,9 @@ import { type SelectOption } from './app-select.options';
           [class.w-9]="variant() !== 'bare'"
           [class.w-7]="variant() === 'bare'">
           @if (pending()) {
-            <i class="pi pi-spinner pi-spin text-xs" aria-hidden="true"></i>
+            <svg lucideLoaderCircle class="size-4 animate-spin" aria-hidden="true"></svg>
           } @else {
-            <i class="pi pi-chevron-down text-xs transition-transform" [class.rotate-180]="cb.expanded()" aria-hidden="true"></i>
+            <svg lucideChevronDown class="size-4 transition-transform" [class.rotate-180]="cb.expanded()" aria-hidden="true"></svg>
           }
         </span>
       </div>
@@ -120,7 +126,7 @@ import { type SelectOption } from './app-select.options';
                   [placeholder]="filterPlaceholder() || ('shared.ui.select.search' | transloco)"
                   [readonly]="readonly()"
                   class="h-full min-w-0 flex-1 border-0 bg-transparent px-0 pr-2 text-sm text-text-strong outline-hidden placeholder:text-text-muted focus:outline-hidden" />
-                <i class="pi pi-search shrink-0 text-xs" aria-hidden="true"></i>
+                <svg lucideSearch class="size-4 shrink-0" aria-hidden="true"></svg>
               </div>
             }
 
@@ -155,7 +161,7 @@ import { type SelectOption } from './app-select.options';
                       <span class="truncate leading-5">{{ option.label }}</span>
                     }
                     @if (isSelected(option)) {
-                      <i class="pi pi-check order-last ml-auto size-4 shrink-0 text-primary" aria-hidden="true"></i>
+                      <svg lucideCheck class="order-last ml-auto size-4 shrink-0 text-primary" aria-hidden="true"></svg>
                     }
                   </li>
                 }

--- a/frontend/src/app/shared/ui/split-button/app-split-button.component.ts
+++ b/frontend/src/app/shared/ui/split-button/app-split-button.component.ts
@@ -1,5 +1,6 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { type MenuItem } from 'primeng/api';
+import { LucideChevronDown } from '@lucide/angular';
 import { cn } from '../cn';
 import { connectedGroupClass, connectedItemClass } from '../connected-group';
 import { AppButtonComponent } from '../button/app-button.component';
@@ -9,7 +10,7 @@ import { AppMenuComponent } from '../menu/app-menu.component';
 @Component({
   selector: 'app-split-button',
   standalone: true,
-  imports: [AppButtonComponent, AppMenuComponent],
+  imports: [AppButtonComponent, AppMenuComponent, LucideChevronDown],
   host: {
     class: 'inline-block align-middle',
     '[class.w-full]': 'fluid()',
@@ -36,7 +37,6 @@ import { AppMenuComponent } from '../menu/app-menu.component';
         [tabIndex]="tabIndex()"
         [label]="label()"
         [ariaLabel]="ariaLabel()"
-        [icon]="icon()"
         [iconPos]="iconPos()"
         (clicked)="clicked.emit($event)">
         <ng-content />
@@ -45,7 +45,6 @@ import { AppMenuComponent } from '../menu/app-menu.component';
         [buttonId]="menuButtonId()"
         type="button"
         iconOnly
-        icon="pi pi-chevron-down"
         [tone]="tone()"
         [variant]="variant()"
         [size]="size()"
@@ -54,7 +53,9 @@ import { AppMenuComponent } from '../menu/app-menu.component';
         [form]="form()"
         [ariaHasPopup]="'menu'"
         [ariaLabel]="menuAriaLabel() || ariaLabel() || label()"
-        (clicked)="menu.toggle($event)" />
+        (clicked)="menu.toggle($event)">
+        <svg lucideChevronDown aria-hidden="true"></svg>
+      </app-button>
       <app-menu #menu [model]="model()" [appendTo]="appendTo()" />
     </span>
   `,
@@ -77,7 +78,6 @@ export class AppSplitButtonComponent {
   readonly label = input('');
   readonly ariaLabel = input('');
   readonly menuAriaLabel = input('');
-  readonly icon = input('');
   readonly iconPos = input<'left' | 'right'>('left');
   readonly model = input<readonly MenuItem[]>([]);
   readonly appendTo = input<'body' | 'self' | HTMLElement>('body');

--- a/frontend/src/app/shared/ui/tabs/app-tabs.component.ts
+++ b/frontend/src/app/shared/ui/tabs/app-tabs.component.ts
@@ -14,6 +14,7 @@ import {
   viewChildren,
 } from '@angular/core';
 import { Tab as NgTab, TabList, Tabs } from '@angular/aria/tabs';
+import { LucideDynamicIcon, type LucideIconData } from '@lucide/angular';
 import { AppSelectComponent } from '../select/app-select.component';
 import { type SelectOption } from '../select/app-select.options';
 import { cn } from '../cn';
@@ -30,7 +31,7 @@ import {
 export interface TabItem {
   id: string;
   label: string;
-  icon?: string;
+  icon?: LucideIconData;
 }
 
 const COLLAPSE_HYSTERESIS = 8;
@@ -38,7 +39,7 @@ const COLLAPSE_HYSTERESIS = 8;
 @Component({
   selector: 'app-tabs',
   standalone: true,
-  imports: [Tabs, TabList, NgTab, AppSelectComponent],
+  imports: [Tabs, TabList, NgTab, AppSelectComponent, LucideDynamicIcon],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'relative block min-w-0' },
   template: `
@@ -71,8 +72,8 @@ const COLLAPSE_HYSTERESIS = 8;
               [style.width.px]="indicatorWidth()"></span>
             @for (tab of tabs(); track tab.id) {
               <button ngTab type="button" [value]="tab.id" [class]="tabClass()">
-                @if (tab.icon) {
-                  <i [class]="tab.icon + ' shrink-0 text-[0.875em] leading-none'" aria-hidden="true"></i>
+                @if (tab.icon; as tabIcon) {
+                  <svg [lucideIcon]="tabIcon" class="size-[0.875em] shrink-0 leading-none" aria-hidden="true"></svg>
                 }
                 <span class="leading-none">{{ tab.label }}</span>
               </button>

--- a/frontend/src/app/shared/ui/tag/app-tag.component.ts
+++ b/frontend/src/app/shared/ui/tag/app-tag.component.ts
@@ -1,11 +1,13 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { translateSignal } from '@jsverse/transloco';
+import { LucideX } from '@lucide/angular';
 import { cn } from '../cn';
 import { tagRemoveVariants, tagVariants, type TagColor, type TagSize } from './app-tag.variants';
 
 @Component({
   selector: 'app-tag',
   standalone: true,
+  imports: [LucideX],
   host: { class: 'inline-flex align-middle' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -18,9 +20,7 @@ import { tagRemoveVariants, tagVariants, type TagColor, type TagSize } from './a
         [style.border-color]="customBorder()"
         [attr.aria-label]="ariaLabel() || null"
         (click)="clicked.emit($event)">
-        @if (icon()) {
-          <i [class]="icon()" aria-hidden="true"></i>
-        }
+        <span class="inline-flex empty:hidden [&>svg]:size-[1em] [&>svg]:shrink-0"><ng-content select="svg" /></span>
         @if (label()) {
           <span>{{ label() }}</span>
         }
@@ -32,9 +32,7 @@ import { tagRemoveVariants, tagVariants, type TagColor, type TagSize } from './a
         [style.background-color]="customBg()"
         [style.color]="customTextColor()"
         [style.border-color]="customBorder()">
-        @if (icon()) {
-          <i [class]="icon()" aria-hidden="true"></i>
-        }
+        <span class="inline-flex empty:hidden [&>svg]:size-[1em] [&>svg]:shrink-0"><ng-content select="svg" /></span>
         @if (label()) {
           <span>{{ label() }}</span>
         }
@@ -45,7 +43,7 @@ import { tagRemoveVariants, tagVariants, type TagColor, type TagSize } from './a
             [class]="removeClass()"
             [attr.aria-label]="resolvedRemoveLabel()"
             (click)="$event.stopPropagation(); remove.emit($event)">
-            <i class="pi pi-times text-[0.7em]" aria-hidden="true"></i>
+            <svg lucideX class="size-[0.9em]" aria-hidden="true"></svg>
           </button>
         }
       </span>
@@ -56,7 +54,6 @@ export class AppTagComponent {
   readonly color = input<TagColor>('neutral');
   readonly size = input<TagSize>('md');
   readonly label = input('');
-  readonly icon = input('');
   readonly styleClass = input('');
   readonly customColor = input('');
   readonly clickable = input(false, { transform: booleanAttribute });

--- a/frontend/src/app/shared/ui/textarea/app-textarea.component.ts
+++ b/frontend/src/app/shared/ui/textarea/app-textarea.component.ts
@@ -11,6 +11,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { type FormValueControl } from '@angular/forms/signals';
+import { LucideLoaderCircle } from '@lucide/angular';
 import { cn } from '../cn';
 import { APP_FIELD } from '../field/app-field.context';
 import { appTextareaVariants } from './app-textarea.variants';
@@ -18,6 +19,7 @@ import { appTextareaVariants } from './app-textarea.variants';
 @Component({
   selector: 'app-textarea',
   standalone: true,
+  imports: [LucideLoaderCircle],
   host: { class: 'relative block w-full' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -44,7 +46,7 @@ import { appTextareaVariants } from './app-textarea.variants';
       (blur)="touched.set(true)"></textarea>
     @if (pending()) {
       <span class="pointer-events-none absolute right-3 top-2.5 inline-flex text-text-muted">
-        <i class="pi pi-spinner pi-spin text-xs" aria-hidden="true"></i>
+        <svg lucideLoaderCircle class="size-4 animate-spin" aria-hidden="true"></svg>
       </span>
     }
   `,


### PR DESCRIPTION
## Description

Second part of the icon library refactor, introducing the lucide icons to the new component library. 

Stacked PR - requires #1828

## Linked Issue

Fixes #1827

## Changes

- Migrate new components in `shared/ui` from Prime icons > Lucide using direct SVG imports. 
- Converted app-input to flexbox to better handle SVG icons. 

## Manual Testing Steps

Open /design-system page, confirm all components are showing icons correctly. 

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
<img width="1243" height="623" alt="Screenshot 2026-06-24 at 20 29 22" src="https://github.com/user-attachments/assets/4b9d6cee-7148-494b-9bcb-6860cbce86cc" />

## Additional Context (Optional)

N/A

## AI Disclosure

Used codex for the mechanical Prime > Lucide icon swap 

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the design system showcase and shared UI controls to use consistent Lucide-based icons across buttons, tabs, selects, date pickers, autocomplete, rating, messages, tags, and more.
  * Standardized pending/loading indicators with Lucide loader styling.

* **Bug Fixes**
  * Improved visual consistency for accordions, split buttons, and message navigation icons, including expanded/rotating chevrons.

* **UI Changes / Breaking**
  * Simplified input visuals (adornments + password reveal), removing the previous trailing-action behavior.
  * Removed icon-related public inputs from Button, Split Button, and Tag components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->