### PR TITLE
chore: use `SERVER_PORT` env var for listening port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,12 +123,12 @@ LABEL org.opencontainers.image.title="Grimmory" \
 ENV APP_VERSION=${APP_VERSION} \
     APP_REVISION=${APP_REVISION}
 
-ARG BOOKLORE_PORT=6060
-ENV BOOKLORE_PORT=${BOOKLORE_PORT}
-EXPOSE ${BOOKLORE_PORT}
+ARG SERVER_PORT=6060
+ENV SERVER_PORT=${SERVER_PORT}
+EXPOSE ${SERVER_PORT}
 
 HEALTHCHECK --interval=60s --timeout=10s --start-period=60s --retries=5 \
-  CMD wget -q --spider http://localhost:${BOOKLORE_PORT}/api/v1/healthcheck
+  CMD wget -q --spider http://localhost:${SERVER_PORT}/api/v1/healthcheck
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["java", "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,12 +123,10 @@ LABEL org.opencontainers.image.title="Grimmory" \
 ENV APP_VERSION=${APP_VERSION} \
     APP_REVISION=${APP_REVISION}
 
-ARG SERVER_PORT=6060
-ENV SERVER_PORT=${SERVER_PORT}
-EXPOSE ${SERVER_PORT}
+EXPOSE 6060
 
 HEALTHCHECK --interval=60s --timeout=10s --start-period=60s --retries=5 \
-  CMD wget -q --spider http://localhost:${SERVER_PORT}/api/v1/healthcheck
+  CMD wget -q --spider http://localhost:${SERVER_PORT:-${BOOKLORE_PORT:-6060}}/api/v1/healthcheck
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["java", "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-jar", "/app/app.jar"]

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ app:
 
 server:
   forward-headers-strategy: native
-  port: ${BOOKLORE_PORT:6060}
+  port: ${SERVER_PORT:${BOOKLORE_PORT:6060}}
   compression:
     enabled: true
     mime-types: text/html,text/css,application/javascript,application/json,image/svg+xml,application/xml,application/atom+xml

--- a/deploy/podman/quadlet/grimmory.container
+++ b/deploy/podman/quadlet/grimmory.container
@@ -20,7 +20,7 @@ Environment=TZ=Etc/UTC
 Secret=grimmory_db_pass,type=env,target=DATABASE_PASSWORD
 Environment=DATABASE_URL=jdbc:mariadb://localhost:3306/grimmory
 Environment=DATABASE_USERNAME=grimmory
-HealthCmd=CMD-SHELL wget -q --spider http://localhost:${BOOKLORE_PORT:-6060}/api/v1/healthcheck
+HealthCmd=CMD-SHELL wget -q --spider http://localhost:${SERVER_PORT:-6060}/api/v1/healthcheck
 HealthInterval=1m
 HealthRetries=5
 HealthStartPeriod=1m


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the name of the environment variable for defining what port to listen on has been changed to `SERVER_PORT` as `BOOKLORE_PORT` is no longer appropriate.  however, `BOOKLORE_PORT` has been left in as a fallback for backwards compatibility

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2017 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->


## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. set `SERVER_PORT` env var to `1234` and confirmed that the server was reachable on that port rather than `6060`
2. set `BOOKLORE_PORT` env var to `1234` and confirmed the same

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated container and runtime port handling to prioritize the `SERVER_PORT` environment variable, with fallbacks to the prior port and finally `6060`.
  * Exposed port `6060` directly in the container image.
  * Adjusted health check probes (including deployment settings) to target the effective server port for more reliable availability monitoring.
  * Maintained compatibility by keeping the previous port behavior as a fallback when `SERVER_PORT` isn’t set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->