### PR TITLE
fix(fb2): use base64 decoder aware of newlines

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractor.java
@@ -51,7 +51,7 @@ public class Fb2MetadataExtractor implements FileMetadataExtractor {
                     String contentType = binary.getAttribute("content-type");
                     if (contentType != null && contentType.startsWith("image/")) {
                         String base64Data = binary.getTextContent().trim();
-                        return Base64.getDecoder().decode(base64Data);
+                        return Base64.getMimeDecoder().decode(base64Data);
                     }
                 }
             }
@@ -73,7 +73,7 @@ public class Fb2MetadataExtractor implements FileMetadataExtractor {
                                 Element binary = (Element) binaries.item(i);
                                 if (imageId.equals(binary.getAttribute("id"))) {
                                     String base64Data = binary.getTextContent().trim();
-                                    return Base64.getDecoder().decode(base64Data);
+                                    return Base64.getMimeDecoder().decode(base64Data);
                                 }
                             }
                         }

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractorTest.java
@@ -499,6 +499,23 @@ class Fb2MetadataExtractorTest {
     }
 
     @Test
+    void extractCover_binaryWithNewLines() throws IOException {
+        byte[] imageData = {(byte) 0x89, 0x50, 0x4E, 0x47};
+        File file = writeFb2("""
+                <description><title-info/></description>
+                <binary id="cover.jpg" content-type="image/jpeg">
+                iVB
+                ORw==
+                </binary>
+                """
+        );
+
+        byte[] cover = extractor.extractCover(file);
+
+        assertThat(cover).isEqualTo(imageData);
+    }
+
+    @Test
     void extractCover_fallbackToCoverpageReference() throws IOException {
         byte[] imageData = {0x01, 0x02, 0x03, 0x04};
         String base64 = Base64.getEncoder().encodeToString(imageData);


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
updates the fb2 base64 decoder to use the RFC2045 compliant MIME Base64 decoder,
which can handle newlines, whitespace, and other characters which are invalid for the base64
data

this fixes the fb2 extractor failing to extract most images

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2223

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* switches fb2 extractor base64 decoder
* add test validating change

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. upload fb2 file
2. observe image is extracted for cover

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FB2 book cover extraction for Base64-encoded images containing line breaks or MIME-formatted content.
  * Covers referenced through both named binaries and cover pages are now handled more reliably.

* **Tests**
  * Added coverage for extracting covers from newline-separated Base64 data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->