### PR TITLE
refactor(books): add command adapter for legacy cache

### DIFF
--- a/frontend/src/app/features/book/data/book-shelf-command.models.ts
+++ b/frontend/src/app/features/book/data/book-shelf-command.models.ts
@@ -1,3 +1,10 @@
+import {BookShelf} from './book-response.models';
+
+interface UpdatedBookShelves {
+  readonly bookId: number;
+  readonly shelves: readonly BookShelf[];
+}
+
 export interface UpdateBookShelfMembershipVariables {
   readonly bookIds: readonly number[];
   readonly assignShelfIds: readonly number[];
@@ -6,4 +13,5 @@ export interface UpdateBookShelfMembershipVariables {
 
 export interface UpdateBookShelfMembershipResult {
   readonly confirmedBookIds: readonly number[];
+  readonly updatedBookShelves: readonly UpdatedBookShelves[];
 }

--- a/frontend/src/app/features/book/data/book-shelf-command.service.ts
+++ b/frontend/src/app/features/book/data/book-shelf-command.service.ts
@@ -10,6 +10,7 @@ import {
   UpdateBookShelfMembershipResult,
   UpdateBookShelfMembershipVariables,
 } from './book-shelf-command.models';
+import {BookShelf} from './book-response.models';
 import {applyBookQueryChangeSet} from './book-query-cache';
 import {invalidateShelfDefinitions} from './shelf-definition-query-cache';
 
@@ -54,12 +55,18 @@ export class BookShelfCommandService {
         shelvesToUnassign: unassignShelfIds,
       },
     ));
+    const updatedBookShelves = response.map(book => ({
+      bookId: book.id,
+      shelves: book.shelves,
+    }));
     return {
       confirmedBookIds: response.map(book => book.id),
+      updatedBookShelves,
     };
   }
 }
 
 interface MembershipBookResponse {
   readonly id: number;
+  readonly shelves: readonly BookShelf[];
 }

