### PR TITLE
fix(api): add refresh token nbf to prevent immediate usage

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/JwtUtils.java
+++ b/backend/src/main/java/org/booklore/config/security/JwtUtils.java
@@ -42,6 +42,8 @@ public class JwtUtils {
     @Getter
     public static final long refreshTokenExpirationMs = 1000L * 60 * 60 * 24 * 30; // 30 days
 
+    private static final long refreshTokenNotBeforeMs = 1000L * 60 * 2; // 2 minutes
+
     @PostConstruct
     public void init() {
         validateSecret();
@@ -78,14 +80,21 @@ public class JwtUtils {
         try {
             JWSSigner signer = new MACSigner(getSecretBytes());
 
-            JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+            var builder = new JWTClaimsSet.Builder()
                     .issuer(JWT_ISSUER)
                     .subject(user.getUsername())
                     .claim("userId", user.getId())
                     .claim("isDefaultPassword", user.isDefaultPassword())
                     .issueTime(Date.from(now))
-                    .expirationTime(Date.from(now.plusMillis(expirationTime)))
-                    .build();
+                    .expirationTime(Date.from(now.plusMillis(expirationTime)));
+
+            if (isRefreshToken) {
+                // Prevent refresh tokens from being used until at least
+                // some `refreshTokenNotBeforeMs` milliseconds from now.
+                builder.notBeforeTime(Date.from(now.plusMillis(refreshTokenNotBeforeMs)));
+            }
+
+            JWTClaimsSet claimsSet = builder.build();
 
             SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claimsSet);
             signedJWT.sign(signer);


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
currently refresh tokens can be used over and over again without any sort of rate limit in place.  this causes performance issues and other problems when applications are misconfigured or otherwise improperly use the refresh token

this change adds a `nbf` (not-before) to the refresh token so that refresh tokens cannot be used immediately after retrieving them, presenting a de-facto rate limit to how often refresh tokens can be exchanged

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2244

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* adds `nbf` claim to refresh token

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

Happy path:

1. set access token expiration to 2 minutes (rather than 2 hours)
1. logged out
2. logged in and grabbed refresh token
3. confirmed refresh token has `nbf`
4. wait 2 minutes
5. use app and see refresh occur with new access token and new refresh token

Not-so-happy path:

7. set access token expiration to 10 seconds
8. log out
9. log in again, wait 10 seconds
10. use app and see refresh token rejection

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
For almost all use cases this has no impact.  This will reject the case where a user logs in, the app decides the access token is invalid for some reason, and immediately attempts to refresh.  Previously this caused a unique exception because the token already existed

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh-token handling by adding a brief activation delay.
  * Access tokens continue to work without delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->