### PR TITLE
fix(api): preserve individual audiobooks during rescans

### DIFF
--- a/backend/src/main/java/org/booklore/service/library/LibraryFileHelper.java
+++ b/backend/src/main/java/org/booklore/service/library/LibraryFileHelper.java
@@ -83,6 +83,84 @@ public class LibraryFileHelper {
                 .toList();
     }
 
+    /**
+     * Keeps an existing library's file representation stable when the scanner encounters an ambiguous
+     * audiobook directory. If that directory already contains individually tracked audiobook files,
+     * expand the folder candidate back to file candidates instead of replacing those books with one
+     * folder-based audiobook during a rescan.
+     */
+    public List<LibraryFile> reconcileRescanCandidates(List<LibraryFile> libraryFiles, List<BookEntity> books) throws IOException {
+        Set<Path> directoriesWithIndividualAudiobooks = books.stream()
+                .filter(book -> book.getBookFiles() != null)
+                .flatMap(book -> book.getBookFiles().stream()
+                        .filter(file -> !file.isFolderBased())
+                        .filter(file -> file.getBookType() == BookFileType.AUDIOBOOK)
+                        .filter(file -> !Boolean.TRUE.equals(book.getDeleted()) || isRestorableDeletedFile(file)))
+                .map(BookFileEntity::getFullFilePath)
+                .map(Path::normalize)
+                .map(Path::getParent)
+                .collect(Collectors.toSet());
+
+        if (directoriesWithIndividualAudiobooks.isEmpty()) {
+            return libraryFiles;
+        }
+
+        List<LibraryFile> reconciledFiles = new ArrayList<>();
+        for (LibraryFile file : libraryFiles) {
+            boolean shouldPreserveIndividualFiles = file.isFolderBased()
+                    && file.getBookFileType() == BookFileType.AUDIOBOOK
+                    && directoriesWithIndividualAudiobooks.contains(file.getFullPath().normalize());
+
+            if (shouldPreserveIndividualFiles) {
+                reconciledFiles.addAll(findIndividualAudioFiles(file));
+            } else {
+                reconciledFiles.add(file);
+            }
+        }
+        return reconciledFiles;
+    }
+
+    private boolean isRestorableDeletedFile(BookFileEntity file) {
+        Path path = file.getFullFilePath();
+        if (FileUtils.shouldIgnore(path) || !Files.isReadable(path)) {
+            return false;
+        }
+        return isNonEmptyRegularFile(path);
+    }
+
+    private List<LibraryFile> findIndividualAudioFiles(LibraryFile folderCandidate) throws IOException {
+        try (var files = Files.list(folderCandidate.getFullPath())) {
+            return files
+                    .filter(file -> !FileUtils.shouldIgnore(file))
+                    .filter(Files::isReadable)
+                    .filter(this::isNonEmptyRegularFile)
+                    .filter(file -> BookFileExtension.fromFileName(file.getFileName().toString())
+                            .map(BookFileExtension::getType)
+                            .filter(type -> type == BookFileType.AUDIOBOOK)
+                            .isPresent())
+                    .sorted()
+                    .map(file -> LibraryFile.builder()
+                            .libraryEntity(folderCandidate.getLibraryEntity())
+                            .libraryPathEntity(folderCandidate.getLibraryPathEntity())
+                            .fileSubPath(FileUtils.getRelativeSubPath(
+                                    folderCandidate.getLibraryPathEntity().getPath(), file))
+                            .fileName(file.getFileName().toString())
+                            .bookFileType(BookFileType.AUDIOBOOK)
+                            .build())
+                    .toList();
+        }
+    }
+
+    private boolean isNonEmptyRegularFile(Path file) {
+        try {
+            BasicFileAttributes attrs = Files.readAttributes(file, BasicFileAttributes.class);
+            return attrs.isRegularFile() && attrs.size() > 0;
+        } catch (IOException e) {
+            log.warn("Failed to read file attributes for [{}]: {}", file, e.getMessage());
+            return false;
+        }
+    }
+
     private String generateUniqueKey(BookEntity book) {
         BookFileEntity primaryFile = book.getPrimaryBookFile();
         if (primaryFile == null) {

--- a/backend/src/main/java/org/booklore/service/library/LibraryProcessingService.java
+++ b/backend/src/main/java/org/booklore/service/library/LibraryProcessingService.java
@@ -84,6 +84,7 @@ public class LibraryProcessingService {
         List<BookEntity> books = bookRepository.findAllByLibraryIdForRescan(libraryId);
 
         List<LibraryFile> allLibraryFiles = libraryFileHelper.getAllLibraryFiles(libraryEntity);
+        allLibraryFiles = libraryFileHelper.reconcileRescanCandidates(allLibraryFiles, books);
         List<LibraryFile> filteredFiles = libraryFileHelper.filterByAllowedFormats(
                 allLibraryFiles, libraryEntity.getAllowedFormats());
 

--- a/backend/src/test/java/org/booklore/service/library/LibraryFileHelperTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryFileHelperTest.java
@@ -486,6 +486,232 @@ class LibraryFileHelperTest {
     }
 
     @Test
+    void detectDeletedBookIds_shouldPreserveIndividualAudiobooksWhenAutoDetectCollapsesTheirFolder() throws IOException {
+        Path authorFolder = Files.createDirectories(tempDir.resolve("Author"));
+        Files.write(authorFolder.resolve("Book One.mp3"), new byte[]{1});
+        Files.write(authorFolder.resolve("Book Two.mp3"), new byte[]{1});
+
+        LibraryEntity library = createLibraryWithMode(tempDir, LibraryOrganizationMode.AUTO_DETECT);
+        LibraryPathEntity libraryPath = library.getLibraryPaths().getFirst();
+
+        BookFileEntity firstFile = BookFileEntity.builder()
+                .fileSubPath("Author")
+                .fileName("Book One.mp3")
+                .bookType(BookFileType.AUDIOBOOK)
+                .build();
+        BookEntity firstBook = BookEntity.builder()
+                .id(1L)
+                .libraryPath(libraryPath)
+                .bookFiles(List.of(firstFile))
+                .build();
+        firstFile.setBook(firstBook);
+
+        BookFileEntity secondFile = BookFileEntity.builder()
+                .fileSubPath("Author")
+                .fileName("Book Two.mp3")
+                .bookType(BookFileType.AUDIOBOOK)
+                .build();
+        BookEntity secondBook = BookEntity.builder()
+                .id(2L)
+                .libraryPath(libraryPath)
+                .bookFiles(List.of(secondFile))
+                .build();
+        secondFile.setBook(secondBook);
+
+        List<LibraryFile> detectedFiles = libraryFileHelper.getAllLibraryFiles(library);
+
+        assertThat(detectedFiles).singleElement().satisfies(file -> {
+            assertThat(file.isFolderBased()).isTrue();
+            assertThat(file.getFullPath()).isEqualTo(authorFolder);
+        });
+        List<LibraryFile> reconciledFiles = libraryFileHelper.reconcileRescanCandidates(
+                detectedFiles, List.of(firstBook, secondBook));
+
+        assertThat(reconciledFiles)
+                .extracting(LibraryFile::getFileName)
+                .containsExactly("Book One.mp3", "Book Two.mp3");
+        assertThat(reconciledFiles).noneMatch(LibraryFile::isFolderBased);
+        assertThat(libraryFileHelper.detectDeletedBookIds(reconciledFiles, List.of(firstBook, secondBook)))
+                .isEmpty();
+        assertThat(libraryFileHelper.detectNewBookPaths(
+                reconciledFiles, List.of(firstBook, secondBook), Collections.emptyList()))
+                .isEmpty();
+    }
+
+    @Test
+    void reconcileRescanCandidates_shouldKeepRealMultiTrackAudiobookFolder() throws IOException {
+        Path audiobookFolder = Files.createDirectories(tempDir.resolve("Author/Book"));
+        Files.write(audiobookFolder.resolve("01.mp3"), new byte[]{1});
+        Files.write(audiobookFolder.resolve("02.mp3"), new byte[]{1});
+
+        LibraryEntity library = createLibraryWithMode(tempDir, LibraryOrganizationMode.AUTO_DETECT);
+        LibraryPathEntity libraryPath = library.getLibraryPaths().getFirst();
+        BookFileEntity folderFile = BookFileEntity.builder()
+                .folderBased(true)
+                .fileSubPath("Author")
+                .fileName("Book")
+                .bookType(BookFileType.AUDIOBOOK)
+                .build();
+        BookEntity book = BookEntity.builder()
+                .id(1L)
+                .libraryPath(libraryPath)
+                .bookFiles(List.of(folderFile))
+                .build();
+        folderFile.setBook(book);
+
+        List<LibraryFile> reconciledFiles = libraryFileHelper.reconcileRescanCandidates(
+                libraryFileHelper.getAllLibraryFiles(library), List.of(book));
+
+        assertThat(reconciledFiles).singleElement().satisfies(file -> {
+            assertThat(file.isFolderBased()).isTrue();
+            assertThat(file.getFullPath()).isEqualTo(audiobookFolder);
+        });
+        assertThat(libraryFileHelper.detectDeletedBookIds(reconciledFiles, List.of(book))).isEmpty();
+    }
+
+    @Test
+    void reconcileRescanCandidates_shouldPreserveMixedEbookAndAudiobookFiles() throws IOException {
+        Path bookFolder = Files.createDirectories(tempDir.resolve("Author/Book"));
+        Files.write(bookFolder.resolve("Book.epub"), new byte[]{1});
+        Files.write(bookFolder.resolve("Book.m4b"), new byte[]{1});
+        Files.write(bookFolder.resolve("Bonus.mp3"), new byte[]{1});
+
+        LibraryEntity library = createLibraryWithMode(tempDir, LibraryOrganizationMode.AUTO_DETECT);
+        List<LibraryFile> detectedFiles = libraryFileHelper.getAllLibraryFiles(library);
+        List<LibraryFile> reconciledFiles = libraryFileHelper.reconcileRescanCandidates(
+                detectedFiles, Collections.emptyList());
+
+        assertThat(reconciledFiles)
+                .extracting(LibraryFile::getFileName)
+                .containsExactlyInAnyOrder("Book.epub", "Book.m4b", "Bonus.mp3");
+        assertThat(reconciledFiles).noneMatch(LibraryFile::isFolderBased);
+    }
+
+    @Test
+    void reconcileRescanCandidates_shouldExposeNewFileInExistingIndividualAudiobookFolder() throws IOException {
+        Path authorFolder = Files.createDirectories(tempDir.resolve("Author"));
+        Files.write(authorFolder.resolve("Existing.mp3"), new byte[]{1});
+        Files.write(authorFolder.resolve("New.mp3"), new byte[]{1});
+
+        LibraryEntity library = createLibraryWithMode(tempDir, LibraryOrganizationMode.AUTO_DETECT);
+        LibraryPathEntity libraryPath = library.getLibraryPaths().getFirst();
+        BookFileEntity existingFile = BookFileEntity.builder()
+                .fileSubPath("Author")
+                .fileName("Existing.mp3")
+                .bookType(BookFileType.AUDIOBOOK)
+                .build();
+        BookEntity existingBook = BookEntity.builder()
+                .id(1L)
+                .libraryPath(libraryPath)
+                .bookFiles(List.of(existingFile))
+                .build();
+        existingFile.setBook(existingBook);
+
+        List<LibraryFile> reconciledFiles = libraryFileHelper.reconcileRescanCandidates(
+                libraryFileHelper.getAllLibraryFiles(library), List.of(existingBook));
+        List<LibraryFile> newFiles = libraryFileHelper.detectNewBookPaths(
+                reconciledFiles, List.of(existingBook), Collections.emptyList());
+
+        assertThat(newFiles).singleElement().satisfies(file -> {
+            assertThat(file.getFileName()).isEqualTo("New.mp3");
+            assertThat(file.isFolderBased()).isFalse();
+        });
+    }
+
+    @Test
+    void reconcileRescanCandidates_shouldExpandFolderWhenDeletedIndividualAudiobookReturns() throws IOException {
+        Path authorFolder = Files.createDirectories(tempDir.resolve("Author"));
+        Files.write(authorFolder.resolve("Returned.mp3"), new byte[]{1});
+        Files.write(authorFolder.resolve("New.mp3"), new byte[]{1});
+
+        LibraryEntity library = createLibraryWithMode(tempDir, LibraryOrganizationMode.AUTO_DETECT);
+        LibraryPathEntity libraryPath = library.getLibraryPaths().getFirst();
+        BookFileEntity returnedFile = BookFileEntity.builder()
+                .fileSubPath("Author")
+                .fileName("Returned.mp3")
+                .bookType(BookFileType.AUDIOBOOK)
+                .build();
+        BookEntity deletedBook = BookEntity.builder()
+                .id(1L)
+                .deleted(true)
+                .libraryPath(libraryPath)
+                .bookFiles(List.of(returnedFile))
+                .build();
+        returnedFile.setBook(deletedBook);
+
+        List<LibraryFile> reconciledFiles = libraryFileHelper.reconcileRescanCandidates(
+                libraryFileHelper.getAllLibraryFiles(library), List.of(deletedBook));
+
+        assertThat(reconciledFiles)
+                .extracting(LibraryFile::getFileName)
+                .containsExactly("New.mp3", "Returned.mp3");
+        assertThat(reconciledFiles).noneMatch(LibraryFile::isFolderBased);
+    }
+
+    @Test
+    void reconcileRescanCandidates_shouldNotLetMissingDeletedAudiobookPinFolder() throws IOException {
+        Path audiobookFolder = Files.createDirectories(tempDir.resolve("Author/Book"));
+        Files.write(audiobookFolder.resolve("01.mp3"), new byte[]{1});
+        Files.write(audiobookFolder.resolve("02.mp3"), new byte[]{1});
+
+        LibraryEntity library = createLibraryWithMode(tempDir, LibraryOrganizationMode.AUTO_DETECT);
+        LibraryPathEntity libraryPath = library.getLibraryPaths().getFirst();
+        BookFileEntity missingFile = BookFileEntity.builder()
+                .fileSubPath("Author/Book")
+                .fileName("Missing.mp3")
+                .bookType(BookFileType.AUDIOBOOK)
+                .build();
+        BookEntity deletedBook = BookEntity.builder()
+                .id(1L)
+                .deleted(true)
+                .libraryPath(libraryPath)
+                .bookFiles(List.of(missingFile))
+                .build();
+        missingFile.setBook(deletedBook);
+
+        List<LibraryFile> reconciledFiles = libraryFileHelper.reconcileRescanCandidates(
+                libraryFileHelper.getAllLibraryFiles(library), List.of(deletedBook));
+
+        assertThat(reconciledFiles).singleElement().satisfies(file -> {
+            assertThat(file.isFolderBased()).isTrue();
+            assertThat(file.getFullPath()).isEqualTo(audiobookFolder);
+        });
+    }
+
+    @Test
+    void reconcileRescanCandidates_shouldIgnoreEmptyAudioFileWhenExpandingFolderCandidate() throws IOException {
+        Path authorFolder = Files.createDirectories(tempDir.resolve("Author"));
+        Files.write(authorFolder.resolve("Existing.mp3"), new byte[]{1});
+        Files.write(authorFolder.resolve("New.mp3"), new byte[]{1});
+        Files.createFile(authorFolder.resolve("Empty.mp3"));
+
+        LibraryEntity library = createLibraryWithMode(tempDir, LibraryOrganizationMode.AUTO_DETECT);
+        LibraryPathEntity libraryPath = library.getLibraryPaths().getFirst();
+        BookFileEntity existingFile = BookFileEntity.builder()
+                .fileSubPath("Author")
+                .fileName("Existing.mp3")
+                .bookType(BookFileType.AUDIOBOOK)
+                .build();
+        BookEntity existingBook = BookEntity.builder()
+                .id(1L)
+                .libraryPath(libraryPath)
+                .bookFiles(List.of(existingFile))
+                .build();
+        existingFile.setBook(existingBook);
+
+        List<LibraryFile> detectedFiles = libraryFileHelper.getAllLibraryFiles(library);
+        assertThat(detectedFiles).singleElement().matches(LibraryFile::isFolderBased);
+
+        List<LibraryFile> reconciledFiles = libraryFileHelper.reconcileRescanCandidates(
+                detectedFiles, List.of(existingBook));
+
+        assertThat(reconciledFiles)
+                .extracting(LibraryFile::getFileName)
+                .containsExactly("Existing.mp3", "New.mp3");
+        assertThat(reconciledFiles).noneMatch(LibraryFile::isFolderBased);
+    }
+
+    @Test
     void detectDeletedBookIds_shouldOnlyDetectBooksMissingFiles() {
         LibraryPathEntity libraryPathEntity = LibraryPathEntity.builder()
                 .path("/books")

--- a/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceRegressionTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceRegressionTest.java
@@ -56,7 +56,7 @@ class LibraryProcessingServiceRegressionTest {
     private LibraryProcessingService libraryProcessingService;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
         libraryProcessingService = new LibraryProcessingService(
                 libraryRepository,
                 bookRepository,
@@ -70,6 +70,8 @@ class LibraryProcessingServiceRegressionTest {
                 bookCoverGenerator,
                 entityManager
         );
+        lenient().when(libraryFileHelper.reconcileRescanCandidates(anyList(), anyList()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
@@ -59,7 +59,7 @@ class LibraryProcessingServiceTest {
     private LibraryProcessingService libraryProcessingService;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
         libraryProcessingService = new LibraryProcessingService(
                 libraryRepository,
                 bookRepository,
@@ -73,6 +73,8 @@ class LibraryProcessingServiceTest {
                 bookCoverGenerator,
                 entityManager
         );
+        lenient().when(libraryFileHelper.reconcileRescanCandidates(anyList(), anyList()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test


### PR DESCRIPTION
## Description

Library rescans could remove individually tracked audiobooks when multiple audio files shared a directory. The scanner represented the directory as one folder-based audiobook, while deletion detection compared that folder path with the stored file paths.

This keeps the existing file representation stable during rescans: if a folder already contains individually tracked audiobooks, the ambiguous folder candidate is expanded back into individual file candidates before deletion, restoration, and new-file detection.

## Linked Issue

Fixes #446

## Changes

- Reconcile ambiguous folder audiobook candidates against existing book files during rescans.
- Leave initial scans and existing folder-based audiobooks unchanged.
- Add regression coverage for deletion, duplicate detection, mixed formats, real multi-track folders, and newly added files.

## Manual Testing Steps

1. Added a regression test with two stored MP3 books in one author directory and confirmed it failed before the fix because both book IDs were detected as deleted.
2. Ran `LibraryFileHelperTest` and the library processing service tests after the fix.
3. Ran the full backend test suite: 3,871 tests, 0 failures, 0 errors, 3 skipped.
4. Ran the backend `check` lifecycle.
5. Ran the frontend dependency check, typecheck, ESLint, Stylelint, production build, and full test suite: 1,712 tests passed, 138 skipped.

```text
./gradlew test --no-daemon --parallel --build-cache
BUILD SUCCESSFUL in 3m 41s
tests=3871 failures=0 errors=0 skipped=3

./gradlew check --no-daemon --parallel --build-cache
BUILD SUCCESSFUL

pnpm --dir frontend run typecheck
pnpm --dir frontend run lint:eslint
pnpm --dir frontend run lint:styles
pnpm --dir frontend run build:prod
pnpm --dir frontend run test
Test Files  306 passed | 81 skipped (387)
Tests       1712 passed | 138 skipped (1850)
```

## Screenshots (Optional)

N/A — no UI changes.

## Additional Context (Optional)

The reconciliation only runs during rescans and only for directories whose persisted records already establish an individual-file layout. This avoids emitting folder and child candidates together during initial imports.

`just` was unavailable locally, so the exact Gradle and pnpm commands used by the `api check` and `ui check` recipes were run directly.

The first full frontend test run had one unrelated five-second timeout in `book-dialog-helper.service.spec.ts`. That test passed alone (3/3), and the complete suite then passed on an immediate rerun with the totals above.

## AI Disclosure

OpenAI Codex — assisted with issue research, root-cause analysis, implementation, and test drafting; the resulting diff was verified with the checks above.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran the equivalent `just ui check` and `just api check` commands described above.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved library rescans for audiobooks stored in folders.
  * Individual audiobook files are now preserved and detected correctly instead of being grouped incorrectly.
  * Multi-track audiobook folders and mixed ebook/audiobook folders continue to be handled properly.
  * Newly added files in existing audiobook folders are now discovered during rescans.
  * Audiobook files associated with deleted books can be restored when still present.
  * Unreadable, missing, or empty audiobook files are excluded from processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->