### PR TITLE
fix(api): ignore unused tasks to stop warnings

### DIFF
--- a/backend/src/main/java/org/booklore/repository/TaskHistoryRepository.java
+++ b/backend/src/main/java/org/booklore/repository/TaskHistoryRepository.java
@@ -1,6 +1,7 @@
 package org.booklore.repository;
 
 import org.booklore.model.entity.TaskHistoryEntity;
+import org.booklore.model.enums.TaskType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,8 +11,13 @@ import java.util.List;
 @Repository
 public interface TaskHistoryRepository extends JpaRepository<TaskHistoryEntity, String> {
 
-    @Query("SELECT t FROM TaskHistoryEntity t WHERE t.createdAt = " +
-           "(SELECT MAX(t2.createdAt) FROM TaskHistoryEntity t2 WHERE t2.type = t.type) " +
-           "ORDER BY t.createdAt DESC")
-    List<TaskHistoryEntity> findLatestTaskForEachType();
+    @Query("""
+    SELECT t FROM TaskHistoryEntity t
+    WHERE
+        t.createdAt = (SELECT MAX(t2.createdAt) FROM TaskHistoryEntity t2 WHERE t2.type = t.type)
+        AND
+        t.type IN (:taskTypes)
+    ORDER BY t.createdAt DESC
+    """)
+    List<TaskHistoryEntity> findLatestTaskForEachType(List<TaskType> taskTypes);
 }

--- a/backend/src/main/java/org/booklore/service/task/TaskHistoryService.java
+++ b/backend/src/main/java/org/booklore/service/task/TaskHistoryService.java
@@ -110,6 +110,7 @@ public class TaskHistoryService {
     public TasksHistoryResponse getLatestTasksForEachType() {
         List<TaskHistoryEntity> latestTasks;
         try {
+            // Limits to all task types so we ignore older deprecated task types that are no longer in the enum
             latestTasks = taskHistoryRepository.findLatestTaskForEachType(Arrays.asList(TaskType.values()));
         } catch (Exception e) {
             log.warn("Error fetching latest tasks, possibly due to removed enum values: {}", e.getMessage());

--- a/backend/src/main/java/org/booklore/service/task/TaskHistoryService.java
+++ b/backend/src/main/java/org/booklore/service/task/TaskHistoryService.java
@@ -110,7 +110,7 @@ public class TaskHistoryService {
     public TasksHistoryResponse getLatestTasksForEachType() {
         List<TaskHistoryEntity> latestTasks;
         try {
-            latestTasks = taskHistoryRepository.findLatestTaskForEachType();
+            latestTasks = taskHistoryRepository.findLatestTaskForEachType(Arrays.asList(TaskType.values()));
         } catch (Exception e) {
             log.warn("Error fetching latest tasks, possibly due to removed enum values: {}", e.getMessage());
             latestTasks = Collections.emptyList();

--- a/backend/src/test/java/org/booklore/service/task/TaskHistoryServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/task/TaskHistoryServiceTest.java
@@ -147,7 +147,7 @@ class TaskHistoryServiceTest {
                 .createdAt(FIXED_TIME.plusMinutes(5))
                 .build();
 
-        when(taskHistoryRepository.findLatestTaskForEachType())
+        when(taskHistoryRepository.findLatestTaskForEachType(any()))
                 .thenReturn(Arrays.asList(importTask, exportTask));
 
         TasksHistoryResponse response = taskHistoryService.getLatestTasksForEachType();
@@ -162,7 +162,7 @@ class TaskHistoryServiceTest {
 
     @Test
     void testGetLatestTasksForEachType_exceptionHandled() {
-        when(taskHistoryRepository.findLatestTaskForEachType()).thenThrow(new RuntimeException("DB error"));
+        when(taskHistoryRepository.findLatestTaskForEachType(any())).thenThrow(new RuntimeException("DB error"));
         TasksHistoryResponse response = taskHistoryService.getLatestTasksForEachType();
         assertNotNull(response);
         assertTrue(response.getTaskHistories().stream().allMatch(h -> h.getId() == null));
@@ -178,7 +178,7 @@ class TaskHistoryServiceTest {
                 .createdAt(FIXED_TIME)
                 .build();
 
-        when(taskHistoryRepository.findLatestTaskForEachType()).thenReturn(Collections.singletonList(invalidTask));
+        when(taskHistoryRepository.findLatestTaskForEachType(any())).thenReturn(Collections.singletonList(invalidTask));
 
         TasksHistoryResponse response = taskHistoryService.getLatestTasksForEachType();
         assertNotNull(response);
@@ -259,7 +259,7 @@ class TaskHistoryServiceTest {
 
     @Test
     void testGetLatestTasksForEachType_emptyRepository() {
-        when(taskHistoryRepository.findLatestTaskForEachType()).thenReturn(Collections.emptyList());
+        when(taskHistoryRepository.findLatestTaskForEachType(any())).thenReturn(Collections.emptyList());
         TasksHistoryResponse response = taskHistoryService.getLatestTasksForEachType();
         assertNotNull(response);
         assertTrue(response.getTaskHistories().stream().allMatch(h -> h.getId() == null));
@@ -275,7 +275,7 @@ class TaskHistoryServiceTest {
                 .progressPercentage(0)
                 .createdAt(FIXED_TIME)
                 .build();
-        when(taskHistoryRepository.findLatestTaskForEachType()).thenReturn(Collections.singletonList(dummyTask));
+        when(taskHistoryRepository.findLatestTaskForEachType(any())).thenReturn(Collections.singletonList(dummyTask));
 
         hiddenTypes.forEach(type -> {
             try {


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
some of the task type enums have been recorded in the `tasks` table but are no longer referred to by the `TaskType` enum.  This leads to warning messages in the log

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2212
related to #1291

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
adds a filter on only active task types to the database query
updates tests for behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. add task to tasks table in the database with `RE_SCAN_LIBRARY` 
2. navigate to settings page -> tasks page
3. observe no error in logs

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
this is distracting from any actual problems in #1291

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task history results so the latest task is correctly shown for each supported task type.
  - Prevented unrelated task types from appearing in latest-task summaries.
  - Preserved descending time order for clearer, more accurate task activity views.
  - Improved consistency across task history views, including cases with empty results, invalid task types, or hidden task types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->