### PR TITLE
feat(language): use consistent language normalization across the frontend

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.ts
@@ -43,6 +43,7 @@ import {TaskHelperService} from '../../../settings/task-management/task-helper.s
 import {FilterLabelHelper} from './filter-label.helper';
 import {LoadingService} from '../../../../core/services/loading.service';
 import {LocalStorageService} from '../../../../shared/service/local-storage.service';
+import {LanguageResolverService} from '../../../../shared/service/language-resolver.service';
 import {BookNavigationService} from '../../service/book-navigation.service';
 import {BookCardOverlayPreferenceService} from './book-card-overlay-preference.service';
 import {BookSelectionService, CheckboxClickEvent} from './book-selection.service';
@@ -119,6 +120,7 @@ export class BookBrowserComponent implements AfterViewInit {
   private scrollService = inject(RouteScrollPositionService);
   private layoutService = inject(LayoutService);
   private readonly t = inject(TranslocoService);
+  private readonly languageResolver = inject(LanguageResolverService);
   private readonly destroyRef = inject(DestroyRef);
 
   constructor() {
@@ -359,7 +361,9 @@ export class BookBrowserComponent implements AfterViewInit {
       const filterName = FilterLabelHelper.getFilterTypeName(filterType);
 
       if (values.length === 1) {
-        const displayValue = FilterLabelHelper.getFilterDisplayValue(filterType, values[0]);
+        const displayValue = filterType === 'language'
+          ? this.languageResolver.displayName(String(values[0]))
+          : FilterLabelHelper.getFilterDisplayValue(filterType, values[0]);
         return `${filterName}: ${displayValue}`;
       }
 

--- a/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.config.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.config.ts
@@ -199,6 +199,12 @@ const extractStringsAsFilters = (values: string[] | undefined): FilterValue[] =>
 const extractSingleString = (value: string | undefined | null): FilterValue[] =>
   value ? [{id: value, name: value}] : [];
 
+let languageDisplayName: (raw: string) => string = raw => raw;
+
+export function registerLanguageDisplayName(resolver: (raw: string) => string): void {
+  languageDisplayName = resolver;
+}
+
 export const FILTER_EXTRACTORS: Readonly<Record<Exclude<FilterType, 'library'>, (book: Book) => FilterValue[]>> = {
   author: (book) => extractStringsAsFilters(book.metadata?.authors),
   category: (book) => extractStringsAsFilters(book.metadata?.categories),
@@ -231,7 +237,10 @@ export const FILTER_EXTRACTORS: Readonly<Record<Exclude<FilterType, 'library'>, 
   lubimyczytacRating: (book) => findInRange(book.metadata?.lubimyczytacRating, RATING_RANGES_5),
   ranobedbRating: (book) => findInRange(book.metadata?.ranobedbRating, RATING_RANGES_5),
   audibleRating: (book) => findInRange(book.metadata?.audibleRating, RATING_RANGES_5),
-  language: (book) => extractSingleString(book.metadata?.language),
+  language: (book) => {
+    const language = book.metadata?.language;
+    return language ? [{id: language, name: languageDisplayName(language)}] : [];
+  },
   pageCount: (book) => findInRange(book.metadata?.pageCount, PAGE_COUNT_RANGES),
   mood: (book) => extractStringsAsFilters(book.metadata?.moods),
   ageRating: (book) => findInRange(book.metadata?.ageRating, AGE_RATING_OPTIONS),

--- a/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-filter/book-filter.service.ts
@@ -8,9 +8,10 @@ import {LibraryService} from '../../../service/library.service';
 import {BookRuleEvaluatorService} from '../../../../magic-shelf/service/book-rule-evaluator.service';
 import {GroupRule} from '../../../../magic-shelf/component/magic-shelf-component';
 import {EntityType} from '../book-browser.component';
-import {Filter, FILTER_CONFIGS, FILTER_EXTRACTORS, FilterType, FilterValue, NUMERIC_ID_FILTER_TYPES, SortMode} from './book-filter.config';
+import {Filter, FILTER_CONFIGS, FILTER_EXTRACTORS, FilterType, FilterValue, NUMERIC_ID_FILTER_TYPES, registerLanguageDisplayName, SortMode} from './book-filter.config';
 import {filterBooksByFilters} from '../filters/sidebar-filter';
 import {BookFilterMode} from '../../../../settings/user-management/user.service';
+import {LanguageResolverService} from '../../../../../shared/service/language-resolver.service';
 
 const MAX_FILTER_ITEMS = 100;
 
@@ -19,6 +20,11 @@ export class BookFilterService {
   private readonly bookService = inject(BookService);
   private readonly libraryService = inject(LibraryService);
   private readonly bookRuleEvaluatorService = inject(BookRuleEvaluatorService);
+  private readonly languageResolver = inject(LanguageResolverService);
+
+  constructor() {
+    registerLanguageDisplayName(raw => this.languageResolver.displayName(raw) || raw);
+  }
 
   createFilterSignals(
     entity: Signal<Library | Shelf | MagicShelf | null>,

--- a/frontend/src/app/features/book/components/book-browser/book-table/book-table-row.component.ts
+++ b/frontend/src/app/features/book/components/book-browser/book-table/book-table-row.component.ts
@@ -9,6 +9,7 @@ import {Tooltip} from '@openng/optimus-ui/tooltip';
 import {Book, BookMetadata} from '../../../model/book.model';
 import {ReadStatusHelper} from '../../../helpers/read-status.helper';
 import {UrlHelperService} from '../../../../../shared/service/url-helper.service';
+import {LanguageResolverService} from '../../../../../shared/service/language-resolver.service';
 import {CoverComponent} from '../../../../../shared/components/cover/cover.component';
 import {AppRatingComponent} from '../../../../../shared/ui/rating/app-rating.component';
 import {RATING_FIELDS, isMetadataFullyLocked} from './book-table.helpers';
@@ -122,6 +123,7 @@ export class BookTableRowComponent {
 
   private readonly datePipe = inject(DatePipe);
   private readonly readStatusHelper = inject(ReadStatusHelper);
+  private readonly languageResolver = inject(LanguageResolverService);
   protected readonly urlHelper = inject(UrlHelperService);
 
   readonly metadata = computed<BookMetadata>(() => {
@@ -238,6 +240,14 @@ export class BookTableRowComponent {
           anchor: seriesName
         }];
       }
+      case 'language': {
+        const language = metadata.language;
+        if (!language) return [];
+        return [{
+          url: this.urlHelper.filterBooksBy('language', language),
+          anchor: this.languageResolver.displayName(language)
+        }];
+      }
       default: {
         const value = this.getMetadataValue(metadata, field);
         values = typeof value === 'string' && value ? [value] : [];
@@ -275,7 +285,7 @@ export class BookTableRowComponent {
       case 'fileSizeKb':
         return this.formatFileSize(book.fileSizeKb);
       case 'language':
-        return metadata.language ?? '';
+        return this.languageResolver.displayName(metadata.language);
       case 'pageCount':
         return metadata.pageCount ?? '';
       case 'amazonReviewCount':

--- a/frontend/src/app/features/book/components/series-page/series-page.component.ts
+++ b/frontend/src/app/features/book/components/series-page/series-page.component.ts
@@ -28,6 +28,7 @@ import {TagComponent} from "../../../../shared/components/tag/tag.component";
 import {AfterViewChecked, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, signal, viewChild} from '@angular/core';
 import {BookCardOverlayPreferenceService} from '../book-browser/book-card-overlay-preference.service';
 import {UrlHelperService} from '../../../../shared/service/url-helper.service';
+import {LanguageResolverService} from '../../../../shared/service/language-resolver.service';
 import {CoverComponent} from '../../../../shared/components/cover/cover.component';
 import {injectQuery} from '@tanstack/angular-query-experimental';
 import {AuthorService} from '../../../author-browser/service/author.service';
@@ -101,6 +102,7 @@ export class SeriesPageComponent implements AfterViewChecked {
   private readonly MOBILE_GRID_COLUMNS = 2;
   private route = inject(ActivatedRoute);
   private bookService = inject(BookService);
+  private languageResolver = inject(LanguageResolverService);
   private bookMetadataManageService = inject(BookMetadataManageService);
   private metadataCenterViewMode: "route" | "dialog" = "route";
   private dialogRef?: DynamicDialogRef | null;
@@ -241,7 +243,7 @@ export class SeriesPageComponent implements AfterViewChecked {
     const languages = new Set<string>();
     for (const book of this.filteredBooks()) {
       if (book.metadata?.language) {
-        languages.add(book.metadata.language);
+        languages.add(this.languageResolver.displayName(book.metadata.language));
       }
     }
     return Array.from(languages);

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -410,7 +410,7 @@
               <span class="metadata-key">{{ t('languageLabel') }}</span>
               @if (book?.metadata!.language) {
                 <span class="metadata-value metadata-link" role="button" tabindex="0" (click)="goToLanguage(book?.metadata!.language!)" (keydown.enter)="goToLanguage(book?.metadata!.language!)">
-                  {{ book?.metadata!.language }}
+                  {{ languageResolver.displayName(book?.metadata!.language) }}
                 </span>
               } @else {
                 <span class="metadata-value">-</span>

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.spec.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.spec.ts
@@ -202,7 +202,7 @@ describe('MetadataViewerComponent', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        {provide: TranslocoService, useValue: {translate}},
+        {provide: TranslocoService, useValue: {translate, getActiveLang: () => 'en', langChanges$: of('en')}},
         {provide: LibraryService, useValue: {findLibraryById}},
         {
           provide: BookDialogHelperService,

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -33,6 +33,7 @@ import {AGE_RATING_OPTIONS, CONTENT_RATING_LABELS, fileSizeRanges, matchScoreRan
 import {BookNavigationService} from '../../../../book/service/book-navigation.service';
 import {BookMetadataHostService} from '../../../../../shared/service/book-metadata-host.service';
 import {AppSettingsService} from '../../../../../shared/service/app-settings.service';
+import {LanguageResolverService} from '../../../../../shared/service/language-resolver.service';
 import {DeleteBookFileEvent, DeleteSupplementaryFileEvent, DetachBookFileEvent, DownloadAdditionalFileEvent, DownloadAllFilesEvent, DownloadEvent, MetadataTabsComponent, ReadEvent} from './metadata-tabs/metadata-tabs.component';
 import {TranslocoDirective, TranslocoPipe, TranslocoService} from '@jsverse/transloco';
 import {AuthorService} from '../../../../author-browser/service/author.service';
@@ -108,6 +109,7 @@ export class MetadataViewerComponent implements OnInit, AfterViewChecked {
   private authorService = inject(AuthorService);
   protected urlHelper = inject(UrlHelperService);
   protected userService = inject(UserService);
+  protected languageResolver = inject(LanguageResolverService);
   private appSettingsService = inject(AppSettingsService);
   private confirmationService = inject(ConfirmationService);
 

--- a/frontend/src/app/features/readers/ebook-reader/dialogs/metadata-dialog.component.html
+++ b/frontend/src/app/features/readers/ebook-reader/dialogs/metadata-dialog.component.html
@@ -55,7 +55,7 @@
             @if (metadata?.language) {
               <div class="metadata-item">
                 <span class="label">{{ t('language') }}</span>
-                <span class="value">{{ metadata?.language }}</span>
+                <span class="value">{{ languageResolver.displayName(metadata?.language) }}</span>
               </div>
             }
 

--- a/frontend/src/app/features/readers/ebook-reader/dialogs/metadata-dialog.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/dialogs/metadata-dialog.component.ts
@@ -2,6 +2,7 @@ import {Component, EventEmitter, inject, Input, Output} from '@angular/core';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
 import {Book} from '../../../book/model/book.model';
 import {UrlHelperService} from '../../../../shared/service/url-helper.service';
+import {LanguageResolverService} from '../../../../shared/service/language-resolver.service';
 import {CoverComponent} from '../../../../shared/components/cover/cover.component';
 
 @Component({
@@ -17,6 +18,7 @@ export class ReaderBookMetadataDialogComponent {
 
   private urlHelperService = inject(UrlHelperService);
   private readonly t = inject(TranslocoService);
+  protected readonly languageResolver = inject(LanguageResolverService);
 
   get metadata() {
     return this.book?.metadata;

--- a/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.spec.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.spec.ts
@@ -1,5 +1,6 @@
 import {signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {of} from 'rxjs';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {TranslocoService} from '@jsverse/transloco';
@@ -56,7 +57,7 @@ describe('LanguageChartComponent', () => {
       providers: [
         {provide: BookService, useValue: {books, isBooksLoading}},
         {provide: LibraryFilterService, useValue: {selectedLibrary}},
-        {provide: TranslocoService, useValue: {translate}},
+        {provide: TranslocoService, useValue: {translate, getActiveLang: () => 'en', langChanges$: of('en')}},
       ],
     });
   });
@@ -103,7 +104,7 @@ describe('LanguageChartComponent', () => {
     expect(component.chartData()).toEqual({labels: [], datasets: []});
   });
 
-  it('aggregates exact normalized keys, shapes mapped and fallback labels, and filters books to the selected library', () => {
+  it('aggregates aliases under one canonical language, shapes mapped and fallback labels, and filters books to the selected library', () => {
     books.set([
       createBook(1, 1, ' EN '),
       createBook(2, 1, 'en'),
@@ -123,11 +124,8 @@ describe('LanguageChartComponent', () => {
     expect(component.totalBooks()).toBe(9);
     expect(component.booksWithLanguage()).toBe(7);
     expect(component.languageStats()).toEqual([
-      {language: 'en', displayName: 'English', count: 2, percentage: (2 / 7) * 100},
-      {language: 'eng', displayName: 'English', count: 1, percentage: (1 / 7) * 100},
-      {language: 'english', displayName: 'English', count: 1, percentage: (1 / 7) * 100},
-      {language: 'spa', displayName: 'Spanish', count: 1, percentage: (1 / 7) * 100},
-      {language: 'spanish', displayName: 'Spanish', count: 1, percentage: (1 / 7) * 100},
+      {language: 'en', displayName: 'English', count: 4, percentage: (4 / 7) * 100},
+      {language: 'es', displayName: 'Spanish', count: 2, percentage: (2 / 7) * 100},
       {language: 'klingon', displayName: 'Klingon', count: 1, percentage: (1 / 7) * 100},
     ]);
   });

--- a/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.ts
+++ b/frontend/src/app/features/stats/component/library-stats/charts/language-chart/language-chart.component.ts
@@ -5,6 +5,7 @@ import {LibraryFilterService} from '../../service/library-filter.service';
 import {BookService} from '../../../../../book/service/book.service';
 import {Book} from '../../../../../book/model/book.model';
 import {TranslocoDirective, TranslocoService} from '@jsverse/transloco';
+import {LanguageResolverService} from '../../../../../../shared/service/language-resolver.service';
 
 interface LanguageStats {
   language: string;
@@ -34,97 +35,6 @@ const LANGUAGE_COLORS = [
   '#A855F7'  // Purple-500
 ] as const;
 
-// Common language code to display name mapping
-const LANGUAGE_NAMES: Record<string, string> = {
-  'en': 'English',
-  'eng': 'English',
-  'english': 'English',
-  'es': 'Spanish',
-  'spa': 'Spanish',
-  'spanish': 'Spanish',
-  'fr': 'French',
-  'fra': 'French',
-  'french': 'French',
-  'de': 'German',
-  'deu': 'German',
-  'german': 'German',
-  'it': 'Italian',
-  'ita': 'Italian',
-  'italian': 'Italian',
-  'pt': 'Portuguese',
-  'por': 'Portuguese',
-  'portuguese': 'Portuguese',
-  'ru': 'Russian',
-  'rus': 'Russian',
-  'russian': 'Russian',
-  'zh': 'Chinese',
-  'zho': 'Chinese',
-  'chinese': 'Chinese',
-  'ja': 'Japanese',
-  'jpn': 'Japanese',
-  'japanese': 'Japanese',
-  'ko': 'Korean',
-  'kor': 'Korean',
-  'korean': 'Korean',
-  'pl': 'Polish',
-  'pol': 'Polish',
-  'polish': 'Polish',
-  'nl': 'Dutch',
-  'nld': 'Dutch',
-  'dutch': 'Dutch',
-  'sv': 'Swedish',
-  'swe': 'Swedish',
-  'swedish': 'Swedish',
-  'ar': 'Arabic',
-  'ara': 'Arabic',
-  'arabic': 'Arabic',
-  'hi': 'Hindi',
-  'hin': 'Hindi',
-  'hindi': 'Hindi',
-  'tr': 'Turkish',
-  'tur': 'Turkish',
-  'turkish': 'Turkish',
-  'cs': 'Czech',
-  'ces': 'Czech',
-  'czech': 'Czech',
-  'da': 'Danish',
-  'dan': 'Danish',
-  'danish': 'Danish',
-  'fi': 'Finnish',
-  'fin': 'Finnish',
-  'finnish': 'Finnish',
-  'no': 'Norwegian',
-  'nor': 'Norwegian',
-  'norwegian': 'Norwegian',
-  'uk': 'Ukrainian',
-  'ukr': 'Ukrainian',
-  'ukrainian': 'Ukrainian',
-  'he': 'Hebrew',
-  'heb': 'Hebrew',
-  'hebrew': 'Hebrew',
-  'el': 'Greek',
-  'ell': 'Greek',
-  'greek': 'Greek',
-  'hu': 'Hungarian',
-  'hun': 'Hungarian',
-  'hungarian': 'Hungarian',
-  'ro': 'Romanian',
-  'ron': 'Romanian',
-  'romanian': 'Romanian',
-  'th': 'Thai',
-  'tha': 'Thai',
-  'thai': 'Thai',
-  'vi': 'Vietnamese',
-  'vie': 'Vietnamese',
-  'vietnamese': 'Vietnamese',
-  'id': 'Indonesian',
-  'ind': 'Indonesian',
-  'indonesian': 'Indonesian',
-  'ms': 'Malay',
-  'msa': 'Malay',
-  'malay': 'Malay'
-};
-
 @Component({
   selector: 'app-language-chart',
   standalone: true,
@@ -136,6 +46,7 @@ export class LanguageChartComponent {
   private readonly bookService = inject(BookService);
   private readonly libraryFilterService = inject(LibraryFilterService);
   private readonly t = inject(TranslocoService);
+  private readonly languageResolver = inject(LanguageResolverService);
   private readonly filteredBooks = computed(() => {
     if (this.bookService.isBooksLoading()) {
       return [];
@@ -218,10 +129,10 @@ export class LanguageChartComponent {
     const languageCounts = new Map<string, number>();
 
     books.forEach(book => {
-      const language = book.metadata?.language?.trim().toLowerCase();
+      const language = book.metadata?.language?.trim();
       if (language) {
-        // Normalize the language to a display name
-        const normalizedKey = this.normalizeLanguage(language);
+        const resolved = this.languageResolver.resolve(language);
+        const normalizedKey = resolved?.tag ?? language.toLowerCase();
         languageCounts.set(normalizedKey, (languageCounts.get(normalizedKey) || 0) + 1);
       }
     });
@@ -231,29 +142,11 @@ export class LanguageChartComponent {
     return Array.from(languageCounts.entries())
       .map(([language, count]) => ({
         language,
-        displayName: this.getDisplayName(language),
+        displayName: this.languageResolver.displayName(language),
         count,
         percentage: (count / total) * 100
       }))
       .sort((a, b) => b.count - a.count)
       .slice(0, 15); // Show top 15 languages
-  }
-
-  private normalizeLanguage(language: string): string {
-    const lower = language.toLowerCase().trim();
-    // Check if it maps to a known language
-    if (LANGUAGE_NAMES[lower]) {
-      return lower;
-    }
-    return lower;
-  }
-
-  private getDisplayName(language: string): string {
-    const lower = language.toLowerCase();
-    if (LANGUAGE_NAMES[lower]) {
-      return LANGUAGE_NAMES[lower];
-    }
-    // Capitalize first letter if no mapping found
-    return language.charAt(0).toUpperCase() + language.slice(1);
   }
 }

--- a/frontend/src/app/shared/service/language-resolver.service.ts
+++ b/frontend/src/app/shared/service/language-resolver.service.ts
@@ -83,6 +83,10 @@ export class LanguageResolverService {
     };
   }
 
+  displayName(raw: string | null | undefined): string {
+    return this.resolve(raw)?.displayName ?? '';
+  }
+
   private canonicalize(lower: string): {base: string; tag: string} {
     const aliased = LANGUAGE_ALIASES[lower];
     if (aliased) {


### PR DESCRIPTION
## Description

This PR implements usage of the `LanguageResolverService` as added in https://github.com/grimmory-tools/grimmory/pull/2005. In all user-visible places on the frontend, the book language is now normalized to use the current users' proper localization to normalize + resolve a book's BCP-47 language code.

## Linked Issue

https://github.com/grimmory-tools/grimmory/issues/2006

## Changes

Adds use of the language resolver's display name in:
- Book browser (grid) and book browser (table)
- Book browser filters
- Series detail pages
- Metadata viewer (modal + page)
- Metadata viewer within the ebook reader (there are no corresponding metadata viewers for PDFs/comics)
- Library stats language chart

## Manual Testing Steps

1. Verify all rendered language codes now use the localized, normalized values
2. Test in a variety of languages

## Screenshots (Optional)

**Book Details**

<img width="1923" height="1485" alt="image" src="https://github.com/user-attachments/assets/12531187-30e6-4e51-bd5b-bd0df9c7405d" />

**Series Details**

<img width="1923" height="1485" alt="image" src="https://github.com/user-attachments/assets/d79b49d9-c0c3-4c01-93c8-3600b4f2fd05" />

**Book Browser (Grid)**

<img width="1923" height="1485" alt="image" src="https://github.com/user-attachments/assets/0721d50b-db05-42b5-a215-106ff84eccff" />


**Book Browser (Table)**

<img width="1923" height="1485" alt="image" src="https://github.com/user-attachments/assets/3695ecef-0cef-4d30-974a-208fd5840ab1" />

**EBook Reader Metadata Viewer**

<img width="1920" height="1485" alt="image" src="https://github.com/user-attachments/assets/dc347f29-28b0-4bb8-ae16-c71a48dac583" />


**Library Stats**

<img width="1923" height="1485" alt="image" src="https://github.com/user-attachments/assets/26b8a8f1-c59a-42c8-a06e-5f840fdaea69" />


## Additional Context (Optional)

As an FYI, I haven't deduped localized filter keys in the book filter options. This means that if a user has books w/ language `en`, `english`, and `English`, that language key will show up 3 times. Why?
- Each row represents a different language filter key value pair, and those are technically different values. We don't ever group together one filter row to many values
- I think it's helpful for admins to notice the dupes, so they can themselves manually resolve the outliers

<img width="223" height="308" alt="image" src="https://github.com/user-attachments/assets/c547682c-6aee-465c-a966-7247b4d9a94b" />
 

## AI Disclosure

N/A

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language codes now display as localized, human-readable names throughout book browsing, metadata, reading dialogs, series pages, and library statistics.
  * Language filters continue using the correct underlying language identifiers while showing clearer names.
  * Language statistics now group equivalent language aliases together more accurately.

* **Bug Fixes**
  * Improved handling of missing or unrecognized language values with sensible fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->