### PR TITLE
fix(komga): resolve user from linked OPDS account instead of BookLore…

### DIFF
--- a/backend/src/main/java/org/booklore/controller/KomgaController.java
+++ b/backend/src/main/java/org/booklore/controller/KomgaController.java
@@ -20,6 +20,7 @@ import org.booklore.model.entity.BookLoreUserEntity;
 import org.booklore.service.book.BookService;
 import org.booklore.service.komga.KomgaService;
 import org.booklore.service.opds.OpdsUserV2Service;
+import org.booklore.service.user.UserService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.Resource;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
@@ -45,6 +46,7 @@ public class KomgaController {
     private final BookService bookService;
     private final AuthenticationService authenticationService;
     private final OpdsUserV2Service opdsUserV2Service;
+    private final UserService userService;
     private final KomgaMapper komgaMapper;
 
     // Inject the dedicated komga mapper bean
@@ -61,12 +63,18 @@ public class KomgaController {
         }
     }
 
-    private void validateBookContentAccess(Long bookId) {
-        BookLoreUser user = authenticationService.getAuthenticatedUser();
-
-        if (user == null) {
+    // The Komga API authenticates against OPDS users (basic auth), so the security
+    // principal is an OpdsUserDetails, never a BookLoreUser.
+    private Long opdsLinkedUserId() {
+        OpdsUserDetails details = authenticationService.getOpdsUser();
+        if (details.getOpdsUserV2() == null || details.getOpdsUserV2().getUserId() == null) {
             throw ApiError.FORBIDDEN.createException("Authentication required");
         }
+        return details.getOpdsUserV2().getUserId();
+    }
+
+    private void validateBookContentAccess(Long bookId) {
+        BookLoreUser user = userService.getBookLoreUser(opdsLinkedUserId());
 
         if (!komgaService.validateBookContentAccess(user, bookId)) {
             throw ApiError.BOOK_NOT_FOUND.createException(bookId);
@@ -232,6 +240,6 @@ public class KomgaController {
             @Parameter(description = "Page number") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "Return all collections without paging") @RequestParam(defaultValue = "false") boolean unpaged) {
-        return writeJson(komgaService.getCollections(page, size, unpaged));
+        return writeJson(komgaService.getCollections(opdsLinkedUserId(), page, size, unpaged));
     }
 }

--- a/backend/src/main/java/org/booklore/service/komga/KomgaService.java
+++ b/backend/src/main/java/org/booklore/service/komga/KomgaService.java
@@ -389,10 +389,10 @@ public class KomgaService {
         return seriesMap;
     }
     
-    public KomgaPageableDto<KomgaCollectionDto> getCollections(int page, int size, boolean unpaged) {
+    public KomgaPageableDto<KomgaCollectionDto> getCollections(Long userId, int page, int size, boolean unpaged) {
         log.debug("Getting collections, page: {}, size: {}, unpaged: {}", page, size, unpaged);
-        
-        List<MagicShelf> magicShelves = magicShelfService.getUserShelves();
+
+        List<MagicShelf> magicShelves = magicShelfService.getUserShelvesForOpds(userId);
         log.debug("Found {} magic shelves", magicShelves.size());
         
         // Convert to collection DTOs - for now, series count is 0 since we don't have 

--- a/backend/src/test/java/org/booklore/service/komga/KomgaServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/komga/KomgaServiceTest.java
@@ -374,6 +374,17 @@ class KomgaServiceTest {
         verify(magicShelfService, never()).getUserShelves();
     }
 
+    @Test
+    void getCollectionsReturnsEmptyPageWhenOpdsUserHasNoShelves() {
+        when(magicShelfService.getUserShelvesForOpds(42L)).thenReturn(List.of());
+
+        KomgaPageableDto<KomgaCollectionDto> result = komgaService.getCollections(42L, 0, 20, false);
+
+        assertThat(result.getContent()).isEmpty();
+        verify(magicShelfService).getUserShelvesForOpds(42L);
+        verify(magicShelfService, never()).getUserShelves();
+    }
+
     BookLoreUser getBookloreUser(boolean isAdmin, List<LibraryEntity> libraries) {
         BookLoreUser.UserPermissions perms = new BookLoreUser.UserPermissions();
 

--- a/backend/src/test/java/org/booklore/service/komga/KomgaServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/komga/KomgaServiceTest.java
@@ -3,7 +3,9 @@ package org.booklore.service.komga;
 import org.booklore.mapper.komga.KomgaMapper;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.Library;
+import org.booklore.model.dto.MagicShelf;
 import org.booklore.model.dto.komga.KomgaBookDto;
+import org.booklore.model.dto.komga.KomgaCollectionDto;
 import org.booklore.model.dto.komga.KomgaPageDto;
 import org.booklore.model.dto.komga.KomgaPageableDto;
 import org.booklore.model.dto.komga.KomgaSeriesDto;
@@ -353,6 +355,23 @@ class KomgaServiceTest {
                 .id(1L)
                 .library(library)
                 .build();
+    }
+
+    @Test
+    void getCollectionsUsesOpdsLinkedUserIdInsteadOfAuthenticatedPrincipal() {
+        MagicShelf shelf = new MagicShelf();
+        shelf.setId(7L);
+        shelf.setName("My Shelf");
+        when(magicShelfService.getUserShelvesForOpds(42L)).thenReturn(List.of(shelf));
+        when(komgaMapper.toKomgaCollectionDto(shelf, 0))
+                .thenReturn(KomgaCollectionDto.builder().id("7").name("My Shelf").build());
+
+        KomgaPageableDto<KomgaCollectionDto> result = komgaService.getCollections(42L, 0, 20, false);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().getName()).isEqualTo("My Shelf");
+        verify(magicShelfService).getUserShelvesForOpds(42L);
+        verify(magicShelfService, never()).getUserShelves();
     }
 
     BookLoreUser getBookloreUser(boolean isAdmin, List<LibraryEntity> libraries) {


### PR DESCRIPTION
## Description

  The Komga-compatible API (`/komga/api/**`) authenticates via Basic Auth against **OPDS users**, so the security principal is
  always an `OpdsUserDetails`, never a `BookLoreUser`. However, `KomgaService.getCollections` and
  `KomgaController.validateBookContentAccess` both called `AuthenticationService.getAuthenticatedUser()`, which throws
  `IllegalStateException: Authenticated principal is not of type BookLoreUser` for any non-`BookLoreUser` principal.

  As a result, Komga clients such as Mihon received a 500 error on every call to list collections, read book pages, download
  files, or fetch thumbnails.

  The fix resolves the linked BookLore user from the OPDS principal (via the `user_id` foreign key on the OPDS account),
  mirroring what the OPDS feed already does with `getUserShelvesForOpds`.

   ## Changes

  - `KomgaController`: added a `opdsLinkedUserId()` helper that extracts the linked BookLore user id from the authenticated
  `OpdsUserDetails` principal.
  - `KomgaController.validateBookContentAccess`: loads the full `BookLoreUser` via
  `UserService.getBookLoreUser(opdsLinkedUserId())` instead of `getAuthenticatedUser()`. This fixes book pages, file download
  and thumbnail endpoints. Existing access checks (admin, assigned libraries, content restrictions) are unchanged and now run
  against the correct user.
  - `KomgaService.getCollections`: now takes the resolved `userId` and calls `MagicShelfService.getUserShelvesForOpds(userId)`
  instead of `getUserShelves()` (which required a `BookLoreUser` principal).
  - `KomgaServiceTest`: added `getCollectionsUsesOpdsLinkedUserIdInsteadOfAuthenticatedPrincipal` to lock in the new
  behaviour.

  ## Manual Testing Steps

  1. Create an OPDS account for a BookLore user (Settings → OPDS).
  2. Configure Mihon with the Komga source pointing to `https://<server>/komga`, using the OPDS credentials.
  3. Browse the library in Mihon and open the collections list → previously returned HTTP 500 with `IllegalStateException` in
  the logs; now returns the user's magic shelves.
  4. Open a comic and read pages / download a book / load thumbnails → previously failed with the same exception on
  `getBookPage`; now works and respects the linked user's library access and content restrictions.
  5. Check server logs: no more `Authenticated principal is not of type BookLoreUser` errors on `/komga/api/**`.

  ## Additional Context

  The linked BookLore user always exists: `opds_user_v2.user_id` is `NOT NULL` with `ON DELETE CASCADE`, so deleting a
  BookLore user removes its OPDS accounts and Basic Auth fails with 401 before reaching this code. A defensive check in
  `opdsLinkedUserId()` still returns a clean 403 instead of a 500 if the link is ever missing.

  ## AI Disclosure

  Claude Code (Fable 5) — diagnosed the root cause, implemented the fix and drafted the test; I reviewed all changes and
  tested manually with Mihon against a Docker deployment.

  ## Checklist

  - [ ] This PR links and implements an accepted issue.
  - [x] This PR is a single focused change.
  - [x] There are new or updated tests validating this change.
  - [ ] I ran `just ui check` and `just api check`.
  - [ ] I have added screenshots if there were any UI changes.
  - [x] I have disclosed any AI usage as per the organization AI Policy above.
  - [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OPDS collection and book access now correctly reflects the authenticated user.
  * Users only see their own eligible magic shelves and collections.
  * Existing handling for unauthorized access and missing books is preserved.

* **Tests**
  * Added coverage verifying user-specific shelf retrieval and collection mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->