### PR TITLE
fix(magic-shelf): remove OPDS permission gate

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/userdetails/OpdsUserDetails.java
+++ b/backend/src/main/java/org/booklore/config/security/userdetails/OpdsUserDetails.java
@@ -35,6 +35,6 @@ public class OpdsUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         BookLoreUser.UserPermissions permissions = user.getPermissions();
-        return permissions.isAdmin() || permissions.isCanAccessOpds();
+        return permissions != null && (permissions.isAdmin() || permissions.isCanAccessOpds());
     }
 }

--- a/backend/src/main/java/org/booklore/config/security/userdetails/OpdsUserDetails.java
+++ b/backend/src/main/java/org/booklore/config/security/userdetails/OpdsUserDetails.java
@@ -31,4 +31,10 @@ public class OpdsUserDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of();
     }
+
+    @Override
+    public boolean isEnabled() {
+        BookLoreUser.UserPermissions permissions = user.getPermissions();
+        return permissions.isAdmin() || permissions.isCanAccessOpds();
+    }
 }

--- a/backend/src/main/java/org/booklore/service/opds/MagicShelfBookService.java
+++ b/backend/src/main/java/org/booklore/service/opds/MagicShelfBookService.java
@@ -127,14 +127,9 @@ public class MagicShelfBookService {
         BookLoreUserEntity entity = userRepository.findByIdWithDetails(userId)
                 .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
 
-        if (entity.getPermissions() == null ||
-                (!entity.getPermissions().isPermissionAccessOpds() && !entity.getPermissions().isPermissionAdmin())) {
-            throw ApiError.FORBIDDEN.createException("You are not allowed to access this resource");
-        }
-
         boolean isOwner = shelf.getUserId().equals(userId);
         boolean isPublic = shelf.isPublic();
-        boolean isAdmin = entity.getPermissions().isPermissionAdmin();
+        boolean isAdmin = entity.getPermissions() != null && entity.getPermissions().isPermissionAdmin();
 
         if (!isOwner && !isPublic && !isAdmin) {
             throw ApiError.FORBIDDEN.createException("You are not allowed to access this magic shelf");

--- a/backend/src/main/java/org/booklore/service/opds/OpdsBookService.java
+++ b/backend/src/main/java/org/booklore/service/opds/OpdsBookService.java
@@ -75,11 +75,6 @@ public class OpdsBookService {
         BookLoreUserEntity entity = userRepository.findByIdWithDetails(userId)
                 .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
 
-        if (entity.getPermissions() == null ||
-                (!entity.getPermissions().isPermissionAccessOpds() && !entity.getPermissions().isPermissionAdmin())) {
-            throw ApiError.FORBIDDEN.createException("You are not allowed to access this resource");
-        }
-
         BookLoreUser user = bookLoreUserTransformer.toDTO(entity);
         boolean isAdmin = user.getPermissions().isAdmin();
         Set<Long> userLibraryIds = getAccessibleLibraries(userId).stream().map(Library::getId).collect(Collectors.toSet());

--- a/backend/src/test/java/org/booklore/service/OpdsBookServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/OpdsBookServiceTest.java
@@ -341,21 +341,6 @@ class OpdsBookServiceTest {
     }
 
     @Test
-    void getBooksPageForV2User_throwsForbidden_whenNoPermission() {
-        OpdsUserV2 v2 = OpdsUserV2.builder().userId(1L).build();
-        BookLoreUserEntity entity = mock(BookLoreUserEntity.class);
-        var permissionsEntity = mock(UserPermissionsEntity.class);
-        when(permissionsEntity.isPermissionAccessOpds()).thenReturn(false);
-        when(permissionsEntity.isPermissionAdmin()).thenReturn(false);
-        when(entity.getPermissions()).thenReturn(permissionsEntity);
-        when(userRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(entity));
-
-        assertThatThrownBy(() ->
-                opdsBookService.getBooksPage(1L, null, null, null, 0, 10)
-        ).hasMessageContaining("You are not allowed to access this resource");
-    }
-
-    @Test
     void getBooksPage_withSingleShelfId_returnsShelfBooks() {
         OpdsUserDetails details = v2UserDetails(1L, false, Set.of(1L));
         BookLoreUserEntity entity = mock(BookLoreUserEntity.class);


### PR DESCRIPTION
## Description

Removes the OPDS permission check for magic shelf access on the backend. 

## Linked Issue

Fixes #2143 

## Changes

Removes OPDS magic shelf permission check

## Manual Testing Steps

Check magic shelf access via server side / endpoints with and without OPDS permissions enabled, confirm magic shelves remain accessible. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined account enablement based on user permissions, improving OPDS eligibility handling.
  * Updated Magic Shelf access rules: private shelves are accessible only to owners or administrators (OPDS access alone no longer grants access).
  * Adjusted OPDS browsing flow to avoid premature forbidden responses and rely on subsequent filtering/validation.
* **Tests**
  * Removed a unit test that asserted an earlier forbidden error for missing OPDS/admin permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->