### PR TITLE
fix(komga): add catch-alls for komga endpoint

### DIFF
--- a/backend/src/main/java/org/booklore/controller/KomgaController.java
+++ b/backend/src/main/java/org/booklore/controller/KomgaController.java
@@ -2,13 +2,16 @@ package org.booklore.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.config.JacksonConfig;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.config.security.userdetails.OpdsUserDetails;
 import org.booklore.exception.ApiError;
+import org.booklore.exception.ErrorResponse;
 import org.booklore.mapper.komga.KomgaMapper;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.komga.KomgaBookDto;
@@ -22,11 +25,13 @@ import org.booklore.service.komga.KomgaService;
 import org.booklore.service.opds.OpdsUserV2Service;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
@@ -239,5 +244,46 @@ public class KomgaController {
             @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "Return all collections without paging") @RequestParam(defaultValue = "false") boolean unpaged) {
         return writeJson(komgaService.getCollections(page, size, unpaged));
+    }
+
+    @Operation(summary = "Unimplemented Komga API Endpoints")
+    @ApiResponse(responseCode = "501", description = "Not Implemented")
+    @RequestMapping(
+            value={
+                    "/v1/readlists",
+                    "/v1/series/new",
+                    "/v1/series/updated",
+                    "/v1/series/list",
+                    "/v1/series/genres",
+                    "/v1/books/ondeck",
+                    "/v1/books/list",
+                    "/v1/books/*/readlists",
+                    "/v1/books/*/manifest",
+            },
+            method = {RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE, RequestMethod.PATCH}
+    )
+    public ResponseEntity<ErrorResponse> notImplemented() {
+        return ResponseEntity
+                .status(HttpStatus.NOT_IMPLEMENTED)
+                .body(
+                        new ErrorResponse(
+                            HttpStatus.NOT_IMPLEMENTED.value(),
+                            "Not Implemented"
+                        )
+                );
+    }
+
+    @Operation(summary = "Catch-all for Komga API", description = "Catch-all endpoint for unhandled Komga API requests.")
+    @ApiResponse(responseCode = "404", description = "Not Found")
+    @RequestMapping(value = "/**", method = {RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE, RequestMethod.PATCH})
+    public ResponseEntity<?> catchAll() {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(
+                        new ErrorResponse(
+                                HttpStatus.NOT_FOUND.value(),
+                                "Not Found"
+                        )
+                );
     }
 }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
updates the komga controller to emit an HTTP 501 for known unimplemented endpoints, and an HTTP 404 for all other URLs

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2267

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. enabled opds + komga & set up user
2. accessed /komga/api/v1/books/foo/readlists & see 501
3. accessed /komga/api/v1/something-else & see 404

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

Example 501

```
{"message":"Not Implemented","status":501,"timestamp":"2026-08-06T21:33:11.023021279"}
```

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responses for unsupported Komga API routes with clear “Not Implemented” status information.
  * Added consistent 404 error responses for unrecognized requests, making routing errors easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->