### PR TITLE
fix: properly flush books during detach

### DIFF
--- a/backend/src/main/java/org/booklore/service/book/BookFileDetachmentService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookFileDetachmentService.java
@@ -15,6 +15,7 @@ import org.booklore.model.entity.LibraryPathEntity;
 import org.booklore.model.entity.UserBookFileProgressEntity;
 import org.booklore.model.entity.UserBookProgressEntity;
 import org.booklore.model.enums.AuditAction;
+import org.booklore.repository.BookFileRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserBookProgressRepository;
 import org.booklore.service.audit.AuditService;
@@ -38,6 +39,7 @@ import java.util.Set;
 public class BookFileDetachmentService {
 
     private final BookRepository bookRepository;
+    private final BookFileRepository bookFileRepository;
     private final UserBookProgressRepository userBookProgressRepository;
     private final AuthenticationService authenticationService;
     private final ReadingProgressService readingProgressService;
@@ -96,10 +98,16 @@ public class BookFileDetachmentService {
         newBook.setMetadata(newMetadata);
 
         sourceBook.getBookFiles().remove(targetFile);
+        newBook.getBookFiles().add(targetFile);
+
+        bookRepository.saveAndFlush(sourceBook);
+        newBook = bookRepository.saveAndFlush(newBook);
+
+        // Only save changes to the target file after the shift in relationship
+        // via source & new book or else we get a hibernate error.
         targetFile.setFileSubPath(newFileSubPath);
         targetFile.setBook(newBook);
-
-        newBook = bookRepository.saveAndFlush(newBook);
+        bookFileRepository.saveAndFlush(targetFile);
 
         try {
             bookCoverService.regenerateCover(newBook.getId());

--- a/backend/src/test/java/org/booklore/service/book/BookFileDetachmentServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookFileDetachmentServiceTest.java
@@ -9,6 +9,7 @@ import org.booklore.model.dto.response.DetachBookFileResponse;
 import org.booklore.model.entity.*;
 import org.booklore.model.enums.AuditAction;
 import org.booklore.model.enums.BookFileType;
+import org.booklore.repository.BookFileRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserBookProgressRepository;
 import org.booklore.service.audit.AuditService;
@@ -17,6 +18,8 @@ import org.booklore.service.progress.ReadingProgressService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,6 +35,7 @@ import static org.mockito.Mockito.*;
 class BookFileDetachmentServiceTest {
 
     @Mock private BookRepository bookRepository;
+    @Mock private BookFileRepository bookFileRepository;
     @Mock private UserBookProgressRepository userBookProgressRepository;
     @Mock private AuthenticationService authenticationService;
     @Mock private ReadingProgressService readingProgressService;
@@ -42,6 +46,9 @@ class BookFileDetachmentServiceTest {
 
     @InjectMocks
     private BookFileDetachmentService service;
+
+    @Captor
+    ArgumentCaptor<BookEntity> bookEntityCaptor;
 
     private LibraryEntity library;
     private LibraryPathEntity libraryPath;
@@ -124,7 +131,7 @@ class BookFileDetachmentServiceTest {
         assertThat(book.getBookFiles()).hasSize(1);
         assertThat(book.getBookFiles().getFirst().getId()).isEqualTo(10L);
         verify(auditService).log(eq(AuditAction.BOOK_FILE_DETACHED), anyString(), eq(1L), anyString());
-        verify(bookRepository).saveAndFlush(argThat(newBook -> {
+        verify(bookRepository, times(2)).saveAndFlush(argThat(newBook -> {
             assertThat(newBook.getMetadata().getTitle()).isEqualTo("Test Book 1");
             return true;
         }));
@@ -148,10 +155,10 @@ class BookFileDetachmentServiceTest {
 
         service.detachBookFile(1L, 11L, false);
 
-        verify(bookRepository).saveAndFlush(argThat(newBook -> {
-            assertThat(newBook.getMetadata().getTitle()).isEqualTo("file-11");
-            return true;
-        }));
+        verify(bookRepository, times(2)).saveAndFlush(bookEntityCaptor.capture());
+
+        var allTitles = bookEntityCaptor.getAllValues().stream().map(e -> e.getMetadata().getTitle());
+        assertThat(allTitles).contains("file-11");
     }
 
     @Test
@@ -176,7 +183,8 @@ class BookFileDetachmentServiceTest {
         assertThat(book.getBookFiles()).hasSize(1);
         assertThat(suppFile.getBook()).isNotSameAs(book);
         assertThat(suppFile.getFileName()).isEqualTo("notes.txt");
-        verify(bookRepository).saveAndFlush(any(BookEntity.class));
+        verify(bookRepository, times(2)).saveAndFlush(any(BookEntity.class));
+        verify(bookFileRepository).saveAndFlush(any(BookFileEntity.class));
     }
 
     @Test
@@ -278,10 +286,10 @@ class BookFileDetachmentServiceTest {
 
         service.detachBookFile(1L, 11L, false);
 
-        verify(bookRepository).saveAndFlush(argThat(newBook -> {
-            assertThat(newBook.getLibraryPath().getId()).isEqualTo(2L);
-            return true;
-        }));
+        verify(bookRepository, times(2)).saveAndFlush(bookEntityCaptor.capture());
+
+        var allLibraryPathIds = bookEntityCaptor.getAllValues().stream().map(e -> e.getLibraryPath().getId());
+        assertThat(allLibraryPathIds).contains(2L);
         assertThat(altFile.getFileSubPath()).isEmpty();
     }
 }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
detaching a file will fail every time because the new book doesn't have any files by the time the regenerate cover has been run.  we need to flush the books + the files together

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2084
closes #1852 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* adds a flush of the source book
* adds a flush of the book file
* updates tests for these new behavios

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. merged multiple books using the find duplicates tool
2. go to the book that was merged and click detach
3. go to library and see detached book

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detaching book files between books to ensure file relationships and paths are saved in the correct order.
  * Fixed issues that could cause errors when moving alternative-format or supplementary files.
  * Ensured updated metadata and library paths are retained after detachment.

* **Tests**
  * Expanded coverage for file detachment, metadata handling, library paths, and supplementary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->