### PR TITLE
fix(amazon): properly parse non-english series information

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -47,7 +47,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     private static final int COUNT_DETAILED_METADATA_TO_GET = 3;
     private static final String BASE_BOOK_URL_SUFFIX = "/dp/";
     private static final Pattern NON_DIGIT_PATTERN = Pattern.compile("[^\\d]");
-    private static final Pattern SERIES_FORMAT_PATTERN = Pattern.compile("Book (\\d+(?:\\.\\d+)?) of (\\d+)");
+    private static final Pattern SERIES_FORMAT_PATTERN = Pattern.compile("\\s(\\d+(?:\\.\\d+)?)\\s+.+\\s+(\\d+)$");
     private static final Pattern PARENTHESES_WITH_WHITESPACE_PATTERN = Pattern.compile("\\s*\\(.*?\\)");
     private static final Pattern NON_ALPHANUMERIC_PATTERN = Pattern.compile("[^\\p{L}\\p{M}0-9]");
     private static final Pattern ASIN_PATH_PATTERN = Pattern.compile("/dp/([A-Z0-9]{10})");

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -285,6 +285,81 @@ public class AmazonBookParserTest {
     }
 
     @Test
+    public void fetchTopMetadata_parsesSeries_USEbook() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/B007978P18", readFixture("ebook-us.html"));
+
+        Book book = getBook("B007978P18");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        var result = amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/B007978P18"));
+
+        assertThat(result.getSeriesName()).isEqualTo("Lord of the Rings");
+        assertThat(result.getSeriesNumber()).isNotNull();
+        assertThat(result.getSeriesNumber()).isEqualTo(3);
+        assertThat(result.getSeriesTotal()).isNotNull();
+        assertThat(result.getSeriesTotal()).isEqualTo(3);
+    }
+
+    @Test
+    public void fetchTopMetadata_parsesSeries_DEPaperback() throws Exception {
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings( "de"));
+
+        mockJsoupConnect("https://www.amazon.de/dp/3608989439", readFixture("book-de.html"));
+
+        Book book = getBook("3608989439");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        var result = amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.de/dp/3608989439"));
+
+        assertThat(result.getSeriesName()).isEqualTo("Der Herr der Ringe. Ausgabe in neuer Übersetzung und Rechtschreibung");
+        assertThat(result.getSeriesNumber()).isNotNull();
+        assertThat(result.getSeriesNumber()).isEqualTo(3);
+        assertThat(result.getSeriesTotal()).isNotNull();
+        assertThat(result.getSeriesTotal()).isEqualTo(3);
+    }
+
+    @Test
+    public void fetchTopMetadata_parsesSeries_DEEbook() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/B01BLSRIX6", readFixture("ebook-de.html"));
+
+        Book book = getBook("B01BLSRIX6");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        var result = amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/B01BLSRIX6"));
+
+        assertThat(result.getSeriesName()).isEqualTo("EchtzeiT");
+        assertThat(result.getSeriesNumber()).isNotNull();
+        assertThat(result.getSeriesNumber()).isEqualTo(2);
+        assertThat(result.getSeriesTotal()).isNotNull();
+        assertThat(result.getSeriesTotal()).isEqualTo(3);
+    }
+
+    @Test
+    public void fetchTopMetadata_parsesSeries_Empty() throws Exception {
+        mockJsoupConnect(
+                "https://www.amazon.com/dp/EXAMPLESKU",
+                "<html><body></body><html>"
+        );
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        var result = amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+
+        assertThat(result.getSeriesName()).isNull();
+        assertThat(result.getSeriesNumber()).isNull();
+        assertThat(result.getSeriesTotal()).isNull();
+    }
+
+    @Test
     public void fetchTopMetadata_usesAsinFromBookWhenAvailable() throws Exception {
         mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
updates the amazon book parser to handle series information across multiple locales

currently the pattern requires that the value is `Book 9 of 9` but in other locales (eg, `amazon.de`) the localization causes this pattern to fail to match.  instead, we are searching for ` 9 anything 9` at the end of the string - so the start is ignored.  for most tested locales this has worked

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2197 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* updates pattern for series matching
* updates tests to add checks for this pattern in multiple locales

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. search for return of the king on amazon.de
2. search for return of the king on amazon.com
3. search for return of the king on amazon.co.jp

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
depends on #2199

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Amazon metadata parsing for series labels that include a book number and total count.
  * Series information is now extracted more reliably across US ebook, German ebook, and German paperback listings.
  * Empty or unavailable Amazon responses are handled without producing incorrect series details.
* **Tests**
  * Added coverage for series names, numbering, totals, regional Amazon URLs, and empty responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->