### PR TITLE
chore(repo): add `just ui dev-unsafe` command

### DIFF
--- a/frontend/Justfile
+++ b/frontend/Justfile
@@ -18,6 +18,10 @@ install-ci:
 dev:
     {{ pnpm }} run dev
 
+# Run the Angular development server for access from the local network.
+dev-network host='0.0.0.0':
+    {{ pnpm }} run dev --host "{{ host }}"
+
 # Run the Angular development server with the default `start` script.
 start:
     {{ pnpm }} run start

--- a/frontend/Justfile
+++ b/frontend/Justfile
@@ -19,7 +19,7 @@ dev:
     {{ pnpm }} run dev
 
 # Run the Angular development server for access from the local network.
-dev-network host='0.0.0.0':
+dev-unsafe host='0.0.0.0':
     {{ pnpm }} run dev --host "{{ host }}"
 
 # Run the Angular development server with the default `start` script.


### PR DESCRIPTION
## Description

Adds `just ui dev-unsafe` as an additional dev server command, launching the server with host/local network args. 

## Linked Issue

Fixes #2141

## Changes

- Add `just ui dev-unsafe`

## Manual Testing Steps

Launch command, confirm command works as intended. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a development server run option that binds to a configurable network host, enabling access from other devices on the local network.
  - Supports setting the host address when starting the development server (defaulting to `0.0.0.0`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->