### PR TITLE
fix(ui): prevent ng-deep overrides from hiding upload modal text

### DIFF
--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-editor/metadata-editor.component.scss
@@ -45,11 +45,11 @@
   border-left: 0 !important;
 }
 
-::ng-deep p-fileupload .p-button-label {
+::ng-deep .cover-actions p-fileupload .p-button-label {
   display: none;
 }
 
-::ng-deep p-fileupload .p-button {
+::ng-deep .cover-actions p-fileupload .p-button {
   padding: 0.525rem 0.4375rem;
 }
 

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.scss
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.scss
@@ -593,22 +593,22 @@
 }
 
 @media (width <= 767px) {
-  ::ng-deep .mobile-icon-only .p-button-label {
+  ::ng-deep .metadata-viewer-container .mobile-icon-only .p-button-label {
     display: none !important;
     padding: 10px !important;
   }
 
-  ::ng-deep .mobile-icon-only .p-button {
+  ::ng-deep .metadata-viewer-container .mobile-icon-only .p-button {
     min-width: auto !important;
     padding: 10px !important;
   }
 
-  ::ng-deep .mobile-icon-only.p-splitbutton .p-button-label {
+  ::ng-deep .metadata-viewer-container .mobile-icon-only.p-splitbutton .p-button-label {
     display: none !important;
     padding: 10px !important;
   }
 
-  ::ng-deep .mobile-icon-only.p-splitbutton .p-button {
+  ::ng-deep .metadata-viewer-container .mobile-icon-only.p-splitbutton .p-button {
     min-width: auto !important;
     padding: 10px !important;
   }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the `::ng-deep` CSS styles were negatively affecting the upload modal when some components were active.  this adds constraints to the CSS styles that are made global so they stop affecting the upload modal and allow the text on the modal buttons to display

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1701

## Changes
* add parent selectors to the CSS selectors that affect `p-button` and `p-buttonlabel`

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

* go to book, click edit metadata to open edit metadata form
* open modal, observe buttons have text

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
This is a hack, the `::ng-deep` stuff seems to be a code smell and causes these sorts of problems.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Scoped metadata editor upload button styling to prevent unintended effects on other upload controls.
  - Scoped mobile metadata viewer button styles while preserving existing dimensions, padding, and label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->