### PR TITLE
fix(ui): add angular query params for breadcrumb navigation

### DIFF
--- a/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.ts
+++ b/frontend/src/app/shared/layout/layout-mobile-topbar/app.mobile-topbar.component.ts
@@ -39,7 +39,9 @@ export class AppMobileTopbarComponent {
   goBack(): void {
     const backTarget = this.backTarget();
     if (backTarget) {
-      this.router.navigate([...backTarget.commands]);
+      this.router.navigate([...backTarget.commands], {
+        queryParamsHandling: backTarget.queryParamsHandling,
+      });
     }
   }
 }

--- a/frontend/src/app/shared/layout/page-header/app.page-header-breadcrumbs.component.ts
+++ b/frontend/src/app/shared/layout/page-header/app.page-header-breadcrumbs.component.ts
@@ -93,6 +93,7 @@ const COLLAPSE_AFTER_ITEMS = 4;
           class="inline-flex min-h-6 min-w-0 max-w-40 items-center rounded px-1 text-inherit transition-colors duration-150 hover:bg-text/8 hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary md:max-w-72"
           [ngClass]="mobile() ? touchTargetClass : ''"
           [routerLink]="routeCommands(breadcrumb)"
+          [queryParamsHandling]="breadcrumb.queryParamsHandling"
         >
           <span class="truncate">{{ breadcrumb.label }}</span>
         </a>
@@ -119,7 +120,7 @@ export class AppPageHeaderBreadcrumbsComponent {
   readonly touchTargetClass = "relative after:absolute after:inset-x-0 after:-inset-y-3 after:content-['']";
 
   private readonly router = inject(Router);
-  private readonly hiddenBreadcrumbMenu = viewChild<AppMenuComponent>('hiddenBreadcrumbMenu');
+  protected readonly hiddenBreadcrumbMenu = viewChild<AppMenuComponent>('hiddenBreadcrumbMenu');
 
   readonly backButton = computed(() => {
     if (this.mobile()) return null;
@@ -134,7 +135,9 @@ export class AppPageHeaderBreadcrumbsComponent {
 
   navigate(breadcrumb: PageHeaderBreadcrumb): void {
     if (breadcrumb.commands?.length) {
-      this.router.navigate([...breadcrumb.commands]);
+      this.router.navigate([...breadcrumb.commands], {
+        queryParamsHandling: breadcrumb.queryParamsHandling,
+      });
     }
   }
 
@@ -143,8 +146,7 @@ export class AppPageHeaderBreadcrumbsComponent {
   }
 
   toggleHiddenBreadcrumbs(event: MouseEvent): void {
-    const menu = this.hiddenBreadcrumbMenu();
-    if (!menu) return;
+    const menu = this.hiddenBreadcrumbMenu()!;
     const origin = event.currentTarget as HTMLElement;
     if (menu.openerElement() === origin) {
       menu.close();

--- a/frontend/src/app/shared/layout/page-header/page-header.service.ts
+++ b/frontend/src/app/shared/layout/page-header/page-header.service.ts
@@ -1,9 +1,11 @@
 import {computed, Injectable, type Signal, signal} from '@angular/core';
+import {type QueryParamsHandling} from '@angular/router';
 import {type TabItem} from '../../ui/tabs/app-tabs.component';
 
 export interface PageHeaderBreadcrumb {
   label: string;
   commands?: readonly unknown[];
+  queryParamsHandling?: QueryParamsHandling;
 }
 
 export interface PageHeader {
@@ -17,6 +19,7 @@ export interface PageHeader {
 export interface PageHeaderTopbarBackTarget {
   label: string;
   commands: readonly unknown[];
+  queryParamsHandling?: QueryParamsHandling;
 }
 
 export interface PageHeaderMobileTopbar {
@@ -41,7 +44,13 @@ export class PageHeaderService {
 
     const parent = header.breadcrumbs?.at(-2);
     const title = header.breadcrumbs?.at(-1)?.label ?? header.title;
-    const backTarget = parent?.commands?.length ? {label: parent.label, commands: parent.commands} : undefined;
+    const backTarget = parent?.commands?.length
+      ? {
+          label: parent.label,
+          commands: parent.commands,
+          queryParamsHandling: parent.queryParamsHandling,
+        }
+      : undefined;
 
     return {title, backTarget};
   });


### PR DESCRIPTION
## Description

Slight tweaks to the page header's breadcrumb so that back button and other navigation preserves the URL. Found when developing the browser UI now that all facet params are carried through the URL. 

## Linked Issue

N/A - Part of #2031 

## Changes

- Add angular query params handling to the header breadcrumb's nav action. 
- Small null guard cleanup in the same file

## Manual Testing Steps

Easiest to see on the 90-core browser branch when navigating back/forth from the new browser with the header breadcrumb - are all sort/filter preferences saved in the URL during navigation.

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumb links and mobile back navigation now preserve query parameters when navigating.
  * Page-header navigation consistently retains each destination’s query-parameter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->