### PR TITLE
fix(ranobedb): prioritize English results

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
@@ -308,7 +308,7 @@ public class RanobeDbParser implements BookParser {
 
                 RanobedbBookResponse.Release release = book.getReleases().stream()
                         .filter(Objects::nonNull)
-                        .min(Comparator.comparingInt(r -> "en".equalsIgnoreCase(r.getLang()) ? 1 : -1))
+                        .max(Comparator.comparingInt(r -> "en".equalsIgnoreCase(r.getLang()) ? 1 : -1))
                         .orElse(null);
 
                 String bookLang = release != null ? release.getLang() : book.getLang();

--- a/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/RanobeDbParser.java
@@ -308,7 +308,7 @@ public class RanobeDbParser implements BookParser {
 
                 RanobedbBookResponse.Release release = book.getReleases().stream()
                         .filter(Objects::nonNull)
-                        .max(Comparator.comparingInt(r -> "en".equalsIgnoreCase(r.getLang()) ? 1 : -1))
+                        .max(Comparator.comparing(r -> "en".equalsIgnoreCase(r.getLang())))
                         .orElse(null);
 
                 String bookLang = release != null ? release.getLang() : book.getLang();

--- a/backend/src/test/java/org/booklore/service/metadata/parser/RanobeDBParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/RanobeDBParserTest.java
@@ -5,7 +5,6 @@ import org.booklore.model.dto.BookMetadata;
 import org.booklore.model.dto.request.FetchMetadataRequest;
 import org.booklore.service.appsettings.AppSettingService;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -20,7 +19,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -89,14 +88,13 @@ class RanobeDbParserTest {
         List<BookMetadata> results = parser.fetchMetadata(book, request);
 
         // Then
-        assertNotNull(results);
-        assertTrue(results.isEmpty(), "Should return empty list when query is empty");
+        assertThat(results).withFailMessage("Should return empty list when query is empty").isEmpty();
     }
 
     @Test
     void testFetchMetadata_Integration_RealBook() throws Exception {
         mockResponse("/books", 200, readFixture("books.json"));
-        mockResponse("/book/", 200, readFixture("book.json"));
+        mockResponse("/book/47136", 200, readFixture("book.json"));
         mockResponse("/staff", 200, readFixture("staff.json"));
 
         // Given
@@ -113,13 +111,37 @@ class RanobeDbParserTest {
         List<BookMetadata> results = parser.fetchMetadata(book, request);
 
         // Then
-        assertNotNull(results);
-        assertFalse(results.isEmpty(), "Should return results for real book");
+        assertThat(results).withFailMessage("Should return results for real book").isNotEmpty();
 
         BookMetadata firstResult = results.getFirst();
-        assertNotNull(firstResult.getTitle(), "Title should be present");
-        assertNotNull(firstResult.getRanobedbId(), "RanobeDB ID should be present");
-        assertTrue(firstResult.getAuthors() != null && !firstResult.getAuthors().isEmpty(),
-            "Authors should be present");
+        assertThat(firstResult.getTitle()).withFailMessage("Title should be present").isNotNull();
+        assertThat(firstResult.getRanobedbId()).withFailMessage("RanobeDB ID should be present").isNotNull();
+
+        var authors = firstResult.getAuthors();
+        assertThat(authors).withFailMessage("Authors should be present").isNotEmpty();
+    }
+
+    @Test
+    void testFetchMetadata_PrioritizesReleaseLanguage() throws Exception {
+        mockResponse("/books", 200, readFixture("books.json"));
+        mockResponse("/book/47136", 200, readFixture("book.json"));
+        mockResponse("/staff", 200, readFixture("staff.json"));
+
+        // Given
+        Book book = Book.builder()
+                .title("Example")
+                .build();
+
+        FetchMetadataRequest request = FetchMetadataRequest.builder()
+                .title("Example")
+                .author("Example")
+                .build();
+
+        // When
+        BookMetadata metadata = parser.fetchTopMetadata(book, request);
+
+        // Then
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getTitle()).isEqualTo("Rascal Does Not Dream of a Beach Queen +");
     }
 }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
invert the ranobedb provider release sorting for language so desired releases are first

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2132 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* invert sort
* add test to validate behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
run search using ranobedb provider

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata lookup now prioritizes English releases when multiple language versions are available.
* **Tests**
  * Updated search and metadata validation to use AssertJ assertions for clearer failure messages.
  * Refreshed integration test expectations, including title/ID/author presence and release-language prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->