### PR TITLE
fix(api): ensure JWTs always have a unique JWT ID

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/JwtUtils.java
+++ b/backend/src/main/java/org/booklore/config/security/JwtUtils.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Set;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -80,6 +81,7 @@ public class JwtUtils {
 
             JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
                     .issuer(JWT_ISSUER)
+                    .jwtID(UUID.randomUUID().toString())
                     .subject(user.getUsername())
                     .claim("userId", user.getId())
                     .claim("isDefaultPassword", user.isDefaultPassword())


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
updates JWTs to include a unique JWT ID.  this prevents multiple refresh tokens created in the same second from failing to validate with the unique constraint

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1182 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* adds JWT ID to all JWTs

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. logged in
2. waited two hours
3. watch refresh token get refreshed

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
Usually this error is some other problem, but by adding a NBF / rate limit we can prevent most of the drawbacks while still improving our JWT ecosystem with JWT IDs

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added a unique identifier to each generated authentication token, improving token traceability and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->