### PR TITLE
refactor(books): add shelf data layer

### DIFF
--- a/frontend/src/app/features/book/data/book-command-pending-state.spec.ts
+++ b/frontend/src/app/features/book/data/book-command-pending-state.spec.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 
-import {overlayPendingBookState} from './book-command-pending-state';
+import {overlayPendingBookState, overlayShelfIds} from './book-command-pending-state';
 import {type BookSummary} from './book-response.models';
 
 describe('overlayPendingBookState', () => {
@@ -9,6 +9,10 @@ describe('overlayPendingBookState', () => {
     libraryId: 2,
     libraryName: 'Library',
     readStatus: 'UNREAD',
+    shelves: [
+      {id: 20, name: 'Remove', publicShelf: false, bookCount: 1},
+      {id: 30, name: 'Keep', publicShelf: false, bookCount: 1},
+    ],
     epubProgress: {
       cfi: 'epubcfi(/6/2)',
       href: 'chapter-1.xhtml',
@@ -55,5 +59,23 @@ describe('overlayPendingBookState', () => {
 
     expect(result.koreaderProgress).toBeUndefined();
     expect(result.epubProgress).toEqual(book.epubProgress);
+  });
+
+  it('leaves shelf membership off the overlaid book', () => {
+    expect(overlayPendingBookState(book, {
+      ...emptyOverlay,
+      readStatuses: new Map([[1, 'READ']]),
+    }).shelves).toBe(book.shelves);
+  });
+
+  it('reports confirmed shelf IDs when nothing is in flight', () => {
+    expect(overlayShelfIds(book, undefined)).toEqual(new Set([20, 30]));
+  });
+
+  it('applies in-flight assignments and removals to the shelf IDs', () => {
+    expect(overlayShelfIds(book, {
+      assignShelfIds: new Set([40]),
+      unassignShelfIds: new Set([20]),
+    })).toEqual(new Set([30, 40]));
   });
 });

--- a/frontend/src/app/features/book/data/book-command-pending-state.ts
+++ b/frontend/src/app/features/book/data/book-command-pending-state.ts
@@ -9,6 +9,13 @@ import {
   SetBookReadStatusVariables,
 } from './book-command.models';
 import {BookReadStatus, BookSummary} from './book-response.models';
+import {bookShelfCommandKeys} from './book-shelf-command-keys';
+import {UpdateBookShelfMembershipVariables} from './book-shelf-command.models';
+
+export interface PendingShelfMembership {
+  readonly assignShelfIds: ReadonlySet<number>;
+  readonly unassignShelfIds: ReadonlySet<number>;
+}
 
 export interface PendingBookOverlay {
   readonly readStatuses: ReadonlyMap<number, BookReadStatus>;
@@ -46,6 +53,27 @@ export function injectPendingBookReadStatuses(): Signal<ReadonlyMap<number, Book
   return injectPendingBookValues<SetBookReadStatusVariables, BookReadStatus>(
     bookCommandKeys.readStatus(),
     (_, variables) => variables.status,
+  );
+}
+
+export function injectPendingBookShelfMembership(): Signal<ReadonlyMap<number, PendingShelfMembership>> {
+  return injectPendingBookValues<UpdateBookShelfMembershipVariables, PendingShelfMembership>(
+    bookShelfCommandKeys.updateMembership(),
+    (current, variables) => {
+      const assignShelfIds = new Set(current?.assignShelfIds);
+      const unassignShelfIds = new Set(current?.unassignShelfIds);
+
+      for (const shelfId of variables.unassignShelfIds) {
+        assignShelfIds.delete(shelfId);
+        unassignShelfIds.add(shelfId);
+      }
+      for (const shelfId of variables.assignShelfIds) {
+        unassignShelfIds.delete(shelfId);
+        assignShelfIds.add(shelfId);
+      }
+
+      return {assignShelfIds, unassignShelfIds};
+    },
   );
 }
 
@@ -94,4 +122,21 @@ function clearedProgress(source: BookProgressSource): Partial<BookSummary> {
     cbxProgress: undefined,
     audiobookProgress: undefined,
   };
+}
+
+export function overlayShelfIds(
+  book: BookSummary,
+  membership: PendingShelfMembership | undefined,
+): ReadonlySet<number> {
+  const shelfIds = new Set((book.shelves ?? []).map(shelf => shelf.id));
+  if (!membership) {
+    return shelfIds;
+  }
+  for (const shelfId of membership.unassignShelfIds) {
+    shelfIds.delete(shelfId);
+  }
+  for (const shelfId of membership.assignShelfIds) {
+    shelfIds.add(shelfId);
+  }
+  return shelfIds;
 }

--- a/frontend/src/app/features/book/data/book-shelf-command-keys.ts
+++ b/frontend/src/app/features/book/data/book-shelf-command-keys.ts
@@ -1,0 +1,9 @@
+import {bookCommandKeys} from './book-command-keys';
+
+export const bookShelfCommandKeys = {
+  updateMembership: () => [...bookCommandKeys.all(), 'shelf', 'update-membership'] as const,
+};
+
+export const bookShelfCommandScopes = {
+  regularShelves: {id: 'books.command.shelf'} as const,
+};

--- a/frontend/src/app/features/book/data/book-shelf-command.models.ts
+++ b/frontend/src/app/features/book/data/book-shelf-command.models.ts
@@ -1,0 +1,9 @@
+export interface UpdateBookShelfMembershipVariables {
+  readonly bookIds: readonly number[];
+  readonly assignShelfIds: readonly number[];
+  readonly unassignShelfIds: readonly number[];
+}
+
+export interface UpdateBookShelfMembershipResult {
+  readonly confirmedBookIds: readonly number[];
+}

--- a/frontend/src/app/features/book/data/book-shelf-command.service.ts
+++ b/frontend/src/app/features/book/data/book-shelf-command.service.ts
@@ -1,0 +1,65 @@
+import {HttpClient} from '@angular/common/http';
+import {inject, Injectable} from '@angular/core';
+import {lastValueFrom} from 'rxjs';
+
+import {API_CONFIG} from '../../../core/config/api-config';
+import {reconcilingMutationOptions} from '../../../core/data/command-options';
+import {bookCommandChangeSet, requireBookIds} from './book-command.models';
+import {bookShelfCommandKeys, bookShelfCommandScopes} from './book-shelf-command-keys';
+import {
+  UpdateBookShelfMembershipResult,
+  UpdateBookShelfMembershipVariables,
+} from './book-shelf-command.models';
+import {applyBookQueryChangeSet} from './book-query-cache';
+import {invalidateShelfDefinitions} from './shelf-definition-query-cache';
+
+@Injectable({providedIn: 'root'})
+export class BookShelfCommandService {
+  private readonly http = inject(HttpClient);
+  private readonly membershipUrl = `${API_CONFIG.BASE_URL}/api/v1/books/shelves`;
+
+  updateMembership() {
+    return reconcilingMutationOptions({
+      mutationKey: bookShelfCommandKeys.updateMembership(),
+      scope: bookShelfCommandScopes.regularShelves,
+      mutationFn: (variables: UpdateBookShelfMembershipVariables) => this.postMembership(
+        requireBookIds(variables.bookIds),
+        variables.assignShelfIds,
+        variables.unassignShelfIds,
+      ),
+      reconcile: async (outcome, variables, client) => {
+        await Promise.all([
+          applyBookQueryChangeSet(
+            client,
+            bookCommandChangeSet(outcome, variables.bookIds, ({confirmedBookIds}) => ({
+              changedBookIds: confirmedBookIds,
+            })),
+          ),
+          invalidateShelfDefinitions(client),
+        ]);
+      },
+    });
+  }
+
+  private async postMembership(
+    bookIds: readonly number[],
+    assignShelfIds: readonly number[],
+    unassignShelfIds: readonly number[],
+  ): Promise<UpdateBookShelfMembershipResult> {
+    const response = await lastValueFrom(this.http.post<readonly MembershipBookResponse[]>(
+      this.membershipUrl,
+      {
+        bookIds,
+        shelvesToAssign: assignShelfIds,
+        shelvesToUnassign: unassignShelfIds,
+      },
+    ));
+    return {
+      confirmedBookIds: response.map(book => book.id),
+    };
+  }
+}
+
+interface MembershipBookResponse {
+  readonly id: number;
+}

--- a/frontend/src/app/features/book/data/shelf-definition-query-cache.ts
+++ b/frontend/src/app/features/book/data/shelf-definition-query-cache.ts
@@ -1,0 +1,9 @@
+import {QueryClient} from '@tanstack/angular-query-experimental';
+
+import {shelfDefinitionQueryKeys} from './shelf-definition-query-keys';
+
+export function invalidateShelfDefinitions(client: QueryClient): Promise<void> {
+  return client.invalidateQueries({
+    queryKey: shelfDefinitionQueryKeys.all(),
+  });
+}

--- a/frontend/src/app/features/book/data/shelf-definition-query-keys.ts
+++ b/frontend/src/app/features/book/data/shelf-definition-query-keys.ts
@@ -1,0 +1,4 @@
+export const shelfDefinitionQueryKeys = {
+  all: () => ['shelves', 'query'] as const,
+  definitions: () => [...shelfDefinitionQueryKeys.all(), 'definitions'] as const,
+};

--- a/frontend/src/app/features/book/data/shelf-definition-query.service.ts
+++ b/frontend/src/app/features/book/data/shelf-definition-query.service.ts
@@ -1,0 +1,38 @@
+import {HttpClient} from '@angular/common/http';
+import {effect, inject, Injectable} from '@angular/core';
+import {queryOptions, QueryClient} from '@tanstack/angular-query-experimental';
+import {lastValueFrom, takeUntil} from 'rxjs';
+
+import {API_CONFIG} from '../../../core/config/api-config';
+import {abortSignal, QUERY_DEFAULTS} from '../../../core/data/query-transport';
+import {ShelfDefinition} from './shelf-definition.models';
+import {shelfDefinitionQueryKeys} from './shelf-definition-query-keys';
+import {AuthService} from '../../../shared/service/auth.service';
+
+@Injectable({providedIn: 'root'})
+export class ShelfDefinitionQueryService {
+  private readonly http = inject(HttpClient);
+  private readonly authService = inject(AuthService);
+  private readonly queryClient = inject(QueryClient);
+  private readonly url = `${API_CONFIG.BASE_URL}/api/v1/shelves`;
+
+  constructor() {
+    effect(() => {
+      if (this.authService.token() === null) {
+        this.queryClient.removeQueries({queryKey: shelfDefinitionQueryKeys.all()});
+      }
+    });
+  }
+
+  definitions() {
+    return queryOptions({
+      queryKey: shelfDefinitionQueryKeys.definitions(),
+      queryFn: ({signal}): Promise<ShelfDefinition[]> => lastValueFrom(
+        this.http.get<ShelfDefinition[]>(this.url).pipe(
+          takeUntil(abortSignal(signal)),
+        ),
+      ),
+      ...QUERY_DEFAULTS,
+    });
+  }
+}

--- a/frontend/src/app/features/book/data/shelf-definition.models.ts
+++ b/frontend/src/app/features/book/data/shelf-definition.models.ts
@@ -1,0 +1,11 @@
+import {IconType} from '../../../shared/icons/icon-selection';
+
+export interface ShelfDefinition {
+  readonly id: number;
+  readonly userId: number;
+  readonly name: string;
+  readonly icon?: string;
+  readonly iconType?: IconType;
+  readonly publicShelf: boolean;
+  readonly bookCount: number;
+}


### PR DESCRIPTION
## Description

Adds initial shelf query layer and command integration with the new book query service, ahead of use in the new browser UI. 

## Linked Issue

Fixes #2186 

## Changes

- New shelf definition query service and related models
- Shelf integration into the book commands, assigning and unassigning books to shelves, and ensuring shelf commands receive the correct pending state and validation when actioned from the book browser. 

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for assigning and removing books from shelves.
  * Added shelf definitions with names, icons, visibility, ownership, and book counts.
  * Added automatic updates to shelf membership while changes are pending.
  * Refreshed shelf information after membership changes to keep displayed data current.

* **Bug Fixes**
  * Improved handling of conflicting pending shelf assignments and removals.
  * Preserved accurate shelf membership while updates are still being processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->