### PR TITLE
fix(ui): page header scrolling and size polish

### DIFF
--- a/frontend/src/app/shared/layout/page-header/app.page-header.component.ts
+++ b/frontend/src/app/shared/layout/page-header/app.page-header.component.ts
@@ -1,5 +1,6 @@
 import {
   afterRenderEffect,
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -41,8 +42,10 @@ export class AppPageHeaderComponent {
 
   readonly isMobile = computed(() => !this.layoutService.isDesktop());
   private readonly stuck = signal(false);
+  readonly isStuck = this.stuck.asReadonly();
 
   readonly pageHeader = input<PageHeader | null>(null);
+  readonly stuckHairline = input(true, {transform: booleanAttribute});
   readonly tabChange = output<string>();
 
   readonly leadMedia = contentChild<TemplateRef<unknown>>('pageHeaderLead');
@@ -89,13 +92,14 @@ export class AppPageHeaderComponent {
       case 'stacked':
         return cn('flex flex-wrap items-start gap-x-6 gap-y-4 pt-0.5 pb-5', pbForTabs, collapseWhenEmpty);
       default:
-        return cn('flex flex-wrap items-start gap-x-6 gap-y-4 pt-7', pbForTabs ?? 'pb-6', collapseWhenEmpty);
+        return cn('flex flex-wrap items-center gap-x-6 gap-y-4 pt-5', pbForTabs ?? 'pb-5', collapseWhenEmpty);
     }
   });
   readonly stickyRegionClass = computed(() =>
     cn(
-      'app-page-header-sticky-region sticky z-30 bg-page',
-      !this.hasTabs() && this.stuck() && 'border-b border-border/70',
+      'app-page-header-sticky-region sticky z-30 bg-page -mx-4 px-4 md:-mx-8 md:px-8 -mb-4 md:-mb-6',
+      !this.hasTabs() && this.stuck() && this.stuckHairline() &&
+        'shadow-[0_1px_0_0_color-mix(in_srgb,var(--color-border)_70%,transparent)]',
       this.isMobile() ? 'top-[var(--mobile-topbar-height)]' : 'top-0',
       this.barCollapsible() && 'has-[.app-page-header-controls:empty]:hidden',
     ),


### PR DESCRIPTION
## Description

Small tweaks to the page header during browser UI development. 

## Linked Issue

N/A - Part of #2031 

## Changes

- Tweaked the hairline divider to a shadow, and added the ability for pages to disable it. useful for pages which add secondary sticky elements (E.g. the new browser's active facet bar)
- Added the sticky scrolling state as a public `isStuck` for pages to use when deciding layout. 
- Used negative margins to fix conflicting padding between the page and the header
- Default spacing tightened on desktop. 

## Manual Testing Steps

N/A - Part of the browser UI branch for reference.

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable hairline effect for sticky page headers.
  * Exposed the header’s sticky state for improved responsive behavior.

* **Style**
  * Refined desktop header spacing and sticky-region styling.
  * Replaced the bottom border with a conditional shadow effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->