### PR TITLE
ci: use gradle lockfile for cache key

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -42,29 +42,9 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
 
-      - name: Restore Gradle Cache
-        id: restore_gradle_cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('backend/**/*.gradle*', 'backend/gradle.lockfile', 'backend/settings.gradle*', 'backend/gradle.properties', 'backend/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
-
       - name: Refresh lockfiles
         working-directory: backend/
         run: ./gradlew dependencies --write-locks
-
-      - name: Save Gradle Cache
-        if: ${{ always() }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ steps.restore_gradle_cache.outputs.cache-primary-key }}
 
       - name: Commit and push
         env:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -49,7 +49,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('backend/**/*.gradle*', 'backend/settings.gradle*', 'backend/gradle.properties', 'backend/gradle/wrapper/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('backend/**/*.gradle*', 'backend/gradle.lockfile', 'backend/settings.gradle*', 'backend/gradle.properties', 'backend/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -52,7 +52,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('backend/**/*.gradle*', 'backend/settings.gradle*', 'backend/gradle.properties', 'backend/gradle/wrapper/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('backend/**/*.gradle*', 'backend/gradle.lockfile', 'backend/settings.gradle*', 'backend/gradle.properties', 'backend/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
adds the gradle lock file to the CI cache key

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2102

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
adds the gradle lock file to the CI cache key

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
see tests running on this PR

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency lockfile refresh handling.
  * Updated Gradle build caching to account for backend lockfile changes, helping ensure builds use the correct cached dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->