### PR TITLE
refactor(ui): use `app-cover` for metadata searcher

### DIFF
--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.html
@@ -160,10 +160,12 @@
               (click)="onBookClick(metadata)"
               (keydown.enter)="onBookClick(metadata)">
               <div class="card-image">
-                <img
-                  [src]="metadata.thumbnailUrl || 'assets/images/missing-cover.jpg'"
-                  [alt]="metadata.title"
-                  loading="lazy"/>
+                <app-cover
+                  class="book-cover"
+                  [src]="metadata.thumbnailUrl"
+                  [title]="metadata.title"
+                  [authors]="metadata.authors ?? []"
+                  [alt]="metadata.title ?? ''"/>
                 <div class="card-overlay">
                   <i class="pi pi-eye"></i>
                   <span>{{ t('selectOverlay') }}</span>

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-searcher/metadata-searcher.component.ts
@@ -14,6 +14,7 @@ import {MetadataPickerComponent} from '../metadata-picker/metadata-picker.compon
 import {BookMetadataService} from '../../../../book/service/book-metadata.service';
 import {Tooltip} from '@openng/optimus-ui/tooltip';
 import {TranslocoDirective} from '@jsverse/transloco';
+import {CoverComponent} from '../../../../../shared/components/cover/cover.component';
 
 @Component({
   selector: 'app-metadata-searcher',
@@ -27,7 +28,8 @@ import {TranslocoDirective} from '@jsverse/transloco';
     MetadataPickerComponent,
     MultiSelect,
     Tooltip,
-    TranslocoDirective
+    TranslocoDirective,
+    CoverComponent
   ],
   standalone: true
 })


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
updates the metadata search component to use the `app-cover` rather than a raw `img` so the placeholder works as expected, and we can drop the hard coded reference to `missing-cover`

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2253

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* switch to `app-cover` from raw image

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Hack up metadata provider to not include images (so I don't have to search for one)
2. Search for Archie vs Predator
3. See the placeholder

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

<img width="658" height="293" alt="image" src="https://github.com/user-attachments/assets/f7ef02ac-6a4d-420e-bf22-8affae9912b4" />

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata search results now display book covers using a richer cover component with thumbnail, title, authors, and fallback alt text.
  * Improved the appearance and accessibility of result cards when cover images are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->