### PR TITLE
refactor(epub): use archiveservice instead of epub4j to read archive

### DIFF
--- a/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
@@ -11,11 +11,11 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.repository.BookRepository;
+import org.booklore.service.ArchiveService;
 import org.booklore.util.FileUtils;
 import org.grimmory.epub4j.domain.*;
 import org.grimmory.epub4j.epub.CoverDetector;
 import org.grimmory.epub4j.epub.EpubReader;
-import org.grimmory.epub4j.native_parsing.NativeArchive;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
@@ -73,6 +73,7 @@ public class EpubReaderService {
             .maximumSize(MAX_CACHE_ENTRIES)
             .expireAfterAccess(Duration.ofMinutes(30))
             .build();
+    private final ArchiveService archiveService;
 
     private record CachedEpubMetadata(EpubBookInfo bookInfo, long lastModified,
                                       Set<String> validPaths,
@@ -380,9 +381,7 @@ public class EpubReaderService {
     }
 
     private void streamEntryFromZip(Path epubPath, String entryName, OutputStream outputStream) throws IOException {
-        try (NativeArchive archive = NativeArchive.open(epubPath)) {
-            archive.streamEntry(entryName, outputStream);
-        }
+        archiveService.transferEntryTo(epubPath, entryName, outputStream);
     }
 
     private String guessContentType(String path) {

--- a/backend/src/test/java/org/booklore/service/reader/EpubReaderServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/reader/EpubReaderServiceTest.java
@@ -7,6 +7,7 @@ import org.booklore.model.dto.response.EpubSpineItem;
 import org.booklore.model.dto.response.EpubTocItem;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.repository.BookRepository;
+import org.booklore.service.ArchiveService;
 import org.booklore.util.FileUtils;
 import org.grimmory.epub4j.domain.*;
 import org.grimmory.epub4j.epub.EpubWriter;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -39,6 +41,9 @@ class EpubReaderServiceTest {
 
     @Mock
     BookRepository bookRepository;
+
+    @Spy
+    ArchiveService archiveService = new ArchiveService();
 
     @InjectMocks
     EpubReaderService epubReaderService;


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
uses the `ArchiveService` we use everywhere else instead of the epub4j libarchive helper

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2055

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
switches from `NativeArchive` resource to `ArchiveService.transferEntryTo`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
Poked around epub reader
Ran Integration tests


## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB entry streaming for more consistent and reliable reading.
  * Streamlined archive handling to support smoother content delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->