### PR TITLE
fix(pdf-reader): reduce default stroke width for pen/ink annotations

### DIFF
--- a/frontend/src/app/features/readers/pdf-reader/services/embedpdf-book.service.ts
+++ b/frontend/src/app/features/readers/pdf-reader/services/embedpdf-book.service.ts
@@ -146,18 +146,24 @@ export class EmbedPdfBookService {
         autoOpenLinks: false,
         tools: [
           {
-            id: 'highlight',
-            defaults: {
-              opacity: 0.4,
-            },
-          },
-          {
-            id: 'inkHighlighter',
-            defaults: {
-              opacity: 0.4,
-            },
-          },
-        ],
+			id: 'highlight',
+			defaults: {
+				opacity: 0.4,
+			},
+		  },
+		  {
+			id: 'inkHighlighter',
+			defaults: {
+				opacity: 0.4,
+			},
+		},
+	  {
+			id: 'ink',
+			defaults: {
+				strokeWidth: 2,
+			},
+		  },
+		],
       },
       zoom: {
         defaultZoomLevel: 'fit-page' as ZoomMode,


### PR DESCRIPTION
## Linked Issue

N/A

## Description

Reduces the default stroke width for the PDF reader's pen/ink annotation tool by setting the default `strokeWidth` to `2`. This provides a thinner default pen while leaving all other annotation tool behaviour unchanged.

## Changes

- Added a default `strokeWidth: 2` for the `ink` annotation tool.
- No changes to other annotation tool defaults.

## Manual Testing Steps

1. Open a PDF.
2. Select the pen/ink annotation tool.
3. Draw a new annotation.
4. Verify the default stroke width is thinner than before.

Related discussion: <[paste your Discussion link here if you posted one](https://github.com/orgs/grimmory-tools/discussions/2079)> 

Before: 
<img width="995" height="630" alt="before" src="https://github.com/user-attachments/assets/0ec71b64-73c9-454e-b0c4-663c17e7217a" />


After:
<img width="1004" height="628" alt="after" src="https://github.com/user-attachments/assets/6982cc7c-3fc4-4e3a-b5b1-948c2e8fff46" />



## AI Disclosure

Yes – Claude was used to assist with implementation and drafting.

## Checklist

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PDF annotation tool configuration while preserving existing highlighting behavior and opacity settings.
  * Improved consistency in how highlight and ink highlighter tools are initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->