### PR TITLE
build(ui): add `--ignore-scripts` when installing pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH="${PNPM_HOME}:${PATH}"
 
 WORKDIR /workspace
 
-RUN npm install -g pnpm@11.3.0
+RUN npm install --ignore-scripts -g pnpm@11.3.0
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,target=/pnpm/store \


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the pr #2065 only targeted `pnpm`, this targets `npm` to add `--ignore-scripts`

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2064

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
adds `--ignore-scripts` to `npm install`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

built image and confirmed it works

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend container build configuration to install the package manager without running installation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->