### PR TITLE
fix(epub): remove refines when referenced elements are removed

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -222,6 +222,10 @@ public class EpubMetadataWriter implements MetadataWriter {
                 hasChanges[0] = true;
             }
 
+            if (hasChanges[0] && removeInvalidMetaRefines(metadataElement, opfDoc)) {
+                hasChanges[0] = true;
+            }
+
             if (hasChanges[0]) {
                 addBookloreMetadata(metadataElement, opfDoc, metadata);
                 cleanupCalibreArtifacts(metadataElement, opfDoc);
@@ -595,6 +599,46 @@ public class EpubMetadataWriter implements MetadataWriter {
                 metadataElement.removeChild(meta);
             }
         }
+    }
+
+    private boolean removeInvalidMetaRefines(Element metadataElement, Document doc) {
+        boolean hasChanges = false;
+
+        // In an ideal world we could set the `validating` flag or
+        // otherwise set the `isId` attribute tag correctly for `id`
+        // but because we cannot, we can't use `getElementById()` on
+        // the document.  With that in mind, we area going to read all
+        // tags, check if they have an `id`, and store that in a `Set`
+        Set<String> ids = new HashSet<>();
+
+        NodeList nodes = doc.getElementsByTagName("*");
+        for (int i = 0; i < nodes.getLength(); i++) {
+            var node = nodes.item(i);
+
+            if (node instanceof Element element) {
+                var idAttribute = element.getAttribute("id");
+                if (!idAttribute.isBlank()) {
+                    ids.add(idAttribute);
+                }
+            }
+        }
+
+        NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
+        for (int i = metas.getLength() - 1; i >= 0; i--) {
+            Element meta = (Element) metas.item(i);
+            String refines = meta.getAttribute("refines");
+
+            if (refines.startsWith("#")) {
+                String refinesId = refines.substring(1);
+
+                if (!ids.contains(refinesId)) {
+                    metadataElement.removeChild(meta);
+                    hasChanges = true;
+                }
+            }
+        }
+
+        return hasChanges;
     }
 
     private void removeMetaByRefines(Element metadataElement, String refines) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -98,8 +98,6 @@ public class EpubMetadataWriter implements MetadataWriter {
                 replaceAndTrackChange(opfDoc, metadataElement, "title", DC_NS, val, hasChanges);
                 if (StringUtils.isNotBlank(metadata.getSubtitle())) {
                     addSubtitleToTitle(metadataElement, opfDoc, metadata.getSubtitle());
-                } else {
-                    removeSubtitleToTitle(metadataElement);
                 }
             });
             helper.copyDescription(clear != null && clear.isDescription(), val -> replaceAndTrackChange(opfDoc, metadataElement, "description", DC_NS, val, hasChanges));
@@ -1000,34 +998,8 @@ public class EpubMetadataWriter implements MetadataWriter {
     }
 
     private void addSubtitleToTitle(Element metadataElement, Document doc, String subtitle) {
-        // Remove existing subtitle elements (both EPUB2 and EPUB3 forms)
-        removeSubtitleToTitle(metadataElement);
-
         final String DC_NS = "http://purl.org/dc/elements/1.1/";
         boolean epub3 = isEpub3(doc);
-
-        if (epub3) {
-            // EPUB3: add subtitle as separate dc:title with title-type refinement
-            String subtitleId = "subtitle-" + UUID.randomUUID().toString().substring(0, 8);
-            Element subtitleElement = doc.createElementNS(DC_NS, "title");
-            subtitleElement.setPrefix("dc");
-            subtitleElement.setAttribute("id", subtitleId);
-            subtitleElement.setTextContent(subtitle);
-            metadataElement.appendChild(subtitleElement);
-
-            Element typeMeta = doc.createElementNS(OPF_NS, "meta");
-            typeMeta.setPrefix("opf");
-            typeMeta.setAttribute("refines", "#" + subtitleId);
-            typeMeta.setAttribute("property", "title-type");
-            typeMeta.setTextContent("subtitle");
-            metadataElement.appendChild(typeMeta);
-        }
-        // EPUB2: subtitle is stored only via booklore:subtitle metadata (written in addBookloreMetadata).
-        // No modification to dc:title is needed — this preserves round-trip fidelity.
-    }
-
-    private void removeSubtitleToTitle(Element metadataElement) {
-        final String DC_NS = "http://purl.org/dc/elements/1.1/";
 
         // Remove existing subtitle elements (both EPUB2 and EPUB3 forms)
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
@@ -1049,6 +1021,25 @@ public class EpubMetadataWriter implements MetadataWriter {
                 metadataElement.removeChild(meta);
             }
         }
