### PR TITLE
fix(epub): support cover edits when no previous cover

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -10,6 +10,7 @@ import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.service.ArchiveService;
 import org.booklore.service.appsettings.AppSettingService;
+import org.booklore.util.MimeDetector;
 import org.booklore.util.SecureXmlUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,10 +30,12 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -45,9 +48,7 @@ import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import java.util.function.Predicate;
-import java.io.UncheckedIOException;
 
 @Slf4j
 @Component
@@ -86,8 +87,7 @@ public class EpubMetadataWriter implements MetadataWriter {
             DocumentBuilder builder = SecureXmlUtils.createSecureDocumentBuilder(true);
             Document opfDoc = builder.parse(opfFile);
 
-            NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
-            Element metadataElement = (Element) metadataList.item(0);
+            Element metadataElement = getOrCreateMetadataElement(opfDoc);
             final String DC_NS = "http://purl.org/dc/elements/1.1/";
 
             boolean[] hasChanges = {false};
@@ -225,6 +225,7 @@ public class EpubMetadataWriter implements MetadataWriter {
                 organizeMetadataElements(metadataElement);
                 removeInvalidMetaRefines(metadataElement, opfDoc);
                 removeEmptyTextNodes(opfDoc);
+                organizePackageElements(opfDoc);
                 Transformer transformer = TransformerFactory.newInstance().newTransformer();
                 transformer.setOutputProperty(OutputKeys.INDENT, "yes");
                 transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
@@ -276,13 +277,61 @@ public class EpubMetadataWriter implements MetadataWriter {
         if (replaceElementText(doc, parent, tag, ns, val, false)) flag[0] = true;
     }
 
-    private void replaceMetaElement(Element metadataElement, Document doc, String name, String newVal, boolean[] flag) {
-        String existing = getMetaContentByName(metadataElement, name);
-        if (!Objects.equals(existing, newVal)) {
-            removeMetaByName(metadataElement, name);
-            if (newVal != null) metadataElement.appendChild(createMetaElement(doc, name, newVal));
-            flag[0] = true;
+    private Optional<Element> getElement(Element parent, String namespace, String tagName) {
+        NodeList metadataElements = parent.getElementsByTagNameNS(namespace, tagName);
+
+        for (int i = 0; i < metadataElements.getLength(); i++ ) {
+            if (metadataElements.item(i) instanceof Element element) {
+                return Optional.of(element);
+            }
         }
+
+        return Optional.empty();
+    }
+
+    private Element getOrCreateElement(Element parent, String namespace, String tagName) {
+        return getElement(parent, namespace, tagName)
+                .orElseGet(() -> {
+                    Element element = parent.getOwnerDocument().createElementNS(namespace, tagName);
+                    parent.appendChild(element);
+                    return element;
+                });
+    }
+
+    private Element getOrCreateMetadataElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "metadata");
+    }
+
+    public Element getOrCreateManifestElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "manifest");
+    }
+
+    public Element getOrCreateSpineElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "spine");
+    }
+
+    private Element upsertMetaElement(Document doc, String name, String content) {
+        var metadata = getOrCreateMetadataElement(doc);
+
+        NodeList metaElements = metadata.getElementsByTagName("meta");
+        for (int i = 0; i < metaElements.getLength(); i++) {
+            if (metaElements.item(i) instanceof Element element) {
+                if (!name.equals(element.getAttribute("name"))) {
+                    continue;
+                }
+
+                // Found target.
+                element.setAttribute("content", content);
+                return element;
+            }
+        }
+
+        // We couldn't find any meta element so we can create it.
+        Element element = doc.createElement("meta");
+        element.setAttribute("name", name);
+        element.setAttribute("content", content);
+        metadata.appendChild(element);
+        return element;
     }
 
     private boolean replaceElementText(Document doc, Element parent, String tagName, String namespaceURI, String newValue, boolean restoreMode) {
@@ -379,6 +428,7 @@ public class EpubMetadataWriter implements MetadataWriter {
             applyCoverImageToEpub(tempDir, opfDoc, coverData);
 
             removeEmptyTextNodes(opfDoc);
+            organizePackageElements(opfDoc);
             Transformer transformer = TransformerFactory.newInstance().newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
@@ -406,37 +456,57 @@ public class EpubMetadataWriter implements MetadataWriter {
         return BookFileType.EPUB;
     }
 
-    private void applyCoverImageToEpub(Path tempDir, Document opfDoc, byte[] coverData) throws IOException {
-        NodeList manifestList = opfDoc.getElementsByTagNameNS(OPF_NS, "manifest");
-        if (manifestList.getLength() == 0) {
-            throw new IOException("No <manifest> element found in OPF document.");
+    private String generateCoverId(Document doc, Path dir, String extension) {
+        // Generate an ID / file combination that does not exist yet.
+        var ids = getDocumentIds(doc);
+        String coverId = "cover";
+        while(ids.contains(coverId) || Files.exists(dir.resolve(coverId + extension))) {
+            coverId = "cover-" + UUID.randomUUID().toString();
+        }
+        return coverId;
+    }
+
+    private Path getManifestItemPath(Path tempDir, Path opfDir, Element element) throws IOException {
+        String href = element.getAttribute("href");
+        String decodedHref = URLDecoder.decode(href, StandardCharsets.UTF_8);
+        if (decodedHref == null || decodedHref.isBlank()) {
+            throw new IOException("Manifest item has no href attribute");
         }
 
-        Element manifest = (Element) manifestList.item(0);
+        Path filePath = opfDir.resolve(decodedHref).normalize();
+
+        if (!filePath.startsWith(tempDir)) {
+            throw new IOException("Manifest item file may not be outside the epub archive");
+        }
+
+        return filePath;
+    }
+
+    private void applyCoverImageToEpub(Path tempDir, Document opfDoc, byte[] coverData) throws IOException {
+        String mediaType = MimeDetector.detect(new ByteArrayInputStream(coverData));
+        String extension = MimeDetector.getExtension(mediaType);
+
+        Element metadataElement = getOrCreateMetadataElement(opfDoc);
+        Element manifestElement = getOrCreateManifestElement(opfDoc);
         Element existingCoverItem = null;
 
         // First, try to find cover via metadata reference (EPUB 3 style)
-        NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
-        if (metadataList.getLength() > 0) {
-            Element metadataElement = (Element) metadataList.item(0);
-            String coverItemId = getMetaContentByName(metadataElement, "cover");
-
-            if (coverItemId != null && !coverItemId.isBlank()) {
-                // Find the item with this id
-                NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
-                for (int i = 0; i < items.getLength(); i++) {
-                    Element item = (Element) items.item(i);
-                    if (coverItemId.equals(item.getAttribute("id"))) {
-                        existingCoverItem = item;
-                        break;
-                    }
+        String coverItemId = getMetaContentByName(metadataElement, "cover");
+        if (coverItemId != null && !coverItemId.isBlank()) {
+            // Find the item with this id
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
+            for (int i = 0; i < items.getLength(); i++) {
+                Element item = (Element) items.item(i);
+                if (coverItemId.equals(item.getAttribute("id"))) {
+                    existingCoverItem = item;
+                    break;
                 }
             }
         }
 
         // If not found, try looking for properties="cover-image" (EPUB 3)
         if (existingCoverItem == null) {
-            NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
             for (int i = 0; i < items.getLength(); i++) {
                 Element item = (Element) items.item(i);
                 String properties = item.getAttribute("properties");
@@ -449,7 +519,7 @@ public class EpubMetadataWriter implements MetadataWriter {
 
         // If still not found, try common id values (EPUB 2 fallback)
         if (existingCoverItem == null) {
-            NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
             for (int i = 0; i < items.getLength(); i++) {
                 Element item = (Element) items.item(i);
                 String itemId = item.getAttribute("id");
@@ -460,16 +530,6 @@ public class EpubMetadataWriter implements MetadataWriter {
             }
         }
 
-        if (existingCoverItem == null) {
-            throw new IOException("No cover item found in manifest");
-        }
-
-        String coverHref = existingCoverItem.getAttribute("href");
-        String decodedCoverHref = URLDecoder.decode(coverHref, StandardCharsets.UTF_8);
-        if (decodedCoverHref == null || decodedCoverHref.isBlank()) {
-            throw new IOException("Cover item has no href attribute");
-        }
-
         Path opfPath;
         try {
             opfPath = findOpfPath(tempDir);
@@ -478,7 +538,69 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
 
         Path opfDir = opfPath.getParent();
-        Path coverFilePath = opfDir.resolve(decodedCoverHref).normalize();
+
+        if (existingCoverItem != null) {
+            try {
+                getManifestItemPath(tempDir, opfDir, existingCoverItem);
+            } catch (IOException e) {
+                log.warn("Invalid cover for epub, ignoring", e);
+                existingCoverItem = null;
+            }
+        }
+
+        if (existingCoverItem == null) {
+            // If there is no existing cover item, we should create one.
+            String coverId = generateCoverId(opfDoc, opfDir, extension);
+
+            existingCoverItem = opfDoc.createElementNS(OPF_NS, "item");
+            existingCoverItem.setAttribute("id", coverId);
+            existingCoverItem.setAttribute("media-type", mediaType);
+            existingCoverItem.setAttribute("href", coverId + extension);
+
+            // Add the item and set the
+            manifestElement.appendChild(existingCoverItem);
+            upsertMetaElement(opfDoc, "cover", coverId);
+        }
+
+        // Remove all item's epub3 `properties` containing `cover-image`.
+        NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
+        for (int i = 0; i < items.getLength(); i++) {
+            if (items.item(i) instanceof Element item) {
+                // Remember: the `properties` attribute is a space delimited list,
+                // so we can't clear it entirely.
+                String properties = Arrays.stream(
+                            item.getAttribute("properties")
+                                    .trim()
+                                    .split("\\s+")
+                        )
+                        .filter(s -> !"cover-image".equals(s))
+                        .collect(Collectors.joining(" "));
+
+                if (properties.isBlank()) {
+                    item.removeAttribute("properties");
+                } else {
+                    item.setAttribute("properties", properties);
+                }
+            }
+        }
+
+        boolean isEpub3 = isEpub3(opfDoc);
+
+        if (isEpub3) {
+            // Add epub3 properties cover-image back to the target cover item.
+            String properties = existingCoverItem.getAttribute("properties")
+                    .trim();
+
+            if (properties.isBlank()) {
+                properties = "cover-image";
+            } else {
+                properties += " cover-image";
+            }
+
+            existingCoverItem.setAttribute("properties", properties);
+        }
+
+        Path coverFilePath = getManifestItemPath(tempDir, opfDir, existingCoverItem);
 
         Files.createDirectories(coverFilePath.getParent());
         Files.write(coverFilePath, coverData);
@@ -597,12 +719,7 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
     }
 
-    private void removeInvalidMetaRefines(Element metadataElement, Document doc) {
-        // In an ideal world we could set the `validating` flag or
-        // otherwise set the `isId` attribute tag correctly for `id`
-        // but because we cannot, we can't use `getElementById()` on
-        // the document.  With that in mind, we area going to read all
-        // tags, check if they have an `id`, and store that in a `Set`
+    private Set<String> getDocumentIds(Document doc) {
         Set<String> ids = new HashSet<>();
 
         NodeList nodes = doc.getElementsByTagName("*");
@@ -616,6 +733,17 @@ public class EpubMetadataWriter implements MetadataWriter {
                 }
             }
         }
+
+        return ids;
+    }
+
+    private void removeInvalidMetaRefines(Element metadataElement, Document doc) {
+        // In an ideal world we could set the `validating` flag or
+        // otherwise set the `isId` attribute tag correctly for `id`
+        // but because we cannot, we can't use `getElementById()` on
+        // the document.  With that in mind, we area going to read all
+        // tags, check if they have an `id`, and store that in a `Set`
+        var ids = getDocumentIds(doc);
 
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
         for (int i = metas.getLength() - 1; i >= 0; i--) {
@@ -1199,6 +1327,26 @@ public class EpubMetadataWriter implements MetadataWriter {
                 metadataElement.removeChild(meta);
             }
         }
+    }
+
+    private void organizePackageElements(Document document) {
+        // Per the epubcheck dtd:
+        // <package> must have as children elements, in this order:
+        //     <metadata>, <manifest>, and <spine>, and optionally may
+        //     include <tours> and/or <guide>.
+        Element metadata = getOrCreateMetadataElement(document);
+        Element manifest = getOrCreateManifestElement(document);
+        Element spine = getOrCreateSpineElement(document);
+        Optional<Element> tours = getElement(document.getDocumentElement(), OPF_NS, "tours");
+        Optional<Element> guide = getElement(document.getDocumentElement(), OPF_NS, "guide");
+
+        Element packageElement = document.getDocumentElement();
+
+        packageElement.appendChild(metadata);
+        packageElement.appendChild(manifest);
+        packageElement.appendChild(spine);
+        tours.ifPresent(packageElement::appendChild);
+        guide.ifPresent(packageElement::appendChild);
     }
 
     private void organizeMetadataElements(Element metadataElement) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -10,6 +10,7 @@ import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.service.ArchiveService;
 import org.booklore.service.appsettings.AppSettingService;
+import org.booklore.util.MimeDetector;
 import org.booklore.util.SecureXmlUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,10 +30,12 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -45,9 +48,7 @@ import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import java.util.function.Predicate;
-import java.io.UncheckedIOException;
 
 @Slf4j
 @Component
@@ -86,8 +87,7 @@ public class EpubMetadataWriter implements MetadataWriter {
             DocumentBuilder builder = SecureXmlUtils.createSecureDocumentBuilder(true);
             Document opfDoc = builder.parse(opfFile);
 
-            NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
-            Element metadataElement = (Element) metadataList.item(0);
+            Element metadataElement = getOrCreateMetadataElement(opfDoc);
             final String DC_NS = "http://purl.org/dc/elements/1.1/";
 
             boolean[] hasChanges = {false};
@@ -225,6 +225,7 @@ public class EpubMetadataWriter implements MetadataWriter {
                 organizeMetadataElements(metadataElement);
                 removeInvalidMetaRefines(metadataElement, opfDoc);
                 removeEmptyTextNodes(opfDoc);
+                organizePackageElements(opfDoc);
                 Transformer transformer = TransformerFactory.newInstance().newTransformer();
                 transformer.setOutputProperty(OutputKeys.INDENT, "yes");
                 transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
@@ -276,13 +277,61 @@ public class EpubMetadataWriter implements MetadataWriter {
         if (replaceElementText(doc, parent, tag, ns, val, false)) flag[0] = true;
     }
 
-    private void replaceMetaElement(Element metadataElement, Document doc, String name, String newVal, boolean[] flag) {
-        String existing = getMetaContentByName(metadataElement, name);
-        if (!Objects.equals(existing, newVal)) {
-            removeMetaByName(metadataElement, name);
-            if (newVal != null) metadataElement.appendChild(createMetaElement(doc, name, newVal));
-            flag[0] = true;
+    private Optional<Element> getElement(Element parent, String namespace, String tagName) {
+        NodeList metadataElements = parent.getElementsByTagNameNS(namespace, tagName);
+
+        for (int i = 0; i < metadataElements.getLength(); i++ ) {
+            if (metadataElements.item(i) instanceof Element element) {
+                return Optional.of(element);
+            }
         }
+
+        return Optional.empty();
+    }
+
+    private Element getOrCreateElement(Element parent, String namespace, String tagName) {
+        return getElement(parent, namespace, tagName)
+                .orElseGet(() -> {
+                    Element element = parent.getOwnerDocument().createElementNS(namespace, tagName);
+                    parent.appendChild(element);
+                    return element;
+                });
+    }
+
+    private Element getOrCreateMetadataElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "metadata");
+    }
+
+    public Element getOrCreateManifestElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "manifest");
+    }
+
+    public Element getOrCreateSpineElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "spine");
+    }
+
+    private Element upsertMetaElement(Document doc, String name, String content) {
+        var metadata = getOrCreateMetadataElement(doc);
+
+        NodeList metaElements = metadata.getElementsByTagName("meta");
+        for (int i = 0; i < metaElements.getLength(); i++) {
+            if (metaElements.item(i) instanceof Element element) {
+                if (!name.equals(element.getAttribute("name"))) {
+                    continue;
+                }
+
+                // Found target.
+                element.setAttribute("content", content);
+                return element;
+            }
+        }
+
+        // We couldn't find any meta element so we can create it.
+        Element element = doc.createElement("meta");
+        element.setAttribute("name", name);
+        element.setAttribute("content", content);
+        metadata.appendChild(element);
+        return element;
     }
 
     private boolean replaceElementText(Document doc, Element parent, String tagName, String namespaceURI, String newValue, boolean restoreMode) {
@@ -379,6 +428,7 @@ public class EpubMetadataWriter implements MetadataWriter {
             applyCoverImageToEpub(tempDir, opfDoc, coverData);
 
             removeEmptyTextNodes(opfDoc);
+            organizePackageElements(opfDoc);
             Transformer transformer = TransformerFactory.newInstance().newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
@@ -406,37 +456,57 @@ public class EpubMetadataWriter implements MetadataWriter {
         return BookFileType.EPUB;
     }
 
-    private void applyCoverImageToEpub(Path tempDir, Document opfDoc, byte[] coverData) throws IOException {
-        NodeList manifestList = opfDoc.getElementsByTagNameNS(OPF_NS, "manifest");
-        if (manifestList.getLength() == 0) {
-            throw new IOException("No <manifest> element found in OPF document.");
+    private String generateCoverId(Document doc, Path dir, String extension) {
+        // Generate an ID / file combination that does not exist yet.
+        var ids = getDocumentIds(doc);
+        String coverId = "cover";
+        while(ids.contains(coverId) || Files.exists(dir.resolve(coverId + extension))) {
+            coverId = "cover-" + UUID.randomUUID().toString();
+        }
+        return coverId;
+    }
+
+    private Path getManifestItemPath(Path tempDir, Path opfDir, Element element) throws IOException {
+        String href = element.getAttribute("href");
+        String decodedHref = URLDecoder.decode(href, StandardCharsets.UTF_8);
+        if (decodedHref == null || decodedHref.isBlank()) {
+            throw new IOException("Manifest item has no href attribute");
         }
 
-        Element manifest = (Element) manifestList.item(0);
+        Path filePath = opfDir.resolve(decodedHref).normalize();
+
+        if (!filePath.startsWith(tempDir)) {
+            throw new IOException("Manifest item file may not be outside the epub archive");
+        }
+
+        return filePath;
+    }
+
+    private void applyCoverImageToEpub(Path tempDir, Document opfDoc, byte[] coverData) throws IOException {
+        String mediaType = MimeDetector.detect(new ByteArrayInputStream(coverData));
+        String extension = MimeDetector.getExtension(mediaType);
+
+        Element metadataElement = getOrCreateMetadataElement(opfDoc);
+        Element manifestElement = getOrCreateManifestElement(opfDoc);
         Element existingCoverItem = null;
 
         // First, try to find cover via metadata reference (EPUB 3 style)
-        NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
-        if (metadataList.getLength() > 0) {
-            Element metadataElement = (Element) metadataList.item(0);
-            String coverItemId = getMetaContentByName(metadataElement, "cover");
-
-            if (coverItemId != null && !coverItemId.isBlank()) {
-                // Find the item with this id
-                NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
-                for (int i = 0; i < items.getLength(); i++) {
-                    Element item = (Element) items.item(i);
-                    if (coverItemId.equals(item.getAttribute("id"))) {
-                        existingCoverItem = item;
-                        break;
-                    }
+        String coverItemId = getMetaContentByName(metadataElement, "cover");
+        if (coverItemId != null && !coverItemId.isBlank()) {
+            // Find the item with this id
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
+            for (int i = 0; i < items.getLength(); i++) {
+                Element item = (Element) items.item(i);
+                if (coverItemId.equals(item.getAttribute("id"))) {
+                    existingCoverItem = item;
+                    break;
                 }
             }
         }
 
         // If not found, try looking for properties="cover-image" (EPUB 3)
         if (existingCoverItem == null) {
-            NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
             for (int i = 0; i < items.getLength(); i++) {
                 Element item = (Element) items.item(i);
                 String properties = item.getAttribute("properties");
@@ -449,7 +519,7 @@ public class EpubMetadataWriter implements MetadataWriter {
 
         // If still not found, try common id values (EPUB 2 fallback)
         if (existingCoverItem == null) {
-            NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
             for (int i = 0; i < items.getLength(); i++) {
                 Element item = (Element) items.item(i);
                 String itemId = item.getAttribute("id");
@@ -460,16 +530,6 @@ public class EpubMetadataWriter implements MetadataWriter {
             }
         }
 
-        if (existingCoverItem == null) {
-            throw new IOException("No cover item found in manifest");
-        }
-
-        String coverHref = existingCoverItem.getAttribute("href");
-        String decodedCoverHref = URLDecoder.decode(coverHref, StandardCharsets.UTF_8);
-        if (decodedCoverHref == null || decodedCoverHref.isBlank()) {
-            throw new IOException("Cover item has no href attribute");
-        }
-
         Path opfPath;
         try {
             opfPath = findOpfPath(tempDir);
@@ -478,7 +538,69 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
 
         Path opfDir = opfPath.getParent();
-        Path coverFilePath = opfDir.resolve(decodedCoverHref).normalize();
+
+        if (existingCoverItem != null) {
+            try {
+                getManifestItemPath(tempDir, opfDir, existingCoverItem);
+            } catch (IOException e) {
+                log.warn("Invalid cover for epub, ignoring", e);
+                existingCoverItem = null;
+            }
+        }
+
+        if (existingCoverItem == null) {
+            // If there is no existing cover item, we should create one.
+            String coverId = generateCoverId(opfDoc, opfDir, extension);
+
+            existingCoverItem = opfDoc.createElementNS(OPF_NS, "item");
+            existingCoverItem.setAttribute("id", coverId);
+            existingCoverItem.setAttribute("media-type", mediaType);
+            existingCoverItem.setAttribute("href", coverId + extension);
+
+            // Add the item and set the
+            manifestElement.appendChild(existingCoverItem);
+            upsertMetaElement(opfDoc, "cover", coverId);
+        }
+
+        // Remove all item's epub3 `properties` containing `cover-image`.
+        NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
+        for (int i = 0; i < items.getLength(); i++) {
+            if (items.item(i) instanceof Element item) {
+                // Remember: the `properties` attribute is a space delimited list,
+                // so we can't clear it entirely.
+                String properties = Arrays.stream(
+                            item.getAttribute("properties")
+                                    .trim()
+                                    .split("\\s+")
+                        )
+                        .filter(s -> !"cover-image".equals(s))
+                        .collect(Collectors.joining(" "));
+
+                if (properties.isBlank()) {
+                    item.removeAttribute("properties");
+                } else {
+                    item.setAttribute("properties", properties);
+                }
+            }
+        }
+
+        boolean isEpub3 = isEpub3(opfDoc);
+
+        if (isEpub3) {
+            // Add epub3 properties cover-image back to the target cover item.
+            String properties = existingCoverItem.getAttribute("properties")
+                    .trim();
+
+            if (properties.isBlank()) {
+                properties = "cover-image";
+            } else {
+                properties += " cover-image";
+            }
+
+            existingCoverItem.setAttribute("properties", properties);
+        }
+
+        Path coverFilePath = getManifestItemPath(tempDir, opfDir, existingCoverItem);
 
         Files.createDirectories(coverFilePath.getParent());
         Files.write(coverFilePath, coverData);
@@ -603,12 +725,7 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
     }
 
-    private void removeInvalidMetaRefines(Element metadataElement, Document doc) {
-        // In an ideal world we could set the `validating` flag or
-        // otherwise set the `isId` attribute tag correctly for `id`
-        // but because we cannot, we can't use `getElementById()` on
-        // the document.  With that in mind, we area going to read all
-        // tags, check if they have an `id`, and store that in a `Set`
+    private Set<String> getDocumentIds(Document doc) {
         Set<String> ids = new HashSet<>();
 
         NodeList nodes = doc.getElementsByTagName("*");
@@ -622,6 +739,17 @@ public class EpubMetadataWriter implements MetadataWriter {
                 }
             }
         }
+
+        return ids;
+    }
+
+    private void removeInvalidMetaRefines(Element metadataElement, Document doc) {
+        // In an ideal world we could set the `validating` flag or
+        // otherwise set the `isId` attribute tag correctly for `id`
+        // but because we cannot, we can't use `getElementById()` on
+        // the document.  With that in mind, we area going to read all
+        // tags, check if they have an `id`, and store that in a `Set`
+        var ids = getDocumentIds(doc);
 
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
         for (int i = metas.getLength() - 1; i >= 0; i--) {
@@ -1205,6 +1333,26 @@ public class EpubMetadataWriter implements MetadataWriter {
                 metadataElement.removeChild(meta);
             }
         }
+    }
+
+    private void organizePackageElements(Document document) {
+        // Per the epubcheck dtd:
+        // <package> must have as children elements, in this order:
+        //     <metadata>, <manifest>, and <spine>, and optionally may
+        //     include <tours> and/or <guide>.
+        Element metadata = getOrCreateMetadataElement(document);
+        Element manifest = getOrCreateManifestElement(document);
+        Element spine = getOrCreateSpineElement(document);
+        Optional<Element> tours = getElement(document.getDocumentElement(), OPF_NS, "tours");
+        Optional<Element> guide = getElement(document.getDocumentElement(), OPF_NS, "guide");
+
+        Element packageElement = document.getDocumentElement();
+
+        packageElement.appendChild(metadata);
+        packageElement.appendChild(manifest);
+        packageElement.appendChild(spine);
+        tours.ifPresent(packageElement::appendChild);
+        guide.ifPresent(packageElement::appendChild);
     }
 
     private void organizeMetadataElements(Element metadataElement) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -1339,12 +1339,13 @@ public class EpubMetadataWriter implements MetadataWriter {
         // Per the epubcheck dtd:
         // <package> must have as children elements, in this order:
         //     <metadata>, <manifest>, and <spine>, and optionally may
-        //     include <tours> and/or <guide>.
+        //     include <tours> and/or <guide>, then `<collection>` items.
         Element metadata = getOrCreateMetadataElement(document);
         Element manifest = getOrCreateManifestElement(document);
         Element spine = getOrCreateSpineElement(document);
         Optional<Element> tours = getElement(document.getDocumentElement(), OPF_NS, "tours");
         Optional<Element> guide = getElement(document.getDocumentElement(), OPF_NS, "guide");
+        NodeList collections = document.getDocumentElement().getElementsByTagNameNS(OPF_NS, "collection");
 
         Element packageElement = document.getDocumentElement();
 
@@ -1353,6 +1354,9 @@ public class EpubMetadataWriter implements MetadataWriter {
         packageElement.appendChild(spine);
         tours.ifPresent(packageElement::appendChild);
         guide.ifPresent(packageElement::appendChild);
+        for (int i = 0; i < collections.getLength(); i++) {
+            packageElement.appendChild(collections.item(i));
+        }
     }
 
     private void organizeMetadataElements(Element metadataElement) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -289,6 +289,19 @@ public class EpubMetadataWriter implements MetadataWriter {
         return Optional.empty();
     }
 
+    private List<Element> getElements(Element parent, String namespace, String tagName) {
+        NodeList metadataElements = parent.getElementsByTagNameNS(namespace, tagName);
+
+        List<Element> elements = new ArrayList<>();
+        for (int i = 0; i < metadataElements.getLength(); i++ ) {
+            if (metadataElements.item(i) instanceof Element element) {
+                elements.add(element);
+            }
+        }
+
+        return elements;
+    }
+
     private Element getOrCreateElement(Element parent, String namespace, String tagName) {
         return getElement(parent, namespace, tagName)
                 .orElseGet(() -> {
@@ -1345,7 +1358,7 @@ public class EpubMetadataWriter implements MetadataWriter {
         Element spine = getOrCreateSpineElement(document);
         Optional<Element> tours = getElement(document.getDocumentElement(), OPF_NS, "tours");
         Optional<Element> guide = getElement(document.getDocumentElement(), OPF_NS, "guide");
-        NodeList collections = document.getDocumentElement().getElementsByTagNameNS(OPF_NS, "collection");
+        List<Element> collections = getElements(document.getDocumentElement(), OPF_NS, "collection");
 
         Element packageElement = document.getDocumentElement();
 
@@ -1354,8 +1367,8 @@ public class EpubMetadataWriter implements MetadataWriter {
         packageElement.appendChild(spine);
         tours.ifPresent(packageElement::appendChild);
         guide.ifPresent(packageElement::appendChild);
-        for (int i = 0; i < collections.getLength(); i++) {
-            packageElement.appendChild(collections.item(i));
+        for (var collection : collections) {
+            packageElement.appendChild(collection);
         }
     }
 

--- a/backend/src/main/java/org/booklore/util/MimeDetector.java
+++ b/backend/src/main/java/org/booklore/util/MimeDetector.java
@@ -8,10 +8,40 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 
 @Slf4j
 @UtilityClass
 public class MimeDetector {
+    private static final Map<String, String> MEDIA_TYPE_EXTENSIONS = Map.ofEntries(
+            Map.entry("text/html", ".html"),
+            Map.entry("application/xhtml+xml", ".html"),
+            Map.entry("application/javascript", ".js"),
+            Map.entry("text/css", ".css"),
+            Map.entry("image/jpeg", ".jpg"),
+            Map.entry("image/png", ".png"),
+            Map.entry("image/gif", ".gif"),
+            Map.entry("image/svg+xml", ".svg"),
+            Map.entry("font/ttf", ".ttf"),
+            Map.entry("font/otf", ".otf"),
+            Map.entry("application/vnd.ms-fontobject", ".eot"),
+            Map.entry("application/xml", ".xml"),
+            Map.entry("application/x-dtbncx+xml", ".ncx"),
+            Map.entry("audio/mpeg", ".mp3"),
+            Map.entry("video/mp4", ".mp4"),
+            Map.entry("audio/mp4", ".m4a"),
+            Map.entry("audio/aac", ".aac"),
+            Map.entry("audio/wav", ".wav"),
+            Map.entry("audio/ogg", ".ogg"),
+            Map.entry("application/oebps-package+xml", ".opf"),
+            Map.entry("image/webp", ".webp"),
+            Map.entry("font/woff", ".woff"),
+            Map.entry("font/woff2", ".woff2"),
+            Map.entry("application/smil+xml", ".smil"),
+            Map.entry("audio/flac", ".flac"),
+            Map.entry("video/webm", ".webm"),
+            Map.entry("image/avif", ".avif")
+    );
 
     // Tika is thread-safe one instance for the whole app.
     private static final Tika TIKA = new Tika();
@@ -46,6 +76,10 @@ public class MimeDetector {
             log.warn("MIME detection failed for {}: {}", path, e.getMessage());
             return "application/octet-stream";
         }
+    }
+
+    public String getExtension(String mediaType) {
+        return MEDIA_TYPE_EXTENSIONS.getOrDefault(mediaType, ".bin");
     }
 
     public boolean isAudio(Path path) throws IOException {

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -148,6 +149,30 @@ class EpubMetadataWriterTest {
             String content = readOpfContent(epubFile);
             assertThat(content).doesNotContain("refines=\"#example2\"");
             assertThat(content).contains("refines=\"#example\"");
+        }
+
+        @Test
+        @DisplayName("Should sort package children in EPUB3")
+        void writeMetadata_shouldSortPackageChildren() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <manifest></manifest>
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                        </metadata>
+                    </package>""";
+
+            File epubFile = createEpubWithOpf(opfContent, "test-sort-package-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+
+            int manifestIndex = content.indexOf("<manifest");
+            int metadataIndex = content.indexOf("<metadata");
+            int spineIndex = content.indexOf("<spine");
+
+            assertThat(metadataIndex).isLessThan(manifestIndex);
+            assertThat(manifestIndex).isLessThan(spineIndex);
         }
     }
 
@@ -623,6 +648,92 @@ class EpubMetadataWriterTest {
             assertThat(content).doesNotContain("prefix=");
             // Should NOT use property= form
             assertThat(content).doesNotContain("property=\"booklore:");
+        }
+    }
+
+    @Nested
+    @DisplayName("Cover Tests")
+    class CoverTests {
+        @Test
+        void shouldCreateManifestItemIfNoneExist() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                    </package>
+                    """,
+                    "no-cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains("href=\"cover.");
+        }
+
+        @Test
+        void shouldAddEpub3CoverImageTag() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                    </package>
+                    """,
+                    "no-cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains("properties=\"cover-image\"");
+        }
+
+        @Test
+        void shouldAllowOnlyOneCoverImagePropertiesEpub3() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                        <manifest>
+                            <item href="foo" properties="cover-image" />
+                            <item href="bar" properties="cover-image" />
+                        </manifest>
+                    </package>
+                    """,
+                    "cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            var pattern = Pattern.compile("properties=\"cover-image\"");
+            var matcher = pattern.matcher(content);
+            int count = 0;
+            while (matcher.find()) {
+                count++;
+            }
+            assertThat(count).isEqualTo(1);
         }
     }
 

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -160,6 +160,7 @@ class EpubMetadataWriterTest {
                     <?xml version="1.0" encoding="UTF-8"?>
                     <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
                         <manifest></manifest>
+                        <collection></collection>
                         <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
                         </metadata>
                     </package>""";
@@ -172,9 +173,11 @@ class EpubMetadataWriterTest {
             int manifestIndex = content.indexOf("<manifest");
             int metadataIndex = content.indexOf("<metadata");
             int spineIndex = content.indexOf("<spine");
+            int collectionIndex = content.indexOf("<collection");
 
             assertThat(metadataIndex).isLessThan(manifestIndex);
             assertThat(manifestIndex).isLessThan(spineIndex);
+            assertThat(spineIndex).isLessThan(collectionIndex);
         }
     }
 

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -150,6 +151,30 @@ class EpubMetadataWriterTest {
             String content = readOpfContent(epubFile);
             assertThat(content).doesNotContain("refines=\"#example2\"");
             assertThat(content).contains("refines=\"#example\"");
+        }
+
+        @Test
+        @DisplayName("Should sort package children in EPUB3")
+        void writeMetadata_shouldSortPackageChildren() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <manifest></manifest>
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                        </metadata>
+                    </package>""";
+
+            File epubFile = createEpubWithOpf(opfContent, "test-sort-package-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+
+            int manifestIndex = content.indexOf("<manifest");
+            int metadataIndex = content.indexOf("<metadata");
+            int spineIndex = content.indexOf("<spine");
+
+            assertThat(metadataIndex).isLessThan(manifestIndex);
+            assertThat(manifestIndex).isLessThan(spineIndex);
         }
     }
 
@@ -691,6 +716,92 @@ class EpubMetadataWriterTest {
             assertThat(content).doesNotContain("prefix=");
             // Should NOT use property= form
             assertThat(content).doesNotContain("property=\"booklore:");
+        }
+    }
+
+    @Nested
+    @DisplayName("Cover Tests")
+    class CoverTests {
+        @Test
+        void shouldCreateManifestItemIfNoneExist() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                    </package>
+                    """,
+                    "no-cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains("href=\"cover.");
+        }
+
+        @Test
+        void shouldAddEpub3CoverImageTag() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                    </package>
+                    """,
+                    "no-cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains("properties=\"cover-image\"");
+        }
+
+        @Test
+        void shouldAllowOnlyOneCoverImagePropertiesEpub3() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                        <manifest>
+                            <item href="foo" properties="cover-image" />
+                            <item href="bar" properties="cover-image" />
+                        </manifest>
+                    </package>
+                    """,
+                    "cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            var pattern = Pattern.compile("properties=\"cover-image\"");
+            var matcher = pattern.matcher(content);
+            int count = 0;
+            while (matcher.find()) {
+                count++;
+            }
+            assertThat(count).isEqualTo(1);
         }
     }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
Writing epub covers would fail unexpectedly in some cases - where there was no existing cover.

The logic to add a cover item manifest in an epub file was never implemented.  It's unclear why, so this PR implements the behavior to add new manifest items in the case that no existing manifest records are valid

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1388

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
Add helper to get extensions from media types to mime detector
Implement cover manifest item creation

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Modify epub to have no cover item / ref
2. Enable write to epub
3. Search metadata for book
4. Apply cover

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

This is a precursor to fixing #1077 

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB cover handling by creating missing cover entries and selecting reliable file extensions.
  * Prevented conflicting cover identifiers and removed duplicate or invalid cover properties.
  * Ensured cover files resolve relative to the correct EPUB location.
  * Improved metadata updates by preserving existing information and creating missing entries when needed.
  * Added a safe fallback for unrecognized file types.

* **Compatibility**
  * Improved support for EPUB 2 and EPUB 3 package structures, metadata organization, manifest and spine entries, and `cover-image` declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->