### PR TITLE
fix(fb2): prioritize explicit cover binary elements

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractor.java
@@ -35,50 +35,74 @@ public class Fb2MetadataExtractor implements FileMetadataExtractor {
     private static final Pattern ISBN_CLEANER_PATTERN = Pattern.compile("[^0-9Xx]");
     private static final Pattern ISO_DATE_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
 
+    private String getCoverId(Document doc) {
+        Element titleInfo = getFirstElementByTagNameNS(doc, FB2_NAMESPACE, "title-info");
+        if (titleInfo == null) {
+            return null;
+        }
+
+        Element coverPage = getFirstElementByTagNameNS(titleInfo, FB2_NAMESPACE, "coverpage");
+        if (coverPage == null) {
+            return null;
+        }
+
+        Element image = getFirstElementByTagNameNS(coverPage, FB2_NAMESPACE, "image");
+        if (image == null) {
+            return null;
+        }
+
+        String href = image.getAttributeNS("http://www.w3.org/1999/xlink", "href");
+        if (!href.startsWith("#")) {
+            return null;
+        }
+
+        return href.substring(1);
+    }
+
+    private Element getCoverBinaryElement(Document doc) {
+        String coverId = getCoverId(doc);
+
+        // Look for cover image in binary elements
+        NodeList binaries = doc.getElementsByTagNameNS(FB2_NAMESPACE, "binary");
+
+        Element coverLike = null;
+
+        for (int i = 0; i < binaries.getLength(); i++) {
+            if (binaries.item(i) instanceof Element binary) {
+                String id = binary.getAttribute("id");
+
+                if (coverId != null && coverId.equals(id)) {
+                    return binary;
+                }
+
+                if (!id.toLowerCase().contains("cover")) {
+                    continue;
+                }
+
+                String contentType = binary.getAttribute("content-type");
+                if (!contentType.startsWith("image/")) {
+                    continue;
+                }
+
+                coverLike = binary;
+            }
+        }
+
+        // Fall back to the cover-like image if it was found;
+        return coverLike;
+    }
+
     @Override
     public byte[] extractCover(File file) {
         try (InputStream inputStream = getInputStream(file)) {
             DocumentBuilder builder = SecureXmlUtils.createSecureDocumentBuilder(true);
             Document doc = builder.parse(inputStream);
 
-            // Look for cover image in binary elements
-            NodeList binaries = doc.getElementsByTagNameNS(FB2_NAMESPACE, "binary");
-            for (int i = 0; i < binaries.getLength(); i++) {
-                Element binary = (Element) binaries.item(i);
-                String id = binary.getAttribute("id");
+            Element binary = getCoverBinaryElement(doc);
 
-                if (id != null && id.toLowerCase().contains("cover")) {
-                    String contentType = binary.getAttribute("content-type");
-                    if (contentType != null && contentType.startsWith("image/")) {
-                        String base64Data = binary.getTextContent().trim();
-                        return Base64.getMimeDecoder().decode(base64Data);
-                    }
-                }
-            }
-
-            // If no cover found by name, try to find the first referenced image in title-info
-            Element titleInfo = getFirstElementByTagNameNS(doc, FB2_NAMESPACE, "title-info");
-            if (titleInfo != null) {
-                NodeList coverPages = titleInfo.getElementsByTagNameNS(FB2_NAMESPACE, "coverpage");
-                if (coverPages.getLength() > 0) {
-                    Element coverPage = (Element) coverPages.item(0);
-                    NodeList images = coverPage.getElementsByTagNameNS(FB2_NAMESPACE, "image");
-                    if (images.getLength() > 0) {
-                        Element image = (Element) images.item(0);
-                        String href = image.getAttributeNS("http://www.w3.org/1999/xlink", "href");
-                        if (href != null && href.startsWith("#")) {
-                            String imageId = href.substring(1);
-                            // Find the binary with this ID
-                            for (int i = 0; i < binaries.getLength(); i++) {
-                                Element binary = (Element) binaries.item(i);
-                                if (imageId.equals(binary.getAttribute("id"))) {
-                                    String base64Data = binary.getTextContent().trim();
-                                    return Base64.getMimeDecoder().decode(base64Data);
-                                }
-                            }
-                        }
-                    }
-                }
+            if (binary != null) {
+                String base64Data = binary.getTextContent().trim();
+                return Base64.getMimeDecoder().decode(base64Data);
             }
 
             return null;

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/Fb2MetadataExtractorTest.java
@@ -516,7 +516,7 @@ class Fb2MetadataExtractorTest {
     }
 
     @Test
-    void extractCover_fallbackToCoverpageReference() throws IOException {
+    void extractCover_readCoverpageReference() throws IOException {
         byte[] imageData = {0x01, 0x02, 0x03, 0x04};
         String base64 = Base64.getEncoder().encodeToString(imageData);
         File file = writeFb2("""
@@ -528,6 +528,52 @@ class Fb2MetadataExtractorTest {
                   </title-info>
                 </description>
                 <binary id="img1" content-type="image/png">%s</binary>
+                """.formatted(base64));
+
+        byte[] cover = extractor.extractCover(file);
+
+        assertThat(cover).isEqualTo(imageData);
+    }
+
+    @Test
+    void extractCover_prioritizeCoverPageReference() throws IOException {
+        byte[] imageDataA = {0x01, 0x02, 0x03, 0x04};
+        byte[] imageDataB = {0x05, 0x06, 0x07, 0x08};
+        byte[] imageDataC = {0x09, 0x10, 0x11, 0x12};
+        String base64A = Base64.getEncoder().encodeToString(imageDataA);
+        String base64B = Base64.getEncoder().encodeToString(imageDataB);
+        String base64C = Base64.getEncoder().encodeToString(imageDataC);
+        File file = writeFb2("""
+                <description>
+                  <title-info>
+                    <coverpage>
+                      <image l:href="#img1"/>
+                    </coverpage>
+                  </title-info>
+                </description>
+                <binary id="img1" content-type="image/png">%s</binary>
+                <binary id="not-cover.jpg" content-type="image/png">%s</binary>
+                <binary id="also-not-cover.jpg" content-type="image/png">%s</binary>
+                """.formatted(base64A, base64B, base64C));
+
+        byte[] cover = extractor.extractCover(file);
+
+        assertThat(cover).isEqualTo(imageDataA);
+    }
+
+    @Test
+    void extractCover_fallsBackWhenCoverPageRefIsMissing() throws IOException {
+        byte[] imageData = {0x01, 0x02, 0x03, 0x04};
+        String base64 = Base64.getEncoder().encodeToString(imageData);
+        File file = writeFb2("""
+                <description>
+                  <title-info>
+                    <coverpage>
+                      <image l:href="#img1"/>
+                    </coverpage>
+                  </title-info>
+                </description>
+                <binary id="cover.jpg" content-type="image/png">%s</binary>
                 """.formatted(base64));
 
         byte[] cover = extractor.extractCover(file);


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
based on my interpretation of the fictionbook format, the cover binary elements are explicitly defined in the `title-info coverpage image` element.  This inverts the behaviors for extracting covers so that the explicitly defined cover page is prioritized, and we do guess-work for cover-like images if no cover can be found

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2228

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
refactors code to make working with the cover extractor easier
updates the behaviors so that the coverpage reference is prioritized
adds tests for that behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

uploaded fb2, cover still extracts

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
fictionbook is a dead format, so it's possible I'm misinterpreting things - but based on the beta spec from 2008 & everything else I can read this is the correct behavior

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cover image extraction from FB2 ebooks by prioritizing the image explicitly referenced by the cover page.
  - Added a reliable fallback that selects another suitable image when the referenced image is missing or unavailable.

- **Tests**
  - Added coverage for referenced-image priority and fallback cover selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->