### PR TITLE
chore(epub): avoid EpubContainer in EpubMetadataExtractor

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -180,19 +180,29 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
         return null;
     }
 
+    private Document getOPFDocumentFromEpub(File epubFile) throws IOException, ParserConfigurationException, SAXException {
+        Book book = new EpubReader().readEpubLazy(epubFile.toPath(), "UTF-8");
+
+        var opfResource = book.getOpfResource();
+
+        if (opfResource == null) {
+            return null;
+        }
+
+        try (var inputStream = opfResource.getInputStream()) {
+            return SecureXmlUtils.createSecureDocumentBuilder(true)
+                    .parse(inputStream);
+        }
+    }
+
     @Override
     public BookMetadata extractMetadata(File epubFile) {
         try {
-            Book book = new EpubReader().readEpubLazy(epubFile.toPath(), "UTF-8");
+            Document doc = getOPFDocumentFromEpub(epubFile);
 
-            var opfResource = book.getOpfResource();
-
-            if (opfResource == null) {
+            if (doc == null) {
                 return null;
             }
-
-            Document doc = SecureXmlUtils.createSecureDocumentBuilder(true)
-                    .parse(opfResource.asInputStream());
 
             Element metadata = (Element) doc.getElementsByTagNameNS("*", "metadata").item(0);
             if (metadata == null) return null;

--- a/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/EpubMetadataExtractor.java
@@ -182,9 +182,17 @@ public class EpubMetadataExtractor implements FileMetadataExtractor {
 
     @Override
     public BookMetadata extractMetadata(File epubFile) {
-        try (EpubContainer container = EpubContainers.open(epubFile.toPath())) {
-            String opfPath = findOpfPath(container);
-            Document doc = parseXmlFromContainer(container, opfPath);
+        try {
+            Book book = new EpubReader().readEpubLazy(epubFile.toPath(), "UTF-8");
+
+            var opfResource = book.getOpfResource();
+
+            if (opfResource == null) {
+                return null;
+            }
+
+            Document doc = SecureXmlUtils.createSecureDocumentBuilder(true)
+                    .parse(opfResource.asInputStream());
 
             Element metadata = (Element) doc.getElementsByTagNameNS("*", "metadata").item(0);
             if (metadata == null) return null;


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
avoid `EpubContainer` in epub4j in the `EpubMetadataExtractor` class by reading via the standard `EpubReader`

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2055 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
replaces `EpubContainer` in `EpubMetadataExtractor`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

uploaded epub to Grimmory
confirmed metadata extracted matches expected

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB metadata extraction by retrieving and parsing OPF content directly from the EPUB.
  * EPUB files missing an OPF now fail gracefully, avoiding extraction errors and returning no metadata.
  * Enhanced OPF XML parsing for improved safety and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->