### PR TITLE
chore: use grimmory for koreader device / device ID

### DIFF
--- a/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
+++ b/backend/src/main/java/org/booklore/service/koreader/KoreaderService.java
@@ -25,6 +25,8 @@ import java.util.Map;
 @AllArgsConstructor
 @Service
 public class KoreaderService {
+    private static final String DEFAULT_DEVICE_NAME = "Grimmory";
+    private static final String DEFAULT_DEVICE_ID = "Grimmory";
 
     private final UserBookProgressRepository progressRepository;
     private final UserBookFileProgressRepository fileProgressRepository;
@@ -61,8 +63,8 @@ public class KoreaderService {
                 .document(bookHash)
                 .progress(progress.getKoreaderProgress())
                 .percentage(progress.getKoreaderProgressPercent())
-                .device("BookLore")
-                .device_id("BookLore")
+                .device(DEFAULT_DEVICE_NAME)
+                .device_id(DEFAULT_DEVICE_ID)
                 .build();
     }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
updates the koreader progress sync to emit `Grimmory` instead of `Booklore`

While #2025 emits the actual device / device ID, this just gets us to the correct branding.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2013

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
updates koreader device / device ID to be `Grimmory`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
read progress with koreader & observe Grimmory as device value

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
N/A

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
N/A

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized device identification in KOReader progress responses.
  * Progress updates now consistently use the default KOReader device details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->