### PR TITLE
refactor(books): add /api/v1/books/ids select-all endpoint

### DIFF
--- a/backend/src/main/java/org/booklore/controller/BookController.java
+++ b/backend/src/main/java/org/booklore/controller/BookController.java
@@ -118,6 +118,21 @@ public class BookController {
         return ResponseEntity.ok(bookFacetService.getFacets(facet, facetLogic, query));
     }
 
+    @Operation(summary = "Get matching book ids", description = "Returns every book id matching the given sort, facet, facet_logic, and query parameters, in sort order. For select-all over the current filters.")
+    @ApiResponse(responseCode = "200", description = "Matching book ids returned successfully")
+    @GetMapping("/ids")
+    public ResponseEntity<List<Long>> getBookIds(
+            @Parameter(description = "Comma-separated sort keys; prefix a key with '-' for descending")
+            @RequestParam(required = false) String sort,
+            @Parameter(description = "Facet selection in key:value form; repeatable")
+            @RequestParam(required = false) List<String> facet,
+            @Parameter(description = "How facet values combine within a group: and, or, or not")
+            @RequestParam(name = "facet_logic", required = false) String facetLogic,
+            @Parameter(description = "Free-text search")
+            @RequestParam(required = false) String query) {
+        return ResponseEntity.ok(bookBrowseService.findAllIds(sort, facet, facetLogic, query));
+    }
+
     @Operation(summary = "Get a book by ID", description = "Retrieve details of a specific book by its ID.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Book details returned successfully"),

--- a/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
@@ -1,5 +1,11 @@
 package org.booklore.service.browse;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.booklore.browse.BrowsePage;
 import org.booklore.browse.CursorCodec;
@@ -48,6 +54,9 @@ public class BookBrowseService {
     private final CursorCodec cursorCodec;
     private final LinksBuilder linksBuilder;
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
     public BrowsePage<Book> browse(String sort, List<String> facet, String facetLogicParam, String query, String cursor, Pageable pageable) {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
         Long userId = user.getId();
@@ -90,6 +99,29 @@ public class BookBrowseService {
                 PAGE_PATH, FACET_PATH, BrowseParams.preserved(facet, facetLogicParam, query), offset, limit, page.getTotalElements(), baseState));
 
         return BrowsePage.of(page.getContent(), offset, limit, page.getTotalElements(), currentCursor, links);
+    }
+
+    public List<Long> findAllIds(String sort, List<String> facet, String facetLogicParam, String query) {
+        BookLoreUser user = authenticationService.getAuthenticatedUser();
+        Long userId = user.getId();
+        boolean isAdmin = user.getPermissions().isAdmin();
+
+        Map<String, List<String>> facets = BookFilterSpecifications.parseFacets(facet);
+        FacetLogic facetLogic = FacetLogic.from(facetLogicParam);
+        List<SortTerm> sortTerms = SortParser.parse(sort, sortRegistry.registry().keys());
+        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, BookFilterSpecifications.libraryIds(user), null);
+
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<BookEntity> root = cq.from(BookEntity.class);
+        cq.select(root.get("id"));
+        Predicate predicate = filter.toPredicate(root, cq, cb);
+        if (predicate != null) {
+            cq.where(predicate);
+        }
+        cq.orderBy(sortRegistry.registry().toOrders(sortTerms, root, cq, cb, userId));
+
+        return entityManager.createQuery(cq).getResultList();
     }
 
     public BrowsePage<Book> wrapLegacy(Page<Book> page, Pageable pageable) {

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
@@ -228,6 +228,44 @@ class BookBrowseServiceTest {
     }
 
     @Test
+    void findAllIdsMatchesPageOrderingForSameFilters() {
+        for (int i = 0; i < 5; i++) {
+            book(String.format("Book%02d", i), List.of());
+        }
+        em.flush();
+
+        List<Long> pageIds = browse("title", null, null, null, 0, 20).content().stream().map(Book::getId).toList();
+        List<Long> allIds = browseService.findAllIds("title", null, null, null);
+
+        assertThat(allIds).isEqualTo(pageIds);
+    }
+
+    @Test
+    void findAllIdsAppliesFacets() {
+        Long horror = book("H", List.of("Horror")).getId();
+        book("R", List.of("Romance"));
+        em.flush();
+        assertThat(browseService.findAllIds(null, List.of("genre:Horror"), null, null)).containsExactly(horror);
+    }
+
+    @Test
+    void findAllIdsRespectsLibraryScoping() {
+        Long inLibrary = book("InLibrary", List.of()).getId();
+        LibraryEntity otherLibrary = LibraryEntity.builder().name("Other").icon("book").watch(false)
+                .formatPriority(List.of(BookFileType.EPUB)).build();
+        em.persist(otherLibrary);
+        LibraryPathEntity otherPath = LibraryPathEntity.builder().library(otherLibrary).path("/o").build();
+        em.persist(otherPath);
+        BookEntity outside = BookEntity.builder()
+                .library(otherLibrary).libraryPath(otherPath).addedOn(Instant.now()).deleted(false).build();
+        em.persist(outside);
+        em.persist(BookMetadataEntity.builder().book(outside).title("Outside").build());
+        em.flush();
+
+        assertThat(browseService.findAllIds(null, null, null, null)).containsExactly(inLibrary);
+    }
+
+    @Test
     void wrapLegacyAddsCursorAndLinksToExistingPage() {
         Book book = Book.builder().id(1L).build();
         org.springframework.data.domain.Page<Book> page =


### PR DESCRIPTION
## Description

This PR is the final of the 3 PRs to add our MVP of new book pagination. This PR just adds a simple `/api/v1/books/ids` endpoint, that operates w/ the same filtering/sorting logic as the books endpoint, but returns an unpaginated list of the IDs. The reason for this is so that if a user hits select all on the browser, we can actually have all of those books pre-selected on the F/E as they lazy load the rest of the page, and so we can use that full list of IDs to inform our existing bulk action endpoints.

## Linked Issue

Finished https://github.com/grimmory-tools/grimmory/issues/1848

## Changes

- Adds the new IDs endpoint- pretty much reuses everything we've already built, just adds a new return all IDs path in the book browse service 

## Manual Testing Steps

1. Test the endpoint and ensure result # and order parity w/ the paginated endpoint

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve all matching book IDs in sorted order.
  * Supports search queries, repeatable facets, facet logic, and sorting filters.
  * Results respect browsing permissions and library access.

* **Tests**
  * Added coverage for sorting, facet filtering, and library scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->