### PR TITLE
chore: use `grimmory.local` for fake email domains

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/service/AuthenticationService.java
+++ b/backend/src/main/java/org/booklore/config/security/service/AuthenticationService.java
@@ -108,7 +108,7 @@ public class AuthenticationService {
                 .id(-1L)
                 .username("system")
                 .name("System User")
-                .email("system@booklore.internal")
+                .email("system@grimmory.internal")
                 .provisioningMethod(ProvisioningMethod.LOCAL)
                 .isDefaultPassword(false)
                 .permissions(permissions)

--- a/backend/src/main/java/org/booklore/mapper/komga/KomgaMapper.java
+++ b/backend/src/main/java/org/booklore/mapper/komga/KomgaMapper.java
@@ -353,7 +353,7 @@ public class KomgaMapper {
     public KomgaUserDto toKomgaUserDto(OpdsUserV2Entity opdsUser) {
         return KomgaUserDto.builder()
                 .id(opdsUser.getId().toString())
-                .email(opdsUser.getUsername() + "@booklore.local")
+                .email(opdsUser.getUsername() + "@grimmory.local")
                 .roles(List.of("USER"))
                 .sharedAllLibraries(true)
                 .build();


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
use `grimmory.local` instead of `booklore.local` for initial admin email addresses / komga fake user email addresses

the initial admin email address will only affect new users

the komga fake email address should affect nobody because the komga API doesn't really work

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2016 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. initial database setup
2. check admin user in database has `grimmory.local` domain
3. confirm user can change

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated system-generated email addresses to use the correct application domains.
  * Ensured user information exported through integrations reflects the updated email domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->