--- a/frontend/src/app/features/book/service/book-command-legacy-adapter.ts
+++ b/frontend/src/app/features/book/service/book-command-legacy-adapter.ts
@@ -1,0 +1,161 @@
+import {
+  CreateMutationOptions,
+  DefaultError,
+  QueryClient,
+  WithRequired,
+} from '@tanstack/angular-query-experimental';
+
+import {
+  DeleteBooksResult,
+  ResetBookProgressResult,
+  SetAllBookMetadataLocksResult,
+  SetBookReadStatusResult,
+} from '../data/book-command.models';
+import {UpdateBookShelfMembershipResult} from '../data/book-shelf-command.models';
+import {BookShelf} from '../data/book-response.models';
+import {Book, ReadStatus} from '../model/book.model';
+import {Shelf} from '../model/shelf.model';
+import {
+  invalidateAllLegacyBooks,
+  patchListOnlyBookFields,
+  patchListOnlyBooksWith,
+  removeListOnlyBooks,
+} from './legacy-book-cache';
+import {SHELVES_QUERY_KEY} from './shelf-query-keys';
+
+type MutationOptionsWithKey<TData, TError, TVariables, TOnMutateResult> =
+  WithRequired<CreateMutationOptions<TData, TError, TVariables, TOnMutateResult>, 'mutationKey'>;
+
+type LegacyBookCachePatch<TData> = (
+  client: QueryClient,
+  data: TData,
+) => Promise<void> | void;
+
+export function withLegacyBookCache<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TOnMutateResult = unknown,
+>(
+  options: MutationOptionsWithKey<TData, TError, TVariables, TOnMutateResult>,
+  patch: LegacyBookCachePatch<TData>,
+): MutationOptionsWithKey<TData, TError, TVariables, TOnMutateResult> {
+  const originalOnSuccess = options.onSuccess;
+  const originalOnError = options.onError;
+
+  return {
+    ...options,
+    onSuccess: async (data, variables, onMutateResult, context) => {
+      await Promise.all([
+        patch(context.client, data),
+        originalOnSuccess?.(data, variables, onMutateResult, context),
+      ]);
+    },
+    onError: async (error, variables, onMutateResult, context) => {
+      await Promise.all([
+        invalidateAllLegacyBooks(context.client),
+        originalOnError?.(error, variables, onMutateResult, context),
+      ]);
+    },
+  };
+}
+
+export const legacyBookCachePatches = {
+  readStatus: (
+    client: QueryClient,
+    results: readonly SetBookReadStatusResult[],
+  ): Promise<void> => patchListOnlyBookFields(client, results.map(result => ({
+    bookId: result.bookId,
+    fields: {
+      readStatus: ReadStatus[result.readStatus],
+      readStatusModifiedTime: result.readStatusModifiedTime ?? undefined,
+      dateFinished: result.dateFinished ?? undefined,
+    },
+  }))),
+  deleteBooks: (
+    client: QueryClient,
+    result: DeleteBooksResult,
+  ): Promise<void> => removeListOnlyBooks(client, result.removedBookIds),
+  resetProgress: (
+    client: QueryClient,
+    results: readonly ResetBookProgressResult[],
+  ): Promise<void> => patchListOnlyBookFields(client, results.map(result => ({
+    bookId: result.bookId,
+    fields: resetProgressPatchFields(result),
+  }))),
+  metadataAllLocks: (
+    client: QueryClient,
+    results: readonly SetAllBookMetadataLocksResult[],
+  ): Promise<void> => patchListOnlyBooksWith(client, results.map(result => ({
+    bookId: result.bookId,
+    updater: book => {
+      if (!book.metadata) {
+        return book;
+      }
+      return {
+        ...book,
+        metadata: {...book.metadata, ...result.metadataLocks},
+      };
+    },
+  }))),
+  shelfMembership: (
+    client: QueryClient,
+    result: UpdateBookShelfMembershipResult,
+  ): Promise<void> => patchLegacyShelfMembership(client, result),
+} as const;
+
+function resetProgressPatchFields(result: ResetBookProgressResult): Partial<Book> {
+  if (result.source !== 'GRIMMORY') {
+    return clearedProgressFields(result.source);
+  }
+  return {
+    ...clearedProgressFields(result.source),
+    readStatus: undefined,
+    readStatusModifiedTime: result.readStatusModifiedTime ?? undefined,
+    dateFinished: undefined,
+    lastReadTime: undefined,
+  };
+}
+
+function clearedProgressFields(source: ResetBookProgressResult['source']): Partial<Book> {
+  if (source === 'KOREADER') {
+    return {koreaderProgress: undefined};
+  }
+  if (source === 'KOBO') {
+    return {koboProgress: undefined};
+  }
+  return {
+    epubProgress: undefined,
+    pdfProgress: undefined,
+    cbxProgress: undefined,
+    audiobookProgress: undefined,
+  };
+}
+
+async function patchLegacyShelfMembership(
+  client: QueryClient,
+  result: UpdateBookShelfMembershipResult,
+): Promise<void> {
+  await Promise.all([
+    patchListOnlyBooksWith(client, result.updatedBookShelves.map(update => ({
+      bookId: update.bookId,
+      updater: book => ({
+        ...book,
+        shelves: update.shelves.map(toLegacyShelf),
+      }),
+    }))),
+    client.invalidateQueries({queryKey: SHELVES_QUERY_KEY, exact: true}),
+  ]);
+}
+
+function toLegacyShelf(shelf: BookShelf): Shelf {
+  return {
+    id: shelf.id,
+    name: shelf.name,
+    icon: shelf.icon,
+    iconType: shelf.iconType as Shelf['iconType'],
+    userId: shelf.userId,
+    publicShelf: shelf.publicShelf,
+    bookCount: shelf.bookCount,
+  };
+}


### PR DESCRIPTION
## Description

Final piece of the browser/pagination data / adaptation work, adding a small temp file to keep the old cache up to date with any actions taken in the new browser UI. 

## Linked Issue

N/A - Part of #2031 

## Changes

- New `book-command-legacy-adapter.ts` handling new browser UI actions and legacy cache updates. 
- Small updates to the shelf command service to preserve the backend's shelf data when a change is made, for use in the adapter. 
- This is temporary - set to be deleted as soon as each area has had a proper migration. 

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of book shelf changes across the application.
  * Updated book lists and shelf views now reflect membership changes more reliably.
  * Improved cache updates for read status, deletion, progress reset, metadata locks, and shelf membership actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->