### PR TITLE
fix(api): avoid `missing-cover.jpg` when getting book thumbnails

### DIFF
--- a/backend/src/main/java/org/booklore/controller/KomgaController.java
+++ b/backend/src/main/java/org/booklore/controller/KomgaController.java
@@ -130,6 +130,9 @@ public class KomgaController {
         
         Long firstBookId = Long.parseLong(books.getContent().getFirst().getId());
         Resource coverImage = bookService.getBookThumbnail(firstBookId);
+        if (coverImage == null) {
+            return ResponseEntity.notFound().build();
+        }
         return ResponseEntity.ok()
                 .header("Content-Type", "image/jpeg")
                 .body(coverImage);
@@ -200,6 +203,9 @@ public class KomgaController {
         validateBookContentAccess(bookId);
 
         Resource coverImage = bookService.getBookThumbnail(bookId);
+        if (coverImage == null) {
+            return ResponseEntity.notFound().build();
+        }
         return ResponseEntity.ok()
                 .header("Content-Type", "image/jpeg")
                 .body(coverImage);

--- a/backend/src/main/java/org/booklore/service/book/BookService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookService.java
@@ -285,7 +285,7 @@ public class BookService {
     }
 
     public Resource getBookThumbnail(long bookId) {
-        return getBookThumbnailIfPresent(bookId).orElseGet(this::getMissingCoverResource);
+        return getBookThumbnailIfPresent(bookId).orElse(null);
     }
 
     public Optional<Resource> getBookCoverIfPresent(long bookId) {
@@ -293,7 +293,7 @@ public class BookService {
     }
 
     public Resource getBookCover(long bookId) {
-        return getBookCoverIfPresent(bookId).orElseGet(this::getMissingCoverResource);
+        return getBookCoverIfPresent(bookId).orElse(null);
     }
 
     public Resource getBookCover(String coverHash) {
@@ -305,16 +305,12 @@ public class BookService {
         return resolveImageResource(fileService.getAudiobookThumbnailFile(bookId), bookId);
     }
 
-    public Resource getAudiobookThumbnail(long bookId) {
-        return getAudiobookThumbnailIfPresent(bookId).orElseGet(this::getMissingCoverResource);
-    }
-
     public Optional<Resource> getAudiobookCoverIfPresent(long bookId) {
         return resolveImageResource(fileService.getAudiobookCoverFile(bookId), bookId);
     }
 
     public Resource getAudiobookCover(long bookId) {
-        return getAudiobookCoverIfPresent(bookId).orElseGet(this::getMissingCoverResource);
+        return getAudiobookCoverIfPresent(bookId).orElse(null);
     }
 
     private Optional<Resource> resolveImageResource(String filePath, long bookId) {
@@ -327,15 +323,6 @@ public class BookService {
         } catch (MalformedURLException e) {
             log.error("Failed to load image for bookId={} from path={}", bookId, filePath, e);
             throw ApiError.INTERNAL_SERVER_ERROR.createException("Failed to load image for bookId=" + bookId);
-        }
-    }
-
-    private Resource getMissingCoverResource() {
-        try {
-            byte[] bytes = new ClassPathResource("static/images/missing-cover.jpg").getInputStream().readAllBytes();
-            return new ByteArrayResource(bytes);
-        } catch (IOException e) {
-            throw ApiError.INTERNAL_SERVER_ERROR.createException("Failed to load missing cover image");
         }
     }
 

--- a/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -310,10 +310,10 @@ class BookServiceTest {
     }
 
     @Test
-    void getBookCover_fileMissing_returnsByteArrayResource() {
+    void getBookCover_fileMissing_returnsNull() {
         when(fileService.getCoverFile(1L)).thenReturn("/tmp/nonexistent2.jpg");
         Resource res = bookService.getBookCover(1L);
-        assertTrue(res instanceof ByteArrayResource);
+        assertNull(res);
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the previous change to switch up the cover made assumptions in the UI that when a cover does not exist it will be `null`.  we kept some of these old flows around but this breaks the fallbacks for OPDS & also emits a value to the komga API which isn't correct

this PR properly returns `null` when a thumbnail doesn't exist instead of the missing cover jpeg.  also updates komga controller to handle this change

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2253 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
updates book service to return null rather than `missing-cover.jpg` when cover is missing
updates komga controller to handle null resource

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. delete cover from book
2. view book in UI
3. see no difference from before - still uses placeholder

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
did not test komga controller change, but looking at Komga this matches with their code

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing book, audiobook, and series artwork is now correctly reported as unavailable instead of displaying a placeholder image.
  * Thumbnail requests return a clear “Not Found” response when no image is available.
  * Existing artwork continues to display normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->