### PR TITLE
fix(db): add explicit collation for icon map migration

### DIFF
--- a/backend/src/main/resources/db/migration/V144__Migrate_entity_icons_to_lucide.sql
+++ b/backend/src/main/resources/db/migration/V144__Migrate_entity_icons_to_lucide.sql
@@ -3,6 +3,7 @@ CREATE TEMPORARY TABLE prime_to_lucide_icon_map (
   prime_icon VARCHAR(64) NOT NULL PRIMARY KEY,
   lucide_icon VARCHAR(64) NOT NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+-- Explicitly add character set / collation to handle improperly configured servers.
 
 INSERT INTO prime_to_lucide_icon_map (prime_icon, lucide_icon) VALUES
     ('address-book', 'contact'),

--- a/backend/src/main/resources/db/migration/V144__Migrate_entity_icons_to_lucide.sql
+++ b/backend/src/main/resources/db/migration/V144__Migrate_entity_icons_to_lucide.sql
@@ -2,7 +2,7 @@
 CREATE TEMPORARY TABLE prime_to_lucide_icon_map (
   prime_icon VARCHAR(64) NOT NULL PRIMARY KEY,
   lucide_icon VARCHAR(64) NOT NULL
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 INSERT INTO prime_to_lucide_icon_map (prime_icon, lucide_icon) VALUES
     ('address-book', 'contact'),
@@ -322,21 +322,21 @@ INSERT INTO prime_to_lucide_icon_map (prime_icon, lucide_icon) VALUES
 
 UPDATE library
 LEFT JOIN prime_to_lucide_icon_map
-  ON REPLACE(REPLACE(library.icon, 'pi pi-', ''), 'pi-', '') = prime_to_lucide_icon_map.prime_icon
+  ON REPLACE(REPLACE(library.icon, 'pi pi-', ''), 'pi-', '') = prime_to_lucide_icon_map.prime_icon COLLATE utf8mb4_general_ci
 SET library.icon = COALESCE(prime_to_lucide_icon_map.lucide_icon, IF(library.icon IS NULL, NULL, 'book')),
     library.icon_type = IF(library.icon IS NULL, NULL, 'LUCIDE')
 WHERE library.icon_type = 'PRIME_NG';
 
 UPDATE shelf
 LEFT JOIN prime_to_lucide_icon_map
-  ON REPLACE(REPLACE(shelf.icon, 'pi pi-', ''), 'pi-', '') = prime_to_lucide_icon_map.prime_icon
+  ON REPLACE(REPLACE(shelf.icon, 'pi pi-', ''), 'pi-', '') = prime_to_lucide_icon_map.prime_icon COLLATE utf8mb4_general_ci
 SET shelf.icon = COALESCE(prime_to_lucide_icon_map.lucide_icon, IF(shelf.icon IS NULL, NULL, 'book')),
     shelf.icon_type = IF(shelf.icon IS NULL, NULL, 'LUCIDE')
 WHERE shelf.icon_type = 'PRIME_NG';
 
 UPDATE magic_shelf
 LEFT JOIN prime_to_lucide_icon_map
-  ON REPLACE(REPLACE(magic_shelf.icon, 'pi pi-', ''), 'pi-', '') = prime_to_lucide_icon_map.prime_icon
+  ON REPLACE(REPLACE(magic_shelf.icon, 'pi pi-', ''), 'pi-', '') = prime_to_lucide_icon_map.prime_icon COLLATE utf8mb4_general_ci
 SET magic_shelf.icon = COALESCE(prime_to_lucide_icon_map.lucide_icon, IF(magic_shelf.icon IS NULL, NULL, 'book')),
     magic_shelf.icon_type = IF(magic_shelf.icon IS NULL, NULL, 'LUCIDE')
 WHERE magic_shelf.icon_type = 'PRIME_NG';


### PR DESCRIPTION
## Description

The icons migration can fail with older databases with tables generated under a different collation (unicode_ci). This fixes the issue with explicit general_ci collations for the icon mapping. 

This patches the existing v144 migration. There's no impact on existing / working users, and it should fix any issues for people who have updated and experienced issues, as well as anyone updating normally. 

## Linked Issue

Fixes #1943 

## Changes

Add explicit `general_ci` collation for the icon maps instead of inheriting the user's shelf/magic shelf table collation. 

## Manual Testing Steps

Migrate with a shelf/magic shelf table set to `unicode_ci`, confirm the migration works without issue. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon migration handling to ensure consistent icon updates across supported languages and character sets.
  * Reduced the likelihood of mismatched or missing icons during the migration process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->