+
+        if (epub3) {
+            // EPUB3: add subtitle as separate dc:title with title-type refinement
+            String subtitleId = "subtitle-" + UUID.randomUUID().toString().substring(0, 8);
+            Element subtitleElement = doc.createElementNS(DC_NS, "title");
+            subtitleElement.setPrefix("dc");
+            subtitleElement.setAttribute("id", subtitleId);
+            subtitleElement.setTextContent(subtitle);
+            metadataElement.appendChild(subtitleElement);
+
+            Element typeMeta = doc.createElementNS(OPF_NS, "meta");
+            typeMeta.setPrefix("opf");
+            typeMeta.setAttribute("refines", "#" + subtitleId);
+            typeMeta.setAttribute("property", "title-type");
+            typeMeta.setTextContent("subtitle");
+            metadataElement.appendChild(typeMeta);
+        }
+        // EPUB2: subtitle is stored only via booklore:subtitle metadata (written in addBookloreMetadata).
+        // No modification to dc:title is needed — this preserves round-trip fidelity.
     }
 
     private void addBookloreMetadata(Element metadataElement, Document doc, BookMetadataEntity metadata) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -98,6 +98,8 @@ public class EpubMetadataWriter implements MetadataWriter {
                 replaceAndTrackChange(opfDoc, metadataElement, "title", DC_NS, val, hasChanges);
                 if (StringUtils.isNotBlank(metadata.getSubtitle())) {
                     addSubtitleToTitle(metadataElement, opfDoc, metadata.getSubtitle());
+                } else {
+                    removeSubtitleToTitle(metadataElement);
                 }
             });
             helper.copyDescription(clear != null && clear.isDescription(), val -> replaceAndTrackChange(opfDoc, metadataElement, "description", DC_NS, val, hasChanges));
@@ -962,8 +964,34 @@ public class EpubMetadataWriter implements MetadataWriter {
     }
 
     private void addSubtitleToTitle(Element metadataElement, Document doc, String subtitle) {
+        // Remove existing subtitle elements (both EPUB2 and EPUB3 forms)
+        removeSubtitleToTitle(metadataElement);
+
         final String DC_NS = "http://purl.org/dc/elements/1.1/";
         boolean epub3 = isEpub3(doc);
+
+        if (epub3) {
+            // EPUB3: add subtitle as separate dc:title with title-type refinement
+            String subtitleId = "subtitle-" + UUID.randomUUID().toString().substring(0, 8);
+            Element subtitleElement = doc.createElementNS(DC_NS, "title");
+            subtitleElement.setPrefix("dc");
+            subtitleElement.setAttribute("id", subtitleId);
+            subtitleElement.setTextContent(subtitle);
+            metadataElement.appendChild(subtitleElement);
+
+            Element typeMeta = doc.createElementNS(OPF_NS, "meta");
+            typeMeta.setPrefix("opf");
+            typeMeta.setAttribute("refines", "#" + subtitleId);
+            typeMeta.setAttribute("property", "title-type");
+            typeMeta.setTextContent("subtitle");
+            metadataElement.appendChild(typeMeta);
+        }
+        // EPUB2: subtitle is stored only via booklore:subtitle metadata (written in addBookloreMetadata).
+        // No modification to dc:title is needed — this preserves round-trip fidelity.
+    }
+
+    private void removeSubtitleToTitle(Element metadataElement) {
+        final String DC_NS = "http://purl.org/dc/elements/1.1/";
 
         // Remove existing subtitle elements (both EPUB2 and EPUB3 forms)
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
@@ -985,25 +1013,6 @@ public class EpubMetadataWriter implements MetadataWriter {
                 metadataElement.removeChild(meta);
             }
         }
-
-        if (epub3) {
-            // EPUB3: add subtitle as separate dc:title with title-type refinement
-            String subtitleId = "subtitle-" + UUID.randomUUID().toString().substring(0, 8);
-            Element subtitleElement = doc.createElementNS(DC_NS, "title");
-            subtitleElement.setPrefix("dc");
-            subtitleElement.setAttribute("id", subtitleId);
-            subtitleElement.setTextContent(subtitle);
-            metadataElement.appendChild(subtitleElement);
-
-            Element typeMeta = doc.createElementNS(OPF_NS, "meta");
-            typeMeta.setPrefix("opf");
-            typeMeta.setAttribute("refines", "#" + subtitleId);
-            typeMeta.setAttribute("property", "title-type");
-            typeMeta.setTextContent("subtitle");
-            metadataElement.appendChild(typeMeta);
-        }
-        // EPUB2: subtitle is stored only via booklore:subtitle metadata (written in addBookloreMetadata).
-        // No modification to dc:title is needed — this preserves round-trip fidelity.
     }
 
     private void addBookloreMetadata(Element metadataElement, Document doc, BookMetadataEntity metadata) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -222,14 +222,11 @@ public class EpubMetadataWriter implements MetadataWriter {
                 hasChanges[0] = true;
             }
 
-            if (hasChanges[0] && removeInvalidMetaRefines(metadataElement, opfDoc)) {
-                hasChanges[0] = true;
-            }
-
             if (hasChanges[0]) {
                 addBookloreMetadata(metadataElement, opfDoc, metadata);
                 cleanupCalibreArtifacts(metadataElement, opfDoc);
                 organizeMetadataElements(metadataElement);
+                removeInvalidMetaRefines(metadataElement, opfDoc);
                 removeEmptyTextNodes(opfDoc);
                 Transformer transformer = TransformerFactory.newInstance().newTransformer();
                 transformer.setOutputProperty(OutputKeys.INDENT, "yes");
@@ -601,9 +598,7 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
     }
 
-    private boolean removeInvalidMetaRefines(Element metadataElement, Document doc) {
-        boolean hasChanges = false;
-
+    private void removeInvalidMetaRefines(Element metadataElement, Document doc) {
         // In an ideal world we could set the `validating` flag or
         // otherwise set the `isId` attribute tag correctly for `id`
         // but because we cannot, we can't use `getElementById()` on
@@ -633,12 +628,9 @@ public class EpubMetadataWriter implements MetadataWriter {
 
                 if (!ids.contains(refinesId)) {
                     metadataElement.removeChild(meta);
-                    hasChanges = true;
                 }
             }
         }
-
-        return hasChanges;
     }
 
     private void removeMetaByRefines(Element metadataElement, String refines) {

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -117,6 +117,28 @@ class EpubMetadataWriterTest {
                 }
             }
         }
+
+        @Test
+        @DisplayName("Should remove extraneous refines in EPUB3")
+        void writeMetadata_removesMissingRefines() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <other id="example">Example</other>
+
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <meta refines="#example" property="identifier-type">wizard</meta>
+                            <meta refines="#example2" property="source-of">magic</meta>
+                        </metadata>
+                    </package>""";
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-role-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).doesNotContain("refines=\"#example2\"");
+            assertThat(content).contains("refines=\"#example\"");
+        }
     }
 
     @Nested

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -461,6 +461,46 @@ class EpubMetadataWriterTest {
             assertThat(content).contains("property=\"title-type\"");
             assertThat(content).contains(">subtitle<");
         }
+
+        @Test
+        @DisplayName("Should remove refinement when subtitle is removed")
+        void epub3_shouldRemoveRefinementWhenRemovingSubtitle() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title id="#subtitle-12b45ebf">Subtitle</dc:title>
+                            <opf:meta xmlns:opf="http://www.idpf.org/2007/opf" property="title-type" refines="#subtitle-12b45ebf">subtitle</opf:meta>
+                        </metadata>
+                    </package>""";
+
+            metadata.setSubtitle(null);
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-subtitle-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).doesNotContain(">subtitle</opf:meta>");
+        }
+
+        @Test
+        @DisplayName("Should do nothing when no subtitle and subtitle is removed")
+        void epub3_shouldSaveNoSubtitleWhenAlreadyNoSubtitle() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                        </metadata>
+                    </package>""";
+
+            metadata.setSubtitle(null);
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-subtitle-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).doesNotContain(">subtitle</opf:meta>");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
updates the epub writer to remove `refines` that no longer have a matching element

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1508 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Open epub file in Metadata Editor
2. Add subitle
3. Remove subtitle
4. Open OPF and see no refinse for subtitle

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EPUB metadata updates so clearing a subtitle removes outdated subtitle information.
  * Removed invalid metadata refinement references that point to missing EPUB elements.
  * Improved EPUB 3 subtitle handling to prevent stale or unnecessary refined subtitle entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->