### PR TITLE
refactor(author): sort authors using `sort_name` field

### DIFF
--- a/backend/src/main/java/org/booklore/app/dto/AppAuthorDetail.java
+++ b/backend/src/main/java/org/booklore/app/dto/AppAuthorDetail.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class AppAuthorDetail {
     private Long id;
     private String name;
+    private String sortName;
     private String description;
     private String asin;
     private int bookCount;

--- a/backend/src/main/java/org/booklore/app/dto/AppAuthorSummary.java
+++ b/backend/src/main/java/org/booklore/app/dto/AppAuthorSummary.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class AppAuthorSummary {
     private Long id;
     private String name;
+    private String sortName;
     private String asin;
     private int bookCount;
     private boolean hasPhoto;

--- a/backend/src/main/java/org/booklore/app/service/AppAuthorService.java
+++ b/backend/src/main/java/org/booklore/app/service/AppAuthorService.java
@@ -86,6 +86,7 @@ public class AppAuthorService {
                     return AppAuthorSummary.builder()
                             .id(author.getId())
                             .name(author.getName())
+                            .sortName(author.getSortName())
                             .asin(author.getAsin())
                             .bookCount((int) bookCount)
                             .hasPhoto(authorHasPhoto)
@@ -128,6 +129,7 @@ public class AppAuthorService {
         return AppAuthorDetail.builder()
                 .id(author.getId())
                 .name(author.getName())
+                .sortName(author.getSortName())
                 .description(author.getDescription())
                 .asin(author.getAsin())
                 .bookCount(bookCount)
@@ -186,11 +188,12 @@ public class AppAuthorService {
 
     private String buildOrderClause(String sortBy, String sortDir) {
         String direction = "asc".equalsIgnoreCase(sortDir) ? "ASC" : "DESC";
+        String sortNameField = "COALESCE(a.sortName, a.name)";
         String field = switch (sortBy != null ? sortBy.toLowerCase() : "") {
-            case "name" -> "a.name";
+            case "name", "sortname", "sort_name" -> sortNameField;
             case "bookcount", "book_count" -> "COUNT(DISTINCT bm.id)";
             case "recent", "id" -> "a.id";
-            default -> "a.name";
+            default -> sortNameField;
         };
         return " ORDER BY " + field + " " + direction;
     }

--- a/backend/src/main/java/org/booklore/mapper/BookMetadataMapper.java
+++ b/backend/src/main/java/org/booklore/mapper/BookMetadataMapper.java
@@ -16,6 +16,16 @@ public interface BookMetadataMapper {
         }
     }
 
+    @AfterMapping
+    default void mapAuthorSortNames(BookMetadataEntity bookMetadataEntity, @MappingTarget BookMetadata bookMetadata) {
+        if (bookMetadata.getAuthors() == null || bookMetadataEntity.getAuthors() == null) {
+            return;
+        }
+        bookMetadata.setAuthorSortNames(bookMetadataEntity.getAuthors().stream()
+                .map(author -> author.getSortName() != null ? author.getSortName() : author.getName())
+                .toList());
+    }
+
     @Named("withRelations")
     @Mapping(target = "description", ignore = true)
     BookMetadata toBookMetadata(BookMetadataEntity bookMetadataEntity, @Context boolean includeDescription);

--- a/backend/src/main/java/org/booklore/model/dto/AuthorDetails.java
+++ b/backend/src/main/java/org/booklore/model/dto/AuthorDetails.java
@@ -10,9 +10,11 @@ import lombok.Data;
 public class AuthorDetails {
     private Long id;
     private String name;
+    private String sortName;
     private String description;
     private String asin;
     private boolean nameLocked;
+    private boolean sortNameLocked;
     private boolean descriptionLocked;
     private boolean asinLocked;
     private boolean photoLocked;

--- a/backend/src/main/java/org/booklore/model/dto/AuthorSummary.java
+++ b/backend/src/main/java/org/booklore/model/dto/AuthorSummary.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class AuthorSummary {
     private Long id;
     private String name;
+    private String sortName;
     private String asin;
     private int bookCount;
     private boolean hasPhoto;

--- a/backend/src/main/java/org/booklore/model/dto/BookMetadata.java
+++ b/backend/src/main/java/org/booklore/model/dto/BookMetadata.java
@@ -61,6 +61,7 @@ public class BookMetadata {
     private Instant coverUpdatedOn;
     private Instant audiobookCoverUpdatedOn;
     private List<String> authors;
+    private List<String> authorSortNames;
     private Set<String> categories;
     private Set<String> moods;
     private Set<String> tags;

--- a/backend/src/main/java/org/booklore/model/dto/request/AuthorUpdateRequest.java
+++ b/backend/src/main/java/org/booklore/model/dto/request/AuthorUpdateRequest.java
@@ -5,9 +5,11 @@ import lombok.Data;
 @Data
 public class AuthorUpdateRequest {
     private String name;
+    private String sortName;
     private String description;
     private String asin;
     private Boolean nameLocked;
+    private Boolean sortNameLocked;
     private Boolean descriptionLocked;
     private Boolean asinLocked;
     private Boolean photoLocked;

--- a/backend/src/main/java/org/booklore/repository/AuthorRepository.java
+++ b/backend/src/main/java/org/booklore/repository/AuthorRepository.java
@@ -22,10 +22,10 @@ public interface AuthorRepository extends JpaRepository<AuthorEntity, Long> {
 
     Optional<AuthorEntity> findByAsin(String asin);
 
-    @Query("SELECT a, COUNT(bm) FROM AuthorEntity a LEFT JOIN a.bookMetadataEntityList bm GROUP BY a ORDER BY a.name")
+    @Query("SELECT a, COUNT(bm) FROM AuthorEntity a LEFT JOIN a.bookMetadataEntityList bm GROUP BY a ORDER BY COALESCE(a.sortName, a.name)")
     List<Object[]> findAllWithBookCount();
 
-    @Query("SELECT a, COUNT(DISTINCT bm) FROM AuthorEntity a LEFT JOIN a.bookMetadataEntityList bm JOIN bm.book b WHERE b.library.id IN :libraryIds GROUP BY a ORDER BY a.name")
+    @Query("SELECT a, COUNT(DISTINCT bm) FROM AuthorEntity a LEFT JOIN a.bookMetadataEntityList bm JOIN bm.book b WHERE b.library.id IN :libraryIds GROUP BY a ORDER BY COALESCE(a.sortName, a.name)")
     List<Object[]> findAllWithBookCountByLibraryIds(@Param("libraryIds") Set<Long> libraryIds);
 
     @Query("SELECT COUNT(b) > 0 FROM AuthorEntity a JOIN a.bookMetadataEntityList bm JOIN bm.book b WHERE a.id = :authorId AND b.library.id IN :libraryIds")

--- a/backend/src/test/java/org/booklore/mapper/BookMetadataMapperTest.java
+++ b/backend/src/test/java/org/booklore/mapper/BookMetadataMapperTest.java
@@ -1,6 +1,7 @@
 package org.booklore.mapper;
 
 import org.booklore.model.dto.BookMetadata;
+import org.booklore.model.entity.AuthorEntity;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,8 +9,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -61,6 +65,19 @@ public class BookMetadataMapperTest {
         assertEquals("hc-id", dto.getHardcoverId());
         assertEquals(4.5, dto.getHardcoverRating());
         assertEquals("gr-id", dto.getGoodreadsId());
+    }
+
+    @Test
+    void mapsAuthorSortNamesInAuthorOrder() {
+        AuthorEntity first = AuthorEntity.builder().name("Aaron Zylocke").sortName("Zylocke, Aaron").build();
+        AuthorEntity second = AuthorEntity.builder().name("Zachary Adams").sortName("Adams, Zachary").build();
+        BookMetadataEntity entity = new BookMetadataEntity();
+        entity.setAuthors(List.of(first, second));
+        when(authorMapper.toAuthorNamesList(anyList())).thenReturn(List.of("Aaron Zylocke", "Zachary Adams"));
+
+        BookMetadata dto = bookMetadataMapper.toBookMetadata(entity);
+
+        assertEquals(List.of("Zylocke, Aaron", "Adams, Zachary"), dto.getAuthorSortNames());
     }
 }
 

--- a/backend/src/test/java/org/booklore/mapper/BookMetadataMapperTest.java
+++ b/backend/src/test/java/org/booklore/mapper/BookMetadataMapperTest.java
@@ -79,5 +79,18 @@ public class BookMetadataMapperTest {
 
         assertEquals(List.of("Zylocke, Aaron", "Adams, Zachary"), dto.getAuthorSortNames());
     }
+
+    @Test
+    void mapsAuthorSortNamesFallsBackToNameWhenSortNameIsNull() {
+        AuthorEntity withSortName = AuthorEntity.builder().name("Aaron Zylocke").sortName("Zylocke, Aaron").build();
+        AuthorEntity withoutSortName = AuthorEntity.builder().name("Zachary Adams").build();
+        BookMetadataEntity entity = new BookMetadataEntity();
+        entity.setAuthors(List.of(withSortName, withoutSortName));
+        when(authorMapper.toAuthorNamesList(anyList())).thenReturn(List.of("Aaron Zylocke", "Zachary Adams"));
+
+        BookMetadata dto = bookMetadataMapper.toBookMetadata(entity);
+
+        assertEquals(List.of("Zylocke, Aaron", "Zachary Adams"), dto.getAuthorSortNames());
+    }
 }
 

--- a/frontend/src/app/features/author-browser/components/author-card/author-card.component.spec.ts
+++ b/frontend/src/app/features/author-browser/components/author-card/author-card.component.spec.ts
@@ -235,8 +235,10 @@ describe('AuthorCardComponent', () => {
     quickMatch$.next({
       id: 9,
       name: 'Ada Lovelace',
+      sortName: 'Lovelace, Ada',
       asin: 'B00MATCH',
       nameLocked: false,
+      sortNameLocked: false,
       descriptionLocked: false,
       asinLocked: true,
       photoLocked: false,

--- a/frontend/src/app/features/author-browser/components/author-detail/author-detail.component.spec.ts
+++ b/frontend/src/app/features/author-browser/components/author-detail/author-detail.component.spec.ts
@@ -34,9 +34,11 @@ describe('AuthorDetailComponent', () => {
   const baseAuthor: AuthorDetails = {
     id: 9,
     name: 'Ada Lovelace',
+    sortName: 'Lovelace, Ada',
     description: 'Analytical engine pioneer',
     asin: 'B00ADA',
     nameLocked: false,
+    sortNameLocked: false,
     descriptionLocked: false,
     asinLocked: false,
     photoLocked: false,

--- a/frontend/src/app/features/author-browser/components/author-editor/author-editor.component.spec.ts
+++ b/frontend/src/app/features/author-browser/components/author-editor/author-editor.component.spec.ts
@@ -24,6 +24,7 @@ describe('AuthorEditorComponent', () => {
     description: 'Analytical engine pioneer',
     asin: 'B00ADA',
     nameLocked: false,
+    sortNameLocked: false,
     descriptionLocked: false,
     asinLocked: false,
     photoLocked: false,

--- a/frontend/src/app/features/author-browser/components/author-match/author-match.component.spec.ts
+++ b/frontend/src/app/features/author-browser/components/author-match/author-match.component.spec.ts
@@ -140,8 +140,10 @@ describe('AuthorMatchComponent', () => {
     const updatedAuthor: AuthorDetails = {
       id: 9,
       name: 'Ada Lovelace',
+      sortName: 'Lovelace, Ada',
       asin: 'B00MATCH',
       nameLocked: false,
+      sortNameLocked: false,
       descriptionLocked: false,
       asinLocked: true,
       photoLocked: false,

--- a/frontend/src/app/features/author-browser/model/author.model.spec.ts
+++ b/frontend/src/app/features/author-browser/model/author.model.spec.ts
@@ -59,6 +59,7 @@ describe('author.model', () => {
       id: 4,
       name: 'Author',
       nameLocked: false,
+      sortNameLocked: false,
       descriptionLocked: true,
       asinLocked: false,
       photoLocked: false

--- a/frontend/src/app/features/author-browser/model/author.model.ts
+++ b/frontend/src/app/features/author-browser/model/author.model.ts
@@ -1,6 +1,7 @@
 export interface AuthorSummary {
   id: number;
   name: string;
+  sortName?: string;
   asin?: string;
   bookCount: number;
   hasPhoto: boolean;
@@ -40,9 +41,11 @@ export const DEFAULT_AUTHOR_FILTERS: AuthorFilters = {
 export interface AuthorDetails {
   id: number;
   name: string;
+  sortName?: string;
   description?: string;
   asin?: string;
   nameLocked: boolean;
+  sortNameLocked: boolean;
   descriptionLocked: boolean;
   asinLocked: boolean;
   photoLocked: boolean;
@@ -71,9 +74,11 @@ export interface AuthorPhotoResult {
 
 export interface AuthorUpdateRequest {
   name?: string;
+  sortName?: string;
   description?: string;
   asin?: string;
   nameLocked?: boolean;
+  sortNameLocked?: boolean;
   descriptionLocked?: boolean;
   asinLocked?: boolean;
   photoLocked?: boolean;

--- a/frontend/src/app/features/book/model/book.model.ts
+++ b/frontend/src/app/features/book/model/book.model.ts
@@ -199,6 +199,7 @@ export interface BookMetadata {
   coverUpdatedOn?: string;
   audiobookCoverUpdatedOn?: string;
   authors?: string[];
+  authorSortNames?: string[];
   categories?: string[];
   moods?: string[];
   tags?: string[];

--- a/frontend/src/app/features/book/service/sort.service.spec.ts
+++ b/frontend/src/app/features/book/service/sort.service.spec.ts
@@ -55,9 +55,9 @@ describe('SortService', () => {
 
   it('sorts by array fields and read status rank', () => {
     const books = [
-      makeBook(1, {metadata: {bookId: 1, authors: ['Jane Zed']}, readStatus: ReadStatus.READ}),
-      makeBook(2, {metadata: {bookId: 2, authors: ['Adam Alpha']}, readStatus: ReadStatus.READING}),
-      makeBook(3, {metadata: {bookId: 3, authors: ['Jane Zed']}, readStatus: ReadStatus.UNREAD}),
+      makeBook(1, {metadata: {bookId: 1, authors: ['Jane Zed'], authorSortNames: ['Zed, Jane']}, readStatus: ReadStatus.READ}),
+      makeBook(2, {metadata: {bookId: 2, authors: ['Adam Alpha'], authorSortNames: ['Alpha, Adam']}, readStatus: ReadStatus.READING}),
+      makeBook(3, {metadata: {bookId: 3, authors: ['Jane Zed'], authorSortNames: ['Zed, Jane']}, readStatus: ReadStatus.UNREAD}),
     ];
 
     expect(service.applyMultiSort(books, [
@@ -67,6 +67,17 @@ describe('SortService', () => {
     expect(service.applyMultiSort(books, [
       {label: 'Status', field: 'readStatus', direction: SortDirection.DESCENDING},
     ]).map(book => book.id)).toEqual([1, 2, 3]);
+  });
+
+  it('falls back to raw author names when sort names are absent', () => {
+    const books = [
+      makeBook(1, {metadata: {bookId: 1, authors: ['Jane Zed']}}),
+      makeBook(2, {metadata: {bookId: 2, authors: ['Adam Alpha']}}),
+    ];
+
+    expect(service.applyMultiSort(books, [
+      {label: 'Authors', field: 'authorSurnameVorname', direction: SortDirection.ASCENDING},
+    ]).map(book => book.id)).toEqual([2, 1]);
   });
 
   it('keeps null values sorted after non-null values and warns on unknown fields', () => {

--- a/frontend/src/app/features/book/service/sort.service.ts
+++ b/frontend/src/app/features/book/service/sort.service.ts
@@ -63,13 +63,8 @@ export class SortService {
   private readonly fieldExtractors: Record<string, (book: Book) => unknown> = {
     title: (book) => book.metadata?.title?.toLowerCase() || null,
     author: (book) => book.metadata?.authors?.map(a => a.toLowerCase()).join(", ") || null,
-    authorSurnameVorname: (book) => book.metadata?.authors?.map(a => {
-      const parts = a.trim().split(/\s+/);
-      if (parts.length < 2) return a.toLowerCase();
-      const surname = parts.pop();
-      const firstname = parts.join(" ");
-      return `${surname}, ${firstname}`.toLowerCase();
-    }).join(", ") || null,
+    authorSurnameVorname: (book) =>
+      (book.metadata?.authorSortNames ?? book.metadata?.authors)?.map(a => a.toLowerCase()).join(", ") || null,
     publishedDate: (book) => {
       const date = book.metadata?.publishedDate;
       return date === null || date === undefined ? null : new Date(date).getTime();


### PR DESCRIPTION
## Description

This PR is the second part of the https://github.com/grimmory-tools/grimmory/issues/1892 epic. It begins using the `sort_name` within the frontend-heavy sorting and filtering logic.

## Linked Issue

Completes https://github.com/grimmory-tools/grimmory/issues/1894

## Changes

- Serializes the `sort_name` field on author responses
- Uses the sort field instead of the name field on backend order sorts
- Serializes `authorSortNames` on book metadata as another string array (same order as author array, just using the sort values instead of proper names)
  - In an ideal world, instead of an array of strings to represent authors, it would be an array of objects that have a name field, and then can also have their sort fields. We aren't going to break/significantly modify the API response right now, so we defer to just including another array of sorted authors. When we have fully implemented pagination on all relevant models and customizable/overrideable sort names on relevant models, we can reevaluate our more core response structures for a future API v3.
- Kill the manual author surname vorname logic on the F/E, to just use the author sorted names array

## Manual Testing Steps

1. Modify a sort name on the B/E
2. Verify that when sorting by author surname the modified sort is properly displayed

## Screenshots (Optional)

N/A

## Additional Context (Optional)

Still non-user facing

## AI Disclosure

N/A

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sortName` (and `sortNameLocked`) support for author details, summaries, and update requests.
  * Books now carry `authorSortNames` so author sorting can use the preferred values.
* **Bug Fixes**
  * Author lists now sort by the preferred sort name when available (falling back to the regular name).
  * Sorting behavior recognizes additional “sort name” options.
  * Book author sorting now prefers `authorSortNames`, with fallback to existing author data.
* **Tests**
  * Updated and expanded unit tests for author and book sorting and new DTO fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->