### PR TITLE
fix(epub): support cover edits when media type changes

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -537,6 +537,18 @@ public class EpubMetadataWriter implements MetadataWriter {
             throw new IOException("Failed to parse container.xml to locate OPF path", e);
         }
 
+        if (existingCoverItem != null) {
+            String existingMediaType = existingCoverItem.getAttribute("media-type");
+            if (!existingMediaType.equals(mediaType)) {
+                // If the existing cover item exists but has a different media type we can't
+                // use it.  However, because it's _possible_ that the cover MAY be used elsewhere
+                // in the epub (such as referenced in HTML) we cannot delete the manifest item
+                // or the file.  All we can do is discard it as the existing cover manifest item,
+                // and treat the epub as if it has no cover, and place a new cover manifest item.
+                existingCoverItem = null;
+            }
+        }
+
         Path opfDir = opfPath.getParent();
 
         if (existingCoverItem != null) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -10,6 +10,7 @@ import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.service.ArchiveService;
 import org.booklore.service.appsettings.AppSettingService;
+import org.booklore.util.MimeDetector;
 import org.booklore.util.SecureXmlUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,10 +30,12 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -45,9 +48,7 @@ import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import java.util.function.Predicate;
-import java.io.UncheckedIOException;
 
 @Slf4j
 @Component
@@ -86,8 +87,7 @@ public class EpubMetadataWriter implements MetadataWriter {
             DocumentBuilder builder = SecureXmlUtils.createSecureDocumentBuilder(true);
             Document opfDoc = builder.parse(opfFile);
 
-            NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
-            Element metadataElement = (Element) metadataList.item(0);
+            Element metadataElement = getOrCreateMetadataElement(opfDoc);
             final String DC_NS = "http://purl.org/dc/elements/1.1/";
 
             boolean[] hasChanges = {false};
@@ -225,6 +225,7 @@ public class EpubMetadataWriter implements MetadataWriter {
                 organizeMetadataElements(metadataElement);
                 removeInvalidMetaRefines(metadataElement, opfDoc);
                 removeEmptyTextNodes(opfDoc);
+                organizePackageElements(opfDoc);
                 Transformer transformer = TransformerFactory.newInstance().newTransformer();
                 transformer.setOutputProperty(OutputKeys.INDENT, "yes");
                 transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
@@ -276,13 +277,61 @@ public class EpubMetadataWriter implements MetadataWriter {
         if (replaceElementText(doc, parent, tag, ns, val, false)) flag[0] = true;
     }
 
-    private void replaceMetaElement(Element metadataElement, Document doc, String name, String newVal, boolean[] flag) {
-        String existing = getMetaContentByName(metadataElement, name);
-        if (!Objects.equals(existing, newVal)) {
-            removeMetaByName(metadataElement, name);
-            if (newVal != null) metadataElement.appendChild(createMetaElement(doc, name, newVal));
-            flag[0] = true;
+    private Optional<Element> getElement(Element parent, String namespace, String tagName) {
+        NodeList metadataElements = parent.getElementsByTagNameNS(namespace, tagName);
+
+        for (int i = 0; i < metadataElements.getLength(); i++ ) {
+            if (metadataElements.item(i) instanceof Element element) {
+                return Optional.of(element);
+            }
         }
+
+        return Optional.empty();
+    }
+
+    private Element getOrCreateElement(Element parent, String namespace, String tagName) {
+        return getElement(parent, namespace, tagName)
+                .orElseGet(() -> {
+                    Element element = parent.getOwnerDocument().createElementNS(namespace, tagName);
+                    parent.appendChild(element);
+                    return element;
+                });
+    }
+
+    private Element getOrCreateMetadataElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "metadata");
+    }
+
+    public Element getOrCreateManifestElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "manifest");
+    }
+
+    public Element getOrCreateSpineElement(Document doc) {
+        return getOrCreateElement(doc.getDocumentElement(), OPF_NS, "spine");
+    }
+
+    private Element upsertMetaElement(Document doc, String name, String content) {
+        var metadata = getOrCreateMetadataElement(doc);
+
+        NodeList metaElements = metadata.getElementsByTagName("meta");
+        for (int i = 0; i < metaElements.getLength(); i++) {
+            if (metaElements.item(i) instanceof Element element) {
+                if (!name.equals(element.getAttribute("name"))) {
+                    continue;
+                }
+
+                // Found target.
+                element.setAttribute("content", content);
+                return element;
+            }
+        }
+
+        // We couldn't find any meta element so we can create it.
+        Element element = doc.createElement("meta");
+        element.setAttribute("name", name);
+        element.setAttribute("content", content);
+        metadata.appendChild(element);
+        return element;
     }
 
     private boolean replaceElementText(Document doc, Element parent, String tagName, String namespaceURI, String newValue, boolean restoreMode) {
@@ -379,6 +428,7 @@ public class EpubMetadataWriter implements MetadataWriter {
             applyCoverImageToEpub(tempDir, opfDoc, coverData);
 
             removeEmptyTextNodes(opfDoc);
+            organizePackageElements(opfDoc);
             Transformer transformer = TransformerFactory.newInstance().newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
@@ -406,37 +456,57 @@ public class EpubMetadataWriter implements MetadataWriter {
         return BookFileType.EPUB;
     }
 
-    private void applyCoverImageToEpub(Path tempDir, Document opfDoc, byte[] coverData) throws IOException {
-        NodeList manifestList = opfDoc.getElementsByTagNameNS(OPF_NS, "manifest");
-        if (manifestList.getLength() == 0) {
-            throw new IOException("No <manifest> element found in OPF document.");
+    private String generateCoverId(Document doc, Path dir, String extension) {
+        // Generate an ID / file combination that does not exist yet.
+        var ids = getDocumentIds(doc);
+        String coverId = "cover";
+        while(ids.contains(coverId) || Files.exists(dir.resolve(coverId + extension))) {
+            coverId = "cover-" + UUID.randomUUID().toString();
+        }
+        return coverId;
+    }
+
+    private Path getManifestItemPath(Path tempDir, Path opfDir, Element element) throws IOException {
+        String href = element.getAttribute("href");
+        String decodedHref = URLDecoder.decode(href, StandardCharsets.UTF_8);
+        if (decodedHref == null || decodedHref.isBlank()) {
+            throw new IOException("Manifest item has no href attribute");
         }
 
-        Element manifest = (Element) manifestList.item(0);
+        Path filePath = opfDir.resolve(decodedHref).normalize();
+
+        if (!filePath.startsWith(tempDir)) {
+            throw new IOException("Manifest item file may not be outside the epub archive");
+        }
+
+        return filePath;
+    }
+
+    private void applyCoverImageToEpub(Path tempDir, Document opfDoc, byte[] coverData) throws IOException {
+        String mediaType = MimeDetector.detect(new ByteArrayInputStream(coverData));
+        String extension = MimeDetector.getExtension(mediaType);
+
+        Element metadataElement = getOrCreateMetadataElement(opfDoc);
+        Element manifestElement = getOrCreateManifestElement(opfDoc);
         Element existingCoverItem = null;
 
         // First, try to find cover via metadata reference (EPUB 3 style)
-        NodeList metadataList = opfDoc.getElementsByTagNameNS(OPF_NS, "metadata");
-        if (metadataList.getLength() > 0) {
-            Element metadataElement = (Element) metadataList.item(0);
-            String coverItemId = getMetaContentByName(metadataElement, "cover");
-
-            if (coverItemId != null && !coverItemId.isBlank()) {
-                // Find the item with this id
-                NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
-                for (int i = 0; i < items.getLength(); i++) {
-                    Element item = (Element) items.item(i);
-                    if (coverItemId.equals(item.getAttribute("id"))) {
-                        existingCoverItem = item;
-                        break;
-                    }
+        String coverItemId = getMetaContentByName(metadataElement, "cover");
+        if (coverItemId != null && !coverItemId.isBlank()) {
+            // Find the item with this id
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
+            for (int i = 0; i < items.getLength(); i++) {
+                Element item = (Element) items.item(i);
+                if (coverItemId.equals(item.getAttribute("id"))) {
+                    existingCoverItem = item;
+                    break;
                 }
             }
         }
 
         // If not found, try looking for properties="cover-image" (EPUB 3)
         if (existingCoverItem == null) {
-            NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
             for (int i = 0; i < items.getLength(); i++) {
                 Element item = (Element) items.item(i);
                 String properties = item.getAttribute("properties");
@@ -449,7 +519,7 @@ public class EpubMetadataWriter implements MetadataWriter {
 
         // If still not found, try common id values (EPUB 2 fallback)
         if (existingCoverItem == null) {
-            NodeList items = manifest.getElementsByTagNameNS(OPF_NS, "item");
+            NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
             for (int i = 0; i < items.getLength(); i++) {
                 Element item = (Element) items.item(i);
                 String itemId = item.getAttribute("id");
@@ -460,16 +530,6 @@ public class EpubMetadataWriter implements MetadataWriter {
             }
         }
 
-        if (existingCoverItem == null) {
-            throw new IOException("No cover item found in manifest");
-        }
-
-        String coverHref = existingCoverItem.getAttribute("href");
-        String decodedCoverHref = URLDecoder.decode(coverHref, StandardCharsets.UTF_8);
-        if (decodedCoverHref == null || decodedCoverHref.isBlank()) {
-            throw new IOException("Cover item has no href attribute");
-        }
-
         Path opfPath;
         try {
             opfPath = findOpfPath(tempDir);
@@ -478,7 +538,69 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
 
         Path opfDir = opfPath.getParent();
-        Path coverFilePath = opfDir.resolve(decodedCoverHref).normalize();
+
+        if (existingCoverItem != null) {
+            try {
+                getManifestItemPath(tempDir, opfDir, existingCoverItem);
+            } catch (IOException e) {
+                log.warn("Invalid cover for epub, ignoring", e);
+                existingCoverItem = null;
+            }
+        }
+
+        if (existingCoverItem == null) {
+            // If there is no existing cover item, we should create one.
+            String coverId = generateCoverId(opfDoc, opfDir, extension);
+
+            existingCoverItem = opfDoc.createElementNS(OPF_NS, "item");
+            existingCoverItem.setAttribute("id", coverId);
+            existingCoverItem.setAttribute("media-type", mediaType);
+            existingCoverItem.setAttribute("href", coverId + extension);
+
+            // Add the item and set the
+            manifestElement.appendChild(existingCoverItem);
+            upsertMetaElement(opfDoc, "cover", coverId);
+        }
+
+        // Remove all item's epub3 `properties` containing `cover-image`.
+        NodeList items = manifestElement.getElementsByTagNameNS(OPF_NS, "item");
+        for (int i = 0; i < items.getLength(); i++) {
+            if (items.item(i) instanceof Element item) {
+                // Remember: the `properties` attribute is a space delimited list,
+                // so we can't clear it entirely.
+                String properties = Arrays.stream(
+                            item.getAttribute("properties")
+                                    .trim()
+                                    .split("\\s+")
+                        )
+                        .filter(s -> !"cover-image".equals(s))
+                        .collect(Collectors.joining(" "));
+
+                if (properties.isBlank()) {
+                    item.removeAttribute("properties");
+                } else {
+                    item.setAttribute("properties", properties);
+                }
+            }
+        }
+
+        boolean isEpub3 = isEpub3(opfDoc);
+
+        if (isEpub3) {
+            // Add epub3 properties cover-image back to the target cover item.
+            String properties = existingCoverItem.getAttribute("properties")
+                    .trim();
+
+            if (properties.isBlank()) {
+                properties = "cover-image";
+            } else {
+                properties += " cover-image";
+            }
+
+            existingCoverItem.setAttribute("properties", properties);
+        }
+
+        Path coverFilePath = getManifestItemPath(tempDir, opfDir, existingCoverItem);
 
         Files.createDirectories(coverFilePath.getParent());
         Files.write(coverFilePath, coverData);
@@ -597,12 +719,7 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
     }
 
-    private void removeInvalidMetaRefines(Element metadataElement, Document doc) {
-        // In an ideal world we could set the `validating` flag or
-        // otherwise set the `isId` attribute tag correctly for `id`
-        // but because we cannot, we can't use `getElementById()` on
-        // the document.  With that in mind, we area going to read all
-        // tags, check if they have an `id`, and store that in a `Set`
+    private Set<String> getDocumentIds(Document doc) {
         Set<String> ids = new HashSet<>();
 
         NodeList nodes = doc.getElementsByTagName("*");
@@ -616,6 +733,17 @@ public class EpubMetadataWriter implements MetadataWriter {
                 }
             }
         }
+
+        return ids;
+    }
+
+    private void removeInvalidMetaRefines(Element metadataElement, Document doc) {
+        // In an ideal world we could set the `validating` flag or
+        // otherwise set the `isId` attribute tag correctly for `id`
+        // but because we cannot, we can't use `getElementById()` on
+        // the document.  With that in mind, we area going to read all
+        // tags, check if they have an `id`, and store that in a `Set`
+        var ids = getDocumentIds(doc);
 
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
         for (int i = metas.getLength() - 1; i >= 0; i--) {
@@ -1199,6 +1327,26 @@ public class EpubMetadataWriter implements MetadataWriter {
                 metadataElement.removeChild(meta);
             }
         }
+    }
+
+    private void organizePackageElements(Document document) {
+        // Per the epubcheck dtd:
+        // <package> must have as children elements, in this order:
+        //     <metadata>, <manifest>, and <spine>, and optionally may
+        //     include <tours> and/or <guide>.
+        Element metadata = getOrCreateMetadataElement(document);
+        Element manifest = getOrCreateManifestElement(document);
+        Element spine = getOrCreateSpineElement(document);
+        Optional<Element> tours = getElement(document.getDocumentElement(), OPF_NS, "tours");
+        Optional<Element> guide = getElement(document.getDocumentElement(), OPF_NS, "guide");
+
+        Element packageElement = document.getDocumentElement();
+
+        packageElement.appendChild(metadata);
+        packageElement.appendChild(manifest);
+        packageElement.appendChild(spine);
+        tours.ifPresent(packageElement::appendChild);
+        guide.ifPresent(packageElement::appendChild);
     }
 
     private void organizeMetadataElements(Element metadataElement) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -550,6 +550,18 @@ public class EpubMetadataWriter implements MetadataWriter {
             throw new IOException("Failed to parse container.xml to locate OPF path", e);
         }
 
+        if (existingCoverItem != null) {
+            String existingMediaType = existingCoverItem.getAttribute("media-type");
+            if (!existingMediaType.equals(mediaType)) {
+                // If the existing cover item exists but has a different media type we can't
+                // use it.  However, because it's _possible_ that the cover MAY be used elsewhere
+                // in the epub (such as referenced in HTML) we cannot delete the manifest item
+                // or the file.  All we can do is discard it as the existing cover manifest item,
+                // and treat the epub as if it has no cover, and place a new cover manifest item.
+                existingCoverItem = null;
+            }
+        }
+
         Path opfDir = opfPath.getParent();
 
         if (existingCoverItem != null) {

--- a/backend/src/main/java/org/booklore/util/MimeDetector.java
+++ b/backend/src/main/java/org/booklore/util/MimeDetector.java
@@ -8,10 +8,40 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 
 @Slf4j
 @UtilityClass
 public class MimeDetector {
+    private static final Map<String, String> MEDIA_TYPE_EXTENSIONS = Map.ofEntries(
+            Map.entry("text/html", ".html"),
+            Map.entry("application/xhtml+xml", ".html"),
+            Map.entry("application/javascript", ".js"),
+            Map.entry("text/css", ".css"),
+            Map.entry("image/jpeg", ".jpg"),
+            Map.entry("image/png", ".png"),
+            Map.entry("image/gif", ".gif"),
+            Map.entry("image/svg+xml", ".svg"),
+            Map.entry("font/ttf", ".ttf"),
+            Map.entry("font/otf", ".otf"),
+            Map.entry("application/vnd.ms-fontobject", ".eot"),
+            Map.entry("application/xml", ".xml"),
+            Map.entry("application/x-dtbncx+xml", ".ncx"),
+            Map.entry("audio/mpeg", ".mp3"),
+            Map.entry("video/mp4", ".mp4"),
+            Map.entry("audio/mp4", ".m4a"),
+            Map.entry("audio/aac", ".aac"),
+            Map.entry("audio/wav", ".wav"),
+            Map.entry("audio/ogg", ".ogg"),
+            Map.entry("application/oebps-package+xml", ".opf"),
+            Map.entry("image/webp", ".webp"),
+            Map.entry("font/woff", ".woff"),
+            Map.entry("font/woff2", ".woff2"),
+            Map.entry("application/smil+xml", ".smil"),
+            Map.entry("audio/flac", ".flac"),
+            Map.entry("video/webm", ".webm"),
+            Map.entry("image/avif", ".avif")
+    );
 
     // Tika is thread-safe one instance for the whole app.
     private static final Tika TIKA = new Tika();
@@ -46,6 +76,10 @@ public class MimeDetector {
             log.warn("MIME detection failed for {}: {}", path, e.getMessage());
             return "application/octet-stream";
         }
+    }
+
+    public String getExtension(String mediaType) {
+        return MEDIA_TYPE_EXTENSIONS.getOrDefault(mediaType, ".bin");
     }
 
     public boolean isAudio(Path path) throws IOException {

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -148,6 +149,30 @@ class EpubMetadataWriterTest {
             String content = readOpfContent(epubFile);
             assertThat(content).doesNotContain("refines=\"#example2\"");
             assertThat(content).contains("refines=\"#example\"");
+        }
+
+        @Test
+        @DisplayName("Should sort package children in EPUB3")
+        void writeMetadata_shouldSortPackageChildren() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <manifest></manifest>
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                        </metadata>
+                    </package>""";
+
+            File epubFile = createEpubWithOpf(opfContent, "test-sort-package-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+
+            int manifestIndex = content.indexOf("<manifest");
+            int metadataIndex = content.indexOf("<metadata");
+            int spineIndex = content.indexOf("<spine");
+
+            assertThat(metadataIndex).isLessThan(manifestIndex);
+            assertThat(manifestIndex).isLessThan(spineIndex);
         }
     }
 
@@ -623,6 +648,92 @@ class EpubMetadataWriterTest {
             assertThat(content).doesNotContain("prefix=");
             // Should NOT use property= form
             assertThat(content).doesNotContain("property=\"booklore:");
+        }
+    }
+
+    @Nested
+    @DisplayName("Cover Tests")
+    class CoverTests {
+        @Test
+        void shouldCreateManifestItemIfNoneExist() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                    </package>
+                    """,
+                    "no-cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains("href=\"cover.");
+        }
+
+        @Test
+        void shouldAddEpub3CoverImageTag() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                    </package>
+                    """,
+                    "no-cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains("properties=\"cover-image\"");
+        }
+
+        @Test
+        void shouldAllowOnlyOneCoverImagePropertiesEpub3() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                            <dc:title>Test Book</dc:title>
+                        </metadata>
+                        <manifest>
+                            <item href="foo" properties="cover-image" />
+                            <item href="bar" properties="cover-image" />
+                        </manifest>
+                    </package>
+                    """,
+                    "cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+            var pattern = Pattern.compile("properties=\"cover-image\"");
+            var matcher = pattern.matcher(content);
+            int count = 0;
+            while (matcher.find()) {
+                count++;
+            }
+            assertThat(count).isEqualTo(1);
         }
     }
 

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -715,8 +715,8 @@ class EpubMetadataWriterTest {
                             <dc:title>Test Book</dc:title>
                         </metadata>
                         <manifest>
-                            <item href="foo" properties="cover-image" />
-                            <item href="bar" properties="cover-image" />
+                            <item href="foo" properties="cover-image" media-type="application/octet-stream" />
+                            <item href="bar" properties="cover-image" media-type="application/octet-stream" />
                         </manifest>
                     </package>
                     """,
@@ -735,6 +735,38 @@ class EpubMetadataWriterTest {
             }
             assertThat(count).isEqualTo(1);
         }
+
+        @Test
+        void shouldMitigateMediaTypeMismatch() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                        </metadata>
+                        <manifest>
+                            <item href="cover.bin" id="cover" properties="cover-image" media-type="image/png" />
+                        </manifest>
+                    </package>
+                    """,
+                    "no-cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+
+            // Removes properties from existing
+            assertThat(content).contains("<item href=\"cover.bin\" id=\"cover\" media-type=\"image/png\"/>");
+
+            // And creates a new item with the prop
+            assertThat(content).contains("properties=\"cover-image\"");
+        }
+
     }
 
     private Document parseOpf(File epubFile) throws Exception {

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -835,7 +835,7 @@ class EpubMetadataWriterTest {
             assertThat(content).contains("<item href=\"cover.bin\" id=\"cover\" media-type=\"image/png\"/>");
 
             // And creates a new item with the prop
-            assertThat(content).contains("properties=\"cover-image\"");
+            assertThat(content).containsPattern("<item href=\"cover-[^\"]+\\.bin\" id=\"cover-[^\"]+\" media-type=\"application/octet-stream\" properties=\"cover-image\"/>.*");
         }
 
     }

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -786,8 +786,8 @@ class EpubMetadataWriterTest {
                             <dc:title>Test Book</dc:title>
                         </metadata>
                         <manifest>
-                            <item href="foo" properties="cover-image" />
-                            <item href="bar" properties="cover-image" />
+                            <item href="foo" properties="cover-image" media-type="application/octet-stream" />
+                            <item href="bar" properties="cover-image" media-type="application/octet-stream" />
                         </manifest>
                     </package>
                     """,
@@ -806,6 +806,38 @@ class EpubMetadataWriterTest {
             }
             assertThat(count).isEqualTo(1);
         }
+
+        @Test
+        void shouldMitigateMediaTypeMismatch() throws Exception {
+            Path thumbnailPath = tempDir.resolve("thumbnail-" + System.nanoTime()).toAbsolutePath();
+            Files.write(thumbnailPath, new byte[]{0x01, 0x02, 0x03});
+
+            File epubFile = createEpubWithOpf(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                        </metadata>
+                        <manifest>
+                            <item href="cover.bin" id="cover" properties="cover-image" media-type="image/png" />
+                        </manifest>
+                    </package>
+                    """,
+                    "no-cover-" + System.nanoTime() + ".epub"
+            );
+
+            writer.saveMetadataToFile(epubFile, metadata, thumbnailPath.toString(), new MetadataClearFlags());
+
+
+            String content = readOpfContent(epubFile);
+
+            // Removes properties from existing
+            assertThat(content).contains("<item href=\"cover.bin\" id=\"cover\" media-type=\"image/png\"/>");
+
+            // And creates a new item with the prop
+            assertThat(content).contains("properties=\"cover-image\"");
+        }
+
     }
 
     private Document parseOpf(File epubFile) throws Exception {

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -387,7 +387,7 @@ class EpubMetadataWriterTest {
                             <meta name="cover" content="cover-image"/>
                         </metadata>
                         <manifest>
-                            <item id="cover-image" href="cover.png" media-type="image/png" properties="cover-image"/>
+                            <item id="cover-image" href="cover.png" media-type="text/plain" properties="cover-image"/>
                         </manifest>
                     </package>""";
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
When a cover is updated in an epub, we replace the manifest item no matter what,
and write to the file that the manifest item originally pointed at.  When the cover is a jpeg
and we're writing a jpeg this works great.

However, when the cover is HTML or a WEBP and we want to write a jpeg, this leads to
issues with our epub afterwards.  The image will try to get loaded as the wrong media type,
or may end up rendering incorrectly if the cover is reused in the epub file.

This PR takes a leaf out of Calibre's book and if the media type of the existing cover is not a
match with our new cover we will refuse to replace the cover directly and will instead treat
the epub as if it had no cover, inserting a new manifest item and a new cover file.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1252

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* updates the `EpubMetadataWriter` to ignore covers when there is a media type mismatch
* adds tests to verify behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. open metadata editor for book
2. search for a webp cover image
3. save new webp cover image into the epub
4. read `content.opf` to ensure the new file has correct extension / media type

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
An alternative would be to directly convert all of the images to the epub's existing cover media type but that's impossible in some cases (eg, it's an HTML file)

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - EPUB cover metadata is now handled correctly when an existing cover uses a different media type.
  - A compatible cover entry is created while preserving the original file and references, preventing broken EPUB resources.
- **Tests**
  - Added coverage for mismatched cover media types and updated cover deduplication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->