### PR TITLE
refactor(ui): switch library and shelf menu to app-menu

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.html
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.html
@@ -28,19 +28,24 @@
             }
           </div>
 
-          @if (userService.currentUser(); as currentUser) {
-            @if (entityType !== EntityType.ALL_BOOKS && entityType !== EntityType.UNSHELVED &&
-            (currentUser.permissions.admin || currentUser.permissions.canManageLibrary)) {
-              <div class="entity-menu-wrapper">
-                <p-button
-                  icon="pi pi-ellipsis-v"
+          @if (entityMenuTarget(); as menuTarget) {
+            <div class="entity-menu-wrapper">
+              <app-library-shelf-menu
+                #entityMenu
+                [target]="menuTarget"
+                [ariaLabel]="'common.moreActionsFor' | transloco: {label: menuTarget.entity.name}" />
+              @if (entityMenu.available()) {
+                <button
+                  pButton
+                  type="button"
                   [rounded]="true"
                   [text]="true"
-                  (click)="entitymenu.toggle($event)">
-                </p-button>
-                <p-menu #entitymenu [model]="entityOptions()" [popup]="true" appendTo="body"></p-menu>
-              </div>
-            }
+                  [attr.aria-label]="'common.moreActionsFor' | transloco: {label: menuTarget.entity.name}"
+                  [appMenuTriggerFor]="entityMenu.menu()">
+                  <i class="pi pi-ellipsis-v" aria-hidden="true"></i>
+                </button>
+              }
+            </div>
           }
         }
       </div>

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.spec.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.spec.ts
@@ -8,7 +8,6 @@ import {ConfirmationService, MessageService} from '@openng/optimus-ui/api';
 import {PageTitleService} from '../../../../shared/service/page-title.service';
 import {BookService} from '../../service/book.service';
 import {BookMetadataManageService} from '../../service/book-metadata-manage.service';
-import {LibraryShelfMenuService} from '../../service/library-shelf-menu.service';
 import {Book} from '../../model/book.model';
 import {SortDirection, SortOption} from '../../model/sort.model';
 import {UserService} from '../../../settings/user-management/user.service';
@@ -292,14 +291,6 @@ function createHarness(options?: {
         useValue: {
           getMoreActionsMenu: vi.fn(() => []),
           getMetadataMenuItems: vi.fn(() => []),
-        },
-      },
-      {
-        provide: LibraryShelfMenuService,
-        useValue: {
-          initializeLibraryMenuItems: vi.fn(() => []),
-          initializeMagicShelfMenuItems: vi.fn(() => []),
-          initializeShelfMenuItems: vi.fn(() => []),
         },
       },
       {provide: PageTitleService, useValue: {setPageTitle: vi.fn()}},

--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -11,13 +11,15 @@ import {DynamicDialogRef} from '@openng/optimus-ui/dynamicdialog';
 import {Library} from '../../model/library.model';
 import {SortDirection, SortOption} from '../../model/sort.model';
 import {Book} from '../../model/book.model';
-import {LibraryShelfMenuService} from '../../service/library-shelf-menu.service';
+import {
+  LibraryShelfMenuComponent,
+  type LibraryShelfMenuTarget,
+} from '../library-shelf-menu/library-shelf-menu.component';
 import {BookTableComponent} from './book-table/book-table.component';
-import {Button} from '@openng/optimus-ui/button';
+import {Button, ButtonDirective} from '@openng/optimus-ui/button';
 import {NgClass} from '@angular/common';
 import {BookCardComponent} from './book-card/book-card.component';
 
-import {Menu} from '@openng/optimus-ui/menu';
 import {InputText} from '@openng/optimus-ui/inputtext';
 import {FormsModule} from '@angular/forms';
 import {BookFilterComponent} from './book-filter/book-filter.component';
@@ -59,6 +61,7 @@ import {filterBooksByFilters} from './filters/sidebar-filter';
 import {LayoutService} from '../../../../shared/layout/layout.service';
 import {createGridDensity} from '../../../../shared/util/grid-density.util';
 import {DeferredRenderState} from './deferred-render-state';
+import {AppMenuTriggerDirective} from '../../../../shared/ui/menu/app-menu-trigger.directive';
 
 export enum EntityType {
   LIBRARY = 'Library',
@@ -81,9 +84,10 @@ const MOBILE_COLUMNS_STORAGE_KEY = 'mobileColumnsPreference';
   styleUrls: ['./book-browser.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    Button, BookCardComponent, Menu, InputText, FormsModule,
+    Button, ButtonDirective, BookCardComponent, InputText, FormsModule,
     BookTableComponent, BookFilterComponent, Tooltip, NgClass, Popover,
     Checkbox, Divider, MultiSelect, TieredMenu, Badge, MultiSortPopoverComponent, TranslocoDirective, TranslocoPipe, GridDensityButtonsComponent,
+    LibraryShelfMenuComponent, AppMenuTriggerDirective,
   ],
   providers: [SeriesCollapseFilter],
 })
@@ -105,7 +109,6 @@ export class BookBrowserComponent implements AfterViewInit {
   private bookMetadataManageService = inject(BookMetadataManageService);
   private dialogHelperService = inject(BookDialogHelperService);
   private bookMenuService = inject(BookMenuService);
-  private libraryShelfMenuService = inject(LibraryShelfMenuService);
   private pageTitle = inject(PageTitleService);
   private loadingService = inject(LoadingService);
   private bookNavigationService = inject(BookNavigationService);
@@ -187,19 +190,17 @@ export class BookBrowserComponent implements AfterViewInit {
     const {entityId, entityType} = this.entityInfo();
     return this.entityService.getEntity(entityId, entityType);
   });
-  readonly entityOptions = computed<MenuItem[]>(() => {
+  readonly entityMenuTarget = computed<LibraryShelfMenuTarget | null>(() => {
     const entity = this.entity();
-    if (!entity) {
-      return [];
+    if (entity?.id == null) return null;
+
+    if (this.entityService.isLibrary(entity)) {
+      return {type: 'library', entity: {...entity, id: entity.id}};
     }
-
-    const actions = this.entityService.isLibrary(entity)
-      ? this.libraryShelfMenuService.initializeLibraryMenuItems(entity)
-      : this.entityService.isMagicShelf(entity)
-        ? this.libraryShelfMenuService.initializeMagicShelfMenuItems(entity)
-        : this.libraryShelfMenuService.initializeShelfMenuItems(entity);
-
-    return actions;
+    if (this.entityService.isMagicShelf(entity)) {
+      return {type: 'magicShelf', entity: {...entity, id: entity.id}};
+    }
+    return {type: 'shelf', entity: {...entity, id: entity.id}};
   });
   // Deferred pipeline: heavy filter/sort runs in a setTimeout so the page chrome
   // and skeletons paint first, then real books replace them on the next task.

--- a/frontend/src/app/features/book/components/library-shelf-menu/library-shelf-menu.component.spec.ts
+++ b/frontend/src/app/features/book/components/library-shelf-menu/library-shelf-menu.component.spec.ts
@@ -1,0 +1,82 @@
+import {signal} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideRouter} from '@angular/router';
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {getTranslocoModule} from '../../../../core/testing/transloco-testing';
+import {LayoutService} from '../../../../shared/layout/layout.service';
+import {UserService} from '../../../settings/user-management/user.service';
+import {LibraryShelfMenuService} from '../../service/library-shelf-menu.service';
+import {LibraryShelfMenuComponent} from './library-shelf-menu.component';
+
+describe('LibraryShelfMenuComponent', () => {
+  let fixture: ComponentFixture<LibraryShelfMenuComponent>;
+  const currentUser = signal({
+    id: 3,
+    permissions: {admin: false, canManageLibrary: true},
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [LibraryShelfMenuComponent, getTranslocoModule()],
+      providers: [
+        provideRouter([]),
+        {provide: UserService, useValue: {currentUser}},
+        {provide: LibraryShelfMenuService, useValue: {}},
+        {provide: LayoutService, useValue: {isDesktop: signal(true)}},
+      ],
+    });
+    fixture = TestBed.createComponent(LibraryShelfMenuComponent);
+  });
+
+  it.each([
+    {
+      name: 'library manager',
+      user: {id: 3, permissions: {admin: false, canManageLibrary: true}},
+      target: {type: 'library', entity: {id: 7, name: 'Library', watch: true, paths: []}},
+      labels: ['Add Physical Book', 'Import ISBNs from File', 'Edit Library', 'Re-scan Library',
+        'Custom Fetch Metadata', 'Auto Fetch Metadata', 'Find Duplicates', 'Delete Library'],
+      disabled: 0,
+      available: true,
+    },
+    {
+      name: 'library reader',
+      user: {id: 3, permissions: {admin: false, canManageLibrary: false}},
+      target: {type: 'library', entity: {id: 7, name: 'Library', watch: true, paths: []}},
+      labels: [],
+      disabled: 0,
+      available: false,
+    },
+    {
+      name: 'public shelf reader',
+      user: {id: 3, permissions: {admin: false, canManageLibrary: false}},
+      target: {type: 'shelf', entity: {id: 11, name: 'Shelf', userId: 99, publicShelf: true}},
+      labels: ['Edit Shelf', 'Delete Shelf'],
+      disabled: 2,
+      available: true,
+    },
+    {
+      name: 'public magic-shelf reader',
+      user: {id: 3, permissions: {admin: false, canManageLibrary: false}},
+      target: {type: 'magicShelf', entity: {id: 13, name: 'Magic', filterJson: '{}', isPublic: true}},
+      labels: ['Edit Magic Shelf', 'Copy JSON', 'Delete Magic Shelf'],
+      disabled: 2,
+      available: true,
+    },
+  ])('renders the $name state', async ({user, target, labels, disabled, available}) => {
+    currentUser.set(user);
+    fixture.componentRef.setInput('target', target);
+    fixture.componentRef.setInput('ariaLabel', 'Actions');
+    await fixture.whenStable();
+
+    fixture.componentInstance.menu().open(fixture.nativeElement);
+    await fixture.whenStable();
+
+    const menu = document.querySelector('app-menu[aria-label="Actions"]') as HTMLElement;
+    const renderedLabels = Array.from(menu.querySelectorAll('app-menu-item'))
+      .map(item => item.textContent?.trim());
+    expect(fixture.componentInstance.available()).toBe(available);
+    expect(renderedLabels).toEqual(labels);
+    expect(menu.querySelectorAll('app-menu-item[aria-disabled="true"]')).toHaveLength(disabled);
+  });
+});

--- a/frontend/src/app/features/book/components/library-shelf-menu/library-shelf-menu.component.ts
+++ b/frontend/src/app/features/book/components/library-shelf-menu/library-shelf-menu.component.ts
@@ -57,6 +57,7 @@ export type LibraryShelfMenuTarget =
               <app-menu-item (selected)="actions.rescanLibrary(currentTarget.entity)">
                 {{ 'book.shelfMenuService.library.rescanLibrary' | transloco }}
               </app-menu-item>
+              <app-menu-separator />
               <app-menu-item (selected)="actions.customFetchLibraryMetadata(currentTarget.entity.id)">
                 {{ 'book.shelfMenuService.library.customFetchMetadata' | transloco }}
               </app-menu-item>

--- a/frontend/src/app/features/book/components/library-shelf-menu/library-shelf-menu.component.ts
+++ b/frontend/src/app/features/book/components/library-shelf-menu/library-shelf-menu.component.ts
@@ -1,0 +1,160 @@
+import {ChangeDetectionStrategy, Component, computed, inject, input, output, viewChild} from '@angular/core';
+import {LucidePencil, LucideTrash2} from '@lucide/angular';
+import {TranslocoPipe} from '@jsverse/transloco';
+
+import {AppMenuComponent} from '../../../../shared/ui/menu/app-menu.component';
+import {AppMenuContentDirective} from '../../../../shared/ui/menu/app-menu-content.directive';
+import {AppMenuItemComponent} from '../../../../shared/ui/menu/app-menu-item.component';
+import {AppMenuSectionComponent} from '../../../../shared/ui/menu/app-menu-section.component';
+import {AppMenuSeparatorComponent} from '../../../../shared/ui/menu/app-menu-separator.component';
+import {MagicShelf} from '../../../magic-shelf/service/magic-shelf.service';
+import {UserService} from '../../../settings/user-management/user.service';
+import {Library} from '../../model/library.model';
+import {Shelf} from '../../model/shelf.model';
+import {LibraryShelfMenuService} from '../../service/library-shelf-menu.service';
+
+type Persisted<T extends {id?: number | null}> = Omit<T, 'id'> & {id: number};
+
+export type LibraryShelfMenuTarget =
+  | {type: 'library'; entity: Persisted<Library>}
+  | {type: 'shelf'; entity: Persisted<Shelf>}
+  | {type: 'magicShelf'; entity: Persisted<MagicShelf>};
+
+@Component({
+  selector: 'app-library-shelf-menu',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {class: 'contents'},
+  imports: [
+    TranslocoPipe,
+    AppMenuComponent,
+    AppMenuContentDirective,
+    AppMenuItemComponent,
+    AppMenuSectionComponent,
+    AppMenuSeparatorComponent,
+  ],
+  template: `
+    @let currentTarget = target();
+    <app-menu
+      [ariaLabel]="ariaLabel()"
+      (opened)="opened.emit()"
+      (closed)="closed.emit()">
+      <ng-template appMenuContent>
+        @if (available()) {
+          @switch (currentTarget.type) {
+            @case ('library') {
+              <app-menu-item (selected)="actions.addPhysicalBook(currentTarget.entity.id)">
+                {{ 'book.shelfMenuService.library.addPhysicalBook' | transloco }}
+              </app-menu-item>
+              <app-menu-item (selected)="actions.importIsbns(currentTarget.entity.id)">
+                {{ 'book.shelfMenuService.library.bulkIsbnImport' | transloco }}
+              </app-menu-item>
+              <app-menu-separator />
+              <app-menu-item
+                [icon]="pencilIcon"
+                (selected)="actions.editLibrary(currentTarget.entity.id)">
+                {{ 'book.shelfMenuService.library.editLibrary' | transloco }}
+              </app-menu-item>
+              <app-menu-item (selected)="actions.rescanLibrary(currentTarget.entity)">
+                {{ 'book.shelfMenuService.library.rescanLibrary' | transloco }}
+              </app-menu-item>
+              <app-menu-item (selected)="actions.customFetchLibraryMetadata(currentTarget.entity.id)">
+                {{ 'book.shelfMenuService.library.customFetchMetadata' | transloco }}
+              </app-menu-item>
+              <app-menu-item (selected)="actions.autoFetchLibraryMetadata(currentTarget.entity.id)">
+                {{ 'book.shelfMenuService.library.autoFetchMetadata' | transloco }}
+              </app-menu-item>
+              <app-menu-item (selected)="actions.findLibraryDuplicates(currentTarget.entity.id)">
+                {{ 'book.shelfMenuService.library.findDuplicates' | transloco }}
+              </app-menu-item>
+              <app-menu-separator />
+              <app-menu-item
+                [icon]="trashIcon"
+                variant="destructive"
+                (selected)="actions.deleteLibrary(currentTarget.entity)">
+                {{ 'book.shelfMenuService.library.deleteLibrary' | transloco }}
+              </app-menu-item>
+            }
+            @case ('shelf') {
+              @if (currentTarget.entity.publicShelf || !canManageShelf()) {
+                <app-menu-section>
+                  @if (currentTarget.entity.publicShelf) {
+                    {{ 'book.shelfMenuService.shelf.publicShelfPrefix' | transloco }}
+                  }
+                  {{ (canManageShelf()
+                    ? 'book.shelfMenuService.shelf.optionsLabel'
+                    : 'book.shelfMenuService.shelf.readOnly') | transloco }}
+                </app-menu-section>
+              }
+              <app-menu-item
+                [icon]="pencilIcon"
+                [disabled]="!canManageShelf()"
+                (selected)="actions.editShelf(currentTarget.entity.id)">
+                {{ 'book.shelfMenuService.shelf.editShelf' | transloco }}
+              </app-menu-item>
+              <app-menu-separator />
+              <app-menu-item
+                [icon]="trashIcon"
+                [disabled]="!canManageShelf()"
+                variant="destructive"
+                (selected)="actions.deleteShelf(currentTarget.entity)">
+                {{ 'book.shelfMenuService.shelf.deleteShelf' | transloco }}
+              </app-menu-item>
+            }
+            @case ('magicShelf') {
+              <app-menu-item
+                [icon]="pencilIcon"
+                [disabled]="!canManageMagicShelf()"
+                (selected)="actions.editMagicShelf(currentTarget.entity.id)">
+                {{ 'book.shelfMenuService.magicShelf.editMagicShelf' | transloco }}
+              </app-menu-item>
+              <app-menu-item (selected)="actions.copyMagicShelfJson(currentTarget.entity.filterJson)">
+                {{ 'book.shelfMenuService.magicShelf.exportJson' | transloco }}
+              </app-menu-item>
+              <app-menu-separator />
+              <app-menu-item
+                [icon]="trashIcon"
+                [disabled]="!canManageMagicShelf()"
+                variant="destructive"
+                (selected)="actions.deleteMagicShelf(currentTarget.entity)">
+                {{ 'book.shelfMenuService.magicShelf.deleteMagicShelf' | transloco }}
+              </app-menu-item>
+            }
+          }
+        }
+      </ng-template>
+    </app-menu>
+  `,
+})
+export class LibraryShelfMenuComponent {
+  readonly target = input.required<LibraryShelfMenuTarget>();
+  readonly ariaLabel = input.required<string>();
+
+  readonly opened = output<void>();
+  readonly closed = output<void>();
+  readonly menu = viewChild.required(AppMenuComponent);
+
+  private readonly currentUser = inject(UserService).currentUser;
+  protected readonly actions = inject(LibraryShelfMenuService);
+  protected readonly pencilIcon = LucidePencil.icon;
+  protected readonly trashIcon = LucideTrash2.icon;
+
+  readonly available = computed(() => {
+    const user = this.currentUser();
+    if (!user) return false;
+    return this.target().type !== 'library'
+      || user.permissions.admin
+      || user.permissions.canManageLibrary;
+  });
+
+  protected readonly canManageShelf = computed(() => {
+    const target = this.target();
+    return target.type === 'shelf' && target.entity.userId === this.currentUser()?.id;
+  });
+
+  protected readonly canManageMagicShelf = computed(() => {
+    const target = this.target();
+    return target.type === 'magicShelf'
+      && (!target.entity.isPublic || !!this.currentUser()?.permissions.admin);
+  });
+}

--- a/frontend/src/app/features/book/components/library-shelf-menu/library-shelf-menu.component.ts
+++ b/frontend/src/app/features/book/components/library-shelf-menu/library-shelf-menu.component.ts
@@ -1,5 +1,5 @@
 import {ChangeDetectionStrategy, Component, computed, inject, input, output, viewChild} from '@angular/core';
-import {LucidePencil, LucideTrash2} from '@lucide/angular';
+import {LucideTrash2} from '@lucide/angular';
 import {TranslocoPipe} from '@jsverse/transloco';
 
 import {AppMenuComponent} from '../../../../shared/ui/menu/app-menu.component';
@@ -51,7 +51,6 @@ export type LibraryShelfMenuTarget =
               </app-menu-item>
               <app-menu-separator />
               <app-menu-item
-                [icon]="pencilIcon"
                 (selected)="actions.editLibrary(currentTarget.entity.id)">
                 {{ 'book.shelfMenuService.library.editLibrary' | transloco }}
               </app-menu-item>
@@ -87,7 +86,6 @@ export type LibraryShelfMenuTarget =
                 </app-menu-section>
               }
               <app-menu-item
-                [icon]="pencilIcon"
                 [disabled]="!canManageShelf()"
                 (selected)="actions.editShelf(currentTarget.entity.id)">
                 {{ 'book.shelfMenuService.shelf.editShelf' | transloco }}
@@ -103,7 +101,6 @@ export type LibraryShelfMenuTarget =
             }
             @case ('magicShelf') {
               <app-menu-item
-                [icon]="pencilIcon"
                 [disabled]="!canManageMagicShelf()"
                 (selected)="actions.editMagicShelf(currentTarget.entity.id)">
                 {{ 'book.shelfMenuService.magicShelf.editMagicShelf' | transloco }}
@@ -136,7 +133,6 @@ export class LibraryShelfMenuComponent {
 
   private readonly currentUser = inject(UserService).currentUser;
   protected readonly actions = inject(LibraryShelfMenuService);
-  protected readonly pencilIcon = LucidePencil.icon;
   protected readonly trashIcon = LucideTrash2.icon;
 
   readonly available = computed(() => {

--- a/frontend/src/app/features/book/service/library-shelf-menu.service.spec.ts
+++ b/frontend/src/app/features/book/service/library-shelf-menu.service.spec.ts
@@ -42,6 +42,7 @@ describe('LibraryShelfMenuService', () => {
   const translocoService = {translate: vi.fn((key: string) => key)};
 
   beforeEach(() => {
+    router.url = '/';
     TestBed.configureTestingModule({
       providers: [
         LibraryShelfMenuService,
@@ -78,6 +79,12 @@ describe('LibraryShelfMenuService', () => {
     confirmationService.confirm.mock.calls[1][0].accept();
     expect(libraryService.deleteLibrary).toHaveBeenCalledWith(7);
     expect(loadingService.hide).toHaveBeenCalledWith('loader-token');
+    expect(router.navigate).not.toHaveBeenCalled();
+
+    router.url = '/library/7/books?sort=title#results';
+    service.deleteLibrary({id: 7, name: 'Main Library'});
+    confirmationService.confirm.mock.calls[2][0].accept();
+    expect(router.navigate).toHaveBeenCalledWith(['/']);
   });
 
   it('runs shelf and magic-shelf actions', () => {
@@ -94,6 +101,17 @@ describe('LibraryShelfMenuService', () => {
     confirmationService.confirm.mock.calls[1][0].accept();
     expect(shelfService.deleteShelf).toHaveBeenCalledWith(11);
     expect(magicShelfService.deleteShelf).toHaveBeenCalledWith(13);
+    expect(router.navigate).not.toHaveBeenCalled();
+
+    router.url = '/shelf/11/books?sort=title#results';
+    service.deleteShelf({id: 11, name: 'Favorites'});
+    confirmationService.confirm.mock.calls[2][0].accept();
+
+    router.url = '/magic-shelf/13/books?sort=title#results';
+    service.deleteMagicShelf({id: 13, name: 'Magic Shelf'});
+    confirmationService.confirm.mock.calls[3][0].accept();
+    expect(router.navigate).toHaveBeenNthCalledWith(1, ['/']);
+    expect(router.navigate).toHaveBeenNthCalledWith(2, ['/']);
   });
 
   it('copies magic-shelf JSON', async () => {

--- a/frontend/src/app/features/book/service/library-shelf-menu.service.spec.ts
+++ b/frontend/src/app/features/book/service/library-shelf-menu.service.spec.ts
@@ -26,7 +26,7 @@ describe('LibraryShelfMenuService', () => {
   const shelfService = {deleteShelf: vi.fn(() => of(undefined))};
   const magicShelfService = {deleteShelf: vi.fn(() => of(undefined))};
   const taskHelperService = {refreshMetadataTask: vi.fn(() => of(undefined))};
-  const router = {navigate: vi.fn(() => Promise.resolve(true))};
+  const router = {url: '/', navigate: vi.fn(() => Promise.resolve(true))};
   const dialogLauncherService = {
     openLibraryEditDialog: vi.fn(() => Promise.resolve(null)),
     openShelfEditDialog: vi.fn(() => Promise.resolve(null)),

--- a/frontend/src/app/features/book/service/library-shelf-menu.service.spec.ts
+++ b/frontend/src/app/features/book/service/library-shelf-menu.service.spec.ts
@@ -1,112 +1,45 @@
 import {TestBed} from '@angular/core/testing';
 import {Router} from '@angular/router';
+import {TranslocoService} from '@jsverse/transloco';
+import {ConfirmationService, MessageService} from '@openng/optimus-ui/api';
 import {of} from 'rxjs';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import type {MenuItem, MenuItemCommandEvent} from '@openng/optimus-ui/api';
-import {ConfirmationService, MessageService} from '@openng/optimus-ui/api';
-import {TranslocoService} from '@jsverse/transloco';
 
-import {LibraryShelfMenuService} from './library-shelf-menu.service';
-import {LibraryService} from './library.service';
-import {ShelfService} from './shelf.service';
-import {TaskHelperService} from '../../settings/task-management/task-helper.service';
-import {UserService} from '../../settings/user-management/user.service';
 import {LoadingService} from '../../../core/services/loading.service';
 import {DialogLauncherService} from '../../../shared/services/dialog-launcher.service';
-import {BookDialogHelperService} from '../components/book-browser/book-dialog-helper.service';
 import {MagicShelfService} from '../../magic-shelf/service/magic-shelf.service';
-import {MetadataRefreshType} from '../../metadata/model/request/metadata-refresh-type.enum';
-import type {Library} from '../model/library.model';
-import type {Shelf} from '../model/shelf.model';
-import type {MagicShelf} from '../../magic-shelf/service/magic-shelf.service';
-
-function buildLibrary(overrides: Partial<Library> = {}): Library {
-  return {
-    id: 7,
-    name: 'Main Library',
-    watch: true,
-    paths: [],
-    ...overrides,
-  };
-}
-
-function buildShelf(overrides: Partial<Shelf> = {}): Shelf {
-  return {
-    id: 11,
-    name: 'Favorites',
-    userId: 3,
-    publicShelf: false,
-    ...overrides,
-  };
-}
-
-function buildMagicShelf(overrides: Partial<MagicShelf> = {}): MagicShelf {
-  return {
-    id: 13,
-    name: 'Magic Shelf',
-    filterJson: '{}',
-    isPublic: false,
-    ...overrides,
-  };
-}
-
-function findMenuItem(items: MenuItem[], label: string): MenuItem {
-  const item = items
-    .flatMap(candidate => candidate.items ?? [candidate])
-    .find(candidate => candidate.label === label);
-  expect(item).toBeDefined();
-  return item!;
-}
-
-function runCommand(item: MenuItem): void {
-  item.command?.({ item } as MenuItemCommandEvent);
-}
+import {TaskHelperService} from '../../settings/task-management/task-helper.service';
+import {BookDialogHelperService} from '../components/book-browser/book-dialog-helper.service';
+import {LibraryService} from './library.service';
+import {LibraryShelfMenuService} from './library-shelf-menu.service';
+import {ShelfService} from './shelf.service';
 
 describe('LibraryShelfMenuService', () => {
   let service: LibraryShelfMenuService;
-  const confirmationService = {
-    confirm: vi.fn(),
-  };
-  const messageService = {
-    add: vi.fn(),
-  };
+
+  const confirmationService = {confirm: vi.fn()};
+  const messageService = {add: vi.fn()};
   const libraryService = {
     refreshLibrary: vi.fn(() => of(undefined)),
     deleteLibrary: vi.fn(() => of(undefined)),
   };
-  const shelfService = {
-    deleteShelf: vi.fn(() => of(undefined)),
-  };
-  const taskHelperService = {
-    refreshMetadataTask: vi.fn(() => of(undefined)),
-  };
-  const userService = {
-    getCurrentUser: vi.fn(() => ({id: 3, permissions: {admin: false}})),
-  };
-  const router = {
-    navigate: vi.fn(),
-  };
+  const shelfService = {deleteShelf: vi.fn(() => of(undefined))};
+  const magicShelfService = {deleteShelf: vi.fn(() => of(undefined))};
+  const taskHelperService = {refreshMetadataTask: vi.fn(() => of(undefined))};
+  const router = {navigate: vi.fn(() => Promise.resolve(true))};
   const dialogLauncherService = {
     openLibraryEditDialog: vi.fn(() => Promise.resolve(null)),
     openShelfEditDialog: vi.fn(() => Promise.resolve(null)),
     openMagicShelfEditDialog: vi.fn(() => Promise.resolve(null)),
   };
-  const magicShelfService = {
-    deleteShelf: vi.fn(() => of(undefined)),
-  };
-  const loadingService = {
-    show: vi.fn(() => 'loader-token'),
-    hide: vi.fn(),
-  };
+  const loadingService = {show: vi.fn(() => 'loader-token'), hide: vi.fn()};
   const bookDialogHelperService = {
     openAddPhysicalBookDialog: vi.fn(() => Promise.resolve(null)),
     openBulkIsbnImportDialog: vi.fn(() => Promise.resolve(null)),
     openDuplicateMergerDialog: vi.fn(() => Promise.resolve(null)),
     openMetadataRefreshDialogWithContext: vi.fn(() => Promise.resolve(null)),
   };
-  const translocoService = {
-    translate: vi.fn((key: string) => key),
-  };
+  const translocoService = {translate: vi.fn((key: string) => key)};
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -116,131 +49,62 @@ describe('LibraryShelfMenuService', () => {
         {provide: MessageService, useValue: messageService},
         {provide: LibraryService, useValue: libraryService},
         {provide: ShelfService, useValue: shelfService},
+        {provide: MagicShelfService, useValue: magicShelfService},
         {provide: TaskHelperService, useValue: taskHelperService},
-        {provide: UserService, useValue: userService},
         {provide: Router, useValue: router},
         {provide: DialogLauncherService, useValue: dialogLauncherService},
-        {provide: MagicShelfService, useValue: magicShelfService},
         {provide: LoadingService, useValue: loadingService},
         {provide: BookDialogHelperService, useValue: bookDialogHelperService},
         {provide: TranslocoService, useValue: translocoService},
       ],
     });
-
     service = TestBed.inject(LibraryShelfMenuService);
   });
 
   afterEach(() => {
     TestBed.resetTestingModule();
-    vi.restoreAllMocks();
-
-    confirmationService.confirm.mockClear();
-    messageService.add.mockClear();
-    libraryService.refreshLibrary.mockClear();
-    libraryService.deleteLibrary.mockClear();
-    shelfService.deleteShelf.mockClear();
-    taskHelperService.refreshMetadataTask.mockClear();
-    userService.getCurrentUser.mockClear();
-    router.navigate.mockClear();
-    dialogLauncherService.openLibraryEditDialog.mockClear();
-    dialogLauncherService.openShelfEditDialog.mockClear();
-    dialogLauncherService.openMagicShelfEditDialog.mockClear();
-    magicShelfService.deleteShelf.mockClear();
-    loadingService.show.mockClear();
-    loadingService.hide.mockClear();
-    bookDialogHelperService.openAddPhysicalBookDialog.mockClear();
-    bookDialogHelperService.openBulkIsbnImportDialog.mockClear();
-    bookDialogHelperService.openDuplicateMergerDialog.mockClear();
-    bookDialogHelperService.openMetadataRefreshDialogWithContext.mockClear();
-    translocoService.translate.mockClear();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
-  it('disables and guards library actions when the library id is missing', () => {
-    const items = service.initializeLibraryMenuItems(buildLibrary({id: undefined}));
+  it('runs accepted library confirmation actions with the resolved name', () => {
+    service.rescanLibrary({id: 7, name: 'Main Library'});
+    expect(confirmationService.confirm.mock.calls[0][0].message)
+      .toBe('book.shelfMenuService.confirm.rescanLibraryMessage');
+    confirmationService.confirm.mock.calls[0][0].accept();
+    expect(libraryService.refreshLibrary).toHaveBeenCalledWith(7);
 
-    const actionLabels = [
-      'book.shelfMenuService.library.addPhysicalBook',
-      'book.shelfMenuService.library.bulkIsbnImport',
-      'book.shelfMenuService.library.editLibrary',
-      'book.shelfMenuService.library.rescanLibrary',
-      'book.shelfMenuService.library.customFetchMetadata',
-      'book.shelfMenuService.library.autoFetchMetadata',
-      'book.shelfMenuService.library.findDuplicates',
-      'book.shelfMenuService.library.deleteLibrary',
-    ];
-
-    for (const label of actionLabels) {
-      const item = findMenuItem(items, label);
-      expect(item.disabled).toBe(true);
-      runCommand(item);
-    }
-
-    expect(bookDialogHelperService.openAddPhysicalBookDialog).not.toHaveBeenCalled();
-    expect(bookDialogHelperService.openBulkIsbnImportDialog).not.toHaveBeenCalled();
-    expect(bookDialogHelperService.openDuplicateMergerDialog).not.toHaveBeenCalled();
-    expect(dialogLauncherService.openLibraryEditDialog).not.toHaveBeenCalled();
-    expect(bookDialogHelperService.openMetadataRefreshDialogWithContext).not.toHaveBeenCalled();
-    expect(taskHelperService.refreshMetadataTask).not.toHaveBeenCalled();
-    expect(confirmationService.confirm).not.toHaveBeenCalled();
+    service.deleteLibrary({id: 7, name: 'Main Library'});
+    confirmationService.confirm.mock.calls[1][0].accept();
+    expect(libraryService.deleteLibrary).toHaveBeenCalledWith(7);
+    expect(loadingService.hide).toHaveBeenCalledWith('loader-token');
   });
 
-  it('passes the concrete library id into library actions when available', () => {
-    const items = service.initializeLibraryMenuItems(buildLibrary({id: 42}));
+  it('runs shelf and magic-shelf actions', () => {
+    service.editShelf(11);
+    service.deleteShelf({id: 11, name: 'Favorites'});
+    service.editMagicShelf(13);
+    service.deleteMagicShelf({id: 13, name: 'Magic Shelf'});
 
-    runCommand(findMenuItem(items, 'book.shelfMenuService.library.addPhysicalBook'));
-    runCommand(findMenuItem(items, 'book.shelfMenuService.library.bulkIsbnImport'));
-    runCommand(findMenuItem(items, 'book.shelfMenuService.library.editLibrary'));
-    runCommand(findMenuItem(items, 'book.shelfMenuService.library.customFetchMetadata'));
-    runCommand(findMenuItem(items, 'book.shelfMenuService.library.autoFetchMetadata'));
-    runCommand(findMenuItem(items, 'book.shelfMenuService.library.findDuplicates'));
-    runCommand(findMenuItem(items, 'book.shelfMenuService.library.rescanLibrary'));
-    runCommand(findMenuItem(items, 'book.shelfMenuService.library.deleteLibrary'));
-
-    expect(bookDialogHelperService.openAddPhysicalBookDialog).toHaveBeenCalledWith(42);
-    expect(bookDialogHelperService.openBulkIsbnImportDialog).toHaveBeenCalledWith(42);
-    expect(dialogLauncherService.openLibraryEditDialog).toHaveBeenCalledWith(42);
-    expect(bookDialogHelperService.openMetadataRefreshDialogWithContext).toHaveBeenCalledWith({
-      metadataRefreshType: MetadataRefreshType.LIBRARY,
-      libraryId: 42
-    });
-    expect(taskHelperService.refreshMetadataTask).toHaveBeenCalledWith({
-      refreshType: MetadataRefreshType.LIBRARY,
-      libraryId: 42,
-    });
-    expect(bookDialogHelperService.openDuplicateMergerDialog).toHaveBeenCalledWith(42);
+    expect(dialogLauncherService.openShelfEditDialog).toHaveBeenCalledWith(11);
+    expect(dialogLauncherService.openMagicShelfEditDialog).toHaveBeenCalledWith(13);
     expect(confirmationService.confirm).toHaveBeenCalledTimes(2);
+
+    confirmationService.confirm.mock.calls[0][0].accept();
+    confirmationService.confirm.mock.calls[1][0].accept();
+    expect(shelfService.deleteShelf).toHaveBeenCalledWith(11);
+    expect(magicShelfService.deleteShelf).toHaveBeenCalledWith(13);
   });
 
-  it('guards shelf actions when the shelf id is missing even for the owner', () => {
-    userService.getCurrentUser.mockReturnValue({id: 3, permissions: {admin: false}});
-    const items = service.initializeShelfMenuItems(buildShelf({id: undefined, userId: 3}));
+  it('copies magic-shelf JSON', async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    vi.stubGlobal('navigator', {clipboard: {writeText}});
 
-    const editItem = findMenuItem(items, 'book.shelfMenuService.shelf.editShelf');
-    const deleteItem = findMenuItem(items, 'book.shelfMenuService.shelf.deleteShelf');
+    service.copyMagicShelfJson('{"rule":true}');
+    await Promise.resolve();
 
-    expect(editItem.disabled).toBe(true);
-    expect(deleteItem.disabled).toBe(true);
-
-    runCommand(editItem);
-    runCommand(deleteItem);
-
-    expect(dialogLauncherService.openShelfEditDialog).not.toHaveBeenCalled();
-    expect(confirmationService.confirm).not.toHaveBeenCalled();
+    expect(writeText).toHaveBeenCalledWith('{"rule":true}');
+    expect(messageService.add).toHaveBeenCalledWith(expect.objectContaining({severity: 'success'}));
   });
 
-  it('guards magic shelf actions when the shelf id is missing', () => {
-    const items = service.initializeMagicShelfMenuItems(buildMagicShelf({id: null}));
-
-    const editItem = findMenuItem(items, 'book.shelfMenuService.magicShelf.editMagicShelf');
-    const deleteItem = findMenuItem(items, 'book.shelfMenuService.magicShelf.deleteMagicShelf');
-
-    expect(editItem.disabled).toBe(true);
-    expect(deleteItem.disabled).toBe(true);
-
-    runCommand(editItem);
-    runCommand(deleteItem);
-
-    expect(dialogLauncherService.openMagicShelfEditDialog).not.toHaveBeenCalled();
-    expect(confirmationService.confirm).not.toHaveBeenCalled();
-  });
 });

--- a/frontend/src/app/features/book/service/library-shelf-menu.service.ts
+++ b/frontend/src/app/features/book/service/library-shelf-menu.service.ts
@@ -112,7 +112,7 @@ export class LibraryShelfMenuService {
           .pipe(finalize(() => this.loadingService.hide(loader)))
           .subscribe({
             complete: () => {
-              void this.router.navigate(['/']);
+              this.navigateHomeIfViewing(`/library/${library.id}/books`);
               this.messageService.add({
                 severity: 'info',
                 summary: this.t.translate('common.success'),
@@ -137,6 +137,7 @@ export class LibraryShelfMenuService {
 
   deleteShelf(shelf: LibraryShelfActionTarget): void {
     this.confirmShelfDeletion(shelf, () => this.shelfService.deleteShelf(shelf.id), {
+      targetUrl: `/shelf/${shelf.id}/books`,
       confirm: 'book.shelfMenuService.confirm.deleteShelfMessage',
       success: 'book.shelfMenuService.toast.shelfDeletedDetail',
       failure: 'book.shelfMenuService.toast.shelfDeleteFailedDetail',
@@ -175,6 +176,7 @@ export class LibraryShelfMenuService {
 
   deleteMagicShelf(shelf: LibraryShelfActionTarget): void {
     this.confirmShelfDeletion(shelf, () => this.magicShelfService.deleteShelf(shelf.id), {
+      targetUrl: `/magic-shelf/${shelf.id}/books`,
       confirm: 'book.shelfMenuService.confirm.deleteMagicShelfMessage',
       success: 'book.shelfMenuService.toast.magicShelfDeletedDetail',
       failure: 'book.shelfMenuService.toast.magicShelfDeleteFailedDetail',
@@ -184,7 +186,7 @@ export class LibraryShelfMenuService {
   private confirmShelfDeletion(
     shelf: LibraryShelfActionTarget,
     deleteShelf: () => Observable<void>,
-    messages: Readonly<{confirm: string; success: string; failure: string}>,
+    messages: Readonly<{targetUrl: string; confirm: string; success: string; failure: string}>,
   ): void {
     this.confirmationService.confirm({
       message: this.t.translate(messages.confirm, {name: shelf.name}),
@@ -200,7 +202,7 @@ export class LibraryShelfMenuService {
       accept: () => {
         deleteShelf().subscribe({
           complete: () => {
-            void this.router.navigate(['/']);
+            this.navigateHomeIfViewing(messages.targetUrl);
             this.messageService.add({
               severity: 'info',
               summary: this.t.translate('common.success'),
@@ -217,5 +219,12 @@ export class LibraryShelfMenuService {
         });
       },
     });
+  }
+
+  private navigateHomeIfViewing(deletedTargetUrl: string): void {
+    const currentPath = this.router.url.replace(/[?#].*$/, '');
+    if (currentPath === deletedTargetUrl) {
+      void this.router.navigate(['/']);
+    }
   }
 }

--- a/frontend/src/app/features/book/service/library-shelf-menu.service.ts
+++ b/frontend/src/app/features/book/service/library-shelf-menu.service.ts
@@ -1,365 +1,221 @@
-import { inject, Injectable } from '@angular/core';
-import { ConfirmationService, MessageService } from '@openng/optimus-ui/api';
-import { Router } from '@angular/router';
-import { LibraryService } from './library.service';
-import { ShelfService } from './shelf.service';
-import { Library } from '../model/library.model';
-import { Shelf } from '../model/shelf.model';
-import { MetadataRefreshType } from '../../metadata/model/request/metadata-refresh-type.enum';
-import { MagicShelf, MagicShelfService } from '../../magic-shelf/service/magic-shelf.service';
-import { TaskHelperService } from '../../settings/task-management/task-helper.service';
-import { UserService } from '../../settings/user-management/user.service';
-import { LoadingService } from '../../../core/services/loading.service';
-import { finalize } from 'rxjs';
-import { DialogLauncherService } from '../../../shared/services/dialog-launcher.service';
-import { BookDialogHelperService } from '../components/book-browser/book-dialog-helper.service';
-import { TranslocoService } from '@jsverse/transloco';
-import type { MenuItem } from '@openng/optimus-ui/api';
+import {inject, Injectable} from '@angular/core';
+import {Router} from '@angular/router';
+import {TranslocoService} from '@jsverse/transloco';
+import {ConfirmationService, MessageService} from '@openng/optimus-ui/api';
+import {finalize, type Observable} from 'rxjs';
 
-@Injectable({
-  providedIn: 'root',
-})
+import {LoadingService} from '../../../core/services/loading.service';
+import {DialogLauncherService} from '../../../shared/services/dialog-launcher.service';
+import {MagicShelfService} from '../../magic-shelf/service/magic-shelf.service';
+import {MetadataRefreshType} from '../../metadata/model/request/metadata-refresh-type.enum';
+import {TaskHelperService} from '../../settings/task-management/task-helper.service';
+import {BookDialogHelperService} from '../components/book-browser/book-dialog-helper.service';
+import {LibraryService} from './library.service';
+import {ShelfService} from './shelf.service';
+
+type LibraryShelfActionTarget = Readonly<{id: number; name: string}>;
+
+@Injectable({providedIn: 'root'})
 export class LibraryShelfMenuService {
-
-  private confirmationService = inject(ConfirmationService);
-  private messageService = inject(MessageService);
-  private libraryService = inject(LibraryService);
-  private shelfService = inject(ShelfService);
-  private taskHelperService = inject(TaskHelperService);
-  private router = inject(Router);
-  private dialogLauncherService = inject(DialogLauncherService);
-  private magicShelfService = inject(MagicShelfService);
-  private userService = inject(UserService);
-  private loadingService = inject(LoadingService);
-  private bookDialogHelperService = inject(BookDialogHelperService);
+  private readonly confirmationService = inject(ConfirmationService);
+  private readonly messageService = inject(MessageService);
+  private readonly libraryService = inject(LibraryService);
+  private readonly shelfService = inject(ShelfService);
+  private readonly taskHelperService = inject(TaskHelperService);
+  private readonly router = inject(Router);
+  private readonly dialogLauncherService = inject(DialogLauncherService);
+  private readonly magicShelfService = inject(MagicShelfService);
+  private readonly loadingService = inject(LoadingService);
+  private readonly bookDialogHelperService = inject(BookDialogHelperService);
   private readonly t = inject(TranslocoService);
 
-  initializeLibraryMenuItems(entity: Library | null): MenuItem[] {
-    const libraryId = entity?.id;
-
-    return [
-      {
-        label: this.t.translate('book.shelfMenuService.library.optionsLabel'),
-        items: [
-          {
-            label: this.t.translate('book.shelfMenuService.library.addPhysicalBook'),
-            icon: 'pi pi-book',
-            disabled: libraryId == null,
-            command: async () => {
-              if (libraryId == null) {
-                return;
-              }
-              await this.bookDialogHelperService.openAddPhysicalBookDialog(libraryId).catch(() => undefined);
-            }
-          },
-          {
-            label: this.t.translate('book.shelfMenuService.library.bulkIsbnImport'),
-            icon: 'pi pi-barcode',
-            disabled: libraryId == null,
-            command: async () => {
-              if (libraryId == null) {
-                return;
-              }
-              await this.bookDialogHelperService.openBulkIsbnImportDialog(libraryId).catch(() => undefined);
-            }
-          },
-          {
-            separator: true
-          },
-          {
-            label: this.t.translate('book.shelfMenuService.library.editLibrary'),
-            icon: 'pi pi-pen-to-square',
-            disabled: libraryId == null,
-            command: () => {
-              if (libraryId == null) {
-                return;
-              }
-              void this.dialogLauncherService.openLibraryEditDialog(libraryId).catch(() => undefined);
-            }
-          },
-          {
-            label: this.t.translate('book.shelfMenuService.library.rescanLibrary'),
-            icon: 'pi pi-refresh',
-            disabled: libraryId == null,
-            command: () => {
-              if (libraryId == null) {
-                return;
-              }
-              this.confirmationService.confirm({
-                message: this.t.translate('book.shelfMenuService.confirm.rescanLibraryMessage', {name: entity?.name}),
-                header: this.t.translate('book.shelfMenuService.confirm.header'),
-                icon: undefined,
-                acceptLabel: this.t.translate('book.shelfMenuService.confirm.rescanLabel'),
-                rejectLabel: this.t.translate('common.cancel'),
-                acceptIcon: undefined,
-                rejectIcon: undefined,
-                acceptButtonStyleClass: undefined,
-                rejectButtonStyleClass: undefined,
-                rejectButtonProps: {
-                  label: this.t.translate('common.cancel'),
-                  severity: 'secondary',
-                },
-                acceptButtonProps: {
-                  label: this.t.translate('book.shelfMenuService.confirm.rescanLabel'),
-                  severity: 'success',
-                },
-                accept: () => {
-                  this.libraryService.refreshLibrary(libraryId).subscribe({
-                    complete: () => {
-                      this.messageService.add({severity: 'info', summary: this.t.translate('common.success'), detail: this.t.translate('book.shelfMenuService.toast.libraryRefreshSuccessDetail')});
-                    },
-                    error: () => {
-                      this.messageService.add({
-                        severity: 'error',
-                        summary: this.t.translate('book.shelfMenuService.toast.failedSummary'),
-                        detail: this.t.translate('book.shelfMenuService.toast.libraryRefreshFailedDetail'),
-                      });
-                    }
-                  });
-                }
-              });
-            }
-          },
-          {
-            label: this.t.translate('book.shelfMenuService.library.customFetchMetadata'),
-            icon: 'pi pi-sync',
-            disabled: libraryId == null,
-            command: async () => {
-              if (libraryId == null) {
-                return;
-              }
-              await this.bookDialogHelperService.openMetadataRefreshDialogWithContext({
-                metadataRefreshType: MetadataRefreshType.LIBRARY,
-                libraryId
-              }).catch(() => undefined);
-            }
-          },
-          {
-            label: this.t.translate('book.shelfMenuService.library.autoFetchMetadata'),
-            icon: 'pi pi-bolt',
-            disabled: libraryId == null,
-            command: () => {
-              if (libraryId == null) {
-                return;
-              }
-              this.taskHelperService.refreshMetadataTask({
-                refreshType: MetadataRefreshType.LIBRARY,
-                libraryId
-              }).subscribe();
-            }
-          },
-          {
-            label: this.t.translate('book.shelfMenuService.library.findDuplicates'),
-            icon: 'pi pi-copy',
-            disabled: libraryId == null,
-            command: async () => {
-              if (libraryId == null) {
-                return;
-              }
-              await this.bookDialogHelperService.openDuplicateMergerDialog(libraryId).catch(() => undefined);
-            }
-          },
-          {
-            separator: true
-          },
-          {
-            label: this.t.translate('book.shelfMenuService.library.deleteLibrary'),
-            icon: 'pi pi-trash',
-            disabled: libraryId == null,
-            command: () => {
-              if (libraryId == null) {
-                return;
-              }
-              this.confirmationService.confirm({
-                message: this.t.translate('book.shelfMenuService.confirm.deleteLibraryMessage', {name: entity?.name}),
-                header: this.t.translate('book.shelfMenuService.confirm.header'),
-                acceptLabel: this.t.translate('common.yes'),
-                rejectLabel: this.t.translate('common.cancel'),
-                rejectButtonProps: {
-                  label: this.t.translate('common.cancel'),
-                  severity: 'secondary',
-                },
-                acceptButtonProps: {
-                  label: this.t.translate('common.yes'),
-                  severity: 'danger',
-                },
-                accept: () => {
-                  const loader = this.loadingService.show(this.t.translate('book.shelfMenuService.loading.deletingLibrary', {name: entity?.name}));
-
-                  this.libraryService.deleteLibrary(libraryId)
-                    .pipe(finalize(() => this.loadingService.hide(loader)))
-                    .subscribe({
-                      complete: () => {
-                        this.router.navigate(['/']);
-                        this.messageService.add({severity: 'info', summary: this.t.translate('common.success'), detail: this.t.translate('book.shelfMenuService.toast.libraryDeletedDetail')});
-                      },
-                      error: () => {
-                        this.messageService.add({
-                          severity: 'error',
-                          summary: this.t.translate('book.shelfMenuService.toast.failedSummary'),
-                          detail: this.t.translate('book.shelfMenuService.toast.libraryDeleteFailedDetail'),
-                        });
-                      }
-                    });
-                }
-              });
-            }
-          }
-        ]
-      }
-    ];
+  addPhysicalBook(libraryId: number): void {
+    void this.bookDialogHelperService.openAddPhysicalBookDialog(libraryId);
   }
 
-  initializeShelfMenuItems(entity: Shelf | null): MenuItem[] {
-    const user = this.userService.getCurrentUser();
-    const shelfId = entity?.id;
-    const isOwner = entity?.userId === user?.id;
-    const isPublicShelf = entity?.publicShelf ?? false;
-    const disableOptions = !isOwner || shelfId == null;
+  importIsbns(libraryId: number): void {
+    void this.bookDialogHelperService.openBulkIsbnImportDialog(libraryId);
+  }
 
-    const items: MenuItem[] = [
-      {
-        label: this.t.translate('book.shelfMenuService.shelf.editShelf'),
-        icon: 'pi pi-pen-to-square',
-        disabled: disableOptions,
-        command: () => {
-          if (shelfId == null) {
-            return;
-          }
+  editLibrary(libraryId: number): void {
+    void this.dialogLauncherService.openLibraryEditDialog(libraryId);
+  }
 
-          void this.dialogLauncherService.openShelfEditDialog(shelfId).catch(() => undefined);
-        }
+  rescanLibrary(library: LibraryShelfActionTarget): void {
+    this.confirmationService.confirm({
+      message: this.t.translate('book.shelfMenuService.confirm.rescanLibraryMessage', {name: library.name}),
+      header: this.t.translate('book.shelfMenuService.confirm.header'),
+      acceptLabel: this.t.translate('book.shelfMenuService.confirm.rescanLabel'),
+      rejectLabel: this.t.translate('common.cancel'),
+      rejectButtonProps: {
+        severity: 'secondary',
       },
-      {
-        separator: true
+      acceptButtonProps: {
+        severity: 'success',
       },
-      {
-        label: this.t.translate('book.shelfMenuService.shelf.deleteShelf'),
-        icon: 'pi pi-trash',
-        disabled: disableOptions,
-        command: () => {
-          if (shelfId == null) {
-            return;
-          }
+      accept: () => {
+        this.libraryService.refreshLibrary(library.id).subscribe({
+          complete: () => {
+            this.messageService.add({
+              severity: 'info',
+              summary: this.t.translate('common.success'),
+              detail: this.t.translate('book.shelfMenuService.toast.libraryRefreshSuccessDetail'),
+            });
+          },
+          error: () => {
+            this.messageService.add({
+              severity: 'error',
+              summary: this.t.translate('book.shelfMenuService.toast.failedSummary'),
+              detail: this.t.translate('book.shelfMenuService.toast.libraryRefreshFailedDetail'),
+            });
+          },
+        });
+      },
+    });
+  }
 
-          this.confirmationService.confirm({
-            message: this.t.translate('book.shelfMenuService.confirm.deleteShelfMessage', {name: entity?.name}),
-            header: this.t.translate('book.shelfMenuService.confirm.header'),
-            acceptLabel: this.t.translate('common.yes'),
-            rejectLabel: this.t.translate('common.cancel'),
-            acceptButtonProps: {
-              label: this.t.translate('common.yes'),
-              severity: 'danger'
-            },
-            rejectButtonProps: {
-              label: this.t.translate('common.cancel'),
-              severity: 'secondary'
-            },
-            accept: () => {
-              this.shelfService.deleteShelf(shelfId).subscribe({
-                complete: () => {
-                  this.router.navigate(['/']);
-                  this.messageService.add({severity: 'info', summary: this.t.translate('common.success'), detail: this.t.translate('book.shelfMenuService.toast.shelfDeletedDetail')});
-                },
-                error: () => {
-                  this.messageService.add({
-                    severity: 'error',
-                    summary: this.t.translate('book.shelfMenuService.toast.failedSummary'),
-                    detail: this.t.translate('book.shelfMenuService.toast.shelfDeleteFailedDetail'),
-                  });
-                }
+  customFetchLibraryMetadata(libraryId: number): void {
+    void this.bookDialogHelperService.openMetadataRefreshDialogWithContext({
+      metadataRefreshType: MetadataRefreshType.LIBRARY,
+      libraryId,
+    });
+  }
+
+  autoFetchLibraryMetadata(libraryId: number): void {
+    this.taskHelperService.refreshMetadataTask({
+      refreshType: MetadataRefreshType.LIBRARY,
+      libraryId,
+    }).subscribe();
+  }
+
+  findLibraryDuplicates(libraryId: number): void {
+    void this.bookDialogHelperService.openDuplicateMergerDialog(libraryId);
+  }
+
+  deleteLibrary(library: LibraryShelfActionTarget): void {
+    this.confirmationService.confirm({
+      message: this.t.translate('book.shelfMenuService.confirm.deleteLibraryMessage', {name: library.name}),
+      header: this.t.translate('book.shelfMenuService.confirm.header'),
+      acceptLabel: this.t.translate('common.yes'),
+      rejectLabel: this.t.translate('common.cancel'),
+      rejectButtonProps: {
+        severity: 'secondary',
+      },
+      acceptButtonProps: {
+        severity: 'danger',
+      },
+      accept: () => {
+        const loader = this.loadingService.show(
+          this.t.translate('book.shelfMenuService.loading.deletingLibrary', {name: library.name}),
+        );
+        this.libraryService.deleteLibrary(library.id)
+          .pipe(finalize(() => this.loadingService.hide(loader)))
+          .subscribe({
+            complete: () => {
+              void this.router.navigate(['/']);
+              this.messageService.add({
+                severity: 'info',
+                summary: this.t.translate('common.success'),
+                detail: this.t.translate('book.shelfMenuService.toast.libraryDeletedDetail'),
               });
-            }
+            },
+            error: () => {
+              this.messageService.add({
+                severity: 'error',
+                summary: this.t.translate('book.shelfMenuService.toast.failedSummary'),
+                detail: this.t.translate('book.shelfMenuService.toast.libraryDeleteFailedDetail'),
+              });
+            },
           });
-        }
-      }
-    ];
+      },
+    });
+  }
 
-    /* Keep the grouped label only when it conveys state (public/read-only). */
-    if (isPublicShelf || disableOptions) {
-      const prefix = isPublicShelf ? this.t.translate('book.shelfMenuService.shelf.publicShelfPrefix') : '';
-      const suffix = disableOptions
-        ? this.t.translate('book.shelfMenuService.shelf.readOnly')
-        : this.t.translate('book.shelfMenuService.shelf.optionsLabel');
-      return [{ label: prefix + suffix, items }];
+  editShelf(shelfId: number): void {
+    void this.dialogLauncherService.openShelfEditDialog(shelfId);
+  }
+
+  deleteShelf(shelf: LibraryShelfActionTarget): void {
+    this.confirmShelfDeletion(shelf, () => this.shelfService.deleteShelf(shelf.id), {
+      confirm: 'book.shelfMenuService.confirm.deleteShelfMessage',
+      success: 'book.shelfMenuService.toast.shelfDeletedDetail',
+      failure: 'book.shelfMenuService.toast.shelfDeleteFailedDetail',
+    });
+  }
+
+  editMagicShelf(shelfId: number): void {
+    void this.dialogLauncherService.openMagicShelfEditDialog(shelfId);
+  }
+
+  copyMagicShelfJson(filterJson: string): void {
+    if (!navigator.clipboard) {
+      this.notifyJsonCopyFailed();
+      return;
     }
 
-    return items;
+    void navigator.clipboard.writeText(filterJson).then(
+      () => {
+        this.messageService.add({
+          severity: 'success',
+          summary: this.t.translate('common.success'),
+          detail: this.t.translate('book.shelfMenuService.toast.magicShelfJsonCopiedDetail'),
+        });
+      },
+      () => this.notifyJsonCopyFailed(),
+    );
   }
 
-  initializeMagicShelfMenuItems(entity: MagicShelf | null): MenuItem[] {
-    const isAdmin = this.userService.getCurrentUser()?.permissions.admin ?? false;
-    const magicShelfId = entity?.id;
-    const isPublicShelf = entity?.isPublic ?? false;
-    const disableOptions = magicShelfId == null || (isPublicShelf && !isAdmin);
+  private notifyJsonCopyFailed(): void {
+    this.messageService.add({
+      severity: 'error',
+      summary: this.t.translate('book.shelfMenuService.toast.failedSummary'),
+      detail: this.t.translate('book.shelfMenuService.toast.magicShelfJsonCopyFailedDetail'),
+    });
+  }
 
-    return [
-      {
-        label: this.t.translate('book.shelfMenuService.magicShelf.editMagicShelf'),
-        icon: 'pi pi-pen-to-square',
-        disabled: disableOptions,
-        command: () => {
-          if (magicShelfId == null) {
-            return;
-          }
+  deleteMagicShelf(shelf: LibraryShelfActionTarget): void {
+    this.confirmShelfDeletion(shelf, () => this.magicShelfService.deleteShelf(shelf.id), {
+      confirm: 'book.shelfMenuService.confirm.deleteMagicShelfMessage',
+      success: 'book.shelfMenuService.toast.magicShelfDeletedDetail',
+      failure: 'book.shelfMenuService.toast.magicShelfDeleteFailedDetail',
+    });
+  }
 
-          void this.dialogLauncherService.openMagicShelfEditDialog(magicShelfId).catch(() => undefined);
-        }
+  private confirmShelfDeletion(
+    shelf: LibraryShelfActionTarget,
+    deleteShelf: () => Observable<void>,
+    messages: Readonly<{confirm: string; success: string; failure: string}>,
+  ): void {
+    this.confirmationService.confirm({
+      message: this.t.translate(messages.confirm, {name: shelf.name}),
+      header: this.t.translate('book.shelfMenuService.confirm.header'),
+      acceptLabel: this.t.translate('common.yes'),
+      rejectLabel: this.t.translate('common.cancel'),
+      acceptButtonProps: {
+        severity: 'danger',
       },
-      {
-        label: this.t.translate('book.shelfMenuService.magicShelf.exportJson'),
-        icon: 'pi pi-copy',
-        command: () => {
-          if (entity?.filterJson) {
-            navigator.clipboard.writeText(entity.filterJson).then(() => {
-              this.messageService.add({severity: 'success', summary: this.t.translate('common.success'), detail: this.t.translate('book.shelfMenuService.toast.magicShelfJsonCopiedDetail')});
+      rejectButtonProps: {
+        severity: 'secondary',
+      },
+      accept: () => {
+        deleteShelf().subscribe({
+          complete: () => {
+            void this.router.navigate(['/']);
+            this.messageService.add({
+              severity: 'info',
+              summary: this.t.translate('common.success'),
+              detail: this.t.translate(messages.success),
             });
-          }
-        }
+          },
+          error: () => {
+            this.messageService.add({
+              severity: 'error',
+              summary: this.t.translate('book.shelfMenuService.toast.failedSummary'),
+              detail: this.t.translate(messages.failure),
+            });
+          },
+        });
       },
-      {
-        separator: true
-      },
-      {
-        label: this.t.translate('book.shelfMenuService.magicShelf.deleteMagicShelf'),
-        icon: 'pi pi-trash',
-        disabled: disableOptions,
-        command: () => {
-          if (magicShelfId == null) {
-            return;
-          }
-
-          this.confirmationService.confirm({
-            message: this.t.translate('book.shelfMenuService.confirm.deleteMagicShelfMessage', {name: entity?.name}),
-            header: this.t.translate('book.shelfMenuService.confirm.header'),
-            acceptLabel: this.t.translate('common.yes'),
-            rejectLabel: this.t.translate('common.cancel'),
-            acceptButtonProps: {
-              label: this.t.translate('common.yes'),
-              severity: 'danger'
-            },
-            rejectButtonProps: {
-              label: this.t.translate('common.cancel'),
-              severity: 'secondary'
-            },
-            accept: () => {
-              this.magicShelfService.deleteShelf(magicShelfId).subscribe({
-                complete: () => {
-                  this.router.navigate(['/']);
-                  this.messageService.add({severity: 'info', summary: this.t.translate('common.success'), detail: this.t.translate('book.shelfMenuService.toast.magicShelfDeletedDetail')});
-                },
-                error: () => {
-                  this.messageService.add({
-                    severity: 'error',
-                    summary: this.t.translate('book.shelfMenuService.toast.failedSummary'),
-                    detail: this.t.translate('book.shelfMenuService.toast.magicShelfDeleteFailedDetail'),
-                  });
-                }
-              });
-            }
-          });
-        }
-      }
-    ];
+    });
   }
 }

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.html
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.html
@@ -71,28 +71,29 @@
   }
 
   <span class="sidebar-item-end-content">
-    @if (shouldShowContextMenuButton()) {
-      <button
-        type="button"
-        class="entity-menu-button"
-        [attr.aria-label]="'common.moreActionsFor' | transloco: { label: currentItem.label }"
-        aria-haspopup="menu"
-        (click)="openContextMenu($event, entitymenu)"
-      >
-        <span class="entity-menu-button-content">
-          <svg lucideEllipsisVertical class="entity-menu-icon" aria-hidden="true"></svg>
-          <span class="entity-menu-count">{{ formatCount(currentItem.bookCount) }}</span>
-        </span>
-      </button>
-      <p-menu
-        #entitymenu
-        [model]="currentItem.contextMenuItems"
-        [popup]="true"
-        appendTo="body"
-        styleClass="sidebar-entity-menu"
-        (onShow)="markContextMenuOpen()"
-        (onHide)="closeContextMenu()"
-      ></p-menu>
+    @if (currentItem.menuTarget; as menuTarget) {
+      <app-library-shelf-menu
+        #entityMenu
+        [target]="menuTarget"
+        [ariaLabel]="'common.moreActionsFor' | transloco: {label: currentItem.label}"
+        (opened)="markContextMenuOpen()"
+        (closed)="closeContextMenu()" />
+
+      @if (entityMenu.available()) {
+        <button
+          type="button"
+          class="entity-menu-button"
+          [attr.aria-label]="'common.moreActionsFor' | transloco: {label: currentItem.label}"
+          [appMenuTriggerFor]="entityMenu.menu()"
+        >
+          <span class="entity-menu-button-content">
+            <svg lucideEllipsisVertical class="entity-menu-icon" aria-hidden="true"></svg>
+            <span class="entity-menu-count">{{ formatCount(currentItem.bookCount) }}</span>
+          </span>
+        </button>
+      } @else if (currentItem.bookCount) {
+        <p class="book-count book-count-end">{{ formatCount(currentItem.bookCount) }}</p>
+      }
     } @else if (currentItem.bookCount) {
       <p class="book-count book-count-end">{{ formatCount(currentItem.bookCount) }}</p>
     }

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.spec.ts
@@ -1,104 +1,35 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { signal } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { AppSidebarItemRowComponent } from './app.sidebar-item-row.component';
-import { UserService } from '../../../features/settings/user-management/user.service';
-import { LayoutService } from '../layout.service';
+import {signal} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {LayoutService} from '../layout.service';
+import {AppSidebarItemRowComponent} from './app.sidebar-item-row.component';
 
 describe('AppSidebarItemRowComponent', () => {
   let fixture: ComponentFixture<AppSidebarItemRowComponent>;
   let component: AppSidebarItemRowComponent;
-
-  const layoutService = {
-    sidebarCollapsed: signal(false),
-    currentPath: signal('/'),
-  };
+  const currentPath = signal('/');
 
   beforeEach(() => {
-    TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       imports: [AppSidebarItemRowComponent],
-      providers: [
-        {
-          provide: UserService,
-          useValue: {
-            currentUser: signal({
-              permissions: {
-                canManageLibrary: true,
-                admin: true,
-              },
-            }),
-          },
-        },
-        { provide: LayoutService, useValue: layoutService },
-      ],
+      providers: [{provide: LayoutService, useValue: {currentPath}}],
     });
-
-    TestBed.overrideComponent(AppSidebarItemRowComponent, { set: { template: '' } });
-
+    TestBed.overrideComponent(AppSidebarItemRowComponent, {set: {template: ''}});
     fixture = TestBed.createComponent(AppSidebarItemRowComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('index', 0);
     fixture.componentRef.setInput('parentKey', 'home-0');
-    layoutService.sidebarCollapsed.set(false);
+    fixture.componentRef.setInput('item', {id: 'dashboard', label: 'Dashboard', routerLink: ['/dashboard']});
   });
 
-  function setItem(item: Parameters<ComponentFixture<AppSidebarItemRowComponent>['componentRef']['setInput']>[1]): void {
-    fixture.componentRef.setInput('item', item);
-  }
-
-  it('passes context menu items through to the template', () => {
-    const editCommand = vi.fn();
-    const nestedCommand = vi.fn();
-
-    const item = {
-      id: 'shelf-a',
-      label: 'Shelf A',
-      type: 'shelf',
-      contextMenuItems: [
-        { label: 'Edit', command: editCommand },
-        { label: 'More', items: [{ label: 'Delete', command: nestedCommand }] },
-      ],
-    };
-    setItem(item);
-
-    fixture.detectChanges();
-
-    const items = component.item().contextMenuItems!;
-    expect(items[0].label).toBe('Edit');
-    items[0].command?.({} as never);
-    expect(editCommand).toHaveBeenCalled();
-
-    expect(items[1].items?.[0].label).toBe('Delete');
-    items[1].items?.[0].command?.({} as never);
-    expect(nestedCommand).toHaveBeenCalled();
-  });
-
-  it('hides the context menu button for items without context menu actions', () => {
-    setItem({ id: 'unshelved', label: 'Unshelved', type: 'shelf' });
-    fixture.detectChanges();
-    expect(component.shouldShowContextMenuButton()).toBe(false);
-  });
-
-  it('exposes admin and canManipulateLibrary as computed signals from UserService', () => {
-    setItem({ id: 'test', label: 'Test' });
-    fixture.detectChanges();
-    expect(component.admin()).toBe(true);
-    expect(component.canManipulateLibrary()).toBe(true);
-  });
-
-  it('reports route as active when currentPath matches item routerLink', () => {
-    setItem({ id: 'dashboard', label: 'Dashboard', routerLink: ['/dashboard'] });
-    layoutService.currentPath.set('/dashboard');
-    fixture.detectChanges();
+  it('reports route as active when the path matches', () => {
+    currentPath.set('/dashboard');
     expect(component.isRouteActive()).toBe(true);
   });
 
-  it('reports route as inactive when currentPath does not match', () => {
-    setItem({ id: 'dashboard', label: 'Dashboard', routerLink: ['/dashboard'] });
-    layoutService.currentPath.set('/library/1/books');
-    fixture.detectChanges();
+  it('reports route as inactive when the path differs', () => {
+    currentPath.set('/library/1/books');
     expect(component.isRouteActive()).toBe(false);
   });
-
 });

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar-item-row.component.ts
@@ -1,15 +1,15 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { Menu } from '@openng/optimus-ui/menu';
 import { Tooltip } from '@openng/optimus-ui/tooltip';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { LucideEllipsisVertical } from '@lucide/angular';
 import { IconSelection, toIconSelection } from '../../icons/icon-selection';
 
-import { UserService } from '../../../features/settings/user-management/user.service';
 import { IconDisplayComponent } from '../../components/icon-display/icon-display.component';
 import { LayoutService } from '../layout.service';
 import { SidebarLeaf } from '../navigation/nav-item.model';
+import {LibraryShelfMenuComponent} from '../../../features/book/components/library-shelf-menu/library-shelf-menu.component';
+import {AppMenuTriggerDirective} from '../../ui/menu/app-menu-trigger.directive';
 
 @Component({
   // Attribute selector so the row renders into its host <li> inside a <ul>.
@@ -19,7 +19,8 @@ import { SidebarLeaf } from '../navigation/nav-item.model';
   styleUrls: ['./app.sidebar-item-row.component.scss'],
   imports: [
     RouterLink,
-    Menu,
+    LibraryShelfMenuComponent,
+    AppMenuTriggerDirective,
     IconDisplayComponent,
     Tooltip,
     TranslocoPipe,
@@ -35,7 +36,6 @@ export class AppSidebarItemRowComponent {
   readonly menuOpen = signal(false);
   readonly key = computed(() => `${this.parentKey()}-${this.index()}`);
 
-  private readonly userService = inject(UserService);
   readonly layoutService = inject(LayoutService);
 
   readonly isRouteActive = computed(() => {
@@ -44,21 +44,9 @@ export class AppSidebarItemRowComponent {
     return this.layoutService.currentPath() === route;
   });
 
-  readonly canManipulateLibrary = computed(() =>
-    this.userService.currentUser()?.permissions.canManageLibrary ?? false
-  );
-
-  readonly admin = computed(() =>
-    this.userService.currentUser()?.permissions.admin ?? false
-  );
-
   runAction(event: Event): void {
     event.preventDefault();
     this.item().action?.();
-  }
-
-  openContextMenu(event: Event, menu: Menu): void {
-    menu.toggle(event);
   }
 
   markContextMenuOpen(): void {
@@ -73,16 +61,6 @@ export class AppSidebarItemRowComponent {
     const item = this.item();
     if (!item.icon) return null;
     return toIconSelection(item.icon, item.iconType);
-  }
-
-  hasContextMenu(): boolean {
-    return (this.item().contextMenuItems?.length ?? 0) > 0;
-  }
-
-  shouldShowContextMenuButton(): boolean {
-    const item = this.item();
-    return this.hasContextMenu()
-      && (item.type !== 'library' || (this.admin() || this.canManipulateLibrary()));
   }
 
   formatCount(count: number | null | undefined): string {

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.html
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.html
@@ -55,22 +55,28 @@
       [tooltipDisabled]="!layoutService.isDesktop()"
       tooltipPosition="bottom"
       [attr.aria-label]="t('add')"
-      aria-haspopup="menu"
-      [attr.aria-expanded]="addMenuOpen() ? 'true' : 'false'"
-      (click)="toggleAddMenu($event, addMenu)"
+      [appMenuTriggerFor]="addMenu"
     >
       <svg lucidePlus aria-hidden="true"></svg>
     </button>
 
-    <p-menu
+    <app-menu
       #addMenu
-      [model]="addMenuItems()"
-      [popup]="true"
-      appendTo="body"
-      styleClass="sidebar-create-menu"
-      (onShow)="addMenuOpen.set(true)"
-      (onHide)="addMenuOpen.set(false)"
-    ></p-menu>
+      [ariaLabel]="t('add')">
+      @if (currentUser(); as user) {
+        @if (user.permissions.admin || user.permissions.canManageLibrary) {
+          <app-menu-item (selected)="dialogLauncherService.openLibraryCreateDialog()">
+            {{ t('createLibrary') }}
+          </app-menu-item>
+        }
+        <app-menu-item (selected)="bookDialogHelperService.openShelfCreatorDialog()">
+          {{ 'book.shelfCreator.title' | transloco }}
+        </app-menu-item>
+        <app-menu-item (selected)="dialogLauncherService.openMagicShelfCreateDialog()">
+          {{ t('createMagicShelf') }}
+        </app-menu-item>
+      }
+    </app-menu>
 
     @if (canUploadBooks()) {
       <button
@@ -177,9 +183,7 @@
         [tooltipDisabled]="!layoutService.isDesktop()"
         tooltipPosition="top"
         [attr.aria-label]="t('add')"
-        aria-haspopup="menu"
-        [attr.aria-expanded]="addMenuOpen() ? 'true' : 'false'"
-        (click)="toggleAddMenu($event, addMenu)"
+        [appMenuTriggerFor]="addMenu"
       >
         <svg lucidePlus aria-hidden="true"></svg>
         <span class="sidebar-footer-action-label">{{ t('add') }}</span>

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.scss
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.scss
@@ -16,10 +16,6 @@
   margin-bottom: var(--sidebar-header-gap-after);
 }
 
-.sidebar-header > p-menu {
-  display: none;
-}
-
 .sidebar-brand {
   /* Shared rendered-height for both SVGs — derived from wordmark's width × aspect
      at default sidebar width. Keeps the wordmark and G-only mark the same pixel

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.spec.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.spec.ts
@@ -10,7 +10,6 @@ import { BookDialogHelperService } from '../../../features/book/components/book-
 import { BookService } from '../../../features/book/service/book.service';
 import { LibraryHealthService } from '../../../features/book/service/library-health.service';
 import { LibraryService } from '../../../features/book/service/library.service';
-import { LibraryShelfMenuService } from '../../../features/book/service/library-shelf-menu.service';
 import { ShelfService } from '../../../features/book/service/shelf.service';
 import { AuthorService } from '../../../features/author-browser/service/author.service';
 import { MagicShelfService } from '../../../features/magic-shelf/service/magic-shelf.service';
@@ -89,14 +88,6 @@ describe('AppSidebarComponent', () => {
         { provide: LibraryHealthService, useValue: { isUnhealthy: vi.fn(() => false) } },
         { provide: ShelfService, useValue: { shelves: signal([]), bookCountByShelfId: signal(new Map()), unshelvedBookCount: signal(0) } },
         { provide: BookService, useValue: { books: signal([]) } },
-        {
-          provide: LibraryShelfMenuService,
-          useValue: {
-            initializeLibraryMenuItems: vi.fn(() => []),
-            initializeShelfMenuItems: vi.fn(() => []),
-            initializeMagicShelfMenuItems: vi.fn(() => []),
-          },
-        },
         {
           provide: DialogLauncherService,
           useValue: {

--- a/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/app.sidebar.component.ts
@@ -1,7 +1,6 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { AppSidebarSectionComponent } from './app.sidebar-section.component';
-import { Menu } from '@openng/optimus-ui/menu';
 import { CdkTrapFocus } from '@angular/cdk/a11y';
 import { CdkConnectedOverlay, CdkOverlayOrigin, ConnectedPosition } from '@angular/cdk/overlay';
 import { BookDialogHelperService } from '../../../features/book/components/book-browser/book-dialog-helper.service';
@@ -30,7 +29,6 @@ import { LibraryService } from '../../../features/book/service/library.service';
 import { LibraryHealthService } from '../../../features/book/service/library-health.service';
 import { ShelfService } from '../../../features/book/service/shelf.service';
 import { BookService } from '../../../features/book/service/book.service';
-import { LibraryShelfMenuService } from '../../../features/book/service/library-shelf-menu.service';
 import { UserService } from '../../../features/settings/user-management/user.service';
 import { MagicShelfService } from '../../../features/magic-shelf/service/magic-shelf.service';
 import { SeriesDataService } from '../../../features/series-browser/service/series-data.service';
@@ -41,10 +39,8 @@ import { AuthService } from '../../service/auth.service';
 import { LayoutService } from '../layout.service';
 import { TranslocoDirective, TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { Tooltip } from '@openng/optimus-ui/tooltip';
-import type { MenuItem } from '@openng/optimus-ui/api';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { NavItem, SidebarSection } from '../navigation/nav-item.model';
-import { buildCreateActionNavItems } from '../navigation/nav-catalog';
+import { SidebarSection } from '../navigation/nav-item.model';
 import {
   buildHomeSection,
   buildLibrarySection,
@@ -60,6 +56,9 @@ import { LibraryImportProgressService } from '../../service/library-import-progr
 import { AppThemeService } from '../../service/app-theme.service';
 import type { AppearancePreference } from '../../model/app-state.model';
 import { APPEARANCE_OPTIONS } from '../theme/appearance-options';
+import {AppMenuComponent} from '../../ui/menu/app-menu.component';
+import {AppMenuItemComponent} from '../../ui/menu/app-menu-item.component';
+import {AppMenuTriggerDirective} from '../../ui/menu/app-menu-trigger.directive';
 
 const DOCUMENTATION_URL = 'https://grimmory.org/docs/getting-started';
 const ABOVE_ALIGN_LEFT: ConnectedPosition[] = [
@@ -145,7 +144,9 @@ function isNewerVersion(latest: string | undefined, current: string | undefined)
     LucideUpload,
     LucideUserPen,
     LucideX,
-    Menu,
+    AppMenuComponent,
+    AppMenuItemComponent,
+    AppMenuTriggerDirective,
     UnifiedNotificationBoxComponent,
     RouterLink,
     TranslocoDirective,
@@ -163,10 +164,9 @@ export class AppSidebarComponent {
   private readonly libraryHealthService = inject(LibraryHealthService);
   private readonly shelfService = inject(ShelfService);
   private readonly bookService = inject(BookService);
-  private readonly libraryShelfMenuService = inject(LibraryShelfMenuService);
-  private readonly dialogLauncherService = inject(DialogLauncherService);
+  protected readonly dialogLauncherService = inject(DialogLauncherService);
   private readonly commandPaletteService = inject(CommandPaletteService);
-  private readonly bookDialogHelperService = inject(BookDialogHelperService);
+  protected readonly bookDialogHelperService = inject(BookDialogHelperService);
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   readonly layoutService = inject(LayoutService);
@@ -230,7 +230,7 @@ export class AppSidebarComponent {
         this.libraryService.bookCountByLibraryId(),
         this.layoutService.librarySort(),
         this.translate,
-        { health: this.libraryHealthService, menuItems: this.libraryShelfMenuService },
+        { health: this.libraryHealthService },
       ),
       ...buildShelfSection(
         this.shelfService.shelves(),
@@ -238,31 +238,15 @@ export class AppSidebarComponent {
         this.shelfService.unshelvedBookCount(),
         this.layoutService.shelfSort(),
         this.translate,
-        { menuItems: this.libraryShelfMenuService },
       ),
       ...buildMagicShelfSection(
         this.magicShelfService.shelves(),
         this.magicShelfService.bookCountByMagicShelfId(),
         this.layoutService.magicShelfSort(),
         this.translate,
-        { menuItems: this.libraryShelfMenuService },
       ),
       ...buildToolsSection(this.translate, this.currentUser()?.permissions ?? {}),
     ];
-  });
-
-  readonly addMenuItems = computed<MenuItem[]>(() => {
-    this.activeLang();
-    const user = this.currentUser();
-    if (!user) return [];
-
-    const actions = buildCreateActionNavItems(this.translate, user.permissions, {
-      createLibrary: () => void this.dialogLauncherService.openLibraryCreateDialog().catch(() => undefined),
-      createShelf: () => void this.bookDialogHelperService.openShelfCreatorDialog().catch(() => undefined),
-      createMagicShelf: () => void this.dialogLauncherService.openMagicShelfCreateDialog().catch(() => undefined),
-      uploadBook: () => void this.dialogLauncherService.openFileUploadDialog().catch(() => undefined),
-    });
-    return this.toMenuItems(actions);
   });
 
   readonly userInitials = computed(() => {
@@ -273,7 +257,6 @@ export class AppSidebarComponent {
   protected readonly notificationsOpen = signal(false);
   protected readonly notificationPopoverOrigin = signal<CdkOverlayOrigin | null>(null);
   private readonly notificationPopoverMobilePositions = signal<ConnectedPosition[]>(ABOVE_ALIGN_CENTER);
-  protected readonly addMenuOpen = signal(false);
   protected readonly aboveMenuPositions = ABOVE_ALIGN_LEFT;
   protected readonly notificationPopoverPositions = computed(() =>
     this.layoutService.isDesktop() ? RIGHT_ALIGN_TOP : this.notificationPopoverMobilePositions()
@@ -367,28 +350,6 @@ export class AppSidebarComponent {
       event.preventDefault();
       this.closeNotificationsPopover();
     }
-  }
-
-  // Temporary: the Optimus UI menu cannot render Lucide icons here.
-  private static readonly ADD_MENU_ICONS: Record<string, string> = {
-    createLibrary: 'pi pi-folder',
-    createShelf: 'pi pi-bookmark',
-    createMagicShelf: 'pi pi-sparkles',
-  };
-
-  private toMenuItems(items: readonly (NavItem | null | undefined)[]): MenuItem[] {
-    return items.flatMap((item): MenuItem[] =>
-      item ? [{
-        label: item.label,
-        icon: AppSidebarComponent.ADD_MENU_ICONS[item.id],
-        routerLink: item.routerLink,
-        command: item.action,
-      }] : []
-    );
-  }
-
-  protected toggleAddMenu(event: MouseEvent, menu: Menu): void {
-    menu.toggle(event);
   }
 
   protected toggleHeaderNotificationsPopover(origin: CdkOverlayOrigin): void {

--- a/frontend/src/app/shared/layout/layout-sidebar/sidebar-sections.spec.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/sidebar-sections.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { Library } from '../../../features/book/model/library.model';
 import { Shelf } from '../../../features/book/model/shelf.model';
@@ -28,15 +28,6 @@ function magicShelf(overrides: Partial<MagicShelf> & { name: string }): MagicShe
 
 const libraryDeps = {
   health: { isUnhealthy: (id: number) => id === 99 },
-  menuItems: { initializeLibraryMenuItems: vi.fn(() => []) },
-};
-
-const shelfDeps = {
-  menuItems: { initializeShelfMenuItems: vi.fn(() => []) },
-};
-
-const magicShelfDeps = {
-  menuItems: { initializeMagicShelfMenuItems: vi.fn(() => []) },
 };
 
 describe('normalizeSortPref', () => {
@@ -139,6 +130,7 @@ describe('buildLibrarySection', () => {
       id: 'library:5',
       label: 'Fiction',
       type: 'library',
+      menuTarget: {type: 'library', entity: libs[0]},
       icon: 'book',
       iconType: 'LUCIDE',
       routerLink: ['/library/5/books'],
@@ -159,7 +151,7 @@ describe('buildShelfSection', () => {
   const sort = { field: 'name', order: 'asc' } as const;
 
   it('renders Unshelved even when no shelves are persisted', () => {
-    const [section] = buildShelfSection([], new Map(), 5, sort, translate, shelfDeps);
+    const [section] = buildShelfSection([], new Map(), 5, sort, translate);
 
     expect(section.items).toEqual([
       expect.objectContaining({
@@ -172,7 +164,7 @@ describe('buildShelfSection', () => {
 
   it('always renders Unshelved as the first item when shelves exist', () => {
     const shelves = [shelf({ id: 1, name: 'Reading' })];
-    const [section] = buildShelfSection(shelves, new Map(), 9, sort, translate, shelfDeps);
+    const [section] = buildShelfSection(shelves, new Map(), 9, sort, translate);
 
     expect(section.items?.[0]).toMatchObject({
       id: 'shelfUnshelved',
@@ -187,10 +179,12 @@ describe('buildShelfSection', () => {
       shelf({ id: 2, name: 'Kobo', systemKey: 'kobo' }),
       shelf({ id: 3, name: 'Archive' }),
     ];
-    const [section] = buildShelfSection(shelves, new Map(), 0, sort, translate, shelfDeps);
+    const [section] = buildShelfSection(shelves, new Map(), 0, sort, translate);
 
     expect(section.items?.map((item) => item.label))
       .toEqual(['layout.menu.unshelved', 'Kobo', 'Archive', 'Reading']);
+    expect(section.items?.find((item) => item.label === 'Kobo')?.menuTarget)
+      .toEqual({type: 'shelf', entity: shelves[1]});
   });
 
   it('keeps the standard ordering when no shelf is marked for pinning', () => {
@@ -199,7 +193,7 @@ describe('buildShelfSection', () => {
       shelf({ id: 2, name: 'Kobo' }),
       shelf({ id: 3, name: 'Archive' }),
     ];
-    const [section] = buildShelfSection(shelves, new Map(), 0, sort, translate, shelfDeps);
+    const [section] = buildShelfSection(shelves, new Map(), 0, sort, translate);
 
     expect(section.items?.map((item) => item.label))
       .toEqual(['layout.menu.unshelved', 'Archive', 'Kobo', 'Reading']);
@@ -211,7 +205,7 @@ describe('buildMagicShelfSection', () => {
   const sort = { field: 'name', order: 'asc' } as const;
 
   it('returns no section when no magic shelves are persisted', () => {
-    expect(buildMagicShelfSection([], new Map(), sort, translate, magicShelfDeps)).toEqual([]);
+    expect(buildMagicShelfSection([], new Map(), sort, translate)).toEqual([]);
   });
 
   it('renders sorted magic shelves with route, icon, and count', () => {
@@ -221,13 +215,15 @@ describe('buildMagicShelfSection', () => {
     ];
     const counts = new Map([[1, 4], [2, 7]]);
 
-    const [section] = buildMagicShelfSection(shelves, counts, sort, translate, magicShelfDeps);
+    const [section] = buildMagicShelfSection(shelves, counts, sort, translate);
     expect(section.items).toEqual([
       expect.objectContaining({
         id: 'magicShelf:1', label: 'Alpha', routerLink: ['/magic-shelf/1/books'], bookCount: 4,
+        menuTarget: {type: 'magicShelf', entity: shelves[1]},
       }),
       expect.objectContaining({
         id: 'magicShelf:2', label: 'Beta', icon: 'sparkles', iconType: 'LUCIDE',
+        menuTarget: {type: 'magicShelf', entity: shelves[0]},
         routerLink: ['/magic-shelf/2/books'], bookCount: 7,
       }),
     ]);

--- a/frontend/src/app/shared/layout/layout-sidebar/sidebar-sections.ts
+++ b/frontend/src/app/shared/layout/layout-sidebar/sidebar-sections.ts
@@ -2,7 +2,6 @@ import { Library } from '../../../features/book/model/library.model';
 import { Shelf } from '../../../features/book/model/shelf.model';
 import { MagicShelf } from '../../../features/magic-shelf/service/magic-shelf.service';
 import { LibraryHealthService } from '../../../features/book/service/library-health.service';
-import { LibraryShelfMenuService } from '../../../features/book/service/library-shelf-menu.service';
 import { SortPref } from '../sidebar-sort-preferences';
 
 import { SidebarLeaf, SidebarSection } from '../navigation/nav-item.model';
@@ -16,15 +15,6 @@ export interface HomeCounts {
 
 export interface LibrarySectionDeps {
   health: Pick<LibraryHealthService, 'isUnhealthy'>;
-  menuItems: Pick<LibraryShelfMenuService, 'initializeLibraryMenuItems'>;
-}
-
-export interface ShelfSectionDeps {
-  menuItems: Pick<LibraryShelfMenuService, 'initializeShelfMenuItems'>;
-}
-
-export interface MagicShelfSectionDeps {
-  menuItems: Pick<LibraryShelfMenuService, 'initializeMagicShelfMenuItems'>;
 }
 
 type TranslateFn = (key: string) => string;
@@ -110,12 +100,12 @@ export function buildLibrarySection(
       id: `library:${library.id}`,
       label: library.name,
       type: 'library',
+      menuTarget: {type: 'library', entity: library},
       icon: library.icon || undefined,
       iconType: library.iconType ?? undefined,
       routerLink: [`/library/${library.id}/books`],
       bookCount: bookCounts.get(library.id) ?? 0,
       unhealthy: deps.health.isUnhealthy(library.id),
-      contextMenuItems: deps.menuItems.initializeLibraryMenuItems(library),
     })),
   }];
 }
@@ -126,7 +116,6 @@ export function buildShelfSection(
   unshelvedCount: number,
   sort: SortPref,
   translate: TranslateFn,
-  deps: ShelfSectionDeps,
 ): SidebarSection[] {
   const sorted = sortByPref(withIds(shelves), sort);
   const pinnedIndex = sorted.findIndex((shelf) => shelf.systemKey === 'kobo');
@@ -142,11 +131,11 @@ export function buildShelfSection(
   }];
 
   if (pinned) {
-    items.push(toShelfNavItem(pinned, bookCounts, deps));
+    items.push(toShelfNavItem(pinned, bookCounts));
   }
 
   for (const shelf of sorted) {
-    items.push(toShelfNavItem(shelf, bookCounts, deps));
+    items.push(toShelfNavItem(shelf, bookCounts));
   }
 
   return [{
@@ -162,17 +151,16 @@ export function buildShelfSection(
 function toShelfNavItem(
   shelf: WithId<Shelf>,
   bookCounts: ReadonlyMap<number, number>,
-  deps: ShelfSectionDeps,
 ): SidebarLeaf {
   return {
     id: `shelf:${shelf.id}`,
     label: shelf.name,
     type: 'shelf',
+    menuTarget: {type: 'shelf', entity: shelf},
     icon: shelf.icon || undefined,
     iconType: shelf.iconType ?? undefined,
     routerLink: [`/shelf/${shelf.id}/books`],
     bookCount: bookCounts.get(shelf.id) ?? 0,
-    contextMenuItems: deps.menuItems.initializeShelfMenuItems(shelf),
   };
 }
 
@@ -181,7 +169,6 @@ export function buildMagicShelfSection(
   bookCounts: ReadonlyMap<number, number>,
   sort: SortPref,
   translate: TranslateFn,
-  deps: MagicShelfSectionDeps,
 ): SidebarSection[] {
   const sorted = sortByPref(withIds(shelves), sort);
   if (sorted.length === 0) return [];
@@ -196,11 +183,11 @@ export function buildMagicShelfSection(
       id: `magicShelf:${shelf.id}`,
       label: shelf.name,
       type: 'magicShelf',
+      menuTarget: {type: 'magicShelf', entity: shelf},
       icon: shelf.icon || undefined,
       iconType: shelf.iconType ?? undefined,
       routerLink: [`/magic-shelf/${shelf.id}/books`],
       bookCount: bookCounts.get(shelf.id) ?? 0,
-      contextMenuItems: deps.menuItems.initializeMagicShelfMenuItems(shelf),
     })),
   }];
 }

--- a/frontend/src/app/shared/layout/navigation/nav-catalog.spec.ts
+++ b/frontend/src/app/shared/layout/navigation/nav-catalog.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildAllNavPages,
-  buildCreateActionNavItems,
   buildHomeNavItems,
   buildQuickActionNavItems,
   findPageNavItem,
@@ -80,24 +79,6 @@ describe('nav-catalog', () => {
       'createShelf',
       'createMagicShelf',
       'uploadBook',
-    ]);
-  });
-
-  it('builds create-only actions without upload', () => {
-    const handlers = {
-      createLibrary: vi.fn(),
-      createShelf: vi.fn(),
-      createMagicShelf: vi.fn(),
-      uploadBook: vi.fn(),
-    };
-
-    expect(buildCreateActionNavItems(translate, {
-      canManageLibrary: true,
-      canUpload: true,
-    }, handlers).map((item) => item.id)).toEqual([
-      'createLibrary',
-      'createShelf',
-      'createMagicShelf',
     ]);
   });
 });

--- a/frontend/src/app/shared/layout/navigation/nav-catalog.ts
+++ b/frontend/src/app/shared/layout/navigation/nav-catalog.ts
@@ -211,21 +211,6 @@ export function buildQuickActionNavItems(
     }));
 }
 
-export function buildCreateActionNavItems(
-  translate: TranslateFn,
-  permissions: ShellNavPermissions,
-  handlers: ShellActionHandlers,
-): NavItem[] {
-  return CREATE_ACTION_DEFINITIONS
-    .filter((definition) => isVisible(definition, permissions))
-    .map((definition) => ({
-      id: definition.id,
-      label: translate(definition.labelKey),
-      icon: definition.icon,
-      action: definition.run(handlers),
-    }));
-}
-
 const ALL_PAGE_DEFINITIONS: readonly PageDefinition[] = [
   ...HOME_PAGE_DEFINITIONS,
   ...SECONDARY_PAGE_DEFINITIONS,

--- a/frontend/src/app/shared/layout/navigation/nav-item.model.ts
+++ b/frontend/src/app/shared/layout/navigation/nav-item.model.ts
@@ -1,5 +1,5 @@
-import type { MenuItem } from '@openng/optimus-ui/api';
 import { IconType } from '../../icons/icon-selection';
+import type {LibraryShelfMenuTarget} from '../../../features/book/components/library-shelf-menu/library-shelf-menu.component';
 
 export type NavItemType =
   | 'library' | 'shelf' | 'magicShelf'
@@ -17,9 +17,9 @@ export interface NavItem {
 
 /** A clickable row inside a sidebar section. */
 export interface SidebarLeaf extends NavItem {
+  menuTarget?: LibraryShelfMenuTarget;
   bookCount?: number;
   unhealthy?: boolean;
-  contextMenuItems?: MenuItem[];
 }
 
 /** A heading that groups leaves in the sidebar. */

--- a/frontend/src/app/shared/ui/menu/menu.styles.ts
+++ b/frontend/src/app/shared/ui/menu/menu.styles.ts
@@ -19,7 +19,7 @@ export const appMenuSheetPanelClass =
   'rounded-t-xl rounded-b-none border-x-0 border-b-0 ' +
   'pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]';
 
-export const appMenuScrollRegionClass = 'flex min-h-0 flex-col overflow-y-auto overscroll-contain';
+export const appMenuScrollRegionClass = 'flex min-h-0 flex-col overflow-x-hidden overflow-y-auto overscroll-contain';
 
 export const appMenuSheetPaneClass = 'will-change-transform animate-in-sheet slide-in-from-bottom-full';
 

--- a/frontend/src/assets/styles/compat.scss
+++ b/frontend/src/assets/styles/compat.scss
@@ -235,15 +235,6 @@
 }
 
 @media #{variables.$mobile-shell-media-query} {
-  .sidebar-entity-menu.p-menu {
-    @include sidebar-fixed-overlay;
-
-    .p-menu-submenu-label {
-      display: none !important;
-    }
-  }
-
-  .sidebar-entity-menu.p-menu,
   .sidebar-flyout-popover.p-popover .p-menu,
   .sidebar-flyout-popover.p-popover .p-tieredmenu {
     > .p-menu-list,

--- a/frontend/src/i18n/en/book.json
+++ b/frontend/src/i18n/en/book.json
@@ -300,6 +300,7 @@
       "magicShelfDeletedDetail": "Magic shelf was deleted",
       "magicShelfDeleteFailedDetail": "Failed to delete shelf",
       "magicShelfJsonCopiedDetail": "Magic shelf JSON copied to clipboard",
+      "magicShelfJsonCopyFailedDetail": "Failed to copy magic shelf JSON",
       "failedSummary": "Failed",
       "dialogLoadFailedDetail": "An error occurred while loading the dialog. Please try again."
     },


### PR DESCRIPTION
## Description

Part of epic #2031 and follow-up to #2044 - Migrates the library and shelf context menu to app-menu, allowing for its use in the new browser UI. 

## Linked Issue

Fixes #2035 

## Changes

- Reworked `library-shelf-menu-service.ts` and added component for the dynamic menu. 
- Swapped sidebar item and browser menu to the new menu. 
- As part of the swap, also done the same for the small "add" menu in the sidebar's footer. 

## Manual Testing Steps

Open library/shelf menus in the sidebar and browser, confirm all options are present, access is correct, mobile sheet UI is used correctly. 

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
<img width="341" height="406" alt="Screenshot 2026-07-19 at 09 41 54" src="https://github.com/user-attachments/assets/1e82d0f4-64a4-425a-91ce-04a80cd4457e" />
<img width="203" height="255" alt="Screenshot 2026-07-19 at 09 41 34" src="https://github.com/user-attachments/assets/063d62bc-fb77-46b8-8304-02b167f38f2c" />

## Additional Context (Optional)

Requires the app-menu PR, will rebase once ready. 

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified “more actions” menu experience for libraries, shelves, and magic shelves across the book browser and sidebar.
  * Menu rendering, availability, and disabled states now follow permissions, with read-only wording when management isn’t allowed.
  * Replaced the sidebar’s previous mobile “Add” dropdown with the new internal menu UI.

* **Bug Fixes**
  * Improved delete and copy actions with loading feedback, safer clipboard handling, and clearer success/error notifications, including more precise post-delete navigation.

* **Tests**
  * Updated and added tests covering the new menu rendering and action flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->