### PR TITLE
refactor(ui): radio group button icon support

### DIFF
--- a/frontend/src/app/shared/ui/radio-group/app-radio-group.component.ts
+++ b/frontend/src/app/shared/ui/radio-group/app-radio-group.component.ts
@@ -10,6 +10,7 @@ import {
   viewChildren,
 } from '@angular/core';
 import { type FormValueControl } from '@angular/forms/signals';
+import { LucideDynamicIcon, type LucideIconData } from '@lucide/angular';
 import { cn } from '../cn';
 import { AppControlTransitionDirective } from '../control.styles';
 import { APP_FIELD } from '../field/app-field.context';
@@ -25,6 +26,7 @@ import {
 export interface RadioOption<T> {
   readonly value: T;
   readonly label: string;
+  readonly icon?: LucideIconData;
   readonly description?: string;
   readonly disabled?: boolean;
 }
@@ -35,7 +37,7 @@ let nextGroupId = 0;
 @Component({
   selector: 'app-radio-group',
   standalone: true,
-  imports: [AppControlTransitionDirective],
+  imports: [AppControlTransitionDirective, LucideDynamicIcon],
   host: { class: 'block' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -62,6 +64,9 @@ let nextGroupId = 0;
             (change)="onSelect(option)"
             (blur)="touched.set(true)" />
           @if (variant() === 'segmented') {
+            @if (option.icon; as optionIcon) {
+              <svg [lucideIcon]="optionIcon" [class]="segmentIconClass" aria-hidden="true"></svg>
+            }
             <span class="truncate leading-none">{{ option.label }}</span>
           } @else {
             <span appControlTransition [class]="dotClass()" aria-hidden="true"></span>
@@ -127,6 +132,7 @@ export class AppRadioGroupComponent<T> implements FormValueControl<T | null> {
       this.variant() === 'card' && 'peer-checked:text-primary-text',
     ),
   );
+  protected readonly segmentIconClass = 'size-[1em] shrink-0';
 
   protected isSelected(option: RadioOption<T>): boolean {
     const value = this.value();


### PR DESCRIPTION
## Description

Adds the ability to use icons in the radio group's button variant 

## Linked Issue

N/A - Part of #2031 

## Changes

- Adds lucide dynamic icon support for the radio control's button variant, matching the other standalone button components. 

## Manual Testing Steps

N/A

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
<img width="183" height="57" alt="Screenshot 2026-08-06 at 08 23 22" src="https://github.com/user-attachments/assets/7ffc2566-d701-47b0-a442-bd004e4a7525" />

## Additional Context (Optional)

Used for the browser UI

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional icon support for radio group options.
  * Icons are now displayed in segmented radio group controls.
  * Standardized icon styling for consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->