### PR TITLE
chore: use `Grimmory` branding for basic auth realms

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -89,10 +89,10 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .httpBasic(basic -> basic
-                        .realmName("Booklore OPDS")
+                        .realmName("Grimmory OPDS")
                         .authenticationEntryPoint((request, response, authException) -> {
                             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            response.setHeader("WWW-Authenticate", "Basic realm=\"Booklore OPDS\"");
+                            response.setHeader("WWW-Authenticate", "Basic realm=\"Grimmory OPDS\"");
                             response.getWriter().write("HTTP Status 401 - " + authException.getMessage());
                         })
                 );
@@ -111,10 +111,10 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .httpBasic(basic -> basic
-                        .realmName("Booklore Komga API")
+                        .realmName("Grimmory Komga API")
                         .authenticationEntryPoint((request, response, authException) -> {
                             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            response.setHeader("WWW-Authenticate", "Basic realm=\"Booklore Komga API\"");
+                            response.setHeader("WWW-Authenticate", "Basic realm=\"Grimmory Komga API\"");
                             response.getWriter().write("HTTP Status 401 - " + authException.getMessage());
                         })
                 );


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
Updates the OPDS / Komga basic auth to use `Grimmory` rather than `Booklore`

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2012

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* update OPDS realm to be `Grimmory OPDS`
* update Komga realm to be `Grimmory Komga API`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. ` curl https://grimmory.for.awful.download/api/v1/opds/ -v`
2. Observe `< www-authenticate: Basic realm="Grimmory OPDS"`

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP Basic authentication prompts to display the correct Grimmory realm name for OPDS and Komga access.
  * Authentication behavior and access controls remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->