### PR TITLE
fix(api): handle exceptions with status codes

### DIFF
--- a/backend/src/main/java/org/booklore/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/booklore/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -115,8 +116,28 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
+        int statusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+        HttpHeaders headers = HttpHeaders.EMPTY;
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "An unexpected error occurred."
+        );
+
+        if (ex instanceof org.springframework.web.ErrorResponse er) {
+            statusCode = er.getStatusCode().value();
+            headers = er.getHeaders();
+            errorResponse = new ErrorResponse(
+                    er.getBody().getStatus(),
+                    er.getBody().getDetail()
+            );
+        }
+
         log.error("Unhandled exception: {}", ex.getMessage(), ex);
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "An unexpected error occurred.");
-        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+
+        return new ResponseEntity<>(
+                errorResponse,
+                headers,
+                statusCode
+        );
     }
 }

--- a/backend/src/test/java/org/booklore/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/org/booklore/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,23 @@
+package org.booklore.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class GlobalExceptionHandlerTest {
+    @Test
+    void handleGenericException_shouldUseSpringErrorResponse() {
+        var ex = new HttpMediaTypeNotAcceptableException(List.of(MediaType.APPLICATION_OCTET_STREAM));
+        var handler = new GlobalExceptionHandler();
+        var response = handler.handleGenericException(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(406);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(406);
+        assertThat(response.getBody().getMessage()).isEqualTo("Acceptable representations: [application/octet-stream].");
+    }
+}


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
spring exceptions that implement `ErrorResponse` have status codes already assigned.  some of those exceptions, like `HttpMediaTypeNotAcceptableException` have a status code and should not emit an HTTP 500

this PR makes it so exceptions that are not otherwise caught and are a spring error response emit the expected status code and message

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2157 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
updates the global exception handler to check for `ErrorResponse` objects

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
made a curl with an incorrect `Accept` at our OPDS endpoints

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to preserve appropriate HTTP status codes, headers, and messages for supported framework errors.
  * Unexpected errors continue to return a clear generic server error response.

* **Tests**
  * Added coverage verifying that content negotiation errors return the correct 406 status and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->