### PR TITLE
fix(metadata): detect FB2 cover in first body image

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractor.java
@@ -34,7 +34,6 @@ public class Fb2MetadataExtractor implements FileMetadataExtractor {
     private static final Pattern KEYWORD_SEPARATOR_PATTERN = Pattern.compile("[,;]");
     private static final Pattern ISBN_CLEANER_PATTERN = Pattern.compile("[^0-9Xx]");
     private static final Pattern ISO_DATE_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
-
     @Override
     public byte[] extractCover(File file) {
         try (InputStream inputStream = getInputStream(file)) {
@@ -64,20 +63,21 @@ public class Fb2MetadataExtractor implements FileMetadataExtractor {
                     Element coverPage = (Element) coverPages.item(0);
                     NodeList images = coverPage.getElementsByTagNameNS(FB2_NAMESPACE, "image");
                     if (images.getLength() > 0) {
-                        Element image = (Element) images.item(0);
-                        String href = image.getAttributeNS("http://www.w3.org/1999/xlink", "href");
-                        if (href != null && href.startsWith("#")) {
-                            String imageId = href.substring(1);
-                            // Find the binary with this ID
-                            for (int i = 0; i < binaries.getLength(); i++) {
-                                Element binary = (Element) binaries.item(i);
-                                if (imageId.equals(binary.getAttribute("id"))) {
-                                    String base64Data = binary.getTextContent().trim();
-                                    return Base64.getDecoder().decode(base64Data);
-                                }
-                            }
+                        byte[] cover = decodeReferencedImage(binaries, (Element) images.item(0));
+                        if (cover != null) {
+                            return cover;
                         }
                     }
+                }
+            }
+
+            // Converter-generated FB2 files sometimes omit coverpage and put page one in the body.
+            // Explicit cover metadata above remains authoritative; this is the last-resort candidate.
+            Element body = getFirstElementByTagNameNS(doc, FB2_NAMESPACE, "body");
+            if (body != null) {
+                NodeList images = body.getElementsByTagNameNS(FB2_NAMESPACE, "image");
+                if (images.getLength() > 0) {
+                    return decodeReferencedImage(binaries, (Element) images.item(0));
                 }
             }
 
@@ -86,6 +86,22 @@ public class Fb2MetadataExtractor implements FileMetadataExtractor {
             log.warn("Failed to extract cover from FB2: {}", file.getName(), e);
             return null;
         }
+    }
+
+    private byte[] decodeReferencedImage(NodeList binaries, Element image) {
+        String href = image.getAttributeNS("http://www.w3.org/1999/xlink", "href");
+        if (href == null || !href.startsWith("#")) {
+            return null;
+        }
+        String imageId = href.substring(1);
+        for (int i = 0; i < binaries.getLength(); i++) {
+            Element binary = (Element) binaries.item(i);
+            if (imageId.equals(binary.getAttribute("id"))) {
+                String base64Data = binary.getTextContent().trim();
+                return Base64.getMimeDecoder().decode(base64Data);
+            }
+        }
+        return null;
     }
 
     @Override

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractorTest.java
@@ -519,6 +519,59 @@ class Fb2MetadataExtractorTest {
     }
 
     @Test
+    void extractCover_fallsBackToFirstBodyImageForConverterGeneratedFb2() throws IOException {
+        byte[] imageData = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
+        String base64 = Base64.getEncoder().encodeToString(imageData);
+        String lineWrappedBase64 = base64.substring(0, 4) + "\n" + base64.substring(4);
+        File file = writeFb2("""
+                <description><title-info/></description>
+                <body>
+                  <section>
+                    <p><image l:href="#_0.jpg"/></p>
+                    <p>Opening text converted from a PDF.</p>
+                  </section>
+                </body>
+                <binary id="_0.jpg" content-type="image/jpeg">%s</binary>
+                """.formatted(lineWrappedBase64));
+
+        byte[] cover = extractor.extractCover(file);
+
+        assertThat(cover).isEqualTo(imageData);
+    }
+
+    @Test
+    void extractCover_standardCoverTakesPriorityOverFirstBodyImage() throws IOException {
+        byte[] standardCover = {0x01, 0x02, 0x03};
+        byte[] bodyImage = {0x04, 0x05, 0x06};
+        File file = writeFb2("""
+                <description>
+                  <title-info>
+                    <coverpage><image l:href="#front.jpg"/></coverpage>
+                  </title-info>
+                </description>
+                <body><section><image l:href="#_0.jpg"/></section></body>
+                <binary id="front.jpg" content-type="image/jpeg">%s</binary>
+                <binary id="_0.jpg" content-type="image/jpeg">%s</binary>
+                """.formatted(
+                        Base64.getEncoder().encodeToString(standardCover),
+                        Base64.getEncoder().encodeToString(bodyImage)));
+
+        byte[] cover = extractor.extractCover(file);
+
+        assertThat(cover).isEqualTo(standardCover);
+    }
+
+    @Test
+    void extractCover_missingFirstBodyImageBinaryReturnsNull() throws IOException {
+        File file = writeFb2("""
+                <description><title-info/></description>
+                <body><section><image l:href="#missing.jpg"/></section></body>
+                """);
+
+        assertThat(extractor.extractCover(file)).isNull();
+    }
+
+    @Test
     void extractCover_noBinaryReturnsNull() throws IOException {
         File file = writeFb2("""
                 <description><title-info/></description>


### PR DESCRIPTION
## Summary
- fall back to the first image referenced from the FB2 body when explicit cover metadata is absent
- preserve cover-named binaries and `<coverpage>` references as higher-priority candidates
- decode line-wrapped base64 from converter-generated referenced images
- add regression coverage for converter-generated FB2 files, precedence, and missing binaries

## Context
Follow-up to #135.

Some PDF-to-FB2 converters omit `<title-info><coverpage>` and place the scanned cover as the first image in `<body>`. In that shape Grimmory reports that the file has no embedded cover even though the referenced JPEG binary is present.

## Validation
- rebased `upstream/develop`: `just api test-class org.booklore.service.metadata.extractor.Fb2MetadataExtractorTest` — passed
- real affected FB2 with the final commit — extracted a decodable 90,256-byte JPEG (402×552)
- runtime backend health — HTTP 200
- full local `just api check` was attempted earlier; Gradle lost its internal `in-progress-results-generic.bin` file without reporting a failing test, so the final upstream-based validation is the focused extractor suite above

## Scope
Backend only; no endpoint, UI, archive-resolution, cover-lock, or probe-persistence changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FB2 cover image extraction, including support for cover images referenced via local `xlink:href`.
  * Added a last-resort fallback to use the first embedded body image when no cover page image is available.
  * Maintains cover page priority and safely returns no cover when referenced image data is missing or undecodable.
* **Tests**
  * Added unit test coverage for the new cover extraction fallback and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->