### PR TITLE
refactor(books): paginate /api/v1/books/page with cursor, sort, facet, search

### DIFF
--- a/backend/src/main/java/org/booklore/browse/BrowsePage.java
+++ b/backend/src/main/java/org/booklore/browse/BrowsePage.java
@@ -1,0 +1,19 @@
+package org.booklore.browse;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BrowsePage<T>(List<T> content, PageMetadata page, List<Link> links) {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record PageMetadata(int number, int size, long totalElements, int totalPages, String cursor) {
+    }
+
+    public static <T> BrowsePage<T> of(List<T> content, long offset, int limit, long totalElements, String cursor, List<Link> links) {
+        int number = limit > 0 ? (int) (offset / limit) : 0;
+        int totalPages = limit > 0 ? (int) Math.ceil((double) totalElements / limit) : 0;
+        return new BrowsePage<>(content, new PageMetadata(number, limit, totalElements, totalPages, cursor), links);
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/CursorCodec.java
+++ b/backend/src/main/java/org/booklore/browse/CursorCodec.java
@@ -15,7 +15,7 @@ public class CursorCodec {
 
     public static final int CURRENT_VERSION = 1;
 
-    private final ObjectMapper mapper = JsonMapper.builder().build();
+    private final ObjectMapper mapper = JsonMapper.shared();
 
     public String encode(CursorState state) {
         byte[] json = mapper.writeValueAsBytes(state.withVersion(CURRENT_VERSION));

--- a/backend/src/main/java/org/booklore/browse/CursorCodec.java
+++ b/backend/src/main/java/org/booklore/browse/CursorCodec.java
@@ -39,6 +39,9 @@ public class CursorCodec {
         if (state.version() != CURRENT_VERSION) {
             throw ApiError.INVALID_CURSOR.createException("Unsupported cursor version: " + state.version());
         }
+        if (state.offset() < 0 || state.offset() > Integer.MAX_VALUE || state.limit() <= 0) {
+            throw ApiError.INVALID_CURSOR.createException("Cursor offset/limit out of range.");
+        }
         return state;
     }
 

--- a/backend/src/main/java/org/booklore/browse/CursorCodec.java
+++ b/backend/src/main/java/org/booklore/browse/CursorCodec.java
@@ -1,0 +1,51 @@
+package org.booklore.browse;
+
+import org.booklore.exception.ApiError;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.Base64;
+import java.util.Objects;
+
+// Pagination cursor- unsigned, unpadded base64url of the JSON CursorState
+// Parameter validation is enforced via the embedded params hash
+@Component
+public class CursorCodec {
+
+    public static final int CURRENT_VERSION = 1;
+
+    private final ObjectMapper mapper = JsonMapper.builder().build();
+
+    public String encode(CursorState state) {
+        byte[] json = mapper.writeValueAsBytes(state.withVersion(CURRENT_VERSION));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(json);
+    }
+
+    public CursorState decode(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            throw ApiError.INVALID_CURSOR.createException("Cursor is missing.");
+        }
+        CursorState state;
+        try {
+            byte[] json = Base64.getUrlDecoder().decode(cursor);
+            state = mapper.readValue(json, CursorState.class);
+        } catch (Exception e) {
+            throw ApiError.INVALID_CURSOR.createException("Cursor is malformed.");
+        }
+        if (state == null) {
+            throw ApiError.INVALID_CURSOR.createException("Cursor is malformed.");
+        }
+        if (state.version() != CURRENT_VERSION) {
+            throw ApiError.INVALID_CURSOR.createException("Unsupported cursor version: " + state.version());
+        }
+        return state;
+    }
+
+    public void verifyParamsMatch(CursorState state, String currentParamsHash) {
+        if (!Objects.equals(state.paramsHash(), currentParamsHash)) {
+            throw ApiError.INVALID_CURSOR.createException(
+                    "Cursor does not match the supplied facet/query parameters. Drop the cursor or re-send the original parameters.");
+        }
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/CursorCodec.java
+++ b/backend/src/main/java/org/booklore/browse/CursorCodec.java
@@ -13,12 +13,10 @@ import java.util.Objects;
 @Component
 public class CursorCodec {
 
-    public static final int CURRENT_VERSION = 1;
-
     private final ObjectMapper mapper = JsonMapper.shared();
 
     public String encode(CursorState state) {
-        byte[] json = mapper.writeValueAsBytes(state.withVersion(CURRENT_VERSION));
+        byte[] json = mapper.writeValueAsBytes(state);
         return Base64.getUrlEncoder().withoutPadding().encodeToString(json);
     }
 
@@ -35,9 +33,6 @@ public class CursorCodec {
         }
         if (state == null) {
             throw ApiError.INVALID_CURSOR.createException("Cursor is malformed.");
-        }
-        if (state.version() != CURRENT_VERSION) {
-            throw ApiError.INVALID_CURSOR.createException("Unsupported cursor version: " + state.version());
         }
         if (state.offset() < 0 || state.offset() > Integer.MAX_VALUE || state.limit() <= 0) {
             throw ApiError.INVALID_CURSOR.createException("Cursor offset/limit out of range.");

--- a/backend/src/main/java/org/booklore/browse/CursorState.java
+++ b/backend/src/main/java/org/booklore/browse/CursorState.java
@@ -1,0 +1,25 @@
+package org.booklore.browse;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// Decoded contents of a pagination cursor (compact base64url JSON via CursorCodec)
+// Offset-with-state: absolute offset/limit, sort string, and a fingerprint of the
+// facet/query params, so a cursor with conflicting params is rejected
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CursorState(
+        @JsonProperty("v") int version,
+        @JsonProperty("o") long offset,
+        @JsonProperty("l") int limit,
+        @JsonProperty("s") String sort,
+        @JsonProperty("f") String paramsHash
+) {
+
+    public CursorState withVersion(int newVersion) {
+        return new CursorState(newVersion, offset, limit, sort, paramsHash);
+    }
+
+    public CursorState withOffset(long newOffset) {
+        return new CursorState(version, newOffset, limit, sort, paramsHash);
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/CursorState.java
+++ b/backend/src/main/java/org/booklore/browse/CursorState.java
@@ -8,18 +8,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 // facet/query params, so a cursor with conflicting params is rejected
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CursorState(
-        @JsonProperty("v") int version,
         @JsonProperty("o") long offset,
         @JsonProperty("l") int limit,
         @JsonProperty("s") String sort,
         @JsonProperty("f") String paramsHash
 ) {
 
-    public CursorState withVersion(int newVersion) {
-        return new CursorState(newVersion, offset, limit, sort, paramsHash);
-    }
-
     public CursorState withOffset(long newOffset) {
-        return new CursorState(version, newOffset, limit, sort, paramsHash);
+        return new CursorState(newOffset, limit, sort, paramsHash);
     }
 }

--- a/backend/src/main/java/org/booklore/browse/FacetLogic.java
+++ b/backend/src/main/java/org/booklore/browse/FacetLogic.java
@@ -1,0 +1,18 @@
+package org.booklore.browse;
+
+public enum FacetLogic {
+    AND,
+    OR,
+    NOT;
+
+    public static FacetLogic from(String value) {
+        if (value == null || value.isBlank()) {
+            return AND;
+        }
+        return switch (value.trim().toLowerCase()) {
+            case "or" -> OR;
+            case "not" -> NOT;
+            default -> AND;
+        };
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/Link.java
+++ b/backend/src/main/java/org/booklore/browse/Link.java
@@ -1,0 +1,15 @@
+package org.booklore.browse;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record Link(List<String> rel, String href, String type) {
+
+    public static final String JSON_TYPE = "application/json";
+
+    public static Link json(List<String> rel, String href) {
+        return new Link(rel, href, JSON_TYPE);
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/LinksBuilder.java
+++ b/backend/src/main/java/org/booklore/browse/LinksBuilder.java
@@ -1,0 +1,53 @@
+package org.booklore.browse;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Builds the paging links for a browse page (self/first/previous/next)
+// Each carries the request's facet/query params + a cursor offset
+@Component
+public class LinksBuilder {
+
+    private final CursorCodec codec;
+
+    public LinksBuilder(CursorCodec codec) {
+        this.codec = codec;
+    }
+
+    public record Context(
+            String pagePath,
+            String preservedQuery,
+            long offset,
+            int limit,
+            long totalElements,
+            CursorState baseState
+    ) {
+    }
+
+    public List<Link> build(Context ctx) {
+        List<Link> links = new ArrayList<>();
+        links.add(pageLink(List.of("self"), ctx, ctx.offset()));
+        links.add(pageLink(List.of("first"), ctx, 0));
+
+        if (ctx.offset() > 0) {
+            long previousOffset = Math.max(0, ctx.offset() - ctx.limit());
+            links.add(pageLink(List.of("previous"), ctx, previousOffset));
+        }
+        if (ctx.offset() + ctx.limit() < ctx.totalElements()) {
+            links.add(pageLink(List.of("next"), ctx, ctx.offset() + ctx.limit()));
+        }
+        return links;
+    }
+
+    private Link pageLink(List<String> rel, Context ctx, long offset) {
+        String cursor = codec.encode(ctx.baseState().withOffset(offset));
+        StringBuilder href = new StringBuilder(ctx.pagePath()).append('?');
+        if (ctx.preservedQuery() != null && !ctx.preservedQuery().isBlank()) {
+            href.append(ctx.preservedQuery()).append('&');
+        }
+        href.append("cursor=").append(cursor);
+        return Link.json(rel, href.toString());
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/ParamsHash.java
+++ b/backend/src/main/java/org/booklore/browse/ParamsHash.java
@@ -19,19 +19,27 @@ public final class ParamsHash {
 
     public static String compute(String query, Map<String, List<String>> facets, FacetLogic logic) {
         StringBuilder canonical = new StringBuilder();
-        canonical.append("q=").append(query == null ? "" : query.trim());
-        canonical.append("|logic=").append(logic == null ? FacetLogic.AND : logic);
-        canonical.append("|facets=");
+        appendField(canonical, query == null ? "" : query.trim());
+        appendField(canonical, (logic == null ? FacetLogic.AND : logic).name());
         if (facets != null) {
             List<String> keys = new ArrayList<>(facets.keySet());
             keys.sort(String::compareTo);
             for (String key : keys) {
+                appendField(canonical, key);
                 List<String> values = new ArrayList<>(facets.get(key));
                 values.sort(String::compareTo);
-                canonical.append(key).append('=').append(String.join(",", values)).append(';');
+                appendField(canonical, Integer.toString(values.size()));
+                for (String value : values) {
+                    appendField(canonical, value);
+                }
             }
         }
         return hash(canonical.toString());
+    }
+
+    private static void appendField(StringBuilder sb, String value) {
+        String v = value == null ? "" : value;
+        sb.append(v.length()).append(':').append(v).append('|');
     }
 
     private static String hash(String input) {

--- a/backend/src/main/java/org/booklore/browse/ParamsHash.java
+++ b/backend/src/main/java/org/booklore/browse/ParamsHash.java
@@ -1,0 +1,46 @@
+package org.booklore.browse;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+// Fingerprint of the request params (query, facet logic, facet selections)
+// Used within the cursor + compared on follow-up so cursors w/ conflicting facets are rejected
+public final class ParamsHash {
+
+    private static final int LENGTH = 12;
+
+    private ParamsHash() {
+    }
+
+    public static String compute(String query, Map<String, List<String>> facets, FacetLogic logic) {
+        StringBuilder canonical = new StringBuilder();
+        canonical.append("q=").append(query == null ? "" : query.trim());
+        canonical.append("|logic=").append(logic == null ? FacetLogic.AND : logic);
+        canonical.append("|facets=");
+        if (facets != null) {
+            List<String> keys = new ArrayList<>(facets.keySet());
+            keys.sort(String::compareTo);
+            for (String key : keys) {
+                List<String> values = new ArrayList<>(facets.get(key));
+                values.sort(String::compareTo);
+                canonical.append(key).append('=').append(String.join(",", values)).append(';');
+            }
+        }
+        return hash(canonical.toString());
+    }
+
+    private static String hash(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes).substring(0, LENGTH);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/SortContext.java
+++ b/backend/src/main/java/org/booklore/browse/SortContext.java
@@ -1,0 +1,17 @@
+package org.booklore.browse;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+// Criteria context handed to a SortOrderBuilder for one sort term
+// Query is available for sorts that need a subquery
+// userId is null for admin/system queries
+public record SortContext<E>(
+        Root<E> root,
+        CriteriaQuery<?> query,
+        CriteriaBuilder cb,
+        boolean descending,
+        Long userId
+) {
+}

--- a/backend/src/main/java/org/booklore/browse/SortOrderBuilder.java
+++ b/backend/src/main/java/org/booklore/browse/SortOrderBuilder.java
@@ -1,0 +1,12 @@
+package org.booklore.browse;
+
+import jakarta.persistence.criteria.Order;
+
+import java.util.List;
+
+// Builds the JPA orders for one sort key (a list so one key can expand to support multiple orders)
+@FunctionalInterface
+public interface SortOrderBuilder<E> {
+
+    List<Order> toOrders(SortContext<E> context);
+}

--- a/backend/src/main/java/org/booklore/browse/SortParser.java
+++ b/backend/src/main/java/org/booklore/browse/SortParser.java
@@ -1,0 +1,48 @@
+package org.booklore.browse;
+
+import org.booklore.exception.ApiError;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+// Parses the sort param- comma-separated keys, each optionally '-' prefixed for descending
+// Always appends an ascending primary key so pagination is stable
+public final class SortParser {
+
+    public static final String TIEBREAKER_KEY = "id";
+
+    private SortParser() {
+    }
+
+    public static List<SortTerm> parse(String sortString, Set<String> knownKeys) {
+        List<SortTerm> terms = new ArrayList<>();
+        boolean tiebreakerCovered = false;
+
+        if (sortString != null && !sortString.isBlank()) {
+            for (String raw : sortString.split(",", -1)) {
+                String token = raw.trim();
+                boolean descending = false;
+                if (token.startsWith("-")) {
+                    descending = true;
+                    token = token.substring(1).trim();
+                }
+                if (token.isEmpty()) {
+                    throw ApiError.INVALID_SORT.createException("Empty sort key in: " + sortString);
+                }
+                if (!knownKeys.contains(token)) {
+                    throw ApiError.INVALID_SORT.createException("Unknown sort key: " + token);
+                }
+                terms.add(new SortTerm(token, descending));
+                if (token.equals(TIEBREAKER_KEY)) {
+                    tiebreakerCovered = true;
+                }
+            }
+        }
+
+        if (!tiebreakerCovered) {
+            terms.add(new SortTerm(TIEBREAKER_KEY, false));
+        }
+        return terms;
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/SortParser.java
+++ b/backend/src/main/java/org/booklore/browse/SortParser.java
@@ -17,7 +17,6 @@ public final class SortParser {
 
     public static List<SortTerm> parse(String sortString, Set<String> knownKeys) {
         List<SortTerm> terms = new ArrayList<>();
-        boolean tiebreakerCovered = false;
 
         if (sortString != null && !sortString.isBlank()) {
             for (String raw : sortString.split(",", -1)) {
@@ -30,19 +29,15 @@ public final class SortParser {
                 if (token.isEmpty()) {
                     throw ApiError.INVALID_SORT.createException("Empty sort key in: " + sortString);
                 }
-                if (!knownKeys.contains(token)) {
+                // id is reserved for the implicit tiebreaker, so to callers it is not a sortable key.
+                if (token.equals(TIEBREAKER_KEY) || !knownKeys.contains(token)) {
                     throw ApiError.INVALID_SORT.createException("Unknown sort key: " + token);
                 }
                 terms.add(new SortTerm(token, descending));
-                if (token.equals(TIEBREAKER_KEY)) {
-                    tiebreakerCovered = true;
-                }
             }
         }
 
-        if (!tiebreakerCovered) {
-            terms.add(new SortTerm(TIEBREAKER_KEY, false));
-        }
+        terms.add(new SortTerm(TIEBREAKER_KEY, false));
         return terms;
     }
 }

--- a/backend/src/main/java/org/booklore/browse/SortRegistry.java
+++ b/backend/src/main/java/org/booklore/browse/SortRegistry.java
@@ -1,0 +1,47 @@
+package org.booklore.browse;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Root;
+import org.booklore.exception.ApiError;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+// Maps sort keys to JPA order builders for one browsable entity
+// Registered keys are the allow-list SortParser validates against
+// Every registry must register the "id" tiebreaker.
+public class SortRegistry<E> {
+
+    private final Map<String, SortOrderBuilder<E>> builders = new LinkedHashMap<>();
+
+    public SortRegistry<E> register(String key, SortOrderBuilder<E> builder) {
+        builders.put(key, builder);
+        return this;
+    }
+
+    public boolean has(String key) {
+        return builders.containsKey(key);
+    }
+
+    public Set<String> keys() {
+        return Collections.unmodifiableSet(builders.keySet());
+    }
+
+    public List<Order> toOrders(List<SortTerm> terms, Root<E> root, CriteriaQuery<?> query, CriteriaBuilder cb, Long userId) {
+        List<Order> orders = new ArrayList<>();
+        for (SortTerm term : terms) {
+            SortOrderBuilder<E> builder = builders.get(term.key());
+            if (builder == null) {
+                throw ApiError.INVALID_SORT.createException("Unknown sort key: " + term.key());
+            }
+            orders.addAll(builder.toOrders(new SortContext<>(root, query, cb, term.descending(), userId)));
+        }
+        return orders;
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/SortTerm.java
+++ b/backend/src/main/java/org/booklore/browse/SortTerm.java
@@ -1,0 +1,4 @@
+package org.booklore.browse;
+
+public record SortTerm(String key, boolean descending) {
+}

--- a/backend/src/main/java/org/booklore/controller/BookController.java
+++ b/backend/src/main/java/org/booklore/controller/BookController.java
@@ -1,5 +1,6 @@
 package org.booklore.controller;
 
+import org.booklore.browse.BrowsePage;
 import org.booklore.config.security.annotation.CheckBookAccess;
 import org.booklore.exception.ApiError;
 import org.booklore.model.dto.Book;
@@ -23,6 +24,7 @@ import org.booklore.service.book.BookService;
 import org.booklore.service.book.BookUpdateService;
 import org.booklore.service.book.DuplicateDetectionService;
 import org.booklore.service.book.PhysicalBookService;
+import org.booklore.service.browse.BookBrowseService;
 import org.booklore.service.metadata.BookMetadataService;
 import org.booklore.service.progress.ReadingProgressService;
 import org.booklore.service.recommender.BookRecommendationService;
@@ -58,6 +60,7 @@ import java.io.IOException;
 public class BookController {
 
     private final BookService bookService;
+    private final BookBrowseService bookBrowseService;
     private final BookUpdateService bookUpdateService;
     private final BookRecommendationService bookRecommendationService;
     private final BookFileAttachmentService bookFileAttachmentService;
@@ -77,12 +80,26 @@ public class BookController {
         return ResponseEntity.ok(bookService.getBookDTOs(withDescription, stripForListView));
     }
 
-    @Operation(summary = "Get books (paginated)", description = "Retrieve a paginated list of books. Supports sorting via 'sort' parameter (e.g. sort=metadata.title,asc).")
+    @Operation(summary = "Get books (paginated)", description = "Retrieve a paginated page of books. Supports cursor pagination plus sort, facet, facet_logic, and query parameters; with none of these the legacy page/size behavior is preserved.")
     @ApiResponse(responseCode = "200", description = "Page of books returned successfully")
     @GetMapping("/page")
-    public ResponseEntity<Page<Book>> getBooksPaged(
-            @Parameter(hidden = true) Pageable pageable) {
-        return ResponseEntity.ok(bookService.getBookDTOsPaged(pageable));
+    public ResponseEntity<BrowsePage<Book>> getBooksPaged(
+            @Parameter(hidden = true) Pageable pageable,
+            @Parameter(description = "Comma-separated sort keys; prefix a key with '-' for descending (e.g. seriesName,-seriesNumber)")
+            @RequestParam(required = false) String sort,
+            @Parameter(description = "Facet selection in key:value form; repeatable (e.g. facet=genre:Horror&facet=read_status:READ)")
+            @RequestParam(required = false) List<String> facet,
+            @Parameter(description = "How facet values combine within a group: and, or, or not")
+            @RequestParam(name = "facet_logic", required = false) String facetLogic,
+            @Parameter(description = "Free-text search across title, series, author, genre, tag, ISBN, and ASIN")
+            @RequestParam(required = false) String query,
+            @Parameter(description = "Opaque pagination cursor from a prior response's links")
+            @RequestParam(required = false) String cursor) {
+        boolean browseMode = sort != null || facet != null || facetLogic != null || query != null || cursor != null;
+        if (browseMode) {
+            return ResponseEntity.ok(bookBrowseService.browse(sort, facet, facetLogic, query, cursor, pageable));
+        }
+        return ResponseEntity.ok(bookBrowseService.wrapLegacy(bookService.getBookDTOsPaged(pageable), pageable));
     }
 
     @Operation(summary = "Get a book by ID", description = "Retrieve details of a specific book by its ID.")

--- a/backend/src/main/java/org/booklore/controller/BookController.java
+++ b/backend/src/main/java/org/booklore/controller/BookController.java
@@ -80,7 +80,7 @@ public class BookController {
         return ResponseEntity.ok(bookService.getBookDTOs(withDescription, stripForListView));
     }
 
-    @Operation(summary = "Get books (paginated)", description = "Retrieve a paginated page of books. Supports cursor pagination plus sort, facet, facet_logic, and query parameters; with none of these the legacy page/size behavior is preserved.")
+    @Operation(summary = "Get books (paginated)", description = "Retrieve a page of books. Supports cursor pagination plus sort, facet, facet_logic, and query parameters; with none of these the legacy page/size behavior is preserved.")
     @ApiResponse(responseCode = "200", description = "Page of books returned successfully")
     @GetMapping("/page")
     public ResponseEntity<BrowsePage<Book>> getBooksPaged(

--- a/backend/src/main/java/org/booklore/exception/ApiError.java
+++ b/backend/src/main/java/org/booklore/exception/ApiError.java
@@ -74,7 +74,11 @@ public enum ApiError {
     OIDC_LOGOUT_REPLAY(HttpStatus.BAD_REQUEST, "Logout token has already been processed"),
     OIDC_LOGOUT_MISSING_JTI(HttpStatus.BAD_REQUEST, "Logout token missing required jti claim"),
     OIDC_INVALID_STATE(HttpStatus.BAD_REQUEST, "Invalid or expired OIDC state parameter"),
-    JWT_INVALID(HttpStatus.UNAUTHORIZED, "Invalid JWT token: %s");
+    JWT_INVALID(HttpStatus.UNAUTHORIZED, "Invalid JWT token: %s"),
+
+    INVALID_SORT(HttpStatus.BAD_REQUEST, "%s"),
+    INVALID_CURSOR(HttpStatus.BAD_REQUEST, "%s"),
+    INVALID_FACET(HttpStatus.BAD_REQUEST, "%s");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/org/booklore/service/book/BookQueryService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookQueryService.java
@@ -52,7 +52,11 @@ public class BookQueryService {
     }
 
     public Page<Book> getAllBooksByLibraryIdsPaged(Collection<Long> libraryIds, Long userId, Pageable pageable) {
-        Page<BookEntity> page = bookRepository.findAll(visibleBooks(libraryIds, userId), pageable);
+        return findBooksPaged(visibleBooks(libraryIds, userId), pageable, userId);
+    }
+
+    public Page<Book> findBooksPaged(Specification<BookEntity> spec, Pageable pageable, Long userId) {
+        Page<BookEntity> page = bookRepository.findAll(spec, pageable);
         Map<Long, BookEntity> booksById = bookRepository
                 .findAllWithMetadataByIds(page.getContent().stream().map(BookEntity::getId).collect(Collectors.toSet()))
                 .stream()

--- a/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
@@ -83,7 +83,7 @@ public class BookBrowseService {
         Page<Book> page = bookQueryService.findBooksPaged(spec, pageRequest, userId);
         enrich(page.getContent(), userId);
 
-        CursorState baseState = new CursorState(CursorCodec.CURRENT_VERSION, offset, limit, sortString, paramsHash);
+        CursorState baseState = new CursorState(offset, limit, sortString, paramsHash);
         String currentCursor = cursorCodec.encode(baseState);
         List<Link> links = linksBuilder.build(new LinksBuilder.Context(
                 PAGE_PATH, BrowseParams.preserved(facet, facetLogicParam, query), offset, limit, page.getTotalElements(), baseState));
@@ -95,7 +95,7 @@ public class BookBrowseService {
         long offset = pageable.getOffset();
         int limit = pageable.getPageSize();
         String paramsHash = ParamsHash.compute(null, Map.of(), FacetLogic.AND);
-        CursorState baseState = new CursorState(CursorCodec.CURRENT_VERSION, offset, limit, null, paramsHash);
+        CursorState baseState = new CursorState(offset, limit, null, paramsHash);
         List<Link> links = linksBuilder.build(new LinksBuilder.Context(
                 PAGE_PATH, "", offset, limit, page.getTotalElements(), baseState));
         return BrowsePage.of(page.getContent(), offset, limit, page.getTotalElements(), cursorCodec.encode(baseState), links);

--- a/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
@@ -1,0 +1,121 @@
+package org.booklore.service.browse;
+
+import lombok.RequiredArgsConstructor;
+import org.booklore.browse.BrowsePage;
+import org.booklore.browse.CursorCodec;
+import org.booklore.browse.CursorState;
+import org.booklore.browse.FacetLogic;
+import org.booklore.browse.Link;
+import org.booklore.browse.LinksBuilder;
+import org.booklore.browse.ParamsHash;
+import org.booklore.browse.SortParser;
+import org.booklore.browse.SortTerm;
+import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.exception.ApiError;
+import org.booklore.model.dto.Book;
+import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.UserBookFileProgressEntity;
+import org.booklore.model.entity.UserBookProgressEntity;
+import org.booklore.service.book.BookQueryService;
+import org.booklore.service.progress.ReadingProgressService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookBrowseService {
+
+    private static final String PAGE_PATH = "/api/v1/books/page";
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final AuthenticationService authenticationService;
+    private final BookQueryService bookQueryService;
+    private final ReadingProgressService readingProgressService;
+    private final BookFilterSpecifications filterSpecifications;
+    private final BookSortRegistry sortRegistry;
+    private final CursorCodec cursorCodec;
+    private final LinksBuilder linksBuilder;
+
+    public BrowsePage<Book> browse(String sort, List<String> facet, String facetLogicParam, String query, String cursor, Pageable pageable) {
+        BookLoreUser user = authenticationService.getAuthenticatedUser();
+        Long userId = user.getId();
+        boolean isAdmin = user.getPermissions().isAdmin();
+
+        Map<String, List<String>> facets = BookFilterSpecifications.parseFacets(facet);
+        FacetLogic facetLogic = FacetLogic.from(facetLogicParam);
+        String paramsHash = ParamsHash.compute(query, facets, facetLogic);
+
+        long offset;
+        int limit;
+        String sortString;
+        if (cursor != null) {
+            CursorState state = cursorCodec.decode(cursor);
+            cursorCodec.verifyParamsMatch(state, paramsHash);
+            offset = state.offset();
+            limit = state.limit();
+            sortString = state.sort();
+        } else {
+            offset = pageable.getOffset();
+            limit = pageable.getPageSize();
+            sortString = sort;
+        }
+        if (limit <= 0) {
+            throw ApiError.INVALID_INPUT.createException("Page size must be positive.");
+        }
+        limit = Math.min(limit, MAX_PAGE_SIZE);
+
+        List<SortTerm> sortTerms = SortParser.parse(sortString, sortRegistry.registry().keys());
+        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, BookFilterSpecifications.libraryIds(user), null);
+        Specification<BookEntity> spec = withSort(filter, sortTerms, userId);
+
+        Pageable pageRequest = PageRequest.of((int) (offset / limit), limit);
+        Page<Book> page = bookQueryService.findBooksPaged(spec, pageRequest, userId);
+        enrich(page.getContent(), userId);
+
+        CursorState baseState = new CursorState(CursorCodec.CURRENT_VERSION, offset, limit, sortString, paramsHash);
+        String currentCursor = cursorCodec.encode(baseState);
+        List<Link> links = linksBuilder.build(new LinksBuilder.Context(
+                PAGE_PATH, BrowseParams.preserved(facet, facetLogicParam, query), offset, limit, page.getTotalElements(), baseState));
+
+        return BrowsePage.of(page.getContent(), offset, limit, page.getTotalElements(), currentCursor, links);
+    }
+
+    public BrowsePage<Book> wrapLegacy(Page<Book> page, Pageable pageable) {
+        long offset = pageable.getOffset();
+        int limit = pageable.getPageSize();
+        String paramsHash = ParamsHash.compute(null, Map.of(), FacetLogic.AND);
+        CursorState baseState = new CursorState(CursorCodec.CURRENT_VERSION, offset, limit, null, paramsHash);
+        List<Link> links = linksBuilder.build(new LinksBuilder.Context(
+                PAGE_PATH, "", offset, limit, page.getTotalElements(), baseState));
+        return BrowsePage.of(page.getContent(), offset, limit, page.getTotalElements(), cursorCodec.encode(baseState), links);
+    }
+
+    private Specification<BookEntity> withSort(Specification<BookEntity> filter, List<SortTerm> sortTerms, Long userId) {
+        return (root, query, cb) -> {
+            if (query.getResultType() != Long.class && query.getResultType() != long.class) {
+                query.orderBy(sortRegistry.registry().toOrders(sortTerms, root, query, cb, userId));
+            }
+            return filter.toPredicate(root, query, cb);
+        };
+    }
+
+    private void enrich(List<Book> books, Long userId) {
+        Set<Long> bookIds = books.stream().map(Book::getId).collect(Collectors.toSet());
+        Map<Long, UserBookProgressEntity> progress = readingProgressService.fetchUserProgress(userId, bookIds);
+        Map<Long, UserBookFileProgressEntity> fileProgress = readingProgressService.fetchUserFileProgress(userId, bookIds);
+        for (Book book : books) {
+            readingProgressService.enrichBookWithProgress(book, progress.get(book.getId()), fileProgress.get(book.getId()));
+        }
+    }
+}

--- a/backend/src/main/java/org/booklore/service/browse/BookFacetRegistry.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookFacetRegistry.java
@@ -1,0 +1,109 @@
+package org.booklore.service.browse;
+
+import org.booklore.app.specification.AppBookSpecification;
+import org.booklore.browse.FacetLogic;
+import org.booklore.exception.ApiError;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.service.opds.MagicShelfBookService;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class BookFacetRegistry {
+
+    private static final String MAGIC_SHELF_PREFIX = "magic:";
+
+    private static final Set<String> NAMES = Set.of(
+            "author", "series", "genre", "tag", "mood", "language", "publisher", "library", "shelf",
+            "file_type", "read_status", "personal_rating", "amazon_rating", "goodreads_rating",
+            "hardcover_rating", "ranobedb_rating", "age_rating", "content_rating", "match_score",
+            "published_year", "file_size", "page_count", "shelf_status",
+            "comic_character", "comic_team", "comic_location", "comic_creator");
+
+    private final MagicShelfBookService magicShelfBookService;
+
+    public BookFacetRegistry(MagicShelfBookService magicShelfBookService) {
+        this.magicShelfBookService = magicShelfBookService;
+    }
+
+    public boolean has(String facetName) {
+        return NAMES.contains(facetName);
+    }
+
+    public Set<String> facetNames() {
+        return NAMES;
+    }
+
+    public Specification<BookEntity> toSpecification(String facetName, List<String> values, FacetLogic logic, Long userId) {
+        String mode = mode(logic);
+        return switch (facetName) {
+            case "author" -> AppBookSpecification.withAuthors(values, mode);
+            case "series" -> AppBookSpecification.inSeriesMulti(values, mode);
+            case "genre" -> AppBookSpecification.withCategories(values, mode);
+            case "tag" -> AppBookSpecification.withTags(values, mode);
+            case "mood" -> AppBookSpecification.withMoods(values, mode);
+            case "language" -> AppBookSpecification.withLanguages(values, mode);
+            case "publisher" -> AppBookSpecification.withPublishers(values, mode);
+            case "library" -> AppBookSpecification.inLibraries(values, mode);
+            case "shelf" -> shelves(values, logic, userId);
+            case "file_type" -> AppBookSpecification.withFileTypes(values, mode);
+            case "read_status" -> AppBookSpecification.withReadStatuses(values, userId, mode);
+            case "personal_rating" -> AppBookSpecification.withPersonalRatings(values, userId, mode);
+            case "amazon_rating" -> AppBookSpecification.withAmazonRatings(values, mode);
+            case "goodreads_rating" -> AppBookSpecification.withGoodreadsRatings(values, mode);
+            case "hardcover_rating" -> AppBookSpecification.withHardcoverRatings(values, mode);
+            case "ranobedb_rating" -> AppBookSpecification.withRanobedbRatings(values, mode);
+            case "age_rating" -> AppBookSpecification.withAgeRatings(values, mode);
+            case "content_rating" -> AppBookSpecification.withContentRatings(values, mode);
+            case "match_score" -> AppBookSpecification.withMatchScores(values, mode);
+            case "published_year" -> AppBookSpecification.withPublishedYears(values, mode);
+            case "file_size" -> AppBookSpecification.withFileSizes(values, mode);
+            case "page_count" -> AppBookSpecification.withPageCounts(values, mode);
+            case "shelf_status" -> AppBookSpecification.withShelfStatus(values, mode);
+            case "comic_character" -> AppBookSpecification.withComicCharacters(values, mode);
+            case "comic_team" -> AppBookSpecification.withComicTeams(values, mode);
+            case "comic_location" -> AppBookSpecification.withComicLocations(values, mode);
+            case "comic_creator" -> AppBookSpecification.withComicCreators(values, mode);
+            default -> throw ApiError.INVALID_FACET.createException("Unknown facet: " + facetName);
+        };
+    }
+
+    private Specification<BookEntity> shelves(List<String> values, FacetLogic logic, Long userId) {
+        List<String> regularIds = new ArrayList<>();
+        List<Specification<BookEntity>> specs = new ArrayList<>();
+        for (String value : values) {
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            if (value.startsWith(MAGIC_SHELF_PREFIX)) {
+                Long magicShelfId = Long.parseLong(value.substring(MAGIC_SHELF_PREFIX.length()));
+                specs.add(magicShelfBookService.toSpecification(userId, magicShelfId));
+            } else {
+                regularIds.add(value);
+            }
+        }
+        if (!regularIds.isEmpty()) {
+            specs.add(AppBookSpecification.inShelves(regularIds, mode(logic)));
+        }
+        if (specs.isEmpty()) {
+            return (root, query, cb) -> cb.conjunction();
+        }
+        return switch (logic) {
+            case OR -> Specification.anyOf(specs);
+            case NOT -> Specification.not(Specification.anyOf(specs));
+            case AND -> Specification.allOf(specs);
+        };
+    }
+
+    private static String mode(FacetLogic logic) {
+        return switch (logic) {
+            case OR -> "or";
+            case NOT -> "not";
+            case AND -> "and";
+        };
+    }
+}

--- a/backend/src/main/java/org/booklore/service/browse/BookFacetRegistry.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookFacetRegistry.java
@@ -80,14 +80,14 @@ public class BookFacetRegistry {
                 continue;
             }
             if (value.startsWith(MAGIC_SHELF_PREFIX)) {
-                Long magicShelfId = Long.parseLong(value.substring(MAGIC_SHELF_PREFIX.length()));
-                specs.add(magicShelfBookService.toSpecification(userId, magicShelfId));
+                specs.add(magicShelfBookService.toSpecification(userId, parseMagicShelfId(value)));
             } else {
                 regularIds.add(value);
             }
         }
         if (!regularIds.isEmpty()) {
-            specs.add(AppBookSpecification.inShelves(regularIds, mode(logic)));
+            String inMode = logic == FacetLogic.AND ? "and" : "or";
+            specs.add(AppBookSpecification.inShelves(regularIds, inMode));
         }
         if (specs.isEmpty()) {
             return (root, query, cb) -> cb.conjunction();
@@ -97,6 +97,14 @@ public class BookFacetRegistry {
             case NOT -> Specification.not(Specification.anyOf(specs));
             case AND -> Specification.allOf(specs);
         };
+    }
+
+    private static long parseMagicShelfId(String value) {
+        try {
+            return Long.parseLong(value.substring(MAGIC_SHELF_PREFIX.length()));
+        } catch (NumberFormatException e) {
+            throw ApiError.INVALID_FACET.createException("Invalid magic shelf id: " + value);
+        }
     }
 
     private static String mode(FacetLogic logic) {

--- a/backend/src/main/java/org/booklore/service/browse/BookFilterSpecifications.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookFilterSpecifications.java
@@ -1,0 +1,83 @@
+package org.booklore.service.browse;
+
+import lombok.RequiredArgsConstructor;
+import org.booklore.app.specification.AppBookSpecification;
+import org.booklore.browse.FacetLogic;
+import org.booklore.exception.ApiError;
+import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.dto.Library;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.repository.UserContentRestrictionRepository;
+import org.booklore.security.policy.ContentRestrictionSpecification;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class BookFilterSpecifications {
+
+    private final BookFacetRegistry facetRegistry;
+    private final UserContentRestrictionRepository restrictionRepository;
+
+    public Specification<BookEntity> base(String query, Map<String, List<String>> facets, FacetLogic facetLogic,
+                                          Long userId, boolean isAdmin, Set<Long> libraryIds, String omitFacet) {
+        List<Specification<BookEntity>> specs = new ArrayList<>();
+        specs.add(AppBookSpecification.notDeleted());
+        if (!isAdmin) {
+            specs.add(inLibraries(libraryIds));
+            specs.add(ContentRestrictionSpecification.from(restrictionRepository.findByUserId(userId)));
+        }
+        if (query != null && !query.isBlank()) {
+            specs.add(BookSearchSpecification.matching(query));
+        }
+        for (Map.Entry<String, List<String>> entry : facets.entrySet()) {
+            if (Objects.equals(entry.getKey(), omitFacet)) {
+                continue;
+            }
+            if (!facetRegistry.has(entry.getKey())) {
+                throw ApiError.INVALID_FACET.createException("Unknown facet: " + entry.getKey());
+            }
+            specs.add(facetRegistry.toSpecification(entry.getKey(), entry.getValue(), facetLogic, userId));
+        }
+        return AppBookSpecification.combine(specs.toArray(Specification[]::new));
+    }
+
+    private static Specification<BookEntity> inLibraries(Set<Long> libraryIds) {
+        return (root, query, cb) -> libraryIds.isEmpty()
+                ? cb.disjunction()
+                : root.get("library").get("id").in(libraryIds);
+    }
+
+    public static Set<Long> libraryIds(BookLoreUser user) {
+        if (user.getAssignedLibraries() == null) {
+            return Set.of();
+        }
+        return user.getAssignedLibraries().stream().map(Library::getId).collect(Collectors.toSet());
+    }
+
+    public static Map<String, List<String>> parseFacets(List<String> facet) {
+        Map<String, List<String>> facets = new LinkedHashMap<>();
+        if (facet == null) {
+            return facets;
+        }
+        for (String entry : facet) {
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+            int colon = entry.indexOf(':');
+            if (colon <= 0 || colon == entry.length() - 1) {
+                throw ApiError.INVALID_FACET.createException("Facet must be in key:value form: " + entry);
+            }
+            facets.computeIfAbsent(entry.substring(0, colon), k -> new ArrayList<>()).add(entry.substring(colon + 1));
+        }
+        return facets;
+    }
+}

--- a/backend/src/main/java/org/booklore/service/browse/BookSearchSpecification.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookSearchSpecification.java
@@ -1,0 +1,49 @@
+package org.booklore.service.browse;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookMetadataEntity;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class BookSearchSpecification {
+
+    private BookSearchSpecification() {
+    }
+
+    public static Specification<BookEntity> matching(String query) {
+        return (root, criteriaQuery, cb) -> {
+            if (query == null || query.isBlank()) {
+                return cb.conjunction();
+            }
+            String pattern = "%" + query.toLowerCase().trim() + "%";
+            Join<BookEntity, BookMetadataEntity> metadata = root.join("metadata", JoinType.LEFT);
+            return cb.or(
+                    cb.like(cb.lower(metadata.get("title")), pattern),
+                    cb.like(cb.lower(metadata.get("seriesName")), pattern),
+                    cb.like(cb.lower(metadata.get("isbn13")), pattern),
+                    cb.like(cb.lower(metadata.get("isbn10")), pattern),
+                    cb.like(cb.lower(metadata.get("asin")), pattern),
+                    collectionMatches(root, criteriaQuery, cb, "authors", pattern),
+                    collectionMatches(root, criteriaQuery, cb, "categories", pattern),
+                    collectionMatches(root, criteriaQuery, cb, "tags", pattern)
+            );
+        };
+    }
+
+    private static Predicate collectionMatches(Root<BookEntity> root, CriteriaQuery<?> query, CriteriaBuilder cb,
+                                               String collectionAttribute, String pattern) {
+        Subquery<Long> sub = query.subquery(Long.class);
+        Root<BookMetadataEntity> m = sub.from(BookMetadataEntity.class);
+        Join<Object, Object> joined = m.join(collectionAttribute, JoinType.INNER);
+        sub.select(cb.literal(1L)).where(
+                cb.equal(m.get("bookId"), root.get("id")),
+                cb.like(cb.lower(joined.get("name")), pattern));
+        return cb.exists(sub);
+    }
+}

--- a/backend/src/main/java/org/booklore/service/browse/BookSortRegistry.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookSortRegistry.java
@@ -1,0 +1,112 @@
+package org.booklore.service.browse;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+import org.booklore.browse.SortContext;
+import org.booklore.browse.SortOrderBuilder;
+import org.booklore.browse.SortRegistry;
+import org.booklore.model.entity.BookEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class BookSortRegistry {
+
+    private static final List<String> PROGRESS_PERCENT_FIELDS = List.of(
+            "pdfProgressPercent", "epubProgressPercent", "cbxProgressPercent",
+            "koreaderProgressPercent", "koboProgressPercent");
+
+    private final SortRegistry<BookEntity> registry = build();
+
+    public SortRegistry<BookEntity> registry() {
+        return registry;
+    }
+
+    private static SortRegistry<BookEntity> build() {
+        SortRegistry<BookEntity> registry = new SortRegistry<>();
+
+        registry.register("id", rootField("id"));
+        registry.register("addedOn", rootField("addedOn"));
+
+        for (String field : List.of(
+                "title", "seriesName", "seriesNumber", "publisher", "publishedDate",
+                "amazonRating", "amazonReviewCount", "goodreadsRating", "goodreadsReviewCount",
+                "hardcoverRating", "hardcoverReviewCount", "ranobedbRating",
+                "narrator", "pageCount", "language")) {
+            registry.register(field, metadataField(field));
+        }
+
+        for (String field : List.of("personalRating", "lastReadTime", "readStatus", "dateFinished")) {
+            registry.register(field, progressField(field));
+        }
+        registry.register("readingProgress", readingProgress());
+
+        return registry;
+    }
+
+    private static SortOrderBuilder<BookEntity> rootField(String field) {
+        return ctx -> List.of(order(ctx, ctx.root().get(field)));
+    }
+
+    private static SortOrderBuilder<BookEntity> metadataField(String field) {
+        return ctx -> List.of(order(ctx, metadataJoin(ctx.root()).get(field)));
+    }
+
+    private static SortOrderBuilder<BookEntity> progressField(String field) {
+        return ctx -> List.of(order(ctx, progressJoin(ctx).get(field)));
+    }
+
+    private static SortOrderBuilder<BookEntity> readingProgress() {
+        return ctx -> {
+            CriteriaBuilder cb = ctx.cb();
+            Join<BookEntity, ?> progress = progressJoin(ctx);
+            Expression<Float> greatest = null;
+            for (String field : PROGRESS_PERCENT_FIELDS) {
+                Expression<Float> value = cb.coalesce(progress.get(field), cb.literal(0f));
+                greatest = greatest == null ? value : greatestOf(cb, greatest, value);
+            }
+            return List.of(order(ctx, greatest));
+        };
+    }
+
+    private static Expression<Float> greatestOf(CriteriaBuilder cb, Expression<Float> a, Expression<Float> b) {
+        return cb.<Float>selectCase()
+                .when(cb.greaterThanOrEqualTo(a, b), a)
+                .otherwise(b);
+    }
+
+    private static Order order(SortContext<BookEntity> ctx, Expression<?> expression) {
+        return ctx.descending() ? ctx.cb().desc(expression) : ctx.cb().asc(expression);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <Y> Join<BookEntity, Y> metadataJoin(Root<BookEntity> root) {
+        for (Join<BookEntity, ?> join : root.getJoins()) {
+            if (join.getAttribute().getName().equals("metadata") && join.getJoinType() == JoinType.LEFT) {
+                return (Join<BookEntity, Y>) join;
+            }
+        }
+        return root.join("metadata", JoinType.LEFT);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Join<BookEntity, ?> progressJoin(SortContext<BookEntity> ctx) {
+        Root<BookEntity> root = ctx.root();
+        for (Join<BookEntity, ?> join : root.getJoins()) {
+            if (join.getAttribute().getName().equals("userBookProgress")) {
+                return join;
+            }
+        }
+        Join<BookEntity, ?> join = root.join("userBookProgress", JoinType.LEFT);
+        CriteriaBuilder cb = ctx.cb();
+        Path<Object> joinUserId = ((Join<BookEntity, Object>) join).get("user").get("id");
+        join.on(ctx.userId() != null ? cb.equal(joinUserId, ctx.userId()) : cb.disjunction());
+        return join;
+    }
+}

--- a/backend/src/main/java/org/booklore/service/browse/BrowseParams.java
+++ b/backend/src/main/java/org/booklore/service/browse/BrowseParams.java
@@ -1,0 +1,34 @@
+package org.booklore.service.browse;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+final class BrowseParams {
+
+    private BrowseParams() {
+    }
+
+    static String preserved(List<String> facet, String facetLogic, String query) {
+        List<String> parts = new ArrayList<>();
+        if (facet != null) {
+            for (String entry : facet) {
+                if (entry != null && !entry.isBlank()) {
+                    parts.add("facet=" + encode(entry));
+                }
+            }
+        }
+        if (facetLogic != null && !facetLogic.isBlank()) {
+            parts.add("facet_logic=" + encode(facetLogic));
+        }
+        if (query != null && !query.isBlank()) {
+            parts.add("query=" + encode(query));
+        }
+        return String.join("&", parts);
+    }
+
+    static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/backend/src/test/java/org/booklore/browse/BrowsePageTest.java
+++ b/backend/src/test/java/org/booklore/browse/BrowsePageTest.java
@@ -1,0 +1,56 @@
+package org.booklore.browse;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BrowsePageTest {
+
+    @Test
+    void derivesPageNumberFromOffsetAndLimit() {
+        BrowsePage<String> page = BrowsePage.of(List.of("a"), 80, 20, 100, "cur", List.of());
+        assertEquals(4, page.page().number());
+        assertEquals(20, page.page().size());
+    }
+
+    @Test
+    void derivesTotalPagesWithCeiling() {
+        // 101 elements, size 20 -> 6 pages
+        BrowsePage<String> page = BrowsePage.of(List.of(), 0, 20, 101, "cur", List.of());
+        assertEquals(6, page.page().totalPages());
+    }
+
+    @Test
+    void exactMultipleTotalPages() {
+        BrowsePage<String> page = BrowsePage.of(List.of(), 0, 20, 100, "cur", List.of());
+        assertEquals(5, page.page().totalPages());
+    }
+
+    @Test
+    void firstPageNumberIsZero() {
+        BrowsePage<String> page = BrowsePage.of(List.of(), 0, 20, 100, "cur", List.of());
+        assertEquals(0, page.page().number());
+    }
+
+    @Test
+    void emptyResultHasZeroPages() {
+        BrowsePage<String> page = BrowsePage.of(List.of(), 0, 20, 0, "cur", List.of());
+        assertEquals(0, page.page().totalPages());
+    }
+
+    @Test
+    void zeroLimitDoesNotDivideByZero() {
+        BrowsePage<String> page = BrowsePage.of(List.of(), 0, 0, 50, "cur", List.of());
+        assertEquals(0, page.page().number());
+        assertEquals(0, page.page().totalPages());
+    }
+
+    @Test
+    void carriesCursorAndTotals() {
+        BrowsePage<String> page = BrowsePage.of(List.of("a", "b"), 0, 20, 42, "the-cursor", List.of());
+        assertEquals("the-cursor", page.page().cursor());
+        assertEquals(42, page.page().totalElements());
+    }
+}

--- a/backend/src/test/java/org/booklore/browse/BrowsePageTest.java
+++ b/backend/src/test/java/org/booklore/browse/BrowsePageTest.java
@@ -4,53 +4,53 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class BrowsePageTest {
 
     @Test
     void derivesPageNumberFromOffsetAndLimit() {
         BrowsePage<String> page = BrowsePage.of(List.of("a"), 80, 20, 100, "cur", List.of());
-        assertEquals(4, page.page().number());
-        assertEquals(20, page.page().size());
+        assertThat(page.page().number()).isEqualTo(4);
+        assertThat(page.page().size()).isEqualTo(20);
     }
 
     @Test
     void derivesTotalPagesWithCeiling() {
         // 101 elements, size 20 -> 6 pages
         BrowsePage<String> page = BrowsePage.of(List.of(), 0, 20, 101, "cur", List.of());
-        assertEquals(6, page.page().totalPages());
+        assertThat(page.page().totalPages()).isEqualTo(6);
     }
 
     @Test
     void exactMultipleTotalPages() {
         BrowsePage<String> page = BrowsePage.of(List.of(), 0, 20, 100, "cur", List.of());
-        assertEquals(5, page.page().totalPages());
+        assertThat(page.page().totalPages()).isEqualTo(5);
     }
 
     @Test
     void firstPageNumberIsZero() {
         BrowsePage<String> page = BrowsePage.of(List.of(), 0, 20, 100, "cur", List.of());
-        assertEquals(0, page.page().number());
+        assertThat(page.page().number()).isZero();
     }
 
     @Test
     void emptyResultHasZeroPages() {
         BrowsePage<String> page = BrowsePage.of(List.of(), 0, 20, 0, "cur", List.of());
-        assertEquals(0, page.page().totalPages());
+        assertThat(page.page().totalPages()).isZero();
     }
 
     @Test
     void zeroLimitDoesNotDivideByZero() {
         BrowsePage<String> page = BrowsePage.of(List.of(), 0, 0, 50, "cur", List.of());
-        assertEquals(0, page.page().number());
-        assertEquals(0, page.page().totalPages());
+        assertThat(page.page().number()).isZero();
+        assertThat(page.page().totalPages()).isZero();
     }
 
     @Test
     void carriesCursorAndTotals() {
         BrowsePage<String> page = BrowsePage.of(List.of("a", "b"), 0, 20, 42, "the-cursor", List.of());
-        assertEquals("the-cursor", page.page().cursor());
-        assertEquals(42, page.page().totalElements());
+        assertThat(page.page().cursor()).isEqualTo("the-cursor");
+        assertThat(page.page().totalElements()).isEqualTo(42);
     }
 }

--- a/backend/src/test/java/org/booklore/browse/CursorCodecTest.java
+++ b/backend/src/test/java/org/booklore/browse/CursorCodecTest.java
@@ -1,0 +1,72 @@
+package org.booklore.browse;
+
+import org.booklore.exception.APIException;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CursorCodecTest {
+
+    private final CursorCodec codec = new CursorCodec();
+
+    @Test
+    void roundTripsBasicState() {
+        CursorState state = new CursorState(CursorCodec.CURRENT_VERSION, 80, 40, "seriesName,-seriesNumber", "abc123def456");
+        CursorState decoded = codec.decode(codec.encode(state));
+        assertEquals(state, decoded);
+    }
+
+    @Test
+    void encodeAlwaysStampsCurrentVersion() {
+        CursorState state = new CursorState(999, 0, 20, "title", "hash00000000");
+        CursorState decoded = codec.decode(codec.encode(state));
+        assertEquals(CursorCodec.CURRENT_VERSION, decoded.version());
+    }
+
+    @Test
+    void producesUrlSafeUnpaddedToken() {
+        CursorState state = new CursorState(CursorCodec.CURRENT_VERSION, 12345, 40, "title", "hash00000000");
+        String cursor = codec.encode(state);
+        assertEquals(cursor.indexOf('+'), -1);
+        assertEquals(cursor.indexOf('/'), -1);
+        assertEquals(cursor.indexOf('='), -1);
+    }
+
+    @Test
+    void blankCursorIsRejected() {
+        assertThrows(APIException.class, () -> codec.decode(null));
+        assertThrows(APIException.class, () -> codec.decode("  "));
+    }
+
+    @Test
+    void garbageCursorIsRejected() {
+        assertThrows(APIException.class, () -> codec.decode("not-a-cursor!!"));
+        assertThrows(APIException.class, () -> codec.decode("YWJjZGVm"));
+    }
+
+    @Test
+    void unsupportedVersionIsRejected() {
+        // encode() always stamps CURRENT_VERSION, so hand-craft a token with a future version.
+        CursorState future = new CursorState(2, 0, 20, "title", "hash00000000");
+        byte[] json = JsonMapper.builder().build().writeValueAsBytes(future);
+        String token = Base64.getUrlEncoder().withoutPadding().encodeToString(json);
+        assertThrows(APIException.class, () -> codec.decode(token));
+    }
+
+    @Test
+    void verifyParamsMatchPassesOnEqualHash() {
+        CursorState state = new CursorState(CursorCodec.CURRENT_VERSION, 0, 20, "title", "samehash0000");
+        assertDoesNotThrow(() -> codec.verifyParamsMatch(state, "samehash0000"));
+    }
+
+    @Test
+    void verifyParamsMatchThrowsOnDifferentHash() {
+        CursorState state = new CursorState(CursorCodec.CURRENT_VERSION, 0, 20, "title", "samehash0000");
+        assertThrows(APIException.class, () -> codec.verifyParamsMatch(state, "otherhash000"));
+    }
+}

--- a/backend/src/test/java/org/booklore/browse/CursorCodecTest.java
+++ b/backend/src/test/java/org/booklore/browse/CursorCodecTest.java
@@ -2,9 +2,6 @@ package org.booklore.browse;
 
 import org.booklore.exception.APIException;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.json.JsonMapper;
-
-import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,21 +13,14 @@ class CursorCodecTest {
 
     @Test
     void roundTripsBasicState() {
-        CursorState state = new CursorState(CursorCodec.CURRENT_VERSION, 80, 40, "seriesName,-seriesNumber", "abc123def456");
+        CursorState state = new CursorState(80, 40, "seriesName,-seriesNumber", "abc123def456");
         CursorState decoded = codec.decode(codec.encode(state));
         assertEquals(state, decoded);
     }
 
     @Test
-    void encodeAlwaysStampsCurrentVersion() {
-        CursorState state = new CursorState(999, 0, 20, "title", "hash00000000");
-        CursorState decoded = codec.decode(codec.encode(state));
-        assertEquals(CursorCodec.CURRENT_VERSION, decoded.version());
-    }
-
-    @Test
     void producesUrlSafeUnpaddedToken() {
-        CursorState state = new CursorState(CursorCodec.CURRENT_VERSION, 12345, 40, "title", "hash00000000");
+        CursorState state = new CursorState(12345, 40, "title", "hash00000000");
         String cursor = codec.encode(state);
         assertEquals(cursor.indexOf('+'), -1);
         assertEquals(cursor.indexOf('/'), -1);
@@ -50,23 +40,14 @@ class CursorCodecTest {
     }
 
     @Test
-    void unsupportedVersionIsRejected() {
-        // encode() always stamps CURRENT_VERSION, so hand-craft a token with a future version.
-        CursorState future = new CursorState(2, 0, 20, "title", "hash00000000");
-        byte[] json = JsonMapper.builder().build().writeValueAsBytes(future);
-        String token = Base64.getUrlEncoder().withoutPadding().encodeToString(json);
-        assertThrows(APIException.class, () -> codec.decode(token));
-    }
-
-    @Test
     void verifyParamsMatchPassesOnEqualHash() {
-        CursorState state = new CursorState(CursorCodec.CURRENT_VERSION, 0, 20, "title", "samehash0000");
+        CursorState state = new CursorState(0, 20, "title", "samehash0000");
         assertDoesNotThrow(() -> codec.verifyParamsMatch(state, "samehash0000"));
     }
 
     @Test
     void verifyParamsMatchThrowsOnDifferentHash() {
-        CursorState state = new CursorState(CursorCodec.CURRENT_VERSION, 0, 20, "title", "samehash0000");
+        CursorState state = new CursorState(0, 20, "title", "samehash0000");
         assertThrows(APIException.class, () -> codec.verifyParamsMatch(state, "otherhash000"));
     }
 }

--- a/backend/src/test/java/org/booklore/browse/FacetLogicTest.java
+++ b/backend/src/test/java/org/booklore/browse/FacetLogicTest.java
@@ -1,0 +1,28 @@
+package org.booklore.browse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FacetLogicTest {
+
+    @Test
+    void defaultsToAndForNullOrBlank() {
+        assertEquals(FacetLogic.AND, FacetLogic.from(null));
+        assertEquals(FacetLogic.AND, FacetLogic.from(""));
+        assertEquals(FacetLogic.AND, FacetLogic.from("   "));
+    }
+
+    @Test
+    void parsesKnownValuesCaseInsensitively() {
+        assertEquals(FacetLogic.OR, FacetLogic.from("or"));
+        assertEquals(FacetLogic.OR, FacetLogic.from("OR"));
+        assertEquals(FacetLogic.NOT, FacetLogic.from("Not"));
+        assertEquals(FacetLogic.AND, FacetLogic.from("and"));
+    }
+
+    @Test
+    void unknownValueFallsBackToAnd() {
+        assertEquals(FacetLogic.AND, FacetLogic.from("xor"));
+    }
+}

--- a/backend/src/test/java/org/booklore/browse/LinksBuilderTest.java
+++ b/backend/src/test/java/org/booklore/browse/LinksBuilderTest.java
@@ -16,7 +16,7 @@ class LinksBuilderTest {
     private final LinksBuilder builder = new LinksBuilder(codec);
 
     private LinksBuilder.Context context(long offset, int limit, long total, String preservedQuery) {
-        CursorState base = new CursorState(CursorCodec.CURRENT_VERSION, offset, limit, "title", "hash00000000");
+        CursorState base = new CursorState(offset, limit, "title", "hash00000000");
         return new LinksBuilder.Context("/api/v1/books/page", preservedQuery, offset, limit, total, base);
     }
 
@@ -112,7 +112,7 @@ class LinksBuilderTest {
     void nullPreservedQueryStillProducesValidLinks() {
         List<Link> links = builder.build(new LinksBuilder.Context(
                 "/api/v1/books/page", null, 0, 20, 5,
-                new CursorState(CursorCodec.CURRENT_VERSION, 0, 20, "title", "hash00000000")));
+                new CursorState(0, 20, "title", "hash00000000")));
         assertTrue(hasRel(links, "self"));
         Link self = withRel(links, "self");
         assertTrue(self.href().startsWith("/api/v1/books/page?cursor="));

--- a/backend/src/test/java/org/booklore/browse/LinksBuilderTest.java
+++ b/backend/src/test/java/org/booklore/browse/LinksBuilderTest.java
@@ -1,0 +1,120 @@
+package org.booklore.browse;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LinksBuilderTest {
+
+    private final CursorCodec codec = new CursorCodec();
+    private final LinksBuilder builder = new LinksBuilder(codec);
+
+    private LinksBuilder.Context context(long offset, int limit, long total, String preservedQuery) {
+        CursorState base = new CursorState(CursorCodec.CURRENT_VERSION, offset, limit, "title", "hash00000000");
+        return new LinksBuilder.Context("/api/v1/books/page", preservedQuery, offset, limit, total, base);
+    }
+
+    private boolean hasRel(List<Link> links, String rel) {
+        return links.stream().anyMatch(l -> l.rel().contains(rel));
+    }
+
+    private Link withRel(List<Link> links, String rel) {
+        Optional<Link> found = links.stream().filter(l -> l.rel().contains(rel)).findFirst();
+        assertTrue(found.isPresent(), "expected a link with rel " + rel);
+        return found.get();
+    }
+
+    @Test
+    void selfAndFirstAlwaysPresent() {
+        List<Link> links = builder.build(context(40, 20, 100, ""));
+        assertTrue(hasRel(links, "self"));
+        assertTrue(hasRel(links, "first"));
+    }
+
+    @Test
+    void firstPageOmitsPreviousButHasNext() {
+        List<Link> links = builder.build(context(0, 20, 100, ""));
+        assertFalse(hasRel(links, "previous"));
+        assertTrue(hasRel(links, "next"));
+    }
+
+    @Test
+    void middlePageHasPreviousAndNext() {
+        List<Link> links = builder.build(context(40, 20, 100, ""));
+        assertTrue(hasRel(links, "previous"));
+        assertTrue(hasRel(links, "next"));
+    }
+
+    @Test
+    void lastPageOmitsNext() {
+        List<Link> links = builder.build(context(80, 20, 100, ""));
+        assertTrue(hasRel(links, "previous"));
+        assertFalse(hasRel(links, "next"));
+    }
+
+    @Test
+    void singlePageOmitsBothPreviousAndNext() {
+        List<Link> links = builder.build(context(0, 20, 12, ""));
+        assertFalse(hasRel(links, "previous"));
+        assertFalse(hasRel(links, "next"));
+    }
+
+    @Test
+    void emptyResultHasNoPreviousOrNext() {
+        List<Link> links = builder.build(context(0, 20, 0, ""));
+        assertFalse(hasRel(links, "previous"));
+        assertFalse(hasRel(links, "next"));
+        assertTrue(hasRel(links, "self"));
+    }
+
+    @Test
+    void pagingLinksCarryPreservedQueryAndCursor() {
+        Link next = withRel(builder.build(context(0, 20, 100, "facet=genre%3AFiction")), "next");
+        assertTrue(next.href().startsWith("/api/v1/books/page?facet=genre%3AFiction&cursor="));
+    }
+
+    @Test
+    void nextCursorAdvancesByLimit() {
+        Link next = withRel(builder.build(context(0, 20, 100, "")), "next");
+        String cursor = next.href().substring(next.href().indexOf("cursor=") + "cursor=".length());
+        assertEquals(20, codec.decode(cursor).offset());
+    }
+
+    @Test
+    void previousCursorClampsAtZero() {
+        // offset 10, limit 20 -> previous offset clamps to 0
+        Link prev = withRel(builder.build(context(10, 20, 100, "")), "previous");
+        String cursor = prev.href().substring(prev.href().indexOf("cursor=") + "cursor=".length());
+        assertEquals(0, codec.decode(cursor).offset());
+    }
+
+    @Test
+    void selfCursorReflectsCurrentOffset() {
+        Link self = withRel(builder.build(context(40, 20, 100, "")), "self");
+        String cursor = self.href().substring(self.href().indexOf("cursor=") + "cursor=".length());
+        assertEquals(40, codec.decode(cursor).offset());
+    }
+
+    @Test
+    void preservedQueryAbsentWhenBlank() {
+        Predicate<Link> isPageLink = l -> l.href().startsWith("/api/v1/books/page");
+        builder.build(context(0, 20, 100, "")).stream().filter(isPageLink)
+                .forEach(l -> assertTrue(l.href().startsWith("/api/v1/books/page?cursor=")));
+    }
+
+    @Test
+    void nullPreservedQueryStillProducesValidLinks() {
+        List<Link> links = builder.build(new LinksBuilder.Context(
+                "/api/v1/books/page", null, 0, 20, 5,
+                new CursorState(CursorCodec.CURRENT_VERSION, 0, 20, "title", "hash00000000")));
+        assertTrue(hasRel(links, "self"));
+        Link self = withRel(links, "self");
+        assertTrue(self.href().startsWith("/api/v1/books/page?cursor="));
+    }
+}

--- a/backend/src/test/java/org/booklore/browse/ParamsHashTest.java
+++ b/backend/src/test/java/org/booklore/browse/ParamsHashTest.java
@@ -65,4 +65,11 @@ class ParamsHashTest {
                 ParamsHash.compute(null, Map.of(), FacetLogic.AND),
                 ParamsHash.compute(null, Map.of(), FacetLogic.AND));
     }
+
+    @Test
+    void valuesWithDelimitersDoNotCollide() {
+        assertNotEquals(
+                ParamsHash.compute(null, Map.of("author", List.of("A,B")), FacetLogic.AND),
+                ParamsHash.compute(null, Map.of("author", List.of("A", "B")), FacetLogic.AND));
+    }
 }

--- a/backend/src/test/java/org/booklore/browse/ParamsHashTest.java
+++ b/backend/src/test/java/org/booklore/browse/ParamsHashTest.java
@@ -1,0 +1,68 @@
+package org.booklore.browse;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ParamsHashTest {
+
+    @Test
+    void isTwelveCharacters() {
+        assertEquals(12, ParamsHash.compute("q", Map.of(), FacetLogic.AND).length());
+    }
+
+    @Test
+    void isDeterministic() {
+        Map<String, List<String>> facets = Map.of("author", List.of("Tolkien"));
+        assertEquals(
+                ParamsHash.compute("hobbit", facets, FacetLogic.AND),
+                ParamsHash.compute("hobbit", facets, FacetLogic.AND));
+    }
+
+    @Test
+    void isIndependentOfFacetKeyOrder() {
+        String a = ParamsHash.compute(null, Map.of("author", List.of("A"), "genre", List.of("G")), FacetLogic.AND);
+        String b = ParamsHash.compute(null, Map.of("genre", List.of("G"), "author", List.of("A")), FacetLogic.AND);
+        assertEquals(a, b);
+    }
+
+    @Test
+    void isIndependentOfValueOrderWithinAFacet() {
+        String a = ParamsHash.compute(null, Map.of("author", List.of("A", "B")), FacetLogic.AND);
+        String b = ParamsHash.compute(null, Map.of("author", List.of("B", "A")), FacetLogic.AND);
+        assertEquals(a, b);
+    }
+
+    @Test
+    void queryChangesHash() {
+        assertNotEquals(
+                ParamsHash.compute("one", Map.of(), FacetLogic.AND),
+                ParamsHash.compute("two", Map.of(), FacetLogic.AND));
+    }
+
+    @Test
+    void facetLogicChangesHash() {
+        Map<String, List<String>> facets = Map.of("author", List.of("A"));
+        assertNotEquals(
+                ParamsHash.compute(null, facets, FacetLogic.AND),
+                ParamsHash.compute(null, facets, FacetLogic.OR));
+    }
+
+    @Test
+    void facetSelectionChangesHash() {
+        assertNotEquals(
+                ParamsHash.compute(null, Map.of("author", List.of("A")), FacetLogic.AND),
+                ParamsHash.compute(null, Map.of("author", List.of("B")), FacetLogic.AND));
+    }
+
+    @Test
+    void nullQueryAndEmptyFacetsAreStable() {
+        assertEquals(
+                ParamsHash.compute(null, Map.of(), FacetLogic.AND),
+                ParamsHash.compute(null, Map.of(), FacetLogic.AND));
+    }
+}

--- a/backend/src/test/java/org/booklore/browse/ParamsHashTest.java
+++ b/backend/src/test/java/org/booklore/browse/ParamsHashTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -68,8 +69,7 @@ class ParamsHashTest {
 
     @Test
     void valuesWithDelimitersDoNotCollide() {
-        assertNotEquals(
-                ParamsHash.compute(null, Map.of("author", List.of("A,B")), FacetLogic.AND),
-                ParamsHash.compute(null, Map.of("author", List.of("A", "B")), FacetLogic.AND));
+        assertThat(ParamsHash.compute(null, Map.of("author", List.of("A,B")), FacetLogic.AND))
+                .isNotEqualTo(ParamsHash.compute(null, Map.of("author", List.of("A", "B")), FacetLogic.AND));
     }
 }

--- a/backend/src/test/java/org/booklore/browse/ParamsHashTest.java
+++ b/backend/src/test/java/org/booklore/browse/ParamsHashTest.java
@@ -6,65 +6,58 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class ParamsHashTest {
 
     @Test
     void isTwelveCharacters() {
-        assertEquals(12, ParamsHash.compute("q", Map.of(), FacetLogic.AND).length());
+        assertThat(ParamsHash.compute("q", Map.of(), FacetLogic.AND)).hasSize(12);
     }
 
     @Test
     void isDeterministic() {
         Map<String, List<String>> facets = Map.of("author", List.of("Tolkien"));
-        assertEquals(
-                ParamsHash.compute("hobbit", facets, FacetLogic.AND),
-                ParamsHash.compute("hobbit", facets, FacetLogic.AND));
+        assertThat(ParamsHash.compute("hobbit", facets, FacetLogic.AND))
+                .isEqualTo(ParamsHash.compute("hobbit", facets, FacetLogic.AND));
     }
 
     @Test
     void isIndependentOfFacetKeyOrder() {
         String a = ParamsHash.compute(null, Map.of("author", List.of("A"), "genre", List.of("G")), FacetLogic.AND);
         String b = ParamsHash.compute(null, Map.of("genre", List.of("G"), "author", List.of("A")), FacetLogic.AND);
-        assertEquals(a, b);
+        assertThat(a).isEqualTo(b);
     }
 
     @Test
     void isIndependentOfValueOrderWithinAFacet() {
         String a = ParamsHash.compute(null, Map.of("author", List.of("A", "B")), FacetLogic.AND);
         String b = ParamsHash.compute(null, Map.of("author", List.of("B", "A")), FacetLogic.AND);
-        assertEquals(a, b);
+        assertThat(a).isEqualTo(b);
     }
 
     @Test
     void queryChangesHash() {
-        assertNotEquals(
-                ParamsHash.compute("one", Map.of(), FacetLogic.AND),
-                ParamsHash.compute("two", Map.of(), FacetLogic.AND));
+        assertThat(ParamsHash.compute("one", Map.of(), FacetLogic.AND))
+                .isNotEqualTo(ParamsHash.compute("two", Map.of(), FacetLogic.AND));
     }
 
     @Test
     void facetLogicChangesHash() {
         Map<String, List<String>> facets = Map.of("author", List.of("A"));
-        assertNotEquals(
-                ParamsHash.compute(null, facets, FacetLogic.AND),
-                ParamsHash.compute(null, facets, FacetLogic.OR));
+        assertThat(ParamsHash.compute(null, facets, FacetLogic.AND))
+                .isNotEqualTo(ParamsHash.compute(null, facets, FacetLogic.OR));
     }
 
     @Test
     void facetSelectionChangesHash() {
-        assertNotEquals(
-                ParamsHash.compute(null, Map.of("author", List.of("A")), FacetLogic.AND),
-                ParamsHash.compute(null, Map.of("author", List.of("B")), FacetLogic.AND));
+        assertThat(ParamsHash.compute(null, Map.of("author", List.of("A")), FacetLogic.AND))
+                .isNotEqualTo(ParamsHash.compute(null, Map.of("author", List.of("B")), FacetLogic.AND));
     }
 
     @Test
     void nullQueryAndEmptyFacetsAreStable() {
-        assertEquals(
-                ParamsHash.compute(null, Map.of(), FacetLogic.AND),
-                ParamsHash.compute(null, Map.of(), FacetLogic.AND));
+        assertThat(ParamsHash.compute(null, Map.of(), FacetLogic.AND))
+                .isEqualTo(ParamsHash.compute(null, Map.of(), FacetLogic.AND));
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/browse/SortParserTest.java
+++ b/backend/src/test/java/org/booklore/browse/SortParserTest.java
@@ -1,0 +1,72 @@
+package org.booklore.browse;
+
+import org.booklore.exception.APIException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SortParserTest {
+
+    private static final Set<String> KEYS = Set.of("id", "title", "seriesName", "seriesNumber");
+
+    @Test
+    void blankSortYieldsTiebreakerOnly() {
+        assertEquals(List.of(new SortTerm("id", false)), SortParser.parse(null, KEYS));
+        assertEquals(List.of(new SortTerm("id", false)), SortParser.parse("   ", KEYS));
+    }
+
+    @Test
+    void parsesSingleAscendingKeyAndAppendsTiebreaker() {
+        List<SortTerm> terms = SortParser.parse("title", KEYS);
+        assertEquals(List.of(new SortTerm("title", false), new SortTerm("id", false)), terms);
+    }
+
+    @Test
+    void dashPrefixMarksDescending() {
+        List<SortTerm> terms = SortParser.parse("-title", KEYS);
+        assertEquals(List.of(new SortTerm("title", true), new SortTerm("id", false)), terms);
+    }
+
+    @Test
+    void parsesMultipleTermsInOrder() {
+        List<SortTerm> terms = SortParser.parse("seriesName,-seriesNumber", KEYS);
+        assertEquals(
+                List.of(new SortTerm("seriesName", false), new SortTerm("seriesNumber", true), new SortTerm("id", false)),
+                terms);
+    }
+
+    @Test
+    void trimsWhitespaceAroundTokens() {
+        List<SortTerm> terms = SortParser.parse(" title , -seriesNumber ", KEYS);
+        assertEquals(
+                List.of(new SortTerm("title", false), new SortTerm("seriesNumber", true), new SortTerm("id", false)),
+                terms);
+    }
+
+    @Test
+    void explicitTiebreakerKeyIsNotDuplicated() {
+        assertEquals(List.of(new SortTerm("id", false)), SortParser.parse("id", KEYS));
+        assertEquals(List.of(new SortTerm("id", true)), SortParser.parse("-id", KEYS));
+    }
+
+    @Test
+    void explicitTiebreakerMidListSuppressesAppendedOne() {
+        List<SortTerm> terms = SortParser.parse("id,title", KEYS);
+        assertEquals(List.of(new SortTerm("id", false), new SortTerm("title", false)), terms);
+    }
+
+    @Test
+    void unknownKeyIsRejected() {
+        assertThrows(APIException.class, () -> SortParser.parse("bogus", KEYS));
+    }
+
+    @Test
+    void emptyTokenIsRejected() {
+        assertThrows(APIException.class, () -> SortParser.parse("title,,id", KEYS));
+        assertThrows(APIException.class, () -> SortParser.parse("-", KEYS));
+    }
+}

--- a/backend/src/test/java/org/booklore/browse/SortParserTest.java
+++ b/backend/src/test/java/org/booklore/browse/SortParserTest.java
@@ -2,12 +2,14 @@ package org.booklore.browse;
 
 import org.booklore.exception.APIException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SortParserTest {
 
@@ -15,58 +17,56 @@ class SortParserTest {
 
     @Test
     void blankSortYieldsTiebreakerOnly() {
-        assertEquals(List.of(new SortTerm("id", false)), SortParser.parse(null, KEYS));
-        assertEquals(List.of(new SortTerm("id", false)), SortParser.parse("   ", KEYS));
+        assertThat(SortParser.parse(null, KEYS)).containsExactly(new SortTerm("id", false));
+        assertThat(SortParser.parse("   ", KEYS)).containsExactly(new SortTerm("id", false));
     }
 
     @Test
     void parsesSingleAscendingKeyAndAppendsTiebreaker() {
-        List<SortTerm> terms = SortParser.parse("title", KEYS);
-        assertEquals(List.of(new SortTerm("title", false), new SortTerm("id", false)), terms);
+        assertThat(SortParser.parse("title", KEYS))
+                .containsExactly(new SortTerm("title", false), new SortTerm("id", false));
     }
 
     @Test
     void dashPrefixMarksDescending() {
-        List<SortTerm> terms = SortParser.parse("-title", KEYS);
-        assertEquals(List.of(new SortTerm("title", true), new SortTerm("id", false)), terms);
+        assertThat(SortParser.parse("-title", KEYS))
+                .containsExactly(new SortTerm("title", true), new SortTerm("id", false));
     }
 
     @Test
     void parsesMultipleTermsInOrder() {
-        List<SortTerm> terms = SortParser.parse("seriesName,-seriesNumber", KEYS);
-        assertEquals(
-                List.of(new SortTerm("seriesName", false), new SortTerm("seriesNumber", true), new SortTerm("id", false)),
-                terms);
+        assertThat(SortParser.parse("seriesName,-seriesNumber", KEYS))
+                .containsExactly(new SortTerm("seriesName", false), new SortTerm("seriesNumber", true), new SortTerm("id", false));
     }
 
     @Test
     void trimsWhitespaceAroundTokens() {
-        List<SortTerm> terms = SortParser.parse(" title , -seriesNumber ", KEYS);
-        assertEquals(
-                List.of(new SortTerm("title", false), new SortTerm("seriesNumber", true), new SortTerm("id", false)),
-                terms);
+        assertThat(SortParser.parse(" title , -seriesNumber ", KEYS))
+                .containsExactly(new SortTerm("title", false), new SortTerm("seriesNumber", true), new SortTerm("id", false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "title", "-title", "seriesName,-seriesNumber"})
+    void alwaysEndsWithIdAscendingTiebreaker(String sort) {
+        List<SortTerm> terms = SortParser.parse(sort.isEmpty() ? null : sort, KEYS);
+        assertThat(terms).endsWith(new SortTerm("id", false));
     }
 
     @Test
-    void explicitTiebreakerKeyIsNotDuplicated() {
-        assertEquals(List.of(new SortTerm("id", false)), SortParser.parse("id", KEYS));
-        assertEquals(List.of(new SortTerm("id", true)), SortParser.parse("-id", KEYS));
-    }
-
-    @Test
-    void explicitTiebreakerMidListSuppressesAppendedOne() {
-        List<SortTerm> terms = SortParser.parse("id,title", KEYS);
-        assertEquals(List.of(new SortTerm("id", false), new SortTerm("title", false)), terms);
+    void idIsRejectedLikeAnUnknownSortKey() {
+        assertThatThrownBy(() -> SortParser.parse("id", KEYS)).isInstanceOf(APIException.class);
+        assertThatThrownBy(() -> SortParser.parse("-id", KEYS)).isInstanceOf(APIException.class);
+        assertThatThrownBy(() -> SortParser.parse("id,title", KEYS)).isInstanceOf(APIException.class);
     }
 
     @Test
     void unknownKeyIsRejected() {
-        assertThrows(APIException.class, () -> SortParser.parse("bogus", KEYS));
+        assertThatThrownBy(() -> SortParser.parse("bogus", KEYS)).isInstanceOf(APIException.class);
     }
 
     @Test
     void emptyTokenIsRejected() {
-        assertThrows(APIException.class, () -> SortParser.parse("title,,id", KEYS));
-        assertThrows(APIException.class, () -> SortParser.parse("-", KEYS));
+        assertThatThrownBy(() -> SortParser.parse("title,,id", KEYS)).isInstanceOf(APIException.class);
+        assertThatThrownBy(() -> SortParser.parse("-", KEYS)).isInstanceOf(APIException.class);
     }
 }

--- a/backend/src/test/java/org/booklore/browse/SortRegistryTest.java
+++ b/backend/src/test/java/org/booklore/browse/SortRegistryTest.java
@@ -1,0 +1,83 @@
+package org.booklore.browse;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Root;
+import org.booklore.exception.APIException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SortRegistryTest {
+
+    @Mock
+    private Root<Object> root;
+    @Mock
+    private CriteriaQuery<?> query;
+    @Mock
+    private CriteriaBuilder cb;
+
+    @Test
+    void registersAndExposesKeysInOrder() {
+        SortRegistry<Object> registry = new SortRegistry<>()
+                .register("id", ascOn("id"))
+                .register("title", ascOn("title"));
+        assertTrue(registry.has("id"));
+        assertTrue(registry.has("title"));
+        assertEquals(List.of("id", "title"), List.copyOf(registry.keys()));
+    }
+
+    @Test
+    void dispatchesEachTermToItsBuilderInOrder() {
+        Order idOrder = mock(Order.class);
+        Order titleOrder = mock(Order.class);
+        SortRegistry<Object> registry = new SortRegistry<>()
+                .register("title", ctx -> List.of(titleOrder))
+                .register("id", ctx -> List.of(idOrder));
+
+        List<Order> orders = registry.toOrders(
+                List.of(new SortTerm("title", false), new SortTerm("id", false)), root, query, cb, 7L);
+
+        assertEquals(List.of(titleOrder, idOrder), orders);
+    }
+
+    @Test
+    void passesDirectionAndUserIdToBuilder() {
+        boolean[] sawDescending = {false};
+        Long[] sawUser = {null};
+        SortRegistry<Object> registry = new SortRegistry<>().register("title", ctx -> {
+            sawDescending[0] = ctx.descending();
+            sawUser[0] = ctx.userId();
+            return List.of(mock(Order.class));
+        });
+
+        registry.toOrders(List.of(new SortTerm("title", true)), root, query, cb, 42L);
+
+        assertTrue(sawDescending[0]);
+        assertEquals(42L, sawUser[0]);
+    }
+
+    @Test
+    void unknownKeyThrows() {
+        SortRegistry<Object> registry = new SortRegistry<>().register("id", ascOn("id"));
+        assertThrows(APIException.class,
+                () -> registry.toOrders(List.of(new SortTerm("bogus", false)), root, query, cb, null));
+    }
+
+    private SortOrderBuilder<Object> ascOn(String attribute) {
+        return ctx -> List.of(mock(Order.class));
+    }
+}

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseRegistryTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseRegistryTest.java
@@ -1,0 +1,266 @@
+package org.booklore.service.browse;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.booklore.BookloreApplication;
+import org.booklore.browse.FacetLogic;
+import org.booklore.browse.SortParser;
+import org.booklore.browse.SortTerm;
+import org.booklore.model.entity.AuthorEntity;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookLoreUserEntity;
+import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.model.entity.CategoryEntity;
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.entity.LibraryPathEntity;
+import org.booklore.model.entity.UserBookProgressEntity;
+import org.booklore.model.enums.BookFileType;
+import org.booklore.model.enums.ReadStatus;
+import org.booklore.repository.BookRepository;
+import org.booklore.service.task.TaskCronService;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = BookloreApplication.class)
+@Transactional
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.datasource.url=jdbc:h2:mem:browsetest;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "app.path-config=build/tmp/test-config",
+        "app.bookdrop-folder=build/tmp/test-bookdrop",
+        "spring.main.allow-bean-definition-overriding=true",
+        "spring.task.scheduling.enabled=false",
+        "app.task.scan-library-cron=*/1 * * * * *",
+        "app.task.process-bookdrop-cron=*/1 * * * * *",
+        "app.features.oidc-enabled=false"
+})
+@Import(BookBrowseRegistryTest.TestConfig.class)
+class BookBrowseRegistryTest {
+
+    @Autowired
+    private BookRepository bookRepository;
+    @Autowired
+    private BookSortRegistry sortRegistry;
+    @Autowired
+    private BookFacetRegistry facetRegistry;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private BookLoreUserEntity user;
+    private LibraryEntity library;
+    private LibraryPathEntity libraryPath;
+    private final Map<String, CategoryEntity> categories = new HashMap<>();
+    private final Map<String, AuthorEntity> authors = new HashMap<>();
+
+    @TestConfiguration
+    public static class TestConfig {
+        @Bean("flyway")
+        @Primary
+        public Flyway flyway() {
+            return org.mockito.Mockito.mock(Flyway.class);
+        }
+
+        @Bean
+        @Primary
+        public TaskCronService taskCronService() {
+            return org.mockito.Mockito.mock(TaskCronService.class);
+        }
+    }
+
+    @BeforeEach
+    void seed() {
+        user = BookLoreUserEntity.builder().username("reader").passwordHash("x").name("Reader").build();
+        em.persist(user);
+        library = LibraryEntity.builder().name("Lib").icon("book").watch(false)
+                .formatPriority(List.of(BookFileType.EPUB)).build();
+        em.persist(library);
+        libraryPath = LibraryPathEntity.builder().library(library).path("/p").build();
+        em.persist(libraryPath);
+    }
+
+    private BookEntity book(String title) {
+        return book(title, null, null, Instant.now(), List.of(), List.of(), null);
+    }
+
+    private BookEntity book(String title, String seriesName, Float seriesNumber, Instant addedOn,
+                            List<String> categoryNames, List<String> authorNames, String isbn13) {
+        BookEntity bookEntity = BookEntity.builder()
+                .library(library).libraryPath(libraryPath).addedOn(addedOn).deleted(false).build();
+        em.persist(bookEntity);
+        BookMetadataEntity metadata = BookMetadataEntity.builder()
+                .book(bookEntity).title(title).seriesName(seriesName).seriesNumber(seriesNumber)
+                .isbn13(isbn13).publishedDate(LocalDate.of(2020, 1, 1)).build();
+        metadata.setCategories(categoryNames.stream().map(this::category).collect(Collectors.toSet()));
+        metadata.setAuthors(authorNames.stream().map(this::author).toList());
+        em.persist(metadata);
+        bookEntity.setMetadata(metadata);
+        return bookEntity;
+    }
+
+    private void progress(BookEntity book, BookLoreUserEntity forUser, Integer personalRating,
+                          ReadStatus status, Float epubPercent, Float pdfPercent) {
+        UserBookProgressEntity p = UserBookProgressEntity.builder()
+                .user(forUser).book(book).personalRating(personalRating).readStatus(status)
+                .epubProgressPercent(epubPercent).pdfProgressPercent(pdfPercent)
+                .lastReadTime(Instant.now()).build();
+        em.persist(p);
+    }
+
+    private CategoryEntity category(String name) {
+        return categories.computeIfAbsent(name, n -> {
+            CategoryEntity e = CategoryEntity.builder().name(n).build();
+            em.persist(e);
+            return e;
+        });
+    }
+
+    private AuthorEntity author(String name) {
+        return authors.computeIfAbsent(name, n -> {
+            AuthorEntity e = AuthorEntity.builder().name(n).build();
+            em.persist(e);
+            return e;
+        });
+    }
+
+    private List<Long> sortedIds(String sortString, Long userId) {
+        List<SortTerm> terms = SortParser.parse(sortString, sortRegistry.registry().keys());
+        Specification<BookEntity> spec = (root, query, cb) -> {
+            query.orderBy(sortRegistry.registry().toOrders(terms, root, query, cb, userId));
+            return cb.conjunction();
+        };
+        return bookRepository.findAll(spec).stream().map(BookEntity::getId).toList();
+    }
+
+    private Set<Long> facetIds(String facet, List<String> values, FacetLogic logic, Long userId) {
+        return bookRepository.findAll(facetRegistry.toSpecification(facet, values, logic, userId)).stream()
+                .map(BookEntity::getId).collect(Collectors.toSet());
+    }
+
+    // ---- sorts ----
+
+    @Test
+    void titleAscendingAndDescending() {
+        Long a = book("Alpha").getId();
+        Long b = book("Bravo").getId();
+        Long c = book("Charlie").getId();
+        em.flush();
+        assertThat(sortedIds("title", user.getId())).containsExactly(a, b, c);
+        assertThat(sortedIds("-title", user.getId())).containsExactly(c, b, a);
+    }
+
+    @Test
+    void idTiebreakerOrdersEqualKeysById() {
+        Long first = book("Same").getId();
+        Long second = book("Same").getId();
+        em.flush();
+        assertThat(sortedIds("title", user.getId())).containsExactly(first, second);
+    }
+
+    @Test
+    void addedOnSorts() {
+        Long older = book("Old", null, null, Instant.parse("2020-01-01T00:00:00Z"), List.of(), List.of(), null).getId();
+        Long newer = book("New", null, null, Instant.parse("2024-01-01T00:00:00Z"), List.of(), List.of(), null).getId();
+        em.flush();
+        assertThat(sortedIds("addedOn", user.getId())).containsExactly(older, newer);
+        assertThat(sortedIds("-addedOn", user.getId())).containsExactly(newer, older);
+    }
+
+    @Test
+    void perUserPersonalRatingSorts() {
+        BookEntity low = book("Low");
+        BookEntity high = book("High");
+        progress(low, user, 3, ReadStatus.READ, null, null);
+        progress(high, user, 7, ReadStatus.READ, null, null);
+        em.flush();
+        assertThat(sortedIds("personalRating", user.getId())).containsExactly(low.getId(), high.getId());
+    }
+
+    @Test
+    void perUserSortIgnoresOtherUsersProgress() {
+        BookLoreUserEntity other = BookLoreUserEntity.builder().username("other").passwordHash("x").name("Other").build();
+        em.persist(other);
+        BookEntity book = book("Rated");
+        progress(book, other, 9, ReadStatus.READ, null, null);
+        em.flush();
+        // The requesting user has no progress row, so the rating is null, not 9.
+        List<Long> byRating = sortedIds("-personalRating", user.getId());
+        assertThat(byRating).containsExactly(book.getId());
+    }
+
+    @Test
+    void readingProgressUsesGreatestOfPercentFields() {
+        BookEntity half = book("Half");
+        BookEntity nearlyDone = book("NearlyDone");
+        progress(half, user, null, ReadStatus.READING, 0.5f, null);
+        progress(nearlyDone, user, null, ReadStatus.READING, null, 0.9f);
+        em.flush();
+        assertThat(sortedIds("-readingProgress", user.getId())).containsExactly(nearlyDone.getId(), half.getId());
+    }
+
+    // ---- facets ----
+
+    @Test
+    void genreFacetOrAndNot() {
+        Long horror = book("H", null, null, Instant.now(), List.of("Horror"), List.of(), null).getId();
+        Long romance = book("R", null, null, Instant.now(), List.of("Romance"), List.of(), null).getId();
+        em.flush();
+        assertThat(facetIds("genre", List.of("Horror"), FacetLogic.OR, user.getId())).containsExactly(horror);
+        assertThat(facetIds("genre", List.of("Horror"), FacetLogic.NOT, user.getId())).contains(romance).doesNotContain(horror);
+    }
+
+    @Test
+    void readStatusFacetIsPerUser() {
+        BookEntity read = book("Read");
+        BookEntity unread = book("Unread");
+        progress(read, user, null, ReadStatus.READ, null, null);
+        progress(unread, user, null, ReadStatus.UNREAD, null, null);
+        em.flush();
+        assertThat(facetIds("read_status", List.of("READ"), FacetLogic.OR, user.getId())).containsExactly(read.getId());
+    }
+
+    // ---- query ----
+
+    @Test
+    void queryMatchesTitleAuthorAndIsbn() {
+        Long byTitle = book("The Hobbit", null, null, Instant.now(), List.of(), List.of(), null).getId();
+        Long byAuthor = book("Unrelated", null, null, Instant.now(), List.of(), List.of("J.R.R. Tolkien"), null).getId();
+        Long byIsbn = book("Another", null, null, Instant.now(), List.of(), List.of(), "9780261103344").getId();
+        em.flush();
+
+        assertThat(matchIds("hobbit")).containsExactly(byTitle);
+        assertThat(matchIds("tolkien")).containsExactly(byAuthor);
+        assertThat(matchIds("9780261103344")).containsExactly(byIsbn);
+    }
+
+    private Set<Long> matchIds(String query) {
+        return bookRepository.findAll(BookSearchSpecification.matching(query)).stream()
+                .map(BookEntity::getId).collect(Collectors.toSet());
+    }
+}

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseRegistryTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseRegistryTest.java
@@ -231,7 +231,7 @@ class BookBrowseRegistryTest {
         Long horror = book("H", null, null, Instant.now(), List.of("Horror"), List.of(), null).getId();
         Long romance = book("R", null, null, Instant.now(), List.of("Romance"), List.of(), null).getId();
         em.flush();
-        assertThat(facetIds("genre", List.of("Horror"), FacetLogic.OR, user.getId())).containsExactly(horror);
+        assertThat(facetIds("genre", List.of("Horror"), FacetLogic.OR, user.getId())).containsExactlyInAnyOrder(horror);
         assertThat(facetIds("genre", List.of("Horror"), FacetLogic.NOT, user.getId())).contains(romance).doesNotContain(horror);
     }
 
@@ -242,7 +242,7 @@ class BookBrowseRegistryTest {
         progress(read, user, null, ReadStatus.READ, null, null);
         progress(unread, user, null, ReadStatus.UNREAD, null, null);
         em.flush();
-        assertThat(facetIds("read_status", List.of("READ"), FacetLogic.OR, user.getId())).containsExactly(read.getId());
+        assertThat(facetIds("read_status", List.of("READ"), FacetLogic.OR, user.getId())).containsExactlyInAnyOrder(read.getId());
     }
 
     // ---- query ----
@@ -254,9 +254,9 @@ class BookBrowseRegistryTest {
         Long byIsbn = book("Another", null, null, Instant.now(), List.of(), List.of(), "9780261103344").getId();
         em.flush();
 
-        assertThat(matchIds("hobbit")).containsExactly(byTitle);
-        assertThat(matchIds("tolkien")).containsExactly(byAuthor);
-        assertThat(matchIds("9780261103344")).containsExactly(byIsbn);
+        assertThat(matchIds("hobbit")).containsExactlyInAnyOrder(byTitle);
+        assertThat(matchIds("tolkien")).containsExactlyInAnyOrder(byAuthor);
+        assertThat(matchIds("9780261103344")).containsExactlyInAnyOrder(byIsbn);
     }
 
     private Set<Long> matchIds(String query) {

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
@@ -1,0 +1,259 @@
+package org.booklore.service.browse;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.booklore.BookloreApplication;
+import org.booklore.browse.BrowsePage;
+import org.booklore.browse.Link;
+import org.booklore.exception.APIException;
+import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.model.dto.Book;
+import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.dto.Library;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookLoreUserEntity;
+import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.model.entity.CategoryEntity;
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.entity.LibraryPathEntity;
+import org.booklore.model.enums.BookFileType;
+import org.booklore.repository.BookRepository;
+import org.booklore.service.task.TaskCronService;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = BookloreApplication.class)
+@Transactional
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.datasource.url=jdbc:h2:mem:browseservicetest;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "app.path-config=build/tmp/test-config",
+        "app.bookdrop-folder=build/tmp/test-bookdrop",
+        "spring.main.allow-bean-definition-overriding=true",
+        "spring.task.scheduling.enabled=false",
+        "app.task.scan-library-cron=*/1 * * * * *",
+        "app.task.process-bookdrop-cron=*/1 * * * * *",
+        "app.features.oidc-enabled=false"
+})
+@Import(BookBrowseServiceTest.TestConfig.class)
+class BookBrowseServiceTest {
+
+    @Autowired
+    private BookBrowseService browseService;
+    @Autowired
+    private BookRepository bookRepository;
+    @MockitoBean
+    private AuthenticationService authenticationService;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private BookLoreUserEntity userEntity;
+    private LibraryEntity library;
+    private LibraryPathEntity libraryPath;
+    private final Map<String, CategoryEntity> categories = new HashMap<>();
+
+    @TestConfiguration
+    public static class TestConfig {
+        @Bean("flyway")
+        @Primary
+        public Flyway flyway() {
+            return mock(Flyway.class);
+        }
+
+        @Bean
+        @Primary
+        public TaskCronService taskCronService() {
+            return mock(TaskCronService.class);
+        }
+    }
+
+    @BeforeEach
+    void seed() {
+        userEntity = BookLoreUserEntity.builder().username("reader").passwordHash("x").name("Reader").build();
+        em.persist(userEntity);
+        library = LibraryEntity.builder().name("Lib").icon("book").watch(false)
+                .formatPriority(List.of(BookFileType.EPUB)).build();
+        em.persist(library);
+        libraryPath = LibraryPathEntity.builder().library(library).path("/p").build();
+        em.persist(libraryPath);
+        when(authenticationService.getAuthenticatedUser()).thenReturn(nonAdminUser());
+    }
+
+    private BookLoreUser nonAdminUser() {
+        BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();
+        permissions.setAdmin(false);
+        return BookLoreUser.builder()
+                .id(userEntity.getId())
+                .assignedLibraries(List.of(Library.builder().id(library.getId()).build()))
+                .permissions(permissions)
+                .build();
+    }
+
+    private BookEntity book(String title, List<String> categoryNames) {
+        BookEntity bookEntity = BookEntity.builder()
+                .library(library).libraryPath(libraryPath).addedOn(Instant.now()).deleted(false).build();
+        em.persist(bookEntity);
+        BookMetadataEntity metadata = BookMetadataEntity.builder().book(bookEntity).title(title).build();
+        metadata.setCategories(categoryNames.stream().map(this::category).collect(Collectors.toSet()));
+        em.persist(metadata);
+        bookEntity.setMetadata(metadata);
+        return bookEntity;
+    }
+
+    private CategoryEntity category(String name) {
+        return categories.computeIfAbsent(name, n -> {
+            CategoryEntity e = CategoryEntity.builder().name(n).build();
+            em.persist(e);
+            return e;
+        });
+    }
+
+    private BrowsePage<Book> browse(String sort, List<String> facet, String query, String cursor, int page, int size) {
+        return browseService.browse(sort, facet, null, query, cursor, PageRequest.of(page, size));
+    }
+
+    private String nextCursor(BrowsePage<Book> page) {
+        Link next = page.links().stream().filter(l -> l.rel().contains("next")).findFirst().orElseThrow();
+        return next.href().substring(next.href().indexOf("cursor=") + "cursor=".length());
+    }
+
+    @Test
+    void returnsPageWithTotalsAndCursorAndLinks() {
+        book("Alpha", List.of());
+        book("Bravo", List.of());
+        em.flush();
+
+        BrowsePage<Book> result = browse(null, null, null, null, 0, 20);
+
+        assertThat(result.content()).hasSize(2);
+        assertThat(result.page().totalElements()).isEqualTo(2);
+        assertThat(result.page().cursor()).isNotBlank();
+        assertThat(result.links().stream().anyMatch(l -> l.rel().contains("self"))).isTrue();
+    }
+
+    @Test
+    void sortIsApplied() {
+        Long b = book("Bravo", List.of()).getId();
+        Long a = book("Alpha", List.of()).getId();
+        em.flush();
+        assertThat(browse("title", null, null, null, 0, 20).content().stream().map(Book::getId)).containsExactly(a, b);
+        assertThat(browse("-title", null, null, null, 0, 20).content().stream().map(Book::getId)).containsExactly(b, a);
+    }
+
+    @Test
+    void facetIsApplied() {
+        Long horror = book("H", List.of("Horror")).getId();
+        book("R", List.of("Romance"));
+        em.flush();
+        BrowsePage<Book> result = browse(null, List.of("genre:Horror"), null, null, 0, 20);
+        assertThat(result.content().stream().map(Book::getId)).containsExactly(horror);
+        assertThat(result.page().totalElements()).isEqualTo(1);
+    }
+
+    @Test
+    void queryIsApplied() {
+        Long hobbit = book("The Hobbit", List.of()).getId();
+        book("Dune", List.of());
+        em.flush();
+        assertThat(browse(null, null, "hobbit", null, 0, 20).content().stream().map(Book::getId)).containsExactly(hobbit);
+    }
+
+    @Test
+    void cursorWalkIsConsistent() {
+        for (int i = 0; i < 5; i++) {
+            book(String.format("Book%02d", i), List.of());
+        }
+        em.flush();
+
+        BrowsePage<Book> page0 = browse("title", null, null, null, 0, 2);
+        assertThat(page0.content()).hasSize(2);
+        assertThat(page0.page().totalElements()).isEqualTo(5);
+
+        BrowsePage<Book> page1 = browse("title", null, null, nextCursor(page0), 0, 2);
+        assertThat(page1.content()).hasSize(2);
+        assertThat(page1.content().stream().map(Book::getId))
+                .doesNotContainAnyElementsOf(page0.content().stream().map(Book::getId).toList());
+    }
+
+    @Test
+    void cursorWithConflictingFacetsIsRejected() {
+        book("Alpha", List.of("Horror"));
+        em.flush();
+        String cursor = browse(null, null, null, null, 0, 20).page().cursor();
+        assertThatThrownBy(() -> browse(null, List.of("genre:Horror"), null, cursor, 0, 20))
+                .isInstanceOf(APIException.class);
+    }
+
+    @Test
+    void deferredSortKeyIsRejected() {
+        book("Alpha", List.of());
+        em.flush();
+        assertThatThrownBy(() -> browse("random", null, null, null, 0, 20))
+                .isInstanceOf(APIException.class);
+        assertThatThrownBy(() -> browse("fileSizeKb", null, null, null, 0, 20))
+                .isInstanceOf(APIException.class);
+    }
+
+    @Test
+    void wrapLegacyAddsCursorAndLinksToExistingPage() {
+        Book book = Book.builder().id(1L).build();
+        org.springframework.data.domain.Page<Book> page =
+                new org.springframework.data.domain.PageImpl<>(List.of(book), PageRequest.of(0, 20), 1);
+
+        BrowsePage<Book> wrapped = browseService.wrapLegacy(page, PageRequest.of(0, 20));
+
+        assertThat(wrapped.content()).hasSize(1);
+        assertThat(wrapped.page().totalElements()).isEqualTo(1);
+        assertThat(wrapped.page().cursor()).isNotBlank();
+        assertThat(wrapped.links().stream().anyMatch(l -> l.rel().contains("self"))).isTrue();
+    }
+
+    @Test
+    void nonAdminSeesOnlyAssignedLibraries() {
+        book("InLibrary", List.of());
+        LibraryEntity otherLibrary = LibraryEntity.builder().name("Other").icon("book").watch(false)
+                .formatPriority(List.of(BookFileType.EPUB)).build();
+        em.persist(otherLibrary);
+        LibraryPathEntity otherPath = LibraryPathEntity.builder().library(otherLibrary).path("/o").build();
+        em.persist(otherPath);
+        BookEntity outside = BookEntity.builder()
+                .library(otherLibrary).libraryPath(otherPath).addedOn(Instant.now()).deleted(false).build();
+        em.persist(outside);
+        BookMetadataEntity md = BookMetadataEntity.builder().book(outside).title("Outside").build();
+        em.persist(md);
+        em.flush();
+
+        BrowsePage<Book> result = browse(null, null, null, null, 0, 20);
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().get(0).getId()).isNotEqualTo(outside.getId());
+    }
+}

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -210,7 +211,8 @@ class BookBrowseServiceTest {
         em.flush();
         String cursor = browse(null, null, null, null, 0, 20).page().cursor();
         assertThatThrownBy(() -> browse(null, List.of("genre:Horror"), null, cursor, 0, 20))
-                .isInstanceOf(APIException.class);
+                .isInstanceOfSatisfying(APIException.class, e -> assertThat(e.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST))
+                .hasMessageContaining("does not match");
     }
 
     @Test
@@ -218,9 +220,11 @@ class BookBrowseServiceTest {
         book("Alpha", List.of());
         em.flush();
         assertThatThrownBy(() -> browse("random", null, null, null, 0, 20))
-                .isInstanceOf(APIException.class);
+                .isInstanceOfSatisfying(APIException.class, e -> assertThat(e.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST))
+                .hasMessageContaining("Unknown sort key");
         assertThatThrownBy(() -> browse("fileSizeKb", null, null, null, 0, 20))
-                .isInstanceOf(APIException.class);
+                .isInstanceOfSatisfying(APIException.class, e -> assertThat(e.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST))
+                .hasMessageContaining("Unknown sort key");
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/browse/BookFacetRegistryMagicShelfTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookFacetRegistryMagicShelfTest.java
@@ -13,7 +13,8 @@ import org.springframework.data.jpa.domain.Specification;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -55,14 +56,15 @@ class BookFacetRegistryMagicShelfTest {
 
     @Test
     void malformedMagicShelfIdThrows() {
-        assertThrows(APIException.class,
-                () -> registry.toSpecification("shelf", List.of("magic:not-a-number"), FacetLogic.AND, 1L));
-        assertThrows(APIException.class,
-                () -> registry.toSpecification("shelf", List.of("magic:"), FacetLogic.AND, 1L));
+        assertThatThrownBy(() -> registry.toSpecification("shelf", List.of("magic:not-a-number"), FacetLogic.AND, 1L))
+                .isInstanceOf(APIException.class);
+        assertThatThrownBy(() -> registry.toSpecification("shelf", List.of("magic:"), FacetLogic.AND, 1L))
+                .isInstanceOf(APIException.class);
     }
 
     @Test
     void emptyShelfValuesDoesNotThrow() {
-        assertDoesNotThrow(() -> registry.toSpecification("shelf", List.of(), FacetLogic.AND, 1L));
+        assertThatCode(() -> registry.toSpecification("shelf", List.of(), FacetLogic.AND, 1L))
+                .doesNotThrowAnyException();
     }
 }

--- a/backend/src/test/java/org/booklore/service/browse/BookFacetRegistryMagicShelfTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookFacetRegistryMagicShelfTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.domain.Specification;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -50,5 +51,18 @@ class BookFacetRegistryMagicShelfTest {
     void unknownFacetThrows() {
         assertThrows(APIException.class,
                 () -> registry.toSpecification("bogus", List.of("x"), FacetLogic.AND, 1L));
+    }
+
+    @Test
+    void malformedMagicShelfIdThrows() {
+        assertThrows(APIException.class,
+                () -> registry.toSpecification("shelf", List.of("magic:not-a-number"), FacetLogic.AND, 1L));
+        assertThrows(APIException.class,
+                () -> registry.toSpecification("shelf", List.of("magic:"), FacetLogic.AND, 1L));
+    }
+
+    @Test
+    void emptyShelfValuesDoesNotThrow() {
+        assertDoesNotThrow(() -> registry.toSpecification("shelf", List.of(), FacetLogic.AND, 1L));
     }
 }

--- a/backend/src/test/java/org/booklore/service/browse/BookFacetRegistryMagicShelfTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookFacetRegistryMagicShelfTest.java
@@ -1,0 +1,54 @@
+package org.booklore.service.browse;
+
+import org.booklore.browse.FacetLogic;
+import org.booklore.exception.APIException;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.service.opds.MagicShelfBookService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookFacetRegistryMagicShelfTest {
+
+    @Mock
+    private MagicShelfBookService magicShelfBookService;
+
+    @InjectMocks
+    private BookFacetRegistry registry;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void magicShelfValueShortCircuitsToMagicShelfSpecification() {
+        Specification<BookEntity> magicSpec = mock(Specification.class);
+        when(magicShelfBookService.toSpecification(7L, 42L)).thenReturn(magicSpec);
+
+        registry.toSpecification("shelf", List.of("magic:42"), FacetLogic.OR, 7L);
+
+        verify(magicShelfBookService).toSpecification(7L, 42L);
+    }
+
+    @Test
+    void regularShelfValueDoesNotTouchMagicShelfService() {
+        registry.toSpecification("shelf", List.of("3"), FacetLogic.OR, 7L);
+        verifyNoInteractions(magicShelfBookService);
+    }
+
+    @Test
+    void unknownFacetThrows() {
+        assertThrows(APIException.class,
+                () -> registry.toSpecification("bogus", List.of("x"), FacetLogic.AND, 1L));
+    }
+}

--- a/backend/src/test/java/org/booklore/service/browse/BookFacetRegistryMagicShelfTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookFacetRegistryMagicShelfTest.java
@@ -11,12 +11,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -50,8 +49,8 @@ class BookFacetRegistryMagicShelfTest {
 
     @Test
     void unknownFacetThrows() {
-        assertThrows(APIException.class,
-                () -> registry.toSpecification("bogus", List.of("x"), FacetLogic.AND, 1L));
+        assertThatThrownBy(() -> registry.toSpecification("bogus", List.of("x"), FacetLogic.AND, 1L))
+                .isInstanceOf(APIException.class);
     }
 
     @Test
@@ -66,5 +65,12 @@ class BookFacetRegistryMagicShelfTest {
     void emptyShelfValuesDoesNotThrow() {
         assertThatCode(() -> registry.toSpecification("shelf", List.of(), FacetLogic.AND, 1L))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void blankAndNullShelfTokensAreIgnored() {
+        assertThatCode(() -> registry.toSpecification("shelf", Arrays.asList(null, "", "   "), FacetLogic.AND, 1L))
+                .doesNotThrowAnyException();
+        verifyNoInteractions(magicShelfBookService);
     }
 }


### PR DESCRIPTION
## Description

In RFC https://github.com/orgs/grimmory-tools/discussions/1580, we agreed upon a new abstraction for handling list request and responses within the platform, in the goal of moving towards a pagination-first approach to content. This PR is the first PR in implementing that RFC, and is the first of 3 PRs to get us to an MVP that represents the design agreed upon in that RFC.

## Linked Issue

Implements https://github.com/grimmory-tools/grimmory/issues/1845?issue=grimmory-tools%7Cgrimmory%7C1846

## Changes

This PR changes two areas- first, it adds a new package, `org.booklore.browse`, and implements several reusable abstractions within that package to support the new pagination behaviour within books. Second, it refactors the existing book pagination endpoint (with backwards compatibility), to implement support for those new pagination request/response structures. I've played with breaking this PR up more, but ultimately, I found it's less digestable to have the abstractions in one PR without the implementation, since it's harder to approve/review unused code if you can't yet see how it is actually used. With that in mind:

**`org.booklore.browse`**:
- `BrowsePage` + `Link`; New response struct (content + page/cursor + links)
- `CursorCodec` / `CursorState` / `ParamsHash`; supports the cursor
- `LinksBuilder`; allows for building `self`/`first`/`previous`/`next` links
- `SortRegistry` / `SortParser`; sort whitelist, `-` for desc, `id` tiebreaker
- `FacetLogic`; support defining logic w/ and/or/not
- New `ApiError` codes

**`GET /api/v1/books/page`**:
- Adds optional `sort`, `facet`, `facet_logic`, `query`, `cursor`
- Backwards compatible w/ no params
- Same `Book` DTO/models response structs, cursor/links are additive
- Shared `BookFilterSpecifications.base()` for filtering, reuses `AppBookSpecification` (for now) + magic shelves
- `BookSortRegistry` for current schema sorts; unsupported keys 400
- `BookSearchSpecification` — title/series/author/ISBN/ASIN/genre/tags
- Content restrictions applied for non-admins
- Extracts `BookQueryService.findBooksPaged`
- Tests for cursor, sort, facets, search, legacy parity, scoping

## Manual Testing Steps

1. Verify w/ no params that behaviour supports legacy w/  cursor/links + nothing removed
2. Follow `next`/`previous` cursors, verify response struct/no gaps
3. Verify valid sorting w/ `?sort=title`, `?sort=-title`, `?sort=seriesName,-seriesNumber
4. Verify invalid sorting (`?sort=bogus`throws 400)
5. Verify valid facets w/ `?facet=genre:Horror`, multiple facets, `?facet_logic=or`
6. Verify valid search queries w/ `?query=Sample`, matches title/author/series/etc
7. Verify that reusing a cursor w/ different throws a 400
8. Verify that for non-admins that library/content restrictions are honoured

## Screenshots (Optional)

N/A

## Additional Context (Optional)

This PR does not address the need for a `GET /api/v1/books/facets` endpoint, an ID select endpoint (`GET /api/v1/books/ids`), and it does not aim to achieve feature parity with these facets W.R.T existing F/E sorting/filtering options. Those will be addressed in the future via https://github.com/grimmory-tools/grimmory/issues/1849.

## AI Disclosure

All code was written by me over the past 3 weeks, specs were drafted by Codex

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded the books browse endpoint to use cursor-based pagination with a dedicated browse response format (items, pagination metadata, and `self/first/previous/next` links).
  * Added cursor-driven sorting, facet filtering, and free-text query search, preserving relevant parameters across navigation; legacy paging is wrapped into the same response shape.
* **Bug Fixes**
  * Added stricter validation and clearer `400 Bad Request` handling for invalid sort, cursor, and facet combinations, including paging edge cases.
* **Documentation**
  * Updated API behavior to reflect the new browse response and link/cursor metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->