### PR TITLE
chore: use `grimmory` in sidecar generatedby

### DIFF
--- a/backend/src/main/java/org/booklore/model/dto/sidecar/SidecarMetadata.java
+++ b/backend/src/main/java/org/booklore/model/dto/sidecar/SidecarMetadata.java
@@ -18,7 +18,7 @@ public class SidecarMetadata {
     private String version = "1.0";
     private Instant generatedAt;
     @Builder.Default
-    private String generatedBy = "booklore";
+    private String generatedBy = "grimmory";
     private SidecarBookMetadata metadata;
     private SidecarCoverInfo cover;
 }

--- a/backend/src/main/java/org/booklore/service/metadata/sidecar/SidecarMetadataMapper.java
+++ b/backend/src/main/java/org/booklore/service/metadata/sidecar/SidecarMetadataMapper.java
@@ -58,7 +58,7 @@ public class SidecarMetadataMapper {
         return SidecarMetadata.builder()
                 .version("1.0")
                 .generatedAt(Instant.now())
-                .generatedBy("booklore")
+                .generatedBy("grimmory")
                 .metadata(bookMetadata)
                 .cover(coverInfo)
                 .build();


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
updates the sidecar `generatedBy` value to be `grimmory` so folks know where the sidecar came from

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #282

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* updates default sidecar generated by value to be `grimmory`
* updates the sidecar generated by value specified in the generator to be `grimmory`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Turned in sidecar generation
2. Made metadata changes to a file with existing sidecar data and observed the updated value
3. Made metadata changes to a file without sidecar data and observed the updated value

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated-by metadata in sidecar files to consistently identify Grimmory instead of Booklore.
  * Ensured this value is applied both by default and during metadata generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->