### PR TITLE
fix(magic-shelf): remove timestamp from magic shelf date checks

### DIFF
--- a/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
+++ b/backend/src/main/java/org/booklore/service/BookRuleEvaluatorService.java
@@ -534,7 +534,7 @@ public class BookRuleEvaluatorService {
         if (value instanceof Boolean) {
             return cb.equal(field, value);
         } else if (value instanceof LocalDate) {
-            return cb.equal(field, value);
+            return cb.equal(field.cast(LocalDate.class), value);
         } else if (value instanceof LocalDateTime) {
             return cb.equal(field, value);
         } else if (rule.getField() == RuleField.READ_STATUS) {
@@ -600,28 +600,28 @@ public class BookRuleEvaluatorService {
     private Predicate buildGreaterThan(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return buildComparisonPredicate(rule, cb, root, progressJoin,
                 (field, dateValue) -> cb.greaterThan(field.as(LocalDateTime.class), dateValue),
-                (field, localDateValue) -> cb.greaterThan(field.as(LocalDate.class), localDateValue),
+                (field, localDateValue) -> cb.greaterThan(field.cast(LocalDate.class), localDateValue),
                 (field, numValue) -> cb.gt(toNumericExpression(field), numValue));
     }
 
     private Predicate buildGreaterThanEqual(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return buildComparisonPredicate(rule, cb, root, progressJoin,
                 (field, dateValue) -> cb.greaterThanOrEqualTo(field.as(LocalDateTime.class), dateValue),
-                (field, localDateValue) -> cb.greaterThanOrEqualTo(field.as(LocalDate.class), localDateValue),
+                (field, localDateValue) -> cb.greaterThanOrEqualTo(field.cast(LocalDate.class), localDateValue),
                 (field, numValue) -> cb.ge(toNumericExpression(field), numValue));
     }
 
     private Predicate buildLessThan(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return buildComparisonPredicate(rule, cb, root, progressJoin,
                 (field, dateValue) -> cb.lessThan(field.as(LocalDateTime.class), dateValue),
-                (field, localDateValue) -> cb.lessThan(field.as(LocalDate.class), localDateValue),
+                (field, localDateValue) -> cb.lessThan(field.cast(LocalDate.class), localDateValue),
                 (field, numValue) -> cb.lt(toNumericExpression(field), numValue));
     }
 
     private Predicate buildLessThanEqual(Rule rule, CriteriaBuilder cb, Root<BookEntity> root, Join<BookEntity, UserBookProgressEntity> progressJoin) {
         return buildComparisonPredicate(rule, cb, root, progressJoin,
                 (field, dateValue) -> cb.lessThanOrEqualTo(field.as(LocalDateTime.class), dateValue),
-                (field, localDateValue) -> cb.lessThanOrEqualTo(field.as(LocalDate.class), localDateValue),
+                (field, localDateValue) -> cb.lessThanOrEqualTo(field.cast(LocalDate.class), localDateValue),
                 (field, numValue) -> cb.le(toNumericExpression(field), numValue));
     }
 
@@ -655,7 +655,7 @@ public class BookRuleEvaluatorService {
         if (start == null || end == null) return cb.conjunction();
 
         if (start instanceof LocalDate && end instanceof LocalDate) {
-            return cb.between(field.as(LocalDate.class), (LocalDate) start, (LocalDate) end);
+            return cb.between(field.cast(LocalDate.class), (LocalDate) start, (LocalDate) end);
         }
 
         if (start instanceof LocalDateTime && end instanceof LocalDateTime) {
@@ -892,17 +892,10 @@ public class BookRuleEvaluatorService {
     private Object normalizeValue(Object value, RuleField field) {
         if (value == null) return null;
 
-        if (field == RuleField.PUBLISHED_DATE) {
+        if (field == RuleField.PUBLISHED_DATE || field == RuleField.DATE_FINISHED ||
+                field == RuleField.LAST_READ_TIME || field == RuleField.ADDED_ON) {
             LocalDateTime parsed = parseDate(value);
             return parsed != null ? parsed.toLocalDate() : null;
-        }
-
-        if (field == RuleField.DATE_FINISHED || field == RuleField.LAST_READ_TIME || field == RuleField.ADDED_ON) {
-            LocalDateTime parsed = parseDate(value);
-            if (parsed != null) {
-                return parsed.atZone(ZoneId.systemDefault()).toInstant();
-            }
-            return null;
         }
 
         if (field == RuleField.READ_STATUS) {

--- a/frontend/src/app/features/magic-shelf/service/book-rule-evaluator.service.ts
+++ b/frontend/src/app/features/magic-shelf/service/book-rule-evaluator.service.ts
@@ -27,14 +27,18 @@ export class BookRuleEvaluatorService {
     }
 
     const rawValue = this.extractBookValue(book, rule.field);
+    const isDateField = rule.field === 'publishedDate' || rule.field === 'dateFinished' ||
+      rule.field === 'lastReadTime' || rule.field === 'addedOn';
+    const withoutTime = (date: Date): Date =>
+      new Date(date.getFullYear(), date.getMonth(), date.getDate());
 
     const normalize = (val: unknown): unknown => {
       if (val === null || val === undefined) return val;
-      if (val instanceof Date) return val;
+      if (val instanceof Date) return isDateField ? withoutTime(val) : val;
       if (typeof val === 'boolean') return String(val);
       if (typeof val === 'string') {
         const date = parseValue(val, 'date');
-        if (date != null) return date;
+        if (date instanceof Date) return isDateField ? withoutTime(date) : date;
         return val.toLowerCase();
       }
       return val;


### PR DESCRIPTION
## Description

Removes the time of day check for Date Added / Date Published / Last Read causing magic shelves to come back empty. 

## Linked Issue

Fixes #2096 

## Changes

- Changed Magic Shelf date rules to use only calendar dates across Published Date, Date Finished, Last Read, and Date Added.
- Cast stored timestamps to dates so time of day no longer affects matching, ordering, date ranges etc. 

## Manual Testing Steps

Create magic shelf rule with the above fields and confirm books pull through. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

Does not affect saving or changes any write behaviour, this is for magic shelf matching only. 

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rule evaluation for date-based conditions by normalizing key date/time fields as date-only (year/month/day).
  * Fixed equality, range, and “between” comparisons to consistently cast and compare dates.
  * Standardized normalization across those date fields to reduce inconsistencies caused by time components and time zones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->