### PR TITLE
ci: proper sha length for release candidate

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -57,7 +57,7 @@ jobs:
           current_version="$base_tag"
           if [ -n "$latest_nightly_sha" ] && [ -n "$latest_nightly_created_at" ]; then
             latest_nightly_date="$(date -u -d "$latest_nightly_created_at" +%Y%m%d)"
-            latest_nightly_short_sha="$(printf '%s' "$latest_nightly_sha" | cut -c1-7)"
+            latest_nightly_short_sha="$(printf '%s' "$latest_nightly_sha" | cut -c1-8)"
             current_version="nightly-${latest_nightly_date}-${latest_nightly_short_sha}"
           fi
 


### PR DESCRIPTION
the release candidate had an off-by-one for the nightly tag SHA length

## Description

<!-- Required. Briefly explain what changed and why. -->
extends the sha checksum length to match between the nightly image tag & the RC notification

## Linked Issue

<!-- Required. Example: Fixes #123 -->
N/A

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
Change cut from 7 -> 8

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

this is very difficult to test and cannot be easily tested with CI

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
N/A

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
N/A

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted how nightly build versions are displayed so the short commit reference now uses 8 characters instead of 7 when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->