### PR TITLE
feat: emit actual koreader device / device ID

### DIFF
--- a/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
+++ b/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
@@ -58,13 +58,21 @@ public class KoreaderService {
                 ? progress.getKoreaderLastSyncTime().getEpochSecond()
                 : null;
 
+        String device = progress.getKoreaderDevice() != null ?
+                progress.getKoreaderDevice() :
+                DEFAULT_DEVICE_NAME;
+
+        String deviceId = progress.getKoreaderDeviceId() != null ?
+                progress.getKoreaderDeviceId() :
+                DEFAULT_DEVICE_ID;
+
         return KoreaderProgress.builder()
                 .timestamp(timestamp)
                 .document(bookHash)
                 .progress(progress.getKoreaderProgress())
                 .percentage(progress.getKoreaderProgressPercent())
-                .device(DEFAULT_DEVICE_NAME)
-                .device_id(DEFAULT_DEVICE_ID)
+                .device(device)
+                .device_id(deviceId)
                 .build();
     }
 

--- a/backend/src/test/java/org/booklore/service/KoreaderServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoreaderServiceTest.java
@@ -131,6 +131,42 @@ class KoreaderServiceTest {
     }
 
     @Test
+    void getProgress_includesDefaultDeviceId() {
+        when(details.isSyncEnabled()).thenReturn(true);
+        var book = new BookEntity();
+        book.setId(99L);
+        when(bookRepo.findByCurrentHash("h")).thenReturn(Optional.of(book));
+        var prog = new UserBookProgressEntity();
+        prog.setKoreaderProgress("p");
+        prog.setKoreaderProgressPercent(0.5F);
+        when(progressRepo.findByUserIdAndBookId(42L, 99L))
+                .thenReturn(Optional.of(prog));
+
+        KoreaderProgress out = service.getProgress("h");
+        assertEquals("Grimmory", out.getDevice());
+        assertEquals("Grimmory", out.getDevice_id());
+    }
+
+    @Test
+    void getProgress_includesSpecifiedDeviceId() {
+        when(details.isSyncEnabled()).thenReturn(true);
+        var book = new BookEntity();
+        book.setId(99L);
+        when(bookRepo.findByCurrentHash("h")).thenReturn(Optional.of(book));
+        var prog = new UserBookProgressEntity();
+        prog.setKoreaderProgress("p");
+        prog.setKoreaderProgressPercent(0.5F);
+        prog.setKoreaderDevice("Example Device");
+        prog.setKoreaderDeviceId("Example Device ID");
+        when(progressRepo.findByUserIdAndBookId(42L, 99L))
+                .thenReturn(Optional.of(prog));
+
+        KoreaderProgress out = service.getProgress("h");
+        assertEquals("Example Device", out.getDevice());
+        assertEquals("Example Device ID", out.getDevice_id());
+    }
+
+    @Test
     void getProgress_bookNotFound() {
         when(details.isSyncEnabled()).thenReturn(true);
         when(bookRepo.findByCurrentHash("h")).thenReturn(Optional.empty());

--- a/backend/src/test/java/org/booklore/service/KoreaderServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoreaderServiceTest.java
@@ -167,6 +167,34 @@ class KoreaderServiceTest {
     }
 
     @Test
+    void getProgress_includesOnlyPartialDeviceInfo() {
+        when(details.isSyncEnabled()).thenReturn(true);
+        var book = new BookEntity();
+        book.setId(99L);
+        when(bookRepo.findByCurrentHash("h")).thenReturn(Optional.of(book));
+        var prog = new UserBookProgressEntity();
+        prog.setKoreaderProgress("p");
+        prog.setKoreaderProgressPercent(0.5F);
+        prog.setKoreaderDevice("Example Device");
+        prog.setKoreaderDeviceId(null);
+        when(progressRepo.findByUserIdAndBookId(42L, 99L))
+                .thenReturn(Optional.of(prog));
+
+        KoreaderProgress out_a = service.getProgress("h");
+        assertEquals("Example Device", out_a.getDevice());
+        assertEquals("Grimmory", out_a.getDevice_id());
+
+        prog.setKoreaderDevice(null);
+        prog.setKoreaderDeviceId("Example Device ID");
+        when(progressRepo.findByUserIdAndBookId(42L, 99L))
+                .thenReturn(Optional.of(prog));
+
+        KoreaderProgress out_b = service.getProgress("h");
+        assertEquals("Grimmory", out_b.getDevice());
+        assertEquals("Example Device ID", out_b.getDevice_id());
+    }
+
+    @Test
     void getProgress_bookNotFound() {
         when(details.isSyncEnabled()).thenReturn(true);
         when(bookRepo.findByCurrentHash("h")).thenReturn(Optional.empty());


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
properly emits the expected koreader device / device ID - with default fallbacks to `Grimmory`.  this will allow koreader users to be less confused when trying to accept progress from remote

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2013

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. run koreader progress sync
2. observe name is no longer `Grimmory` and is instead the name of the ereader that last pushed progress

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Koreader progress responses now preserve the saved device name and device ID.
  * Missing device details continue to use the default values, including when only one field is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->