### PR TITLE
feat(shared): add LanguageResolverService for normalizing + localizing language codes

### DIFF
--- a/frontend/src/app/shared/service/language-resolver.service.spec.ts
+++ b/frontend/src/app/shared/service/language-resolver.service.spec.ts
@@ -1,0 +1,136 @@
+import {TestBed} from '@angular/core/testing';
+import {BehaviorSubject} from 'rxjs';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {TranslocoService} from '@jsverse/transloco';
+import {LanguageResolverService} from './language-resolver.service';
+
+describe('LanguageResolverService', () => {
+  const langChanges$ = new BehaviorSubject<string>('en');
+
+  beforeEach(() => {
+    langChanges$.next('en');
+
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: TranslocoService, useValue: {langChanges$, getActiveLang: () => langChanges$.getValue()}},
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function createService(): LanguageResolverService {
+    return TestBed.inject(LanguageResolverService);
+  }
+
+  it('returns null for missing or blank values', () => {
+    const service = createService();
+
+    expect(service.resolve(null)).toBeNull();
+    expect(service.resolve(undefined)).toBeNull();
+    expect(service.resolve('')).toBeNull();
+    expect(service.resolve('   ')).toBeNull();
+  });
+
+  it('resolves a plain base language', () => {
+    const service = createService();
+
+    expect(service.resolve('en')).toEqual({
+      raw: 'en',
+      tag: 'en',
+      base: 'en',
+      languageName: 'English',
+      regionName: null,
+      displayName: 'English',
+      recognized: true,
+    });
+  });
+
+  it('canonicalizes casing and underscore separators and splits out the region name', () => {
+    const service = createService();
+
+    expect(service.resolve(' EN_ca ')).toEqual({
+      raw: 'EN_ca',
+      tag: 'en-CA',
+      base: 'en',
+      languageName: 'English',
+      regionName: 'Canada',
+      displayName: 'English (Canada)',
+      recognized: true,
+    });
+  });
+
+  it('folds ISO 639-2 codes and English language names into the base code', () => {
+    const service = createService();
+
+    expect(service.resolve('eng')?.tag).toBe('en');
+    expect(service.resolve(' English ')?.tag).toBe('en');
+    expect(service.resolve('spa')?.languageName).toBe('Spanish');
+    expect(service.resolve('eng-CA')).toMatchObject({
+      tag: 'en-CA',
+      base: 'en',
+      regionName: 'Canada',
+    });
+  });
+
+  it('resolves script subtags into the secondary name', () => {
+    const service = createService();
+
+    expect(service.resolve('zh-hant')).toMatchObject({
+      tag: 'zh-Hant',
+      base: 'zh',
+      languageName: 'Chinese',
+      regionName: 'Traditional',
+    });
+  });
+
+  it('falls back to the capitalized raw value for unrecognized languages', () => {
+    const service = createService();
+
+    expect(service.resolve('klingon')).toEqual({
+      raw: 'klingon',
+      tag: 'klingon',
+      base: 'klingon',
+      languageName: 'Klingon',
+      regionName: null,
+      displayName: 'Klingon',
+      recognized: false,
+    });
+  });
+
+  it('keeps structurally invalid values as their own group without throwing', () => {
+    const service = createService();
+
+    expect(service.resolve('not a language!')).toMatchObject({
+      tag: 'not a language!',
+      base: 'not a language!',
+      languageName: 'Not a language!',
+      recognized: false,
+    });
+  });
+
+  it('localizes names to the active UI locale, capitalized, and reacts to locale changes', () => {
+    const service = createService();
+
+    expect(service.resolve('en-CA')?.languageName).toBe('English');
+
+    langChanges$.next('fr');
+
+    expect(service.resolve('en-CA')).toMatchObject({
+      languageName: 'Anglais',
+      regionName: 'Canada',
+      displayName: 'Anglais (Canada)',
+    });
+  });
+
+  it('falls back to English display names when the active locale is invalid', () => {
+    const service = createService();
+
+    langChanges$.next('not-a-real-locale-!!');
+
+    expect(service.resolve('en-CA')?.languageName).toBe('English');
+  });
+});

--- a/frontend/src/app/shared/service/language-resolver.service.ts
+++ b/frontend/src/app/shared/service/language-resolver.service.ts
@@ -1,0 +1,157 @@
+import {Injectable, inject} from '@angular/core';
+import {toSignal} from '@angular/core/rxjs-interop';
+import {TranslocoService} from '@jsverse/transloco';
+
+export interface ResolvedLanguage {
+  raw: string;
+  tag: string;
+  base: string;
+  languageName: string;
+  regionName: string | null;
+  displayName: string;
+  recognized: boolean;
+}
+
+const LANGUAGE_ALIASES: Record<string, string> = {
+  eng: 'en', english: 'en',
+  spa: 'es', spanish: 'es',
+  fra: 'fr', fre: 'fr', french: 'fr',
+  deu: 'de', ger: 'de', german: 'de',
+  ita: 'it', italian: 'it',
+  por: 'pt', portuguese: 'pt',
+  rus: 'ru', russian: 'ru',
+  zho: 'zh', chi: 'zh', chinese: 'zh',
+  jpn: 'ja', japanese: 'ja',
+  kor: 'ko', korean: 'ko',
+  pol: 'pl', polish: 'pl',
+  nld: 'nl', dut: 'nl', dutch: 'nl',
+  swe: 'sv', swedish: 'sv',
+  ara: 'ar', arabic: 'ar',
+  hin: 'hi', hindi: 'hi',
+  tur: 'tr', turkish: 'tr',
+  ces: 'cs', cze: 'cs', czech: 'cs',
+  dan: 'da', danish: 'da',
+  fin: 'fi', finnish: 'fi',
+  nor: 'no', norwegian: 'no',
+  ukr: 'uk', ukrainian: 'uk',
+  heb: 'he', hebrew: 'he',
+  ell: 'el', gre: 'el', greek: 'el',
+  hun: 'hu', hungarian: 'hu',
+  ron: 'ro', rum: 'ro', romanian: 'ro',
+  tha: 'th', thai: 'th',
+  vie: 'vi', vietnamese: 'vi',
+  ind: 'id', indonesian: 'id',
+  msa: 'ms', may: 'ms', malay: 'ms'
+};
+
+type DisplayNamesType = 'language' | 'region' | 'script';
+
+@Injectable({providedIn: 'root'})
+export class LanguageResolverService {
+  private readonly translocoService = inject(TranslocoService);
+  private readonly displayNamesCache = new Map<string, Intl.DisplayNames | null>();
+
+  public readonly activeLocale = toSignal(this.translocoService.langChanges$, {
+    initialValue: this.translocoService.getActiveLang()
+  });
+
+  resolve(raw: string | null | undefined): ResolvedLanguage | null {
+    const trimmed = raw?.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const {base, tag} = this.canonicalize(trimmed.toLowerCase());
+    const locale = this.activeLocale() || 'en';
+
+    const resolvedName = this.lookup(locale, 'language', base);
+    const recognized = resolvedName !== null;
+    const languageName = this.capitalize(resolvedName ?? base, locale);
+    const secondaryName = this.secondaryName(locale, tag, base);
+    const regionName = secondaryName ? this.capitalize(secondaryName, locale) : null;
+    const resolvedDisplayName = (recognized ? this.lookup(locale, 'language', tag) : null)
+      ?? (regionName ? `${languageName} (${regionName})` : languageName);
+
+    return {
+      raw: trimmed,
+      tag,
+      base,
+      languageName,
+      regionName,
+      displayName: this.capitalize(resolvedDisplayName, locale),
+      recognized
+    };
+  }
+
+  private canonicalize(lower: string): {base: string; tag: string} {
+    const aliased = LANGUAGE_ALIASES[lower];
+    if (aliased) {
+      return {base: aliased, tag: aliased};
+    }
+
+    try {
+      const canonical = Intl.getCanonicalLocales(lower.replace(/_/g, '-'))[0];
+      if (!canonical) {
+        return {base: lower, tag: lower};
+      }
+      const subtags = canonical.split('-');
+      const base = LANGUAGE_ALIASES[subtags[0].toLowerCase()] ?? subtags[0].toLowerCase();
+      return {base, tag: [base, ...subtags.slice(1)].join('-')};
+    } catch {
+      return {base: lower, tag: lower};
+    }
+  }
+
+  private secondaryName(locale: string, tag: string, base: string): string | null {
+    if (tag === base) {
+      return null;
+    }
+    try {
+      const parsed = new Intl.Locale(tag);
+      if (parsed.region) {
+        return this.lookup(locale, 'region', parsed.region) ?? parsed.region;
+      }
+      if (parsed.script) {
+        return this.lookup(locale, 'script', parsed.script) ?? parsed.script;
+      }
+    } catch {
+      return tag.slice(base.length + 1);
+    }
+    return tag.slice(base.length + 1);
+  }
+
+  private lookup(locale: string, type: DisplayNamesType, code: string): string | null {
+    const displayNames = this.displayNames(locale, type) ?? this.displayNames('en', type);
+    if (!displayNames) {
+      return null;
+    }
+    try {
+      const name = displayNames.of(code);
+      return name && name.toLowerCase() !== code.toLowerCase() ? name : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private displayNames(locale: string, type: DisplayNamesType): Intl.DisplayNames | null {
+    const key = `${locale}:${type}`;
+    let instance = this.displayNamesCache.get(key);
+    if (instance === undefined) {
+      try {
+        instance = new Intl.DisplayNames([locale], {type, languageDisplay: 'standard'});
+      } catch {
+        instance = null;
+      }
+      this.displayNamesCache.set(key, instance);
+    }
+    return instance;
+  }
+
+  private capitalize(value: string, locale: string): string {
+    try {
+      return value.charAt(0).toLocaleUpperCase(locale) + value.slice(1);
+    } catch {
+      return value.charAt(0).toUpperCase() + value.slice(1);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a shared `LanguageResolverService`, which is the first step towards refactoring the platform to more pragmatically handle displaying/viewing/filtering by languages.

## Linked Issue

Resolves https://github.com/grimmory-tools/grimmory/issues/2004

## Changes

- Introduces an unused`LanguageResolverService` that outputs languages in a struct

Sample `ResolveLanguage` structs:

Canadian English w/ French locale active:
```
{
  raw: 'en-CA',
  tag: 'en-CA',
  base: 'en',
  languageName: 'Anglais',
  regionName: 'Canada',
  displayName: 'Anglais (Canada)',
  recognized: true
}
```

Klingon (unknown value):
```
{
  raw: 'klingon',
  tag: 'klingon',
  base: 'klingon',
  languageName: 'Klingon',
  regionName: null,
  displayName: 'Klingon',
  recognized: false
}
```

Canadian English w/ English locale active:
```
{
  raw: 'EN_ca',
  tag: 'en-CA',
  base: 'en',
  languageName: 'English',
  regionName: 'Canada',
  displayName: 'English (Canada)',
  recognized: true
}
```

## Manual Testing Steps

1. Spec coverage
2.
3.

## Screenshots (Optional)

N/A

## Additional Context (Optional)

This is the first PR to implement this shared service. The following PRs will then refactor existing language spots to use the service

## AI Disclosure

Spec coverage

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language and locale resolution with normalized codes, regions, scripts, and language names.
  * Added localized display names that update when the application language changes.
  * Added graceful fallbacks for missing, invalid, or unrecognized language values.

* **Tests**
  * Added comprehensive coverage for normalization, localization, fallback behavior, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->