### PR TITLE
fix: use expected ranobedb rate limit

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
@@ -50,7 +50,7 @@ public class RanobeDbParser implements BookParser {
             .expireAfterWrite(Duration.ofHours(1))
             .build();
 
-    // Rate limiter: 2 requests per second
+    // Rate limiter
     private static final int MAX_REQUESTS_PER_WINDOW = 60;
     private static final long RATE_LIMIT_WINDOW_MS = 60000; // 60 seconds in milliseconds
     private final AtomicLong lastRequestTime = new AtomicLong(0);

--- a/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
@@ -51,10 +51,10 @@ public class RanobeDbParser implements BookParser {
             .build();
 
     // Rate limiter: 2 requests per second
-    private static final int MAX_REQUESTS_PER_SECOND = 2;
-    private static final long RATE_LIMIT_WINDOW_MS = 1000; // 1 second in milliseconds
+    private static final int MAX_REQUESTS_PER_WINDOW = 60;
+    private static final long RATE_LIMIT_WINDOW_MS = 60000; // 60 seconds in milliseconds
     private final AtomicLong lastRequestTime = new AtomicLong(0);
-    private final AtomicLong tokenCount = new AtomicLong(MAX_REQUESTS_PER_SECOND);
+    private final AtomicLong tokenCount = new AtomicLong(MAX_REQUESTS_PER_WINDOW);
 
     private record SearchTerms(String title, Integer authorId) {}
 
@@ -80,44 +80,37 @@ public class RanobeDbParser implements BookParser {
         return metadataList.isEmpty() ? null : metadataList.getFirst();
     }
 
-    private void waitForRateLimit() {
+    private void waitForRateLimit() throws InterruptedException {
         while (true) {
             long currentTime = System.currentTimeMillis();
             long lastTime = lastRequestTime.get();
             long timeSinceLastRequest = currentTime - lastTime;
+            long currentTokens = tokenCount.get();
 
             // Refill tokens based on time elapsed
-            if (timeSinceLastRequest >= RATE_LIMIT_WINDOW_MS) {
-                // More than 1 second has passed, refill to max tokens
-                if (lastRequestTime.compareAndSet(lastTime, currentTime)) {
-                    tokenCount.set(MAX_REQUESTS_PER_SECOND);
-                }
-            } else {
-                // Calculate how many tokens to add based on time elapsed
-                long tokensToAdd = (timeSinceLastRequest * MAX_REQUESTS_PER_SECOND) / RATE_LIMIT_WINDOW_MS;
-                if (tokensToAdd > 0) {
-                    long currentTokens = tokenCount.get();
-                    long newTokens = Math.min(currentTokens + tokensToAdd, MAX_REQUESTS_PER_SECOND);
-                    tokenCount.compareAndSet(currentTokens, newTokens);
+            if (timeSinceLastRequest > RATE_LIMIT_WINDOW_MS / MAX_REQUESTS_PER_WINDOW) {
+                long tokensToAdd = timeSinceLastRequest / (RATE_LIMIT_WINDOW_MS / MAX_REQUESTS_PER_WINDOW);
+                long newTokens = Math.min(currentTokens + tokensToAdd, MAX_REQUESTS_PER_WINDOW);
+                if (tokenCount.compareAndSet(currentTokens, newTokens)) {
+                    currentTokens = newTokens;
+                    lastRequestTime.set(System.currentTimeMillis());
                 }
             }
 
             // Try to consume a token
-            long currentTokens = tokenCount.get();
             if (currentTokens > 0) {
                 if (tokenCount.compareAndSet(currentTokens, currentTokens - 1)) {
-                    lastRequestTime.set(System.currentTimeMillis());
                     return; // Successfully acquired a token
                 }
             } else {
                 // No tokens available, wait before retrying
                 try {
-                    long waitTime = RATE_LIMIT_WINDOW_MS / MAX_REQUESTS_PER_SECOND;
+                    long waitTime = RATE_LIMIT_WINDOW_MS / MAX_REQUESTS_PER_WINDOW;
                     Thread.sleep(waitTime);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     log.warn("Rate limiter interrupted", e);
-                    return;
+                    throw e;
                 }
             }
         }

--- a/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
@@ -53,8 +53,10 @@ public class RanobeDbParser implements BookParser {
     // Rate limiter
     private static final int MAX_REQUESTS_PER_WINDOW = 60;
     private static final long RATE_LIMIT_WINDOW_MS = 60000; // 60 seconds in milliseconds
-    private final AtomicLong lastRequestTime = new AtomicLong(0);
-    private final AtomicLong tokenCount = new AtomicLong(MAX_REQUESTS_PER_WINDOW);
+    private static final long TOKEN_GENERATION_INTERVAL = RATE_LIMIT_WINDOW_MS / MAX_REQUESTS_PER_WINDOW;
+    private final Object waitLock = new Object();
+    private long lastTokenGenerationTime = 0;
+    private long tokenCount = MAX_REQUESTS_PER_WINDOW;
 
     private record SearchTerms(String title, Integer authorId) {}
 
@@ -82,36 +84,35 @@ public class RanobeDbParser implements BookParser {
 
     private void waitForRateLimit() throws InterruptedException {
         while (true) {
-            long currentTime = System.currentTimeMillis();
-            long lastTime = lastRequestTime.get();
-            long timeSinceLastRequest = currentTime - lastTime;
-            long currentTokens = tokenCount.get();
+            synchronized (waitLock) {
+                long currentTime = System.currentTimeMillis();
+                long timeSinceLastRequest = currentTime - lastTokenGenerationTime;
 
-            // Refill tokens based on time elapsed
-            if (timeSinceLastRequest > RATE_LIMIT_WINDOW_MS / MAX_REQUESTS_PER_WINDOW) {
-                long tokensToAdd = timeSinceLastRequest / (RATE_LIMIT_WINDOW_MS / MAX_REQUESTS_PER_WINDOW);
-                long newTokens = Math.min(currentTokens + tokensToAdd, MAX_REQUESTS_PER_WINDOW);
-                if (tokenCount.compareAndSet(currentTokens, newTokens)) {
-                    currentTokens = newTokens;
-                    lastRequestTime.set(System.currentTimeMillis());
+                // Refill tokens based on time elapsed
+                if (timeSinceLastRequest > TOKEN_GENERATION_INTERVAL) {
+                    long tokensToAdd = timeSinceLastRequest / TOKEN_GENERATION_INTERVAL;
+
+                    tokenCount = Math.min(tokenCount + tokensToAdd, MAX_REQUESTS_PER_WINDOW);
+
+                    // Bring us to when the last token was generated - which is likely
+                    // in the past because of rounding.
+                    lastTokenGenerationTime += tokensToAdd * TOKEN_GENERATION_INTERVAL;
+                }
+
+                // Try to consume a token
+                if (tokenCount > 0) {
+                    tokenCount--;
+                    return; // Successfully acquired a token
                 }
             }
 
-            // Try to consume a token
-            if (currentTokens > 0) {
-                if (tokenCount.compareAndSet(currentTokens, currentTokens - 1)) {
-                    return; // Successfully acquired a token
-                }
-            } else {
-                // No tokens available, wait before retrying
-                try {
-                    long waitTime = RATE_LIMIT_WINDOW_MS / MAX_REQUESTS_PER_WINDOW;
-                    Thread.sleep(waitTime);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    log.warn("Rate limiter interrupted", e);
-                    throw e;
-                }
+            // No tokens available, wait before retrying
+            try {
+                Thread.sleep(TOKEN_GENERATION_INTERVAL);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Rate limiter interrupted", e);
+                throw e;
             }
         }
     }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
switches the rate limiting to be 60 requests a minute rather than 2 requests every second.  this allows us to burst and most regular queries are faster

also refactors the rate limit code to support these changes & avoid race conditions

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2050

## Changes
* renames in many places from seconds to `_WINDOW`
* updates the rate limiting code to better support this new approach

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. searched multiple times with randobedb
2. watched log messages for rate limiting messages

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
N/A

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
extracted from #1804

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request throttling to deliver smoother, more consistent pacing using a rolling token-bucket approach.
  * Enhanced interruption handling during throttling: interrupted operations now stop promptly, log a warning, and preserve the thread’s interruption status by re-interrupting and rethrowing the interruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->