### PR TITLE
chore(db): avoid warning on running migration

### DIFF
--- a/backend/src/main/resources/db/migration/V140__Create_kobo_span_map_table.sql
+++ b/backend/src/main/resources/db/migration/V140__Create_kobo_span_map_table.sql
@@ -5,7 +5,7 @@ CREATE TABLE kobo_span_map
     file_hash     VARCHAR(128)          NOT NULL,
     span_map_json LONGTEXT              NOT NULL,
     created_at    datetime              NOT NULL,
-    CONSTRAINT pk_kobo_span_map PRIMARY KEY (id),
+    PRIMARY KEY (id),
     CONSTRAINT uk_kobo_span_map_book_file UNIQUE (book_file_id)
 );
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
when running all of the migrations a warning occurs

```
DB: Name 'pk_kobo_span_map' ignored for PRIMARY key.
```

## Linked Issue

<!-- Required. Example: Fixes #123 -->
N/A

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
Removes `CONSTRAINT name` portion of the primary key definition.

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1.
2.
3.

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->

## Checklist

- [ ] This PR links and implements an accepted issue.
- [ ] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [ ] I have disclosed any AI usage as per the organization AI Policy above.
- [ ] I understand all of my submitted changes.
