### PR TITLE
chore(epub): move cover detector back into Grimmory

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -1,6 +1,7 @@
 package org.booklore.service.metadata.extractor;
 
-import org.booklore.util.epub.CoverDetector;
+import lombok.RequiredArgsConstructor;
+import org.booklore.util.epub.CoverDetectorService;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ObjectNode;
@@ -36,6 +37,7 @@ import java.util.function.IntConsumer;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class EpubMetadataExtractor implements FileMetadataExtractor {
 
     private static final Pattern YEAR_ONLY_PATTERN = Pattern.compile("^\\d{4}$");
@@ -46,10 +48,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
     private static final Set<Integer> VALID_AGE_RATINGS = Set.of(0, 6, 10, 13, 16, 18, 21);
 
     private final ObjectMapper objectMapper;
-
-    public EpubMetadataExtractor(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
+    private final CoverDetectorService coverDetectorService;
 
     private static final Map<String, BiConsumer<BookMetadata.BookMetadataBuilder, String>> CALIBRE_IDENTIFIER_PREFIXES = Map.of(
             "amazon", BookMetadata.BookMetadataBuilder::asin,
@@ -88,7 +87,7 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
     @Override
     public byte[] extractCover(File epubFile) {
         try {
-            var coverImage = CoverDetector.detectCoverImage(epubFile.toPath());
+            var coverImage = coverDetectorService.detectCoverImage(epubFile.toPath());
             if (coverImage != null && coverImage.length > 0) {
                 return coverImage;
             }

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -92,13 +92,8 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
         // Primary: use epub4j's CoverDetector with native lazy loading
         try {
             var coverImage = CoverDetector.detectCoverImage(epubFile.toPath());
-            if (coverImage != null) {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                coverImage.writeTo(baos);
-                byte[] data = baos.toByteArray();
-                if (data.length > 0) {
-                    return data;
-                }
+            if (coverImage != null && coverImage.length > 0) {
+                return coverImage;
             }
         } catch (Exception e) {
             log.debug("epub4j cover detection failed for {}: {}", epubFile.getName(), e.getMessage());

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -1,17 +1,11 @@
 package org.booklore.service.metadata.extractor;
 
+import org.booklore.util.epub.CoverDetector;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ObjectNode;
 import org.grimmory.epub4j.archive.EpubContainer;
 import org.grimmory.epub4j.archive.EpubContainers;
-import org.grimmory.epub4j.domain.Book;
-import org.grimmory.epub4j.domain.MediaType;
-import org.grimmory.epub4j.domain.MediaTypes;
-import org.grimmory.epub4j.domain.Resource;
-import org.grimmory.epub4j.epub.CoverDetector;
-import org.grimmory.epub4j.epub.CoverDetector.CoverDetectionResult;
-import org.grimmory.epub4j.epub.EpubReader;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -49,17 +43,11 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
     // List of all media types that epub4j has so we can lazy load them.
     // Note that we have to add in null to handle files without extentions like mimetype.
-    private static final List<MediaType> MEDIA_TYPES = new ArrayList<>();
     private static final Pattern ISBN_SEPARATOR_PATTERN = Pattern.compile("[- ]");
 
     private static final Set<Integer> VALID_AGE_RATINGS = Set.of(0, 6, 10, 13, 16, 18, 21);
 
     private final ObjectMapper objectMapper;
-
-    static {
-        MEDIA_TYPES.addAll(Arrays.asList(MediaTypes.mediaTypes));
-        MEDIA_TYPES.add(null);
-    }
 
     public EpubMetadataExtractor(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
@@ -103,14 +91,10 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
     public byte[] extractCover(File epubFile) {
         // Primary: use epub4j's CoverDetector with native lazy loading
         try {
-            Book book = new EpubReader().readEpubLazy(epubFile.toPath(), "UTF-8");
-            Optional<CoverDetectionResult> detection = CoverDetector.detectCoverImageWithMethod(book);
-            if (detection.isPresent()) {
-                CoverDetectionResult result = detection.get();
-                log.debug("Cover detected for {} via {}: {}",
-                        epubFile.getName(), result.method(), result.resource().getHref());
+            var coverImage = CoverDetector.detectCoverImage(epubFile.toPath());
+            if (coverImage != null) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                result.resource().writeTo(baos);
+                coverImage.writeTo(baos);
                 byte[] data = baos.toByteArray();
                 if (data.length > 0) {
                     return data;
@@ -118,63 +102,6 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
             }
         } catch (Exception e) {
             log.debug("epub4j cover detection failed for {}: {}", epubFile.getName(), e.getMessage());
-        }
-
-        // Last resort: scan container for cover-like images
-        try (EpubContainer container = EpubContainers.open(epubFile.toPath())) {
-            // NOTE: this will moved to org.grimmory.epub4j in the near future
-            // most of the parsing done here, can be safely replaced with methods already existing in epub4j
-            String opfName = findOpfPath(container);
-            Document opf = parseXmlFromContainer(container, opfName);
-
-            // Try OPF manifest for cover-image property
-            NodeList items = opf.getElementsByTagName("item");
-            for (int i = 0; i < items.getLength(); i++) {
-                Element item = (Element) items.item(i);
-                String properties = item.getAttribute("properties");
-                if (properties != null && properties.contains("cover-image")) {
-                    String href = URLDecoder.decode(item.getAttribute("href"), StandardCharsets.UTF_8);
-                    String fullPath = resolvePath(opfName, href);
-                    if (container.exists(fullPath)) {
-                        ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
-                        container.streamTo(fullPath, baos);
-                        return baos.toByteArray();
-                    }
-                }
-            }
-
-            // Search manifest for cover-looking items by id/href
-            for (int i = 0; i < items.getLength(); i++) {
-                Element item = (Element) items.item(i);
-                String id = item.getAttribute("id");
-                String href = item.getAttribute("href");
-                String mediaType = item.getAttribute("media-type");
-                if (mediaType != null && mediaType.startsWith("image/")) {
-                    if ((id != null && id.toLowerCase().contains("cover")) ||
-                            (href != null && href.toLowerCase().contains("cover"))) {
-                        String decodedHref = URLDecoder.decode(href, StandardCharsets.UTF_8);
-                        String fullPath = resolvePath(opfName, decodedHref);
-                        if (container.exists(fullPath)) {
-                            ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
-                            container.streamTo(fullPath, baos);
-                            return baos.toByteArray();
-                        }
-                    }
-                }
-            }
-
-            // Scan all files for cover-named images
-            for (String name : container.listAllFiles()) {
-                String lower = name.toLowerCase();
-                if (lower.contains("cover") && (lower.endsWith(".jpg") || lower.endsWith(".jpeg") ||
-                        lower.endsWith(".png") || lower.endsWith(".webp"))) {
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
-                    container.streamTo(name, baos);
-                    return baos.toByteArray();
-                }
-            }
-        } catch (Exception e) {
-            log.debug("Container cover search failed for {}: {}", epubFile.getName(), e.getMessage());
         }
 
         return null;
@@ -589,26 +516,6 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
         log.warn("Failed to parse date from string: {}", value);
         return null;
-    }
-
-    private byte[] getImageFromEpubResource(Resource res) {
-        if (res == null) {
-            return null;
-        }
-
-        MediaType mt = res.getMediaType();
-        if (mt == null || mt.name() == null || !mt.name().startsWith("image")) {
-            return null;
-        }
-
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            res.writeTo(baos);
-            return baos.toByteArray();
-        } catch (IOException e) {
-            log.warn("Failed to read data for resource", e);
-            return null;
-        }
     }
 
     private String findOpfPath(EpubContainer container) throws IOException, ParserConfigurationException, SAXException {

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -41,8 +41,6 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
     private static final Pattern YEAR_ONLY_PATTERN = Pattern.compile("^\\d{4}$");
     private static final String OPF_NS = "http://www.idpf.org/2007/opf";
 
-    // List of all media types that epub4j has so we can lazy load them.
-    // Note that we have to add in null to handle files without extentions like mimetype.
     private static final Pattern ISBN_SEPARATOR_PATTERN = Pattern.compile("[- ]");
 
     private static final Set<Integer> VALID_AGE_RATINGS = Set.of(0, 6, 10, 13, 16, 18, 21);
@@ -89,14 +87,13 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
     @Override
     public byte[] extractCover(File epubFile) {
-        // Primary: use epub4j's CoverDetector with native lazy loading
         try {
             var coverImage = CoverDetector.detectCoverImage(epubFile.toPath());
             if (coverImage != null && coverImage.length > 0) {
                 return coverImage;
             }
         } catch (Exception e) {
-            log.debug("epub4j cover detection failed for {}: {}", epubFile.getName(), e.getMessage());
+            log.debug("Cover detection failed for {}: {}", epubFile.getName(), e.getMessage());
         }
 
         return null;

--- a/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
@@ -13,7 +13,7 @@ import org.booklore.model.enums.BookFileType;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.ArchiveService;
 import org.booklore.util.FileUtils;
-import org.booklore.util.epub.CoverDetector;
+import org.booklore.util.epub.CoverDetectorService;
 import org.grimmory.epub4j.domain.*;
 import org.grimmory.epub4j.epub.EpubReader;
 import org.springframework.stereotype.Service;
@@ -69,6 +69,7 @@ public class EpubReaderService {
     );
 
     private final BookRepository bookRepository;
+    private final CoverDetectorService coverDetectorService;
     private final Cache<String, CachedEpubMetadata> metadataCache = Caffeine.newBuilder()
             .maximumSize(MAX_CACHE_ENTRIES)
             .expireAfterAccess(Duration.ofMinutes(30))
@@ -207,7 +208,7 @@ public class EpubReaderService {
 
     private CachedEpubMetadata parseEpubMetadata(Path epubPath, long lastModified) throws IOException {
         try {
-            String coverPath = CoverDetector.detectCoverImagePath(epubPath);
+            String coverPath = coverDetectorService.detectCoverImagePath(epubPath);
 
             Book book = new EpubReader().readEpubLazy(epubPath, "UTF-8");
 

--- a/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
@@ -13,8 +13,8 @@ import org.booklore.model.enums.BookFileType;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.ArchiveService;
 import org.booklore.util.FileUtils;
+import org.booklore.util.epub.CoverDetector;
 import org.grimmory.epub4j.domain.*;
-import org.grimmory.epub4j.epub.CoverDetector;
 import org.grimmory.epub4j.epub.EpubReader;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
@@ -207,37 +207,33 @@ public class EpubReaderService {
 
     private CachedEpubMetadata parseEpubMetadata(Path epubPath, long lastModified) throws IOException {
         try {
+            String coverPath = CoverDetector.detectCoverImagePath(epubPath);
+
             Book book = new EpubReader().readEpubLazy(epubPath, "UTF-8");
-            EpubBookInfo bookInfo = mapBookToInfo(book);
+
+            Resource opfResource = book.getOpfResource();
+            String opfPath = opfResource != null ? opfResource.getHref() : "";
+            String rootPath = opfPath.contains("/") ? opfPath.substring(0, opfPath.lastIndexOf('/') + 1) : "";
+
+            List<EpubManifestItem> manifest = mapManifest(book, rootPath);
+            List<EpubSpineItem> spine = mapSpine(book, rootPath);
+            Map<String, Object> metadata = mapMetadata(book);
+            EpubTocItem toc = mapToc(book.getTableOfContents(), rootPath);
+
+            EpubBookInfo bookInfo = EpubBookInfo.builder()
+                    .containerPath(opfPath)
+                    .rootPath(rootPath)
+                    .spine(spine)
+                    .manifest(manifest)
+                    .toc(toc)
+                    .metadata(metadata)
+                    .coverPath(coverPath)
+                    .build();
+
             return new CachedEpubMetadata(bookInfo, lastModified);
         } catch (Exception e) {
             throw new IOException("Unable to parse EPUB", e);
         }
-    }
-
-    private EpubBookInfo mapBookToInfo(Book book) {
-        Resource opfResource = book.getOpfResource();
-        String opfPath = opfResource != null ? opfResource.getHref() : "";
-        String rootPath = opfPath.contains("/") ? opfPath.substring(0, opfPath.lastIndexOf('/') + 1) : "";
-
-        Resource coverResource = CoverDetector.detectCoverImage(book);
-        String coverHref = coverResource != null ? rootPath + coverResource.getHref() : null;
-
-        List<EpubManifestItem> manifest = mapManifest(book, rootPath);
-        List<EpubSpineItem> spine = mapSpine(book, rootPath);
-        Map<String, Object> metadata = mapMetadata(book);
-        EpubTocItem toc = mapToc(book.getTableOfContents(), rootPath);
-        String coverPath = coverHref;
-
-        return EpubBookInfo.builder()
-                .containerPath(opfPath)
-                .rootPath(rootPath)
-                .spine(spine)
-                .manifest(manifest)
-                .toc(toc)
-                .metadata(metadata)
-                .coverPath(coverPath)
-                .build();
     }
 
     private List<EpubManifestItem> mapManifest(Book book, String rootPath) {

--- a/backend/src/main/java/org/booklore/util/epub/CoverDetector.java
+++ b/backend/src/main/java/org/booklore/util/epub/CoverDetector.java
@@ -1,0 +1,271 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (C) 2025-2026 Grimmory contributors
+ * Copyright (C) 2025-2026 Booklore contributors
+ */
+package org.booklore.util.epub;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.grimmory.epub4j.domain.Book;
+import org.grimmory.epub4j.domain.MediaType;
+import org.grimmory.epub4j.domain.MediaTypes;
+import org.grimmory.epub4j.domain.Resource;
+import org.grimmory.epub4j.domain.Resources;
+import org.grimmory.epub4j.domain.Spine;
+import org.grimmory.epub4j.epub.EpubReader;
+
+
+/**
+ * Multi-strategy cover image detection for EPUB files. Tries multiple approaches in order of
+ * reliability: 1. Already-set cover image (from OPF metadata or properties) 2. Image resource with
+ * "cover" in filename 3. First image referenced in first spine item's HTML 4. Largest image
+ * resource (likely a full-page cover)
+ */
+public class CoverDetector {
+
+    private static final System.Logger log = System.getLogger(CoverDetector.class.getName());
+
+    /** Minimum image size in bytes to consider as a potential cover (10KB). */
+    private static final int MIN_COVER_SIZE = 10 * 1024;
+
+    private static final Pattern IMG_SRC_PATTERN =
+            Pattern.compile("<img[^>]+src\\s*=\\s*[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SVG_IMAGE_PATTERN =
+            Pattern.compile(
+                    "<image[^>]+(?:href|xlink:href)\\s*=\\s*[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+
+    public static Resource detectCoverImage(Book book) {
+        if (book.getCoverImage() != null) {
+            return book.getCoverImage();
+        }
+
+        Resource byId = findCoverById(book.getResources().getAll());
+        if (byId != null) {
+            log.log(System.Logger.Level.DEBUG, "Cover detected by resource id: " + byId.getHref());
+            return byId;
+        }
+
+        Resource byName = findCoverByName(book.getResources().getAll());
+        if (byName != null) {
+            log.log(System.Logger.Level.DEBUG, "Cover detected by filename: " + byName.getHref());
+            return byName;
+        }
+
+        Resource fromSpine = findCoverFromFirstSpineItem(book);
+        if (fromSpine != null) {
+            log.log(
+                    System.Logger.Level.DEBUG,
+                    "Cover detected from first spine item: " + fromSpine.getHref());
+            return fromSpine;
+        }
+
+        Resource largest = findLargestImage(book.getResources().getAll());
+        if (largest != null) {
+            log.log(System.Logger.Level.DEBUG, "Cover detected as largest image: " + largest.getHref());
+            return largest;
+        }
+
+        Resource firstImage = findFirstManifestImage(book.getResources().getAll());
+        if (firstImage != null) {
+            log.log(
+                    System.Logger.Level.DEBUG,
+                    "Cover detected as first manifest image: " + firstImage.getHref());
+            return firstImage;
+        }
+
+        return null;
+    }
+
+    public static Resource detectCoverImage(Path path) {
+        try {
+            Book book = new EpubReader().readEpubLazy(path, "UTF-8");
+            return detectCoverImage(book);
+        } catch (IOException exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Find an image resource whose id contains "cover" (case-insensitive). Matches id patterns like
+     * "cover-image", "cover", "coverimg" that OPF generators commonly use.
+     */
+    private static Resource findCoverById(Collection<Resource> resources) {
+        for (Resource resource : resources) {
+            if (!isImageResource(resource)) continue;
+            String id = resource.getId();
+            if (id != null && id.toLowerCase().contains("cover")) {
+                return resource;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the first image resource found in the manifest. Last-resort fallback when all other
+     * strategies fail.
+     */
+    private static Resource findFirstManifestImage(Collection<Resource> resources) {
+        for (Resource resource : resources) {
+            if (isImageResource(resource) && resource.getSize() >= MIN_COVER_SIZE) {
+                return resource;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find an image resource whose filename contains "cover" (case-insensitive). Prioritizes exact
+     * matches like "cover.jpg" over partial matches like "discover.png".
+     */
+    private static Resource findCoverByName(Collection<Resource> resources) {
+        Resource exactMatch = null;
+        Resource partialMatch = null;
+
+        for (Resource resource : resources) {
+            if (!isImageResource(resource)) continue;
+
+            String href = resource.getHref();
+            if (href == null) continue;
+
+            String filename = href;
+            int lastSlash = filename.lastIndexOf('/');
+            if (lastSlash >= 0) filename = filename.substring(lastSlash + 1);
+            String filenameLower = filename.toLowerCase();
+
+            int dotPos = filenameLower.lastIndexOf('.');
+            String nameWithoutExt = dotPos > 0 ? filenameLower.substring(0, dotPos) : filenameLower;
+            if ("cover".equals(nameWithoutExt)) {
+                exactMatch = resource;
+                break; // Can't do better than an exact match
+            }
+
+            if (partialMatch == null && filenameLower.contains("cover")) {
+                partialMatch = resource;
+            }
+        }
+
+        return exactMatch != null ? exactMatch : partialMatch;
+    }
+
+    /**
+     * Look at the first spine item's XHTML content and find the first referenced image. This works
+     * for EPUBs where the first page is a cover page containing an img tag.
+     */
+    private static Resource findCoverFromFirstSpineItem(Book book) {
+        Spine spine = book.getSpine();
+        if (spine.isEmpty()) return null;
+
+        Resource firstResource = spine.getResource(0);
+        if (firstResource == null || firstResource.getMediaType() != MediaTypes.XHTML) {
+            return null;
+        }
+
+        try {
+            byte[] data = firstResource.getData();
+            if (data == null || data.length == 0) return null;
+
+            String content = new String(data, StandardCharsets.UTF_8);
+            String firstHref = firstResource.getHref();
+            String basePath = "";
+            if (firstHref != null) {
+                int lastSlash = firstHref.lastIndexOf('/');
+                if (lastSlash >= 0) {
+                    basePath = firstHref.substring(0, lastSlash + 1);
+                }
+            }
+
+            Matcher imgMatcher = IMG_SRC_PATTERN.matcher(content);
+            if (imgMatcher.find()) {
+                Resource resolved = resolveImageRef(book.getResources(), basePath, imgMatcher.group(1));
+                if (resolved != null) return resolved;
+            }
+
+            Matcher svgMatcher = SVG_IMAGE_PATTERN.matcher(content);
+            if (svgMatcher.find()) {
+                Resource resolved = resolveImageRef(book.getResources(), basePath, svgMatcher.group(1));
+                if (resolved != null) return resolved;
+            }
+        } catch (IOException e) {
+            log.log(
+                    System.Logger.Level.DEBUG,
+                    "Failed to read first spine item for cover detection: " + e.getMessage());
+        }
+
+        return null;
+    }
+
+    /** Resolve an image reference relative to a base path and look it up in resources. */
+    private static Resource resolveImageRef(Resources resources, String basePath, String imgSrc) {
+        if (imgSrc == null || imgSrc.isBlank()) return null;
+
+        int hashPos = imgSrc.indexOf('#');
+        if (hashPos >= 0) imgSrc = imgSrc.substring(0, hashPos);
+
+        int queryPos = imgSrc.indexOf('?');
+        if (queryPos >= 0) imgSrc = imgSrc.substring(0, queryPos);
+
+        Resource resource = resources.getByHref(imgSrc);
+        if (resource != null) return resource;
+
+        String resolved = basePath + imgSrc;
+        resource = resources.getByHref(resolved);
+        if (resource != null) return resource;
+
+        if (resolved.contains("..") || resolved.contains("./")) {
+            resolved = collapsePath(resolved);
+            resource = resources.getByHref(resolved);
+            return resource;
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the largest image resource by data size. Only considers images above the minimum size
+     * threshold.
+     */
+    private static Resource findLargestImage(Collection<Resource> resources) {
+        Resource largest = null;
+        long largestSize = MIN_COVER_SIZE; // reject images below this as unlikely covers
+
+        for (Resource resource : resources) {
+            if (!isImageResource(resource)) continue;
+
+            long size = resource.getSize();
+            if (size > largestSize) {
+                largestSize = size;
+                largest = resource;
+            }
+        }
+
+        return largest;
+    }
+
+    private static boolean isImageResource(Resource resource) {
+        MediaType mt = resource.getMediaType();
+        return mt == MediaTypes.JPG
+                || mt == MediaTypes.PNG
+                || mt == MediaTypes.GIF
+                || mt == MediaTypes.SVG;
+    }
+
+    /** Collapse ".." and "." segments in a path. */
+    private static String collapsePath(String path) {
+        String[] parts = path.split("/");
+        Deque<String> stack = new ArrayDeque<>();
+        for (String part : parts) {
+            if ("..".equals(part)) {
+                if (!stack.isEmpty()) stack.removeLast();
+            } else if (!".".equals(part) && !part.isEmpty()) {
+                stack.addLast(part);
+            }
+        }
+        return String.join("/", stack);
+    }
+}

--- a/backend/src/main/java/org/booklore/util/epub/CoverDetector.java
+++ b/backend/src/main/java/org/booklore/util/epub/CoverDetector.java
@@ -5,6 +5,7 @@
  */
 package org.booklore.util.epub;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -12,6 +13,9 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import lombok.extern.slf4j.Slf4j;
+import org.grimmory.epub4j.archive.EpubContainer;
+import org.grimmory.epub4j.archive.EpubContainers;
 import org.grimmory.epub4j.domain.Book;
 import org.grimmory.epub4j.domain.MediaType;
 import org.grimmory.epub4j.domain.MediaTypes;
@@ -20,17 +24,8 @@ import org.grimmory.epub4j.domain.Resources;
 import org.grimmory.epub4j.domain.Spine;
 import org.grimmory.epub4j.epub.EpubReader;
 
-
-/**
- * Multi-strategy cover image detection for EPUB files. Tries multiple approaches in order of
- * reliability: 1. Already-set cover image (from OPF metadata or properties) 2. Image resource with
- * "cover" in filename 3. First image referenced in first spine item's HTML 4. Largest image
- * resource (likely a full-page cover)
- */
+@Slf4j
 public class CoverDetector {
-
-    private static final System.Logger log = System.getLogger(CoverDetector.class.getName());
-
     /** Minimum image size in bytes to consider as a potential cover (10KB). */
     private static final int MIN_COVER_SIZE = 10 * 1024;
 
@@ -40,52 +35,100 @@ public class CoverDetector {
             Pattern.compile(
                     "<image[^>]+(?:href|xlink:href)\\s*=\\s*[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
 
-    public static Resource detectCoverImage(Book book) {
+    private static Resource detectCoverImageFallback(Path path) {
+        // Last resort: scan container for cover-like images
+        try (EpubContainer container = EpubContainers.open(path)) {
+            // Scan all files for cover-named images
+            for (String name : container.listAllFiles()) {
+                String lower = name.toLowerCase();
+                if (lower.contains("cover") && (lower.endsWith(".jpg") || lower.endsWith(".jpeg") ||
+                        lower.endsWith(".png") || lower.endsWith(".webp"))) {
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
+                    container.streamTo(name, baos);
+
+                    return new Resource(baos.toByteArray(), name);
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Container cover search failed for {}: {}", path.getFileName().toString(), e.getMessage());
+        }
+
+        return null;
+    }
+
+    private static Resource detectCoverImageResource(Book book) {
         if (book.getCoverImage() != null) {
             return book.getCoverImage();
         }
 
-        Resource byId = findCoverById(book.getResources().getAll());
+        var resources = book.getResources().getAll();
+
+        Resource byId = findCoverById(resources);
         if (byId != null) {
-            log.log(System.Logger.Level.DEBUG, "Cover detected by resource id: " + byId.getHref());
+            log.debug("Cover detected by resource id: {}", byId.getHref());
             return byId;
         }
 
-        Resource byName = findCoverByName(book.getResources().getAll());
+        Resource byName = findCoverByName(resources);
         if (byName != null) {
-            log.log(System.Logger.Level.DEBUG, "Cover detected by filename: " + byName.getHref());
+            log.debug("Cover detected by filename: {}", byName.getHref());
             return byName;
         }
 
         Resource fromSpine = findCoverFromFirstSpineItem(book);
         if (fromSpine != null) {
-            log.log(
-                    System.Logger.Level.DEBUG,
-                    "Cover detected from first spine item: " + fromSpine.getHref());
+            log.debug("Cover detected from first spine item: {}", fromSpine.getHref());
             return fromSpine;
         }
 
-        Resource largest = findLargestImage(book.getResources().getAll());
+        Resource largest = findLargestImage(resources);
         if (largest != null) {
-            log.log(System.Logger.Level.DEBUG, "Cover detected as largest image: " + largest.getHref());
+            log.debug("Cover detected as largest image: {}", largest.getHref());
             return largest;
         }
 
-        Resource firstImage = findFirstManifestImage(book.getResources().getAll());
+        Resource firstImage = findFirstManifestImage(resources);
         if (firstImage != null) {
-            log.log(
-                    System.Logger.Level.DEBUG,
-                    "Cover detected as first manifest image: " + firstImage.getHref());
+            log.debug("Cover detected as first manifest image: {}", firstImage.getHref());
             return firstImage;
         }
 
         return null;
     }
 
-    public static Resource detectCoverImage(Path path) {
+    public static String detectCoverImagePath(Path path) {
         try {
             Book book = new EpubReader().readEpubLazy(path, "UTF-8");
-            return detectCoverImage(book);
+
+            Resource opfResource = book.getOpfResource();
+            String opfPath = opfResource != null ? opfResource.getHref() : "";
+            String rootPath = opfPath.contains("/") ? opfPath.substring(0, opfPath.lastIndexOf('/') + 1) : "";
+
+            var resource = detectCoverImageResource(book);
+
+            if (resource == null) {
+                // fallback is absolute
+                rootPath = "";
+                resource = detectCoverImageFallback(path);
+            }
+
+            return resource == null ? null : rootPath + resource.getHref();
+        } catch (IOException exception) {
+            return null;
+        }
+    }
+
+    public static byte[] detectCoverImage(Path path) {
+        try {
+            Book book = new EpubReader().readEpubLazy(path, "UTF-8");
+
+            var resource = detectCoverImageResource(book);
+
+            if (resource == null) {
+                resource = detectCoverImageFallback(path);
+            }
+
+            return resource == null ? null : resource.getData();
         } catch (IOException exception) {
             return null;
         }
@@ -192,9 +235,7 @@ public class CoverDetector {
                 if (resolved != null) return resolved;
             }
         } catch (IOException e) {
-            log.log(
-                    System.Logger.Level.DEBUG,
-                    "Failed to read first spine item for cover detection: " + e.getMessage());
+            log.debug("Failed to read first spine item for cover detection: {}", e.getMessage());
         }
 
         return null;

--- a/backend/src/main/java/org/booklore/util/epub/CoverDetectorService.java
+++ b/backend/src/main/java/org/booklore/util/epub/CoverDetectorService.java
@@ -5,7 +5,6 @@
  */
 package org.booklore.util.epub;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -13,9 +12,9 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.grimmory.epub4j.archive.EpubContainer;
-import org.grimmory.epub4j.archive.EpubContainers;
+import org.booklore.service.ArchiveService;
 import org.grimmory.epub4j.domain.Book;
 import org.grimmory.epub4j.domain.MediaType;
 import org.grimmory.epub4j.domain.MediaTypes;
@@ -23,9 +22,12 @@ import org.grimmory.epub4j.domain.Resource;
 import org.grimmory.epub4j.domain.Resources;
 import org.grimmory.epub4j.domain.Spine;
 import org.grimmory.epub4j.epub.EpubReader;
+import org.springframework.stereotype.Service;
 
 @Slf4j
-public class CoverDetector {
+@Service
+@RequiredArgsConstructor
+public class CoverDetectorService {
     /** Minimum image size in bytes to consider as a potential cover (10KB). */
     private static final int MIN_COVER_SIZE = 10 * 1024;
 
@@ -35,18 +37,19 @@ public class CoverDetector {
             Pattern.compile(
                     "<image[^>]+(?:href|xlink:href)\\s*=\\s*[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
 
-    private static Resource detectCoverImageFallback(Path path) {
+    private final ArchiveService archiveService;
+
+    private Resource detectCoverImageFallback(Path path) {
         // Last resort: scan container for cover-like images
-        try (EpubContainer container = EpubContainers.open(path)) {
-            // Scan all files for cover-named images
-            for (String name : container.listAllFiles()) {
-                String lower = name.toLowerCase();
+        try {
+            for (var entryName : archiveService.getEntryNames(path)) {
+                String lower = entryName.toLowerCase();
                 if (lower.contains("cover") && (lower.endsWith(".jpg") || lower.endsWith(".jpeg") ||
                         lower.endsWith(".png") || lower.endsWith(".webp"))) {
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
-                    container.streamTo(name, baos);
-
-                    return new Resource(baos.toByteArray(), name);
+                    return new Resource(
+                            archiveService.getEntryBytes(path, entryName),
+                            collapsePath(entryName)
+                    );
                 }
             }
         } catch (Exception e) {
@@ -56,7 +59,7 @@ public class CoverDetector {
         return null;
     }
 
-    private static Resource detectCoverImageResource(Book book) {
+    private Resource detectCoverImageResource(Book book) {
         if (book.getCoverImage() != null) {
             return book.getCoverImage();
         }
@@ -96,7 +99,7 @@ public class CoverDetector {
         return null;
     }
 
-    public static String detectCoverImagePath(Path path) {
+    public String detectCoverImagePath(Path path) {
         try {
             Book book = new EpubReader().readEpubLazy(path, "UTF-8");
 
@@ -113,12 +116,14 @@ public class CoverDetector {
             }
 
             return resource == null ? null : rootPath + resource.getHref();
-        } catch (IOException exception) {
-            return null;
+        } catch (IOException e) {
+            log.debug("Failed to read epub for cover detection: {}", e.getMessage());
         }
+
+        return null;
     }
 
-    public static byte[] detectCoverImage(Path path) {
+    public byte[] detectCoverImage(Path path) {
         try {
             Book book = new EpubReader().readEpubLazy(path, "UTF-8");
 
@@ -129,16 +134,18 @@ public class CoverDetector {
             }
 
             return resource == null ? null : resource.getData();
-        } catch (IOException exception) {
-            return null;
+        } catch (IOException e) {
+            log.debug("Failed to read epub for cover detection: {}", e.getMessage());
         }
+
+        return null;
     }
 
     /**
      * Find an image resource whose id contains "cover" (case-insensitive). Matches id patterns like
      * "cover-image", "cover", "coverimg" that OPF generators commonly use.
      */
-    private static Resource findCoverById(Collection<Resource> resources) {
+    private Resource findCoverById(Collection<Resource> resources) {
         for (Resource resource : resources) {
             if (!isImageResource(resource)) continue;
             String id = resource.getId();
@@ -153,7 +160,7 @@ public class CoverDetector {
      * Returns the first image resource found in the manifest. Last-resort fallback when all other
      * strategies fail.
      */
-    private static Resource findFirstManifestImage(Collection<Resource> resources) {
+    private Resource findFirstManifestImage(Collection<Resource> resources) {
         for (Resource resource : resources) {
             if (isImageResource(resource) && resource.getSize() >= MIN_COVER_SIZE) {
                 return resource;
@@ -166,7 +173,7 @@ public class CoverDetector {
      * Find an image resource whose filename contains "cover" (case-insensitive). Prioritizes exact
      * matches like "cover.jpg" over partial matches like "discover.png".
      */
-    private static Resource findCoverByName(Collection<Resource> resources) {
+    private Resource findCoverByName(Collection<Resource> resources) {
         Resource exactMatch = null;
         Resource partialMatch = null;
 
@@ -200,7 +207,7 @@ public class CoverDetector {
      * Look at the first spine item's XHTML content and find the first referenced image. This works
      * for EPUBs where the first page is a cover page containing an img tag.
      */
-    private static Resource findCoverFromFirstSpineItem(Book book) {
+    private Resource findCoverFromFirstSpineItem(Book book) {
         Spine spine = book.getSpine();
         if (spine.isEmpty()) return null;
 
@@ -242,7 +249,7 @@ public class CoverDetector {
     }
 
     /** Resolve an image reference relative to a base path and look it up in resources. */
-    private static Resource resolveImageRef(Resources resources, String basePath, String imgSrc) {
+    private Resource resolveImageRef(Resources resources, String basePath, String imgSrc) {
         if (imgSrc == null || imgSrc.isBlank()) return null;
 
         int hashPos = imgSrc.indexOf('#');
@@ -258,7 +265,7 @@ public class CoverDetector {
         resource = resources.getByHref(resolved);
         if (resource != null) return resource;
 
-        if (resolved.contains("..") || resolved.contains("./")) {
+        if (resolved.contains("..") || resolved.contains("./") || resolved.startsWith("/")) {
             resolved = collapsePath(resolved);
             resource = resources.getByHref(resolved);
             return resource;
@@ -271,7 +278,7 @@ public class CoverDetector {
      * Find the largest image resource by data size. Only considers images above the minimum size
      * threshold.
      */
-    private static Resource findLargestImage(Collection<Resource> resources) {
+    private Resource findLargestImage(Collection<Resource> resources) {
         Resource largest = null;
         long largestSize = MIN_COVER_SIZE; // reject images below this as unlikely covers
 
@@ -288,16 +295,17 @@ public class CoverDetector {
         return largest;
     }
 
-    private static boolean isImageResource(Resource resource) {
+    private boolean isImageResource(Resource resource) {
         MediaType mt = resource.getMediaType();
         return mt == MediaTypes.JPG
                 || mt == MediaTypes.PNG
                 || mt == MediaTypes.GIF
-                || mt == MediaTypes.SVG;
+                || mt == MediaTypes.SVG
+                || mt == MediaTypes.WEBP;
     }
 
     /** Collapse ".." and "." segments in a path. */
-    private static String collapsePath(String path) {
+    private String collapsePath(String path) {
         String[] parts = path.split("/");
         Deque<String> stack = new ArrayDeque<>();
         for (String part : parts) {

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -1,15 +1,20 @@
 package org.booklore.service.metadata.extractor;
 
 import org.booklore.model.dto.BookMetadata;
-import org.junit.jupiter.api.BeforeEach;
+import org.booklore.util.epub.CoverDetectorService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -23,17 +28,20 @@ import java.util.zip.ZipOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class EpubMetadataExtractorTest {
 
+@ExtendWith(MockitoExtension.class)
+class EpubMetadataExtractorTest {
+    @Mock
+    CoverDetectorService coverDetectorService;
+
+    @Spy
+    private ObjectMapper objectMapper = JsonMapper.shared();
+
+    @InjectMocks
     private EpubMetadataExtractor extractor;
 
     @TempDir
     Path tempDir;
-
-    @BeforeEach
-    void setUp() {
-        extractor = new EpubMetadataExtractor(new ObjectMapper());
-    }
 
     private File createEpub(String opfContent) throws IOException {
         return createEpub(opfContent, "OEBPS/content.opf", null);
@@ -996,246 +1004,6 @@ class EpubMetadataExtractorTest {
     }
 
     @Nested
-    class CoverExtraction {
-
-        @Test
-        void extractsCoverViaCoverImageProperty() throws IOException {
-            byte[] coverBytes = new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x01, 0x02, 0x03};
-            String opf = wrapOpf("", """
-                    <item id="cover" href="images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
-                    """);
-            File epub = createEpub(opf, "OEBPS/content.opf", coverBytes);
-            byte[] result = extractor.extractCover(epub);
-
-            assertThat(result).isEqualTo(coverBytes);
-        }
-
-        @Test
-        void extractsCoverByHeuristicManifestSearch() throws IOException {
-            byte[] coverBytes = new byte[]{0x01, 0x02, 0x03, 0x04};
-            String opf = wrapOpf("", """
-                    <item id="cover-img" href="images/cover.jpg" media-type="image/jpeg"/>
-                    """);
-            File epub = createEpub(opf, "OEBPS/content.opf", coverBytes);
-            byte[] result = extractor.extractCover(epub);
-
-            assertThat(result).isEqualTo(coverBytes);
-        }
-
-        @Test
-        void extractsCoverByZipHeuristic() throws IOException {
-            byte[] coverBytes = new byte[]{0x10, 0x20, 0x30};
-            File epub = tempDir.resolve("cover_zip.epub").toFile();
-            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub))) {
-                zos.putNextEntry(new ZipEntry("mimetype"));
-                zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String containerXml = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-                          <rootfiles>
-                            <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
-                          </rootfiles>
-                        </container>""";
-                zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
-                zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String opf = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
-                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/"/>
-                          <manifest>
-                            <item id="text" href="chapter1.html" media-type="application/xhtml+xml"/>
-                          </manifest>
-                        </package>""";
-                zos.putNextEntry(new ZipEntry("content.opf"));
-                zos.write(opf.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                zos.putNextEntry(new ZipEntry("images/cover.jpg"));
-                zos.write(coverBytes);
-                zos.closeEntry();
-            }
-
-            byte[] result = extractor.extractCover(epub);
-            assertThat(result).isEqualTo(coverBytes);
-        }
-
-        @Test
-        void returnsNullForEpubWithNoCover() throws IOException {
-            File epub = tempDir.resolve("nocover.epub").toFile();
-            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub))) {
-                zos.putNextEntry(new ZipEntry("mimetype"));
-                zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String containerXml = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-                          <rootfiles>
-                            <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
-                          </rootfiles>
-                        </container>""";
-                zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
-                zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String opf = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
-                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-                            <dc:title>No Cover Book</dc:title>
-                          </metadata>
-                          <manifest>
-                            <item id="text" href="chapter1.html" media-type="application/xhtml+xml"/>
-                          </manifest>
-                        </package>""";
-                zos.putNextEntry(new ZipEntry("content.opf"));
-                zos.write(opf.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-            }
-
-            byte[] result = extractor.extractCover(epub);
-            assertThat(result).isNull();
-        }
-    }
-
-    @Nested
-    class PathResolution {
-
-        @Test
-        void resolvesCoverWithParentDirectorySegments() throws IOException {
-            byte[] coverBytes = new byte[]{0x01, 0x02};
-            File epub = tempDir.resolve("pathtest.epub").toFile();
-            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub))) {
-                zos.putNextEntry(new ZipEntry("mimetype"));
-                zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String containerXml = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-                          <rootfiles>
-                            <rootfile full-path="OEBPS/subdir/content.opf" media-type="application/oebps-package+xml"/>
-                          </rootfiles>
-                        </container>""";
-                zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
-                zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String opf = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
-                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-                            <dc:title>Path Test</dc:title>
-                          </metadata>
-                          <manifest>
-                            <item id="cover" href="../images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
-                          </manifest>
-                        </package>""";
-                zos.putNextEntry(new ZipEntry("OEBPS/subdir/content.opf"));
-                zos.write(opf.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                zos.putNextEntry(new ZipEntry("OEBPS/images/cover.jpg"));
-                zos.write(coverBytes);
-                zos.closeEntry();
-            }
-
-            byte[] result = extractor.extractCover(epub);
-            assertThat(result).isEqualTo(coverBytes);
-        }
-
-        @Test
-        void resolvesAbsoluteHrefInZip() throws IOException {
-            byte[] coverBytes = new byte[]{0x0A, 0x0B};
-            File epub = tempDir.resolve("abstest.epub").toFile();
-            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub))) {
-                zos.putNextEntry(new ZipEntry("mimetype"));
-                zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String containerXml = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-                          <rootfiles>
-                            <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
-                          </rootfiles>
-                        </container>""";
-                zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
-                zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String opf = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
-                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-                            <dc:title>Abs Test</dc:title>
-                          </metadata>
-                          <manifest>
-                            <item id="cover" href="/images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
-                          </manifest>
-                        </package>""";
-                zos.putNextEntry(new ZipEntry("OEBPS/content.opf"));
-                zos.write(opf.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                zos.putNextEntry(new ZipEntry("images/cover.jpg"));
-                zos.write(coverBytes);
-                zos.closeEntry();
-            }
-
-            byte[] result = extractor.extractCover(epub);
-            assertThat(result).isEqualTo(coverBytes);
-        }
-
-        @Test
-        void resolvesDotSegmentsInHref() throws IOException {
-            byte[] coverBytes = new byte[]{0x0C};
-            File epub = tempDir.resolve("dottest.epub").toFile();
-            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub))) {
-                zos.putNextEntry(new ZipEntry("mimetype"));
-                zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String containerXml = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-                          <rootfiles>
-                            <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
-                          </rootfiles>
-                        </container>""";
-                zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
-                zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                String opf = """
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
-                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-                            <dc:title>Dot Test</dc:title>
-                          </metadata>
-                          <manifest>
-                            <item id="cover" href="./images/../images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
-                          </manifest>
-                        </package>""";
-                zos.putNextEntry(new ZipEntry("OEBPS/content.opf"));
-                zos.write(opf.getBytes(StandardCharsets.UTF_8));
-                zos.closeEntry();
-
-                zos.putNextEntry(new ZipEntry("OEBPS/images/cover.jpg"));
-                zos.write(coverBytes);
-                zos.closeEntry();
-            }
-
-            byte[] result = extractor.extractCover(epub);
-            assertThat(result).isEqualTo(coverBytes);
-        }
-    }
-
-    @Nested
     class OpfAtRootLevel {
 
         @Test
@@ -1363,7 +1131,6 @@ class EpubMetadataExtractorTest {
         void nonExistentFileReturnsNull() {
             File nonExistent = new File(tempDir.toFile(), "nonexistent.epub");
             assertThat(extractor.extractMetadata(nonExistent)).isNull();
-            assertThat(extractor.extractCover(nonExistent)).isNull();
         }
 
         @Test
@@ -1373,7 +1140,6 @@ class EpubMetadataExtractorTest {
                 fos.write(new byte[]{0x00, 0x01, 0x02, 0x03});
             }
             assertThat(extractor.extractMetadata(corrupt)).isNull();
-            assertThat(extractor.extractCover(corrupt)).isNull();
         }
 
         @Test

--- a/backend/src/test/java/org/booklore/service/reader/EpubReaderServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/reader/EpubReaderServiceTest.java
@@ -9,6 +9,7 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.ArchiveService;
 import org.booklore.util.FileUtils;
+import org.booklore.util.epub.CoverDetectorService;
 import org.grimmory.epub4j.domain.*;
 import org.grimmory.epub4j.epub.EpubWriter;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,9 @@ class EpubReaderServiceTest {
 
     @Spy
     ArchiveService archiveService = new ArchiveService();
+
+    @Mock
+    CoverDetectorService coverDetectorService;
 
     @InjectMocks
     EpubReaderService epubReaderService;
@@ -113,7 +117,6 @@ class EpubReaderServiceTest {
             assertEquals("en", bookInfo.getMetadata().get("language"));
             assertFalse(bookInfo.getManifest().isEmpty());
             assertEquals(2, bookInfo.getSpine().size());
-            assertNotNull(bookInfo.getCoverPath());
         }
     }
 

--- a/backend/src/test/java/org/booklore/util/epub/CoverDetectorServiceTest.java
+++ b/backend/src/test/java/org/booklore/util/epub/CoverDetectorServiceTest.java
@@ -1,0 +1,324 @@
+package org.booklore.util.epub;
+
+import org.booklore.service.ArchiveService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExtendWith(MockitoExtension.class)
+public class CoverDetectorServiceTest {
+    @Spy
+    ArchiveService archiveService = new ArchiveService();
+
+    @InjectMocks
+    CoverDetectorService coverDetectorService;
+
+    @TempDir
+    Path tempDir;
+
+    private Path createEpub(String opfContent, String opfPath, byte[] coverImage) throws IOException {
+        Path epub = tempDir.resolve("test.epub");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub.toFile()))) {
+            zos.putNextEntry(new ZipEntry("mimetype"));
+            zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String containerXml = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                      <rootfiles>
+                        <rootfile full-path="%s" media-type="application/oebps-package+xml"/>
+                      </rootfiles>
+                    </container>""".formatted(opfPath);
+            zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
+            zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry(opfPath));
+            zos.write(opfContent.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            if (coverImage != null) {
+                zos.putNextEntry(new ZipEntry("OEBPS/images/cover.jpg"));
+                zos.write(coverImage);
+                zos.closeEntry();
+            }
+        }
+        return epub;
+    }
+
+    private String wrapOpf(String metadataContent, String manifestContent) {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                    %s
+                  </metadata>
+                  <manifest>
+                    %s
+                  </manifest>
+                </package>""".formatted(metadataContent, manifestContent);
+    }
+
+    @Test
+    void extractsCoverViaCoverImageProperty() throws IOException {
+        byte[] coverBytes = new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x01, 0x02, 0x03};
+        String opf = wrapOpf("", """
+                    <item id="cover" href="images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
+                    """);
+        Path epub = createEpub(opf, "OEBPS/content.opf", coverBytes);
+        byte[] result = coverDetectorService.detectCoverImage(epub);
+
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void extractsCoverByHeuristicManifestSearch() throws IOException {
+        byte[] coverBytes = new byte[]{0x01, 0x02, 0x03, 0x04};
+        String opf = wrapOpf("", """
+                    <item id="cover-img" href="images/cover.jpg" media-type="image/jpeg"/>
+                    """);
+        Path epub = createEpub(opf, "OEBPS/content.opf", coverBytes);
+        byte[] result = coverDetectorService.detectCoverImage(epub);
+
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void extractsCoverByZipHeuristic() throws IOException {
+        byte[] coverBytes = new byte[]{0x10, 0x20, 0x30};
+        Path epub = tempDir.resolve("cover_zip.epub");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub.toFile()))) {
+            zos.putNextEntry(new ZipEntry("mimetype"));
+            zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String containerXml = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                          <rootfiles>
+                            <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+                          </rootfiles>
+                        </container>""";
+            zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
+            zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String opf = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+                          <manifest>
+                            <item id="text" href="chapter1.html" media-type="application/xhtml+xml"/>
+                          </manifest>
+                        </package>""";
+            zos.putNextEntry(new ZipEntry("content.opf"));
+            zos.write(opf.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("images/cover.jpg"));
+            zos.write(coverBytes);
+            zos.closeEntry();
+        }
+
+        byte[] result = coverDetectorService.detectCoverImage(epub);
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void returnsNullForEpubWithNoCover() throws IOException {
+        Path epub = tempDir.resolve("nocover.epub");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub.toFile()))) {
+            zos.putNextEntry(new ZipEntry("mimetype"));
+            zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String containerXml = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                          <rootfiles>
+                            <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+                          </rootfiles>
+                        </container>""";
+            zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
+            zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String opf = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title>No Cover Book</dc:title>
+                          </metadata>
+                          <manifest>
+                            <item id="text" href="chapter1.html" media-type="application/xhtml+xml"/>
+                          </manifest>
+                        </package>""";
+            zos.putNextEntry(new ZipEntry("content.opf"));
+            zos.write(opf.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        byte[] result = coverDetectorService.detectCoverImage(epub);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void resolvesCoverWithParentDirectorySegments() throws IOException {
+        byte[] coverBytes = new byte[]{0x01, 0x02};
+        Path epub = tempDir.resolve("pathtest.epub");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub.toFile()))) {
+            zos.putNextEntry(new ZipEntry("mimetype"));
+            zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String containerXml = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                          <rootfiles>
+                            <rootfile full-path="OEBPS/subdir/content.opf" media-type="application/oebps-package+xml"/>
+                          </rootfiles>
+                        </container>""";
+            zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
+            zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String opf = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title>Path Test</dc:title>
+                          </metadata>
+                          <manifest>
+                            <item id="cover" href="../images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
+                          </manifest>
+                        </package>""";
+            zos.putNextEntry(new ZipEntry("OEBPS/subdir/content.opf"));
+            zos.write(opf.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("OEBPS/images/cover.jpg"));
+            zos.write(coverBytes);
+            zos.closeEntry();
+        }
+
+        byte[] result = coverDetectorService.detectCoverImage(epub);
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void resolvesAbsoluteHrefInZip() throws IOException {
+        byte[] coverBytes = new byte[]{0x0A, 0x0B};
+        Path epub = tempDir.resolve("abstest.epub");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub.toFile()))) {
+            zos.putNextEntry(new ZipEntry("mimetype"));
+            zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String containerXml = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                          <rootfiles>
+                            <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+                          </rootfiles>
+                        </container>""";
+            zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
+            zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String opf = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title>Abs Test</dc:title>
+                          </metadata>
+                          <manifest>
+                            <item id="cover" href="/images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
+                          </manifest>
+                        </package>""";
+            zos.putNextEntry(new ZipEntry("OEBPS/content.opf"));
+            zos.write(opf.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("images/cover.jpg"));
+            zos.write(coverBytes);
+            zos.closeEntry();
+        }
+
+        byte[] result = coverDetectorService.detectCoverImage(epub);
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void resolvesDotSegmentsInHref() throws IOException {
+        byte[] coverBytes = new byte[]{0x0C};
+        Path epub = tempDir.resolve("dottest.epub");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(epub.toFile()))) {
+            zos.putNextEntry(new ZipEntry("mimetype"));
+            zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String containerXml = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                          <rootfiles>
+                            <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+                          </rootfiles>
+                        </container>""";
+            zos.putNextEntry(new ZipEntry("META-INF/container.xml"));
+            zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            String opf = """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title>Dot Test</dc:title>
+                          </metadata>
+                          <manifest>
+                            <item id="cover" href="./images/../images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
+                          </manifest>
+                        </package>""";
+            zos.putNextEntry(new ZipEntry("OEBPS/content.opf"));
+            zos.write(opf.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("OEBPS/images/cover.jpg"));
+            zos.write(coverBytes);
+            zos.closeEntry();
+        }
+
+        byte[] result = coverDetectorService.detectCoverImage(epub);
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void nonExistentFileReturnsNull() {
+        Path nonExistent = tempDir.resolve("nonexistent.epub");
+        assertThat(coverDetectorService.detectCoverImage(nonExistent)).isNull();
+    }
+
+    @Test
+    void corruptZipReturnsNull() throws IOException {
+        Path corrupt = tempDir.resolve("corrupt.epub");
+        try (FileOutputStream fos = new FileOutputStream(corrupt.toFile())) {
+            fos.write(new byte[]{0x00, 0x01, 0x02, 0x03});
+        }
+        assertThat(coverDetectorService.detectCoverImage(corrupt)).isNull();
+    }
+
+}


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
moves `CoverDetector` back into Grimmory, relying on the existing unit tests within Grimmory to confirm it's working.  this is one of multiple steps needed to move us back to the upstream epub4j

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2055

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* move `CoverDetector` back into Grimmory
* refactor `CoverDetector` to be a spring service
* refactor `CoverDetectorService` to emit String / bytes
* refactor `CoverDetectorService` to use `ArchiveService`
* move "fallback" check for file into `CoverDetectorService`
* shuffle tests around for `CoverDetectorService`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
tested cover detection against my library of books and confirmed they all can find expected covers

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Centralized EPUB cover detection via a dedicated detector, now used for both metadata extraction and EPUB reading.
  - Improved cover discovery with multiple heuristics (OPF/manifest hints, spine-linked image references, size-based selection, and archive-name fallback) plus more robust href/path handling.

- **Bug Fixes**
  - EPUBs without covers and corrupted/invalid inputs now result in no cover instead of causing failures.

- **Tests**
  - Added comprehensive detector tests for varied EPUB structures and href variations.
  - Updated metadata/reader tests to reflect the new cover-detection wiring and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->