### PR TITLE
fix(epub): support safe doctypes in OPF

### DIFF
--- a/backend/src/main/java/org/booklore/util/SecureXmlUtils.java
+++ b/backend/src/main/java/org/booklore/util/SecureXmlUtils.java
@@ -7,6 +7,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import java.util.List;
 
 @Slf4j
 @UtilityClass
@@ -16,24 +17,48 @@ public class SecureXmlUtils {
     private static final DocumentBuilderFactory NS_AWARE_FACTORY;
     private static final DocumentBuilderFactory NON_NS_AWARE_FACTORY;
 
+    private static final List<String> DISABLED_FEATURE_FLAGS = List.of(
+        // Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-general-entities
+        // Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-general-entities
+        // JDK7+ - http://xml.org/sax/features/external-general-entities
+        //This feature has to be used together with the following one, otherwise it will not protect you from XXE for sure
+        "http://xml.org/sax/features/external-general-entities",
+
+        // Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-parameter-entities
+        // Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities
+        // JDK7+ - http://xml.org/sax/features/external-parameter-entities
+        //This feature has to be used together with the previous one, otherwise it will not protect you from XXE for sure
+        "http://xml.org/sax/features/external-parameter-entities",
+
+        // Disable external DTDs as well
+        "http://apache.org/xml/features/nonvalidating/load-external-dtd"
+    );
+
     static {
-        try {
-            NS_AWARE_FACTORY = buildFactory(true);
-            NON_NS_AWARE_FACTORY = buildFactory(false);
-        } catch (ParserConfigurationException e) {
-            throw new ExceptionInInitializerError(e);
-        }
+        NS_AWARE_FACTORY = buildFactory(true);
+        NON_NS_AWARE_FACTORY = buildFactory(false);
     }
 
-    private static DocumentBuilderFactory buildFactory(boolean namespaceAware) throws ParserConfigurationException {
+    private static DocumentBuilderFactory buildFactory(boolean namespaceAware) {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(namespaceAware);
 
-        // Prevent XXE attacks
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        // We cannot explicitly disable DTDs but we can disable a number of feature flags that allow
+        // users to exploit issues & enable feature flags to protect users.
+        for (var featureFlag : DISABLED_FEATURE_FLAGS) {
+            try {
+                factory.setFeature(featureFlag, false);
+            } catch (ParserConfigurationException e) {
+                log.error("Feature {} is not supported by your XML processor.", featureFlag, e);
+            }
+        }
+
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException e) {
+            log.error("Feature FEATURE_SECURE_PROCESSING is not supported by your XML processor.", e);
+        }
+
         factory.setXIncludeAware(false);
         factory.setExpandEntityReferences(false);
 

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/EpubMetadataExtractorTest.java
@@ -1446,5 +1446,75 @@ class EpubMetadataExtractorTest {
 
             assertThat(metadata.getContentRating()).isEqualTo(rating);
         }
+
+        @Test
+        void invalidDocTypeIsIgnored() throws IOException {
+            String opf = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <!DOCTYPE html>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                      <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                        <dc:title>Root OPF</dc:title>
+                        <dc:creator opf:role="aut">Root Author</dc:creator>
+                        <dc:date>2020</dc:date>
+                      </metadata>
+                      <manifest/>
+                    </package>""";
+            File epub = createEpub(opf, "OEBPS/content.opf", null);
+            BookMetadata metadata = extractor.extractMetadata(epub);
+
+            assertThat(metadata.getTitle()).isEqualTo("Root OPF");
+            assertThat(metadata.getAuthors()).containsExactly("Root Author");
+            assertThat(metadata.getPublishedDate()).isEqualTo(LocalDate.of(2020, 1, 1));
+        }
+
+        @Test
+        void xxePreventsDataAccess() throws IOException {
+            // https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing
+            String opf = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <!DOCTYPE foo [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                      <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                        <dc:title>&xxe;</dc:title>
+                      </metadata>
+                      <manifest/>
+                    </package>""";
+            File epub = createEpub(opf, "OEBPS/content.opf", null);
+            BookMetadata metadata = extractor.extractMetadata(epub);
+
+            // Test is the name of the file.
+            assertThat(metadata.getTitle()).isEqualTo("test");
+        }
+
+        @Test
+        void xxePreventsBillionLaughs() throws IOException {
+            // https://en.wikipedia.org/wiki/Billion_laughs_attack
+            String opf = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <!DOCTYPE lolz [
+                     <!ELEMENT lolz (#PCDATA)>
+                     <!ENTITY lol1 "lollollollollollollollollollol">
+                     <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+                     <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+                     <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+                     <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+                     <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+                     <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+                     <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+                     <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+                    ]>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                      <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                        <dc:title><lolz>&lol9;</lolz></dc:title>
+                      </metadata>
+                      <manifest/>
+                    </package>""";
+            File epub = createEpub(opf, "OEBPS/content.opf", null);
+            BookMetadata metadata = extractor.extractMetadata(epub);
+
+            // Test is the name of the file.
+            assertThat(metadata.getTitle()).isEqualTo("test");
+        }
     }
 }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
in some cases we need to allow doctypes, as some epubs retain them.  However, DTD can allow for XML External Entity injection attacks, so there are still concerns that need to be addressed.

This PR loosens the XML parser security model to allow _some_ DTD values while still protecting against XML External Entity injection attacks that could negatively affect the server.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2195

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

Follows OWASP guidelines to safely enable DTD
Adds tests against the attacks that these are protecting against

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Added an epub that has a DTD in the OPF
2. Added a regular epub without any DTD
3. Observed both get read correctly by grimmory

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB metadata extraction when files contain invalid or unusual XML declarations.
  * Prevented external entity and oversized entity expansion from exposing local data or affecting processing.
  * Added a reliable fallback to the EPUB filename when a title cannot be safely extracted.
* **Security**
  * Strengthened XML parsing protections while allowing recoverable EPUB files to continue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->