### PR TITLE
refactor(metadata): normalize metadata provider language fields to BCP-47

### DIFF
--- a/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
+++ b/backend/src/main/java/org/booklore/util/LanguageNormalizer.java
@@ -4,7 +4,9 @@ import com.neovisionaries.i18n.LanguageAlpha3Code;
 import com.neovisionaries.i18n.LanguageCode;
 import lombok.experimental.UtilityClass;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.IllformedLocaleException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -21,14 +23,32 @@ public class LanguageNormalizer {
         }
         String trimmed = input.trim();
 
-        String primary = BCP47_SEPARATOR.split(trimmed)[0];
+        String[] subtags = BCP47_SEPARATOR.split(trimmed);
+        String primary = resolveCode(subtags[0]);
 
-        String result = resolveCode(primary);
-        if (result == null && !primary.equals(trimmed)) {
-            result = resolveCode(trimmed);
+        if (primary == null) {
+            if (subtags.length > 1) {
+                String byFullName = resolveCode(trimmed);
+                if (byFullName != null) {
+                    return byFullName;
+                }
+            }
+            return trimmed.toLowerCase(Locale.ROOT);
         }
 
-        return result != null ? result : trimmed.toLowerCase(Locale.ROOT).strip();
+        if (subtags.length == 1) {
+            return primary;
+        }
+        return canonicalizeTag(primary, subtags);
+    }
+
+    private String canonicalizeTag(String primary, String[] subtags) {
+        String tag = primary + "-" + String.join("-", Arrays.copyOfRange(subtags, 1, subtags.length));
+        try {
+            return new Locale.Builder().setLanguageTag(tag).build().toLanguageTag();
+        } catch (IllformedLocaleException e) {
+            return primary;
+        }
     }
 
     private String resolveCode(String input) {

--- a/backend/src/test/java/org/booklore/util/LanguageNormalizerTest.java
+++ b/backend/src/test/java/org/booklore/util/LanguageNormalizerTest.java
@@ -25,9 +25,32 @@ class LanguageNormalizerTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"fr-FR,fr", "en-US,en", "pt-BR,pt", "fr_FR,fr"})
-    void bcp47Tags_extractsPrimarySubtag(String input, String expected) {
+    @CsvSource({"fr-FR,fr-FR", "en-US,en-US", "pt-BR,pt-BR", "fr_FR,fr-FR", "en-us,en-US", "PT-br,pt-BR"})
+    void bcp47Tags_preservesRegionWithCanonicalCasing(String input, String expected) {
         assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"fre-FR,fr-FR", "eng_US,en-US", "por-BR,pt-BR"})
+    void alpha3PrimarySubtag_normalizedToAlpha2KeepingRegion(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"zh-hant,zh-Hant", "zh-hans-cn,zh-Hans-CN", "sr-latn,sr-Latn"})
+    void scriptSubtags_canonicalCasing(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"en,en", "fr,fr", "eng,en", "fre,fr", "English,en", "French,fr"})
+    void bareCodesAndNames_resolveToAlpha2WithoutRegion(String input, String expected) {
+        assertEquals(expected, LanguageNormalizer.normalize(input));
+    }
+
+    @Test
+    void illFormedSubtags_fallBackToPrimaryLanguage() {
+        assertEquals("en", LanguageNormalizer.normalize("en-notarealsubtag"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Description

Language normalization previously collapsed BCP-47 tags to their ISO 639-1 subtags, discarding regional/script detail (`pt-BR` became just `pt`). Once https://github.com/grimmory-tools/grimmory/pull/2258 is in, the `LanguageResolverService` will properly handle BCP-47 tags. As a result, we should now update the language normalization for metadata providers to ISO 639-1, but preserve remaining subtags with standard BCP-47 casing (`fre_fr` -> `fr-FR`, `zh-hans-cn` -> `zh-Hans-CN`). Poorly formed trailing subtags fall back to the resolved primary language.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory/issues/2007

## Changes

- Updates the metadata language normalizer to properly output BCP-47 aligned language tags

## Manual Testing Steps

1. Verify that fetched languages from metadata sources properly format to BCP-47 tags

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language recognition for standardized language tags.
  * Regional information is now preserved when valid, including country and script details.
  * Added support for three-letter language codes and language names.
  * Invalid or malformed tags now fall back gracefully to the recognized primary language.
* **Tests**
  * Expanded coverage for language codes, names, regions, scripts, and invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->