### PR TITLE
fix(ui): drop file size link that does not work

### DIFF
--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.html
@@ -616,7 +616,7 @@
               <div class="metadata-item">
                 <span class="metadata-key">{{ t('fileSizeLabel') }}</span>
                 @if (book?.primaryFile?.fileSizeKb) {
-                  <span class="metadata-value metadata-link" role="button" tabindex="0" (click)="goToFileSizeRange(book?.primaryFile?.fileSizeKb!)" (keydown.enter)="goToFileSizeRange(book?.primaryFile?.fileSizeKb!)">
+                  <span class="metadata-value">
                     {{ formatFileSize(book?.primaryFile) }}
                   </span>
                 } @else {

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-viewer.component.ts
@@ -29,7 +29,7 @@ import {BookDialogHelperService} from '../../../../book/components/book-browser/
 import {LibraryService} from '../../../../book/service/library.service';
 import {TagColor, TagComponent} from '../../../../../shared/components/tag/tag.component';
 import {TaskHelperService} from '../../../../settings/task-management/task-helper.service';
-import {AGE_RATING_OPTIONS, CONTENT_RATING_LABELS, fileSizeRanges, matchScoreRanges, pageCountRanges} from '../../../../book/components/book-browser/book-filter/book-filter.config';
+import {AGE_RATING_OPTIONS, CONTENT_RATING_LABELS, matchScoreRanges, pageCountRanges} from '../../../../book/components/book-browser/book-filter/book-filter.config';
 import {BookNavigationService} from '../../../../book/service/book-navigation.service';
 import {BookMetadataHostService} from '../../../../../shared/service/book-metadata-host.service';
 import {AppSettingsService} from '../../../../../shared/service/app-settings.service';
@@ -870,13 +870,6 @@ export class MetadataViewerComponent implements OnInit, AfterViewChecked {
     const range = pageCountRanges.find(r => pageCount >= r.min && pageCount < r.max);
     if (range) {
       this.handleMetadataClick('pageCount', range.id.toString());
-    }
-  }
-
-  goToFileSizeRange(fileSizeKb: number): void {
-    const range = fileSizeRanges.find(r => fileSizeKb >= r.min && fileSizeKb < r.max);
-    if (range) {
-      this.handleMetadataClick('fileSize', range.id.toString());
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the file size link in the metadata viewer links to a feature that does not operate as expected and is easier to remove than it is to implement

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2265

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

Drops file size filter link from UI of metadata

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Load metadata
2. No more link

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
This UX flow was confusing anyway and given it doesn't work and we will be reworking things soon anyway I felt it was best to drop it

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * File-size metadata is now displayed as plain formatted text instead of a clickable link.
  * Removed navigation from the metadata viewer to file-size range filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->