### PR TITLE
fix(ui): overlay, menu and button polish

### DIFF
--- a/frontend/src/app/features/command-palette/command-palette.component.ts
+++ b/frontend/src/app/features/command-palette/command-palette.component.ts
@@ -12,6 +12,7 @@ import { LucideSearch, LucideX } from '@lucide/angular';
 import { CoverComponent } from '../../shared/components/cover/cover.component';
 import { IconDisplayComponent } from '../../shared/components/icon-display/icon-display.component';
 import { MOBILE_SHELL_ACTIVE_PROPERTY } from '../../shared/layout/layout.service';
+import { scrollLockStrategy } from '../../shared/ui/scroll-lock';
 import { PaletteItem } from './command-palette.model';
 import { CommandPaletteService } from './command-palette.service';
 
@@ -164,7 +165,7 @@ export class CommandPaletteComponent {
     this.refreshAvailableHeight();
     this.overlayRef = this.overlay.create({
       positionStrategy: this.buildPositionStrategy(),
-      scrollStrategy: this.overlay.scrollStrategies.block(),
+      scrollStrategy: scrollLockStrategy(),
       hasBackdrop: true,
       backdropClass: 'command-palette-backdrop',
       panelClass: 'command-palette-panel',

--- a/frontend/src/app/shared/ui/button/app-button.variants.ts
+++ b/frontend/src/app/shared/ui/button/app-button.variants.ts
@@ -63,7 +63,7 @@ export const buttonVariants = cva(
       {
         tone: 'neutral',
         variant: 'ghost',
-        class: `bg-transparent border-transparent text-text-secondary ${neutralSurfaceHoverClass} hover:text-text-strong`,
+        class: 'bg-transparent border-transparent text-text-secondary hover:bg-surface-hover hover:text-text-strong',
       },
       { tone: 'primary', variant: 'ghost', class: 'bg-transparent border-transparent text-primary hover:bg-primary/10' },
       { tone: 'danger', variant: 'ghost', class: 'bg-transparent border-transparent text-danger hover:bg-danger/10' },

--- a/frontend/src/app/shared/ui/menu/menu.styles.ts
+++ b/frontend/src/app/shared/ui/menu/menu.styles.ts
@@ -19,7 +19,7 @@ export const appMenuSheetPanelClass =
   'rounded-t-xl rounded-b-none border-x-0 border-b-0 ' +
   'pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]';
 
-export const appMenuScrollRegionClass = 'flex min-h-0 flex-col overflow-x-hidden overflow-y-auto overscroll-contain';
+export const appMenuScrollRegionClass = 'flex min-h-0 flex-col overflow-y-auto overscroll-contain';
 
 export const appMenuSheetPaneClass = 'will-change-transform animate-in-sheet slide-in-from-bottom-full';
 
@@ -53,7 +53,7 @@ export function appMenuItemRowClass(variant: AppMenuItemVariant): string {
 
 export const appMenuLeadingSlotClass = 'flex size-4 shrink-0 items-center justify-center text-text-muted';
 export const appMenuBadgeSlotClass = cn(appMenuLeadingSlotClass, 'text-xs font-medium tabular-nums');
-export const appMenuIconClass = 'size-4 shrink-0';
+export const appMenuIconClass = 'size-3.5 shrink-0';
 export const appMenuSpinnerClass = 'size-4 shrink-0 border-2';
 export const appMenuLabelClass = 'min-w-0 flex-1 truncate leading-5';
 export const appMenuShortcutClass = overlayListShortcutClass;

--- a/frontend/src/app/shared/ui/overlay-list.styles.ts
+++ b/frontend/src/app/shared/ui/overlay-list.styles.ts
@@ -8,7 +8,7 @@ const overlayListItemStateClass = 'hover:bg-surface-hover hover:text-text-strong
 export const overlayListActiveItemStateClass = 'bg-surface-hover text-text-strong';
 export const overlayListItemRowClass =
   'flex min-h-7 w-full select-none items-center gap-2 px-2 py-1 text-sm leading-5 text-inherit no-underline outline-hidden ' +
-  'pointer-coarse:min-h-11 pointer-coarse:px-3';
+  'touch-manipulation pointer-coarse:min-h-11 pointer-coarse:px-3';
 export const overlayListItemContentClass = cn(
   'rounded-sm text-text',
   overlayListItemStateClass,


### PR DESCRIPTION
## Description

Small UI refinements done as part of the browser UI rework for visual refinement and accessibility. 

## Linked Issue

N/A - Part of #2031 

## Changes

- Use the correct scroll lock behaviour in the command palette, identical to other dropdowns / menus. Avoids any potential layout shift when opening search from any scrollbar visibility. 
- Refined ghost button's hover to use the standard UI hover token
- Shrunk menu icons in `app-menu` from `size-4` -> `size-3.5` for visual balance
- Add `touch-manipulation` to overlay list rows, removing the 300ms delay on mobile touchscreen between tap and action, and avoiding spurious double tap zooms. 

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined menu presentation with slightly smaller icons and improved horizontal content handling.
  * Improved touch responsiveness for overlay list items.
  * Standardized the neutral ghost button hover appearance.

* **Bug Fixes**
  * Improved command palette scrolling behavior to prevent unintended page movement while the palette is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->