### PR TITLE
feat(helm): add configurable deployment update strategy

### DIFF
--- a/deploy/helm/grimmory/ci/no-persistence-values.yaml
+++ b/deploy/helm/grimmory/ci/no-persistence-values.yaml
@@ -1,8 +1,11 @@
 # No persistent volumes — all storage disabled.
 # Database: bundled MariaDB
 # Persistence: both PVCs disabled
+# Update strategy: RollingUpdate, safe with no ReadWriteOnce volumes to contend
 persistence:
   dataVolume:
     enabled: false
   booksVolume:
     enabled: false
+updateStrategy:
+  type: RollingUpdate

--- a/deploy/helm/grimmory/templates/deployment.yaml
+++ b/deploy/helm/grimmory/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "grimmory.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "grimmory.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/grimmory/values.yaml
+++ b/deploy/helm/grimmory/values.yaml
@@ -153,6 +153,15 @@ persistence:
     enabled: true
     size: 10Gi
     existingClaim: ""
+# Deployment update strategy.
+# The PVCs above are ReadWriteOnce, and a surging replacement pod scheduled to
+# another node cannot attach a volume the outgoing pod still holds, so the
+# rollout deadlocks on a Multi-Attach error. Recreate avoids that by tearing
+# the old pod down first, at the cost of brief downtime during an upgrade.
+# Switch to RollingUpdate when persistence is disabled or the volumes are
+# ReadWriteMany.
+updateStrategy:
+  type: Recreate
 # Additional environment variables for the application container.
 # Example:
 # extraEnv:


### PR DESCRIPTION
## Problem

The chart provisions `ReadWriteOnce` PVCs for the data and books volumes (`templates/pvc.yaml`, both enabled by default) and mounts them into a Deployment that sets no `strategy`. That means the Kubernetes default applies: `RollingUpdate` with `maxSurge: 25%`, which for a single replica rounds up to one surging pod.

On a multi-node cluster the surging pod is frequently scheduled onto a different node than the outgoing one, and cannot attach a volume the outgoing pod still holds:

```
Warning  FailedAttachVolume  attachdetach-controller
  Multi-Attach error for volume "pvc-087a37dd-..."
  Volume is already used by pod(s) grimmory-6c458fd57c-wpz42
```

The new pod stays in `Init:0/1` indefinitely and the old one keeps serving, so the upgrade silently never completes. The only way out is scaling the Deployment to zero by hand and back up. I hit this on Longhorn, but it applies to any non-shared storage backend — EBS, Ceph RBD, local-path, and so on.

## Change

Expose an `updateStrategy` value and render it into the Deployment, defaulting to `Recreate` so the shipped defaults are internally consistent: the chart enables `ReadWriteOnce` persistence out of the box, and `Recreate` is the strategy that works with it. The tradeoff is brief downtime during an upgrade, which is already the de facto behaviour today — except it currently requires manual intervention to finish.

```yaml
updateStrategy:
  type: Recreate
```

The value is rendered through `with`, so users are not locked in:

| values | rendered `spec.strategy` |
|---|---|
| default | `type: Recreate` |
| `updateStrategy.type=RollingUpdate` | `type: RollingUpdate` |
| `updateStrategy.type=RollingUpdate`, `rollingUpdate.maxSurge=0` | passed through verbatim |
| `updateStrategy=null` | field omitted entirely (cluster default) |

`ci/no-persistence-values.yaml` now also sets `RollingUpdate`, since that config has no `ReadWriteOnce` volumes to contend over — this keeps both branches of the template covered by `ct lint`.

## Notes

This is a behaviour change for anyone currently relying on the implicit `RollingUpdate` **and** running with persistence disabled or on `ReadWriteMany` volumes; they need to set `updateStrategy.type: RollingUpdate` explicitly. Everyone else is either unaffected or actively fixed by it. Happy to default to `{}` (preserving today's behaviour) and leave `Recreate` as a documented opt-in instead, if you would rather not change the default in a patch release — let me know which you prefer.

Verified with `helm lint` and `helm template` across all four permutations in the table above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable deployment update strategies for Helm installations.
  * Deployments now default to replacing existing pods before starting new ones, supporting persistent storage configurations.
  * Added an alternative rolling update configuration for deployments without persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->