### PR TITLE
test(frontend): Set timezone to UTC during tests

### DIFF
--- a/frontend/Justfile
+++ b/frontend/Justfile
@@ -32,7 +32,7 @@ watch:
 
 # Run the frontend test suite.
 test:
-    {{ pnpm }} run test
+    TZ=UTC {{ pnpm }} run test
 
 # Run the frontend tests with a coverage report.
 coverage:


### PR DESCRIPTION
## Description

Previously, when running any date-related tests, they would fail for me due to timezone issues. Forcing tests to run under UTC fixes them. I only set them for frontend atm since I haven't worked on the backend, but it may be reasonable to set for backend tests in the future. I reported this in the discord development channel.

## Linked Issue

<!-- Required. Example: Fixes #123 -->

## Changes

* Set timezone to UTC for frontend tests via the `just ui test` task.

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Run tests without this via `TZ=America/New_York just ui test`
2. Apply this change or run tests again via `TZ=UTC just ui test`
3. Observe 5 test failures in the first, but none in the second

## AI Disclosure

None

## Checklist

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test execution to use UTC, improving consistency across environments and reducing timezone-related test differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->