### PR TITLE
fix: return 404 for EntityNotFoundException

### DIFF
--- a/backend/src/main/java/org/booklore/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/booklore/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.booklore.exception;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
@@ -73,6 +74,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException ex) {
         ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Resource not found.");
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                ex.getMessage() != null ? ex.getMessage() : "Resource not found."
+        );
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 

--- a/backend/src/test/java/org/booklore/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/org/booklore/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package org.booklore.exception;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
@@ -19,5 +20,17 @@ public class GlobalExceptionHandlerTest {
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getStatus()).isEqualTo(406);
         assertThat(response.getBody().getMessage()).isEqualTo("Acceptable representations: [application/octet-stream].");
+    }
+
+    @Test
+    void handleEntityNotFoundException_shouldReturnNotFound() {
+        var ex = new EntityNotFoundException("Annotation not found: 42");
+        var handler = new GlobalExceptionHandler();
+        var response = handler.handleEntityNotFoundException(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(404);
+        assertThat(response.getBody().getMessage()).isEqualTo("Annotation not found: 42");
     }
 }


### PR DESCRIPTION
## Description

Deleting a missing annotation raised `EntityNotFoundException`, which previously fell through to the generic handler and became HTTP 500. Clients expect a 404 for a missing resource.

## Linked Issue

Fixes #1858

## Changes

- Map `EntityNotFoundException` to HTTP 404 in `GlobalExceptionHandler` (covers annotations and other services using the same pattern).
- Add a unit test for the new handler.

## Manual Testing Steps

1. Run the unit test `handleEntityNotFoundException_shouldReturnNotFound`.
2. Start the API and call `DELETE /api/v1/annotations/{missingId}` with a non-existent id.
3. Confirm the response status is 404 (not 500) and the body carries the not-found message.

## Additional Context (Optional)

No UI changes.

## AI Disclosure

Cursor - helped draft the exception mapping, unit test, and this PR description; I reviewed all changes.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.
