### PR TITLE
fix(book): refresh duplicate merger after deleting books

### DIFF
--- a/frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.spec.ts
+++ b/frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.spec.ts
@@ -1,14 +1,85 @@
-import {describe, it} from 'vitest';
+import {ChangeDetectorRef, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {DynamicDialogConfig, DynamicDialogRef} from '@openng/optimus-ui/dynamicdialog';
+import {ConfirmationService, MessageService} from '@openng/optimus-ui/api';
+import {TranslocoService} from '@jsverse/transloco';
+import {of} from 'rxjs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-// NOTE(frontend-seam): Real coverage here needs seams around dialog config/bootstrap state,
-// paginator state, confirmation flows, and multi-step duplicate merge orchestration so the
-// component can be tested without building a full dialog-plus-confirmation harness.
-describe.skip('DuplicateMergerComponent', () => {
-  it('needs scanning seams to verify preset toggles, duplicate detection request shaping, and display-group initialization', () => {
-    // TODO(seam): Cover applyPreset and scan once the dialog config and duplicate scan subscription flow are isolated behind test doubles.
+import {Book, DuplicateGroup} from '../../model/book.model';
+import {AppSettingsService} from '../../../../shared/service/app-settings.service';
+import {UrlHelperService} from '../../../../shared/service/url-helper.service';
+import {BookFileService} from '../../service/book-file.service';
+import {BookService} from '../../service/book.service';
+import {DuplicateMergerComponent} from './duplicate-merger.component';
+
+const createBook = (id: number): Book => ({id, libraryId: 1, libraryName: 'Main Library'});
+
+const createGroup = (books: Book[]): DuplicateGroup => ({
+  suggestedTargetBookId: books[0].id,
+  matchReason: 'TITLE_AUTHOR',
+  books,
+});
+
+describe('DuplicateMergerComponent', () => {
+  const changeDetectorRef = {markForCheck: vi.fn()};
+  const dialogConfig = {data: {libraryId: 1}};
+  const bookFileService = {findDuplicates: vi.fn()};
+  const bookService = {deleteBooks: vi.fn()};
+  const confirmationService = {confirm: vi.fn()};
+  const messageService = {add: vi.fn()};
+  const translocoService = {translate: vi.fn((key: string) => key)};
+  const urlHelper = {getThumbnailUrl: vi.fn()};
+  const appSettingsService = {appSettings: signal(null)};
+
+  let component: DuplicateMergerComponent;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    appSettingsService.appSettings.set(null);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: ChangeDetectorRef, useValue: changeDetectorRef},
+        {provide: DynamicDialogConfig, useValue: dialogConfig},
+        {provide: DynamicDialogRef, useValue: {close: vi.fn()}},
+        {provide: BookFileService, useValue: bookFileService},
+        {provide: BookService, useValue: bookService},
+        {provide: ConfirmationService, useValue: confirmationService},
+        {provide: MessageService, useValue: messageService},
+        {provide: TranslocoService, useValue: translocoService},
+        {provide: UrlHelperService, useValue: urlHelper},
+        {provide: AppSettingsService, useValue: appSettingsService},
+      ]
+    });
+
+    component = TestBed.runInInjectionContext(() => new DuplicateMergerComponent());
   });
 
-  it('needs merge seams to verify target selection, dismissal, pagination, and attach-file success and failure handling', () => {
-    // TODO(seam): Cover the merge workflow after extracting confirmation, loader, and dialog-close side effects from the component runtime.
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('removes a deleted book from its group, dismisses the group, and notifies change detection', () => {
+    const deletedBookId = 2;
+
+    bookFileService.findDuplicates.mockReturnValue(of([
+      createGroup([createBook(1), createBook(2)]),
+    ]));
+    component.ngOnInit();
+    component.scan();
+
+    const group = component.groups[0];
+    component.toggleDeleteSelection(group, deletedBookId);
+
+    bookService.deleteBooks.mockReturnValue(of({deleted: [deletedBookId], failedFileDeletions: []}));
+    confirmationService.confirm.mockImplementation(config => config.accept());
+
+    component.deleteGroup(group);
+
+    expect(group.books.map(book => book.id)).toEqual([1]);
+    expect(group.dismissed).toBe(true);
+    expect(changeDetectorRef.markForCheck).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.ts
+++ b/frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, OnDestroy, OnInit, signal} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, OnDestroy, OnInit, signal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {DynamicDialogConfig, DynamicDialogRef} from '@openng/optimus-ui/dynamicdialog';
 import {Button} from '@openng/optimus-ui/button';
@@ -79,6 +79,7 @@ export class DuplicateMergerComponent implements OnInit, OnDestroy {
   private readonly t = inject(TranslocoService);
   readonly urlHelper = inject(UrlHelperService);
   private readonly appSettingsService = inject(AppSettingsService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
 
   ngOnInit(): void {
     this.libraryId = this.config.data.libraryId;
@@ -384,6 +385,7 @@ export class DuplicateMergerComponent implements OnInit, OnDestroy {
             if (group.books.length <= 1) {
               group.dismissed = true;
             }
+            this.changeDetectorRef.markForCheck();
           }
         });
       }


### PR DESCRIPTION
## Description

The "Find Duplicates" modal did not refresh its group contents after deleting a book, so deleted books stayed visible until the user interacted with another checkbox or radio button. This could lead users to click "Delete" a second time or assume something went wrong.

Root cause: the app runs zoneless change detection (`provideZonelessChangeDetection()` in `main.ts`), so async callbacks â like the HTTP response from `deleteBooks()` â do not automatically schedule a re-render. `deleteGroup()` mutates the `DisplayGroup` state in place (`group.books = ...`, `group.dismissed = true`) inside that callback without writing a signal or marking the view dirty, so the DOM stayed stale until a user interaction triggered change detection.

The fix injects `ChangeDetectorRef` and calls `markForCheck()` right after the group is updated, marking the component dirty so the zoneless scheduler re-renders it immediately.

## Linked Issue

Fixes #2159

## Changes

- `frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.ts`
  - Inject `ChangeDetectorRef` into the component.
  - Call `changeDetectorRef.markForCheck()` after a group is mutated in `deleteGroup()` (removing deleted books and dismissing the group when one or fewer books remain).
- `frontend/src/app/features/book/components/duplicate-merger/duplicate-merger.component.spec.ts`
  - Replaced the previously skipped placeholder spec with a real test covering the delete flow: verifies deleted books are removed from the group, the group is dismissed when only one book remains, and change detection is notified.

## Manual Testing Steps

1. Click the kebab menu next to a library.
2. Click "Find Duplicates" and then "Scan".
3. Find an entry with duplicates, select (checkbox) the copy to remove and, if needed, the "main" (radio button).
4. Click "Delete" and confirm.
5. Verify the green toast "Books Deleted: 1 book(s) deleted successfully" appears and the deleted book disappears from the modal immediately (previously it stayed until another interactive element was clicked).

## Screenshots

Selecting the duplicate copy to remove:
<img width="1239" height="917" alt="Screenshot From 2026-08-08 20-39-10" src="https://github.com/user-attachments/assets/7f11eac2-ed58-4b34-8c68-968985e62fea" />


Confirming the deletion:
<img width="1239" height="917" alt="Screenshot From 2026-08-08 20-39-15" src="https://github.com/user-attachments/assets/b467e756-6281-43aa-9d1e-aadf3001d8ab" />


After confirming, the deleted book is removed from the modal immediately a no manual refresh needed:
<img width="1239" height="917" alt="Screenshot From 2026-08-08 20-39-27" src="https://github.com/user-attachments/assets/a2c9e934-9b1c-4775-8ca7-07996106f278" />



The deleted book is removed from the "Find Duplicates" modal right after clicking "Delete" â no manual refresh needed.



## Additional Context (Optional)

The deletion itself already happened server-side and instantly (visible in the logs); this was purely a client-side rendering issue caused by in-place mutation of the group state without a change-detection trigger.

Verification note: the local machine has limited RAM (14 GB), so the equivalent check steps were run with constrained worker counts rather than the literal `just` recipes. All green:
- `vitest run ...duplicate-merger.component.spec.ts --maxWorkers=2` (1 passed)
- `TZ=UTC vitest run --maxWorkers=2 --pool=forks` (full frontend suite: 1707 passed, 0 failed)
- `pnpm run lint:eslint`, `pnpm run lint:styles`, `pnpm run typecheck`
- `CI=1 NG_CLI_ANALYTICS=false pnpm run build:prod`
- `./gradlew check --max-workers=1` (backend: 3889 tests, 0 failed)

## AI Disclosure

None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-book removal so the interface refreshes immediately after a duplicate is deleted.
  * Ensured dismissed duplicate groups update correctly.

* **Tests**
  * Added automated coverage for duplicate-book deletion and group dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->