### PR TITLE
fix(docker): disable heap dumps by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,6 @@ ENV JAVA_TOOL_OPTIONS="-XX:+UseShenandoahGC \
     -XX:MaxRAMPercentage=60.0 \
     -XX:InitialRAMPercentage=8.0 \
     -XX:+ExitOnOutOfMemoryError \
-    -XX:+HeapDumpOnOutOfMemoryError \
-    -XX:HeapDumpPath=/tmp/heapdump.hprof \
     -XX:MaxMetaspaceSize=256m \
     -XX:ReservedCodeCacheSize=48m \
     -Xss512k \

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ services:
       - JDK_JAVA_OPTIONS=-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/data
 ```
 
-The JVM writes the dump to the mounted `/app/data` volume. Remove the option after collecting the diagnostic data because heap dumps can be large and contain sensitive application data.
+The JVM creates a PID-specific `.hprof` file in the mounted `/app/data` directory. Remove the option after collecting the diagnostic data because heap dumps can be large and contain sensitive application data.
 
 Additional deployment examples:
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,19 @@ docker compose up -d
 
 Open http://localhost:6060, create your admin account, and start building your library. (All libraries must be created within directories mounted on the host, e.g. the `/books/` directory in the sample `docker-compose.yml` above.)
 
+#### Optional: Capture Heap Dumps for OOM Debugging
+
+Heap dumps are disabled by default. To enable them temporarily, add the following environment variable to the `grimmory` service:
+
+```yaml
+services:
+  grimmory:
+    environment:
+      - JDK_JAVA_OPTIONS=-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/data
+```
+
+The JVM writes the dump to the mounted `/app/data` volume. Remove the option after collecting the diagnostic data because heap dumps can be large and contain sensitive application data.
+
 Additional deployment examples:
 
 - Docker Compose: [`deploy/compose/docker-compose.yml`](deploy/compose/docker-compose.yml)

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -21,9 +21,10 @@ services:
       - SWAGGER_ENABLED=false
       - FORCE_DISABLE_OIDC=false
       # ALLOWED_ORIGINS=
-      # Override JVM memory defaults (the image ships sensible defaults for ~512 MB heap).
-      # Uncomment and adjust if you want a tighter or looser cap:
-      # JAVA_TOOL_OPTIONS=-Xmx256m
+      # Add JVM options without replacing the image defaults. For example:
+      # - JDK_JAVA_OPTIONS=-Xmx256m
+      # Heap dumps are disabled by default. Enable them only when debugging an OOM:
+      # - JDK_JAVA_OPTIONS=-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/data
     depends_on:
       mariadb:
         condition: service_healthy

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -21,9 +21,11 @@ services:
       - SWAGGER_ENABLED=false
       - FORCE_DISABLE_OIDC=false
       # ALLOWED_ORIGINS=
-      # Add JVM options without replacing the image defaults. For example:
+      # Override JVM memory defaults (the image ships sensible defaults for ~512 MB heap).
+      # Uncomment and adjust if you want a tighter or looser cap:
       # - JDK_JAVA_OPTIONS=-Xmx256m
       # Heap dumps are disabled by default. Enable them only when debugging an OOM:
+      # The JVM creates a PID-specific .hprof file in /app/data.
       # - JDK_JAVA_OPTIONS=-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/data
     depends_on:
       mariadb:

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - REMOTE_DEBUG_ENABLED=true
       - ALLOWED_ORIGINS=*
       - API_DOCS_ENABLED=true
-      - JAVA_TOOL_OPTIONS=-XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=8.0 -XX:+ExitOnOutOfMemoryError -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=48m -Xss512k -XX:CICompilerCount=2 -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -XX:ShenandoahUncommitDelay=5000 -XX:ShenandoahGuaranteedGCInterval=30000 -XX:MaxDirectMemorySize=256m --enable-native-access=ALL-UNNAMED --enable-preview
+      - JAVA_TOOL_OPTIONS=-XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=8.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=48m -Xss512k -XX:CICompilerCount=2 -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -XX:ShenandoahUncommitDelay=5000 -XX:ShenandoahGuaranteedGCInterval=30000 -XX:MaxDirectMemorySize=256m --enable-native-access=ALL-UNNAMED --enable-preview
     stdin_open: true
     tty: true
     restart: unless-stopped

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - REMOTE_DEBUG_ENABLED=true
       - ALLOWED_ORIGINS=*
       - API_DOCS_ENABLED=true
-      - JAVA_TOOL_OPTIONS=-XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=8.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=48m -Xss512k -XX:CICompilerCount=2 -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -XX:ShenandoahUncommitDelay=5000 -XX:ShenandoahGuaranteedGCInterval=30000 -XX:MaxDirectMemorySize=256m --enable-native-access=ALL-UNNAMED --enable-preview
+      - JAVA_TOOL_OPTIONS=-XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=8.0 -XX:+ExitOnOutOfMemoryError -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=48m -Xss512k -XX:CICompilerCount=2 -XX:+UnlockExperimentalVMOptions -XX:+UseStringDeduplication -XX:ShenandoahUncommitDelay=5000 -XX:ShenandoahGuaranteedGCInterval=30000 -XX:MaxDirectMemorySize=256m --enable-native-access=ALL-UNNAMED --enable-preview
     stdin_open: true
     tty: true
     restart: unless-stopped


### PR DESCRIPTION
## Description

Disable automatic heap dumps in the production image while keeping them enabled in the development Compose stack. Heap dumps are unnecessary for normal production operation and can consume significant disk space, so the opt-in production debugging path is now documented instead.

## Linked Issue

Fixes #1743

## Changes

- Remove `HeapDumpOnOutOfMemoryError` and `HeapDumpPath` from the production image defaults.
- Keep heap dumps enabled in the development Compose stack for debugging.
- Document how to opt in with `JDK_JAVA_OPTIONS` without replacing the image's existing JVM tuning.
- Store opt-in dumps in the persistent `/app/data` volume.

## Manual Testing Steps

1. Run `docker compose -f dev.docker-compose.yml config --quiet`.
2. Run `docker compose -f deploy/compose/docker-compose.yml config --quiet`.
3. Run `docker buildx build --check --platform linux/amd64 .` and confirm there are no warnings.
4. Inspect Temurin 25 with `-XX:+PrintFlagsFinal` and confirm `HeapDumpOnOutOfMemoryError` is `false` by default, then set the documented `JDK_JAVA_OPTIONS` value and confirm it becomes `true` with `HeapDumpPath=/app/data`.

## Additional Context

This change only touches container configuration and documentation, so the backend and frontend test suites were not run.

## AI Disclosure

Codex - implemented the container configuration and documentation changes, researched the JDK 25 flag behavior, ran the validation listed above, and drafted this PR. Review feedback was addressed in a follow-up commit.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] Screenshots are not applicable because there are no UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [ ] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JVM memory sizing for container deployments.
  * Applications now exit promptly when an out-of-memory error occurs.
  * Added optional instructions for temporarily capturing heap dumps for troubleshooting.

* **Documentation**
  * Updated Docker Compose guidance for configuring JVM options without overriding defaults.
  * Documented heap dump storage, cleanup recommendations, and diagnostic considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->