### PR TITLE
fix(ui): adjust accessible font scaling

### DIFF
--- a/frontend/src/assets/styles/tailwind.css
+++ b/frontend/src/assets/styles/tailwind.css
@@ -52,6 +52,7 @@
   font-style: normal;
   font-weight: 200 800;
   font-display: swap;
+  size-adjust: 107%;
   src: url("../fonts/AtkinsonHyperlegibleNext-wght.woff2") format("woff2");
 }
 
@@ -60,6 +61,7 @@
   font-style: italic;
   font-weight: 200 800;
   font-display: swap;
+  size-adjust: 107%;
   src: url("../fonts/AtkinsonHyperlegibleNext-Italic-wght.woff2") format("woff2");
 }
 


### PR DESCRIPTION
## Description

The accessible font was a little smaller than the default, this tweaks the scaling to keep the sizes consistent when switching. 
## Linked Issue

N/A

## Changes

- Adjusts Atkinson Hyperlegible font to scale-up by 7%, visually matching the default font. 

## Manual Testing Steps

Switch to accessible font, confirm the visual size matches the default rather than scaling down. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the display sizing for the Atkinson Hyperlegible Next font to improve visual consistency across normal and italic text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->