### PR TITLE
docs: use actual tags instead of fake examples

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     # Stable release example:
     image: ghcr.io/grimmory-tools/grimmory:latest
     # The suggested deployment approach is to use a specific version rather than `latest`
-    # so upgrading is more straightforward and happens convenient.  In those cases, you can
+    # so upgrading is more straightforward and convenient.  In those cases, you can
     # use the tagged version, such as `v3.2.4` rather than `latest`.
     container_name: grimmory
     environment:

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -4,12 +4,10 @@ services:
   # and mounted volumes. Replace only the image line(s) with Grimmory tags.
   grimmory:
     # Stable release example:
-    image: grimmory/grimmory:v0.38.2
-    # Convenience tag:
-    # image: grimmory/grimmory:latest
-    # Or the GHCR image:
-    # image: ghcr.io/grimmory-tools/grimmory:v0.38.2
-    # The image already embeds its own release version metadata.
+    image: ghcr.io/grimmory-tools/grimmory:latest
+    # The suggested deployment approach is to use a specific version rather than `latest`
+    # so upgrading is more straightforward and happens convenient.  In those cases, you can
+    # use the tagged version, such as `v3.2.4` rather than `latest`.
     container_name: grimmory
     environment:
       - USER_ID=1000

--- a/deploy/podman/quadlet/README.md
+++ b/deploy/podman/quadlet/README.md
@@ -10,9 +10,9 @@ This directory contains an example of how to use a rootless Podman pod defined t
    ```bash
    echo -n "YOUR PASSWORD" | podman secret create grimmory_db_pass -
    ```
-4. (Optional) `podman pull ghcr.io/grimmory-tools/grimmory:v0.38.2` to pre-pull the image
+4. (Optional) `podman pull ghcr.io/grimmory-tools/grimmory:latest` to pre-pull the image
   * If you have a slow connection, this is recommended because systemd will time out if the image pull takes too long.
-  * To follow rolling releases instead, set the image tag to `latest` in `grimmory.container`.
+  * To follow tagged releases instead, set the image tag to the latest tagged release in `grimmory.container`.
 5. Run `systemctl --user daemon-reload` to pick up the new Quadlet unit.
 6. Start the pod with `systemctl --user start grimmory-pod.service`
 

--- a/deploy/podman/quadlet/grimmory.container
+++ b/deploy/podman/quadlet/grimmory.container
@@ -6,7 +6,7 @@ After=grimmory-db.container
 [Container]
 ContainerName=grimmory
 # The suggested deployment approach is to use a specific version rather than `latest`
-# so upgrading is more straightforward and happens convenient.  In those cases, you can
+# so upgrading is more straightforward and convenient.  In those cases, you can
 # use the tagged version, such as `v3.2.4` rather than `latest`.
 Image=ghcr.io/grimmory-tools/grimmory:latest
 Pod=grimmory.pod

--- a/deploy/podman/quadlet/grimmory.container
+++ b/deploy/podman/quadlet/grimmory.container
@@ -5,7 +5,10 @@ After=grimmory-db.container
 
 [Container]
 ContainerName=grimmory
-Image=ghcr.io/grimmory-tools/grimmory:v0.38.2
+# The suggested deployment approach is to use a specific version rather than `latest`
+# so upgrading is more straightforward and happens convenient.  In those cases, you can
+# use the tagged version, such as `v3.2.4` rather than `latest`.
+Image=ghcr.io/grimmory-tools/grimmory:latest
 Pod=grimmory.pod
 AutoUpdate=registry
 Pull=always

--- a/docs/forward-auth-with-proxy.md
+++ b/docs/forward-auth-with-proxy.md
@@ -37,7 +37,7 @@ REMOTE_AUTH_GROUPS_DELIMITER=\\s+          # Regex pattern for splitting groups.
 ```yaml
 services:
   grimmory:
-    image: ghcr.io/grimmory-tools/grimmory:v0.38.2
+    image: ghcr.io/grimmory-tools/grimmory:latest
     environment:
       # Forward Auth Configuration
       - REMOTE_AUTH_ENABLED=true


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
some users want to get started immediately, so they will try to use exactly what we have for the docker-compose / quadlet config and it will fail with the `v0.38.2` tag.  this switches everything to `latest` and includes a message that users are suggested to use tagged release instead

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2138

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
swap tags referenced in example configs to `latest`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
N/A

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment**
  * Updated Docker Compose, Podman Quadlet, and related setup instructions to pull the Grimmory image from the new registry.
  * Adjusted example configurations and guidance to use the `latest` tag in illustrative setups.
  * Updated inline guidance to recommend using a specific version tag (e.g., `v3.x.x`) for more predictable upgrades.
* **Documentation**
  * Refreshed proxy/Compose documentation examples to match the new image reference and tagging guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->