### PR TITLE
fix(ui): add missing page titles

### DIFF
--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.spec.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.spec.ts
@@ -13,6 +13,7 @@ import {Book} from '../../../book/model/book.model';
 import {BookService} from '../../../book/service/book.service';
 import {UserService} from '../../../settings/user-management/user.service';
 import {BookMetadataCenterComponent} from './book-metadata-center.component';
+import {TranslocoService} from '@jsverse/transloco';
 
 describe('BookMetadataCenterComponent', () => {
   let appSettingsSignal: WritableSignal<AppSettings | null>;
@@ -55,6 +56,7 @@ describe('BookMetadataCenterComponent', () => {
         {provide: UserService, useValue: {currentUser: currentUserSignal}},
         {provide: AppSettingsService, useValue: {appSettings: appSettingsSignal}},
         {provide: BookMetadataHostService, useValue: {bookSwitches$: new Subject<number>()}},
+        {provide: TranslocoService, useValue: {translate: (key: string) => key}},
       ],
     });
   });

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
@@ -131,7 +131,9 @@ export class BookMetadataCenterComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.pageTitle.setPageTitle(this.t.translate('metadata.center.title'));
+    if (!this.config) {
+      this.pageTitle.setPageTitle(this.t.translate('metadata.center.title'));
+    }
     const bookIdFromDialog: number | undefined = this.config?.data?.bookId;
     if (bookIdFromDialog != null) {
       this.currentBookId.set(bookIdFromDialog);

--- a/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/book-metadata-center.component.ts
@@ -10,13 +10,14 @@ import {Tab, TabList, TabPanel, TabPanels, Tabs,} from '@openng/optimus-ui/tabs'
 import {DynamicDialogConfig, DynamicDialogRef} from '@openng/optimus-ui/dynamicdialog';
 import {Button} from '@openng/optimus-ui/button';
 import {BookMetadataHostService} from '../../../../shared/service/book-metadata-host.service';
-import {TranslocoDirective} from '@jsverse/transloco';
+import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {MetadataViewerComponent} from './metadata-viewer/metadata-viewer.component';
 import {MetadataEditorComponent} from './metadata-editor/metadata-editor.component';
 import {MetadataSearcherComponent} from './metadata-searcher/metadata-searcher.component';
 import {SidecarViewerComponent} from './sidecar-viewer/sidecar-viewer.component';
 import {injectQuery, queryOptions} from '@tanstack/angular-query-experimental';
 import {bookRecommendationsQueryKey} from '../../../book/service/book-query-keys';
+import {PageTitleService} from '../../../../shared/service/page-title.service';
 
 enum BookMetadataTab {
   View = 'view',
@@ -52,6 +53,8 @@ export class BookMetadataCenterComponent implements OnInit {
   private appSettingsService = inject(AppSettingsService);
   private metadataHostService = inject(BookMetadataHostService);
   private destroyRef = inject(DestroyRef);
+  private pageTitle = inject(PageTitleService);
+  private t = inject(TranslocoService);
   readonly config = inject(DynamicDialogConfig, {optional: true});
   readonly ref = inject(DynamicDialogRef, {optional: true});
   BookMetadataTab = BookMetadataTab;
@@ -128,6 +131,7 @@ export class BookMetadataCenterComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.pageTitle.setPageTitle(this.t.translate('metadata.center.title'));
     const bookIdFromDialog: number | undefined = this.config?.data?.bookId;
     if (bookIdFromDialog != null) {
       this.currentBookId.set(bookIdFromDialog);

--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
@@ -216,6 +216,7 @@ export class EbookReaderComponent implements OnInit {
     ]).pipe(
       switchMap(([, book]) => {
         this.book.set(book);
+        this.pageTitle.setBookPageTitle(book);
         const bookType = (this.altBookType as BookType | undefined) ?? book.primaryFile?.bookType;
         if (!bookType) {
           return throwError(() => new Error('Book type not found'));
@@ -243,7 +244,6 @@ export class EbookReaderComponent implements OnInit {
         ]);
       }),
       switchMap(([, , {book, bookType, bookFileId}]) => {
-        this.pageTitle.setBookPageTitle(book);
         this.progressService.initialize(this.bookId, bookType, bookFileId);
         this.selectionService.initialize(this.bookId);
         this.headerService.initialize(this.bookId, book.metadata?.title || '');

--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
@@ -35,6 +35,7 @@ import {TranslocoPipe} from '@jsverse/transloco';
 import {RelocateProgressData} from './state/progress.service';
 import {WakeLockService} from '../../../shared/service/wake-lock.service';
 import {ViewEvent} from './core/view-manager.service';
+import {PageTitleService} from '../../../shared/service/page-title.service';
 
 interface PendingInitialChapterRestore {
   href: string;
@@ -96,6 +97,7 @@ export class EbookReaderComponent implements OnInit {
   private noteService = inject(ReaderNoteService);
   private wakeLockService = inject(WakeLockService);
   private messageService = inject(MessageService);
+  private pageTitle = inject(PageTitleService);
 
   public sidebarService = inject(ReaderSidebarService);
   public leftSidebarService = inject(ReaderLeftSidebarService);
@@ -241,6 +243,7 @@ export class EbookReaderComponent implements OnInit {
         ]);
       }),
       switchMap(([, , {book, bookType, bookFileId}]) => {
+        this.pageTitle.setBookPageTitle(book);
         this.progressService.initialize(this.bookId, bookType, bookFileId);
         this.selectionService.initialize(this.bookId);
         this.headerService.initialize(this.bookId, book.metadata?.title || '');

--- a/frontend/src/app/features/stats/component/library-stats/library-stats.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/library-stats.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, inject} from '@angular/core';
+import {Component, computed, inject, OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {CdkDragDrop, DragDropModule, moveItemInArray} from '@angular/cdk/drag-drop';
 import {Select} from '@openng/optimus-ui/select';
@@ -18,6 +18,7 @@ import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {BookService} from '../../../book/service/book.service';
 import {LibraryService} from '../../../book/service/library.service';
 import {StatsChartThemeService} from '../shared/stats-chart-theme.service';
+import {PageTitleService} from '../../../../shared/service/page-title.service';
 
 interface ChartConfig {
   id: string;
@@ -51,13 +52,14 @@ import {provideCharts, withDefaultRegisterables} from 'ng2-charts';
   templateUrl: './library-stats.component.html',
   styleUrls: ['./library-stats.component.scss']
 })
-export class LibraryStatsComponent {
+export class LibraryStatsComponent implements OnInit {
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly librariesSummaryService = inject(LibrariesSummaryService);
   private readonly bookService = inject(BookService);
   private readonly libraryService = inject(LibraryService);
   private readonly t = inject(TranslocoService);
   private readonly chartTheme = inject(StatsChartThemeService);
+  private readonly pageTitle = inject(PageTitleService);
 
   public readonly isLoading = computed(() =>
     this.bookService.isBooksLoading() || this.libraryService.isLibrariesLoading()
@@ -81,6 +83,10 @@ export class LibraryStatsComponent {
 
   constructor() {
     this.chartTheme.activate();
+  }
+
+  ngOnInit(): void {
+    this.pageTitle.setPageTitle(this.t.translate('statsLibrary.main.title'));
   }
 
   onLibraryChange(selectedLibrary: LibraryOption | null): void {

--- a/frontend/src/app/features/stats/component/user-stats/user-stats.component.spec.ts
+++ b/frontend/src/app/features/stats/component/user-stats/user-stats.component.spec.ts
@@ -5,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {UserService} from '../../../settings/user-management/user.service';
 import {UserChartConfigService} from './service/user-chart-config.service';
 import {UserStatsComponent} from './user-stats.component';
+import {TranslocoService} from '@jsverse/transloco';
 
 describe('UserStatsComponent', () => {
   let chartConfigService: {
@@ -38,6 +39,7 @@ describe('UserStatsComponent', () => {
           },
         },
         {provide: UserChartConfigService, useValue: chartConfigService},
+        {provide: TranslocoService, useValue: {translate: (key: string) => key }},
       ],
     });
   });

--- a/frontend/src/app/features/stats/component/user-stats/user-stats.component.ts
+++ b/frontend/src/app/features/stats/component/user-stats/user-stats.component.ts
@@ -1,9 +1,9 @@
-import {Component, computed, inject, signal} from '@angular/core';
+import {Component, computed, inject, OnInit, signal} from '@angular/core';
 import {CdkDragDrop, DragDropModule} from '@angular/cdk/drag-drop';
 import {Dialog} from '@openng/optimus-ui/dialog';
 import {Button} from '@openng/optimus-ui/button';
 import {UserService} from '../../../settings/user-management/user.service';
-import {TranslocoDirective} from '@jsverse/transloco';
+import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {PeakHoursChartComponent} from './charts/peak-hours-chart/peak-hours-chart.component';
 import {FavoriteDaysChartComponent} from './charts/favorite-days-chart/favorite-days-chart.component';
 import {ReadingDNAChartComponent} from './charts/reading-dna-chart/reading-dna-chart.component';
@@ -29,8 +29,8 @@ import {PublicationEraChartComponent} from './charts/publication-era-chart/publi
 import {SessionArchetypesChartComponent} from './charts/session-archetypes-chart/session-archetypes-chart.component';
 import {UserChartConfig, UserChartConfigService} from './service/user-chart-config.service';
 import {StatsChartThemeService} from '../shared/stats-chart-theme.service';
-
 import {provideCharts, withDefaultRegisterables} from 'ng2-charts';
+import {PageTitleService} from '../../../../shared/service/page-title.service';
 
 @Component({
   selector: 'app-user-stats',
@@ -68,10 +68,12 @@ import {provideCharts, withDefaultRegisterables} from 'ng2-charts';
   templateUrl: './user-stats.component.html',
   styleUrls: ['./user-stats.component.scss']
 })
-export class UserStatsComponent {
+export class UserStatsComponent implements OnInit {
   private userService = inject(UserService);
   private chartConfigService = inject(UserChartConfigService);
   private readonly chartTheme = inject(StatsChartThemeService);
+  private readonly pageTitle = inject(PageTitleService);
+  private readonly t = inject(TranslocoService);
 
   public currentYear = new Date().getFullYear();
   public readonly userName = computed(() => {
@@ -84,6 +86,10 @@ export class UserStatsComponent {
 
   constructor() {
     this.chartTheme.activate();
+  }
+
+  ngOnInit(): void {
+    this.pageTitle.setPageTitle(this.t.translate('statsUser.main.titleBarTitle'))
   }
 
   toggleChart(chartId: string): void {

--- a/frontend/src/i18n/cs/stats-user.json
+++ b/frontend/src/i18n/cs/stats-user.json
@@ -1,6 +1,7 @@
 {
   "main": {
     "title": "",
+    "titleBarTitle": "",
     "customizeLayout": "",
     "chartConfig": "",
     "resetLayout": "",

--- a/frontend/src/i18n/da/stats-user.json
+++ b/frontend/src/i18n/da/stats-user.json
@@ -255,6 +255,7 @@
         "close": "",
         "customizeLayout": "",
         "title": "",
+        "titleBarTitle": "",
         "hideAll": "",
         "showAll": ""
     },

--- a/frontend/src/i18n/de/stats-user.json
+++ b/frontend/src/i18n/de/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "{{ name }}s Lesestatistiken",
+        "titleBarTitle": "Lesestatistiken",
         "customizeLayout": "Layout anpassen",
         "chartConfig": "Diagrammkonfiguration",
         "resetLayout": "Layout zurücksetzen",

--- a/frontend/src/i18n/en/stats-user.json
+++ b/frontend/src/i18n/en/stats-user.json
@@ -1,6 +1,7 @@
 {
   "main": {
     "title": "{{ name }}'s Reading Statistics",
+    "titleBarTitle": "Reading Statistics",
     "customizeLayout": "Customize Layout",
     "chartConfig": "Chart Configuration",
     "resetLayout": "Reset Layout",

--- a/frontend/src/i18n/es/stats-user.json
+++ b/frontend/src/i18n/es/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Estadísticas de lectura de {{ name }}",
+        "titleBarTitle": "Estadísticas de lectura",
         "customizeLayout": "Personalizar diseño",
         "chartConfig": "Configuración de gráficos",
         "resetLayout": "Restablecer diseño",

--- a/frontend/src/i18n/fr/stats-user.json
+++ b/frontend/src/i18n/fr/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Statistiques de lecture de {{ name }}",
+        "titleBarTitle": "Statistiques de lecture",
         "customizeLayout": "Personnaliser la disposition",
         "chartConfig": "Configuration des graphiques",
         "resetLayout": "Réinitialiser la disposition",

--- a/frontend/src/i18n/hr/stats-user.json
+++ b/frontend/src/i18n/hr/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Statistika čitanja korisnika {{ name }}",
+        "titleBarTitle": "Statistika čitanja",
         "customizeLayout": "Prilagodi raspored",
         "chartConfig": "Konfiguracija grafikona",
         "resetLayout": "Vrati raspored",

--- a/frontend/src/i18n/hu/stats-user.json
+++ b/frontend/src/i18n/hu/stats-user.json
@@ -255,6 +255,7 @@
         "close": "",
         "customizeLayout": "",
         "title": "",
+        "titleBarTitle": "",
         "hideAll": "",
         "showAll": ""
     },

--- a/frontend/src/i18n/id/stats-user.json
+++ b/frontend/src/i18n/id/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Statistik Bacaan {{ name }}",
+        "titleBarTitle": "Statistik Bacaan",
         "chartConfig": "Konfigurasi Bagan",
         "close": "Tutup",
         "resetLayout": "",

--- a/frontend/src/i18n/it/stats-user.json
+++ b/frontend/src/i18n/it/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Statistiche di lettura di {{ name }}",
+        "titleBarTitle": "Statistiche di lettura",
         "customizeLayout": "Personalizza layout",
         "chartConfig": "Configurazione grafici",
         "resetLayout": "Ripristina layout",

--- a/frontend/src/i18n/ja/stats-user.json
+++ b/frontend/src/i18n/ja/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "{{ name }}さんの読書統計",
+        "titleBarTitle": "統計情報の読み方",
         "customizeLayout": "レイアウトをカスタマイズ",
         "chartConfig": "チャート設定",
         "resetLayout": "レイアウトをリセット",

--- a/frontend/src/i18n/ko/stats-user.json
+++ b/frontend/src/i18n/ko/stats-user.json
@@ -1,6 +1,7 @@
 {
   "main": {
     "title": "",
+    "titleBarTitle": "",
     "customizeLayout": "",
     "chartConfig": "",
     "resetLayout": "",

--- a/frontend/src/i18n/nl/stats-user.json
+++ b/frontend/src/i18n/nl/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "{{ name }}'s Lees Statistieken",
+        "titleBarTitle": "Lees Statistieken",
         "customizeLayout": "Lay-out aanpassen",
         "resetLayout": "Lay-out opnieuw instellen",
         "hideAll": "Alles verbergen",

--- a/frontend/src/i18n/pl/stats-user.json
+++ b/frontend/src/i18n/pl/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Statystyki czytania {{ name }}",
+        "titleBarTitle": "Statystyki czytania",
         "customizeLayout": "Dostosuj układ",
         "chartConfig": "Konfiguracja wykresów",
         "resetLayout": "Resetuj układ",

--- a/frontend/src/i18n/pt/stats-user.json
+++ b/frontend/src/i18n/pt/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Estatísticas de Leitura de {{ name }}",
+        "titleBarTitle": "Estatísticas de Leitura",
         "customizeLayout": "Personalizar Layout",
         "chartConfig": "Configuração de Gráficos",
         "resetLayout": "Redefinir Layout",

--- a/frontend/src/i18n/ru/stats-user.json
+++ b/frontend/src/i18n/ru/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Статистика чтения {{ name }}",
+        "titleBarTitle": "Статистика чтения",
         "customizeLayout": "Настроить макет",
         "chartConfig": "Настройка графиков",
         "resetLayout": "Сбросить макет",

--- a/frontend/src/i18n/sk/stats-user.json
+++ b/frontend/src/i18n/sk/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Štatistiky čítania používateľa {{ name }}",
+        "titleBarTitle": "Štatistiky čítania",
         "customizeLayout": "Uprav rozloženie",
         "chartConfig": "",
         "resetLayout": "",

--- a/frontend/src/i18n/sl/stats-user.json
+++ b/frontend/src/i18n/sl/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Bralna statistika uporabnika {{ name }}",
+        "titleBarTitle": "Bralna statistika",
         "customizeLayout": "Prilagodi postavitev",
         "chartConfig": "Konfiguracija grafov",
         "resetLayout": "Ponastavi postavitev",

--- a/frontend/src/i18n/sv/stats-user.json
+++ b/frontend/src/i18n/sv/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "{{ name }}s lasstatistik",
+        "titleBarTitle": "Lässtatistik",
         "customizeLayout": "Anpassa layout",
         "chartConfig": "Diagramkonfiguration",
         "resetLayout": "Aterstall layout",

--- a/frontend/src/i18n/uk/stats-user.json
+++ b/frontend/src/i18n/uk/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "Статистика читання {{ name }}",
+        "titleBarTitle": "Статистика читання",
         "customizeLayout": "Налаштувати макет",
         "chartConfig": "Налаштування графіків",
         "resetLayout": "Скинути макет",

--- a/frontend/src/i18n/zh/stats-user.json
+++ b/frontend/src/i18n/zh/stats-user.json
@@ -1,6 +1,7 @@
 {
     "main": {
         "title": "{{ name }} 的阅读统计",
+        "titleBarTitle": "的阅读统计",
         "customizeLayout": "自定义布局",
         "chartConfig": "图表配置",
         "resetLayout": "重置布局",


### PR DESCRIPTION
## Description

The linked issue (and its first comment) mentions a couple of pages that don't set the page title so I checked every route in the application and added `this.pageTitle.setPageTitle()` where it is missing.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/108

## Changes

- set page title for the following components: `BookMetadataCenterComponent`, `EbookReaderComponent`, `LibraryStatsComponent`, `UserStatsComponent`
- for the "Reading Stats" page there is a title, its value is "{{ name }}'s Reading Statistics". I found it unnecessarily long so i created a new key-value pair: `"titleBarTitle": "Reading Statistics"`. I added the new key for every language and set its value based on `title`. For most languages it was easy to figure out the translation based on the original `title` (which I validated with Google Translate) but there are languages (Japanese, for example) where I had to rely completely on Google Translate.

## Manual Testing Steps

1. opened `app.routes.ts`
2. made sure I navigate to every single route in the application and check the page title

## Screenshots (Optional)

I didn't find it necessary to create screenshots for this fix but please let me know and I will create some.

## AI Disclosure

None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically sets translated page titles on the metadata center, ebook reader, and library/user statistics pages; title updates occur during component initialization and initial book load, and the ebook reader title stays in sync with the opened book.
* **Tests**
  * Updated component test setups to provide a mocked translation service, ensuring page-title initialization runs correctly in the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->