### PR TITLE
fix(api): emit correct `Content-Type` for covers

### DIFF
--- a/backend/src/main/java/org/booklore/controller/BookMediaController.java
+++ b/backend/src/main/java/org/booklore/controller/BookMediaController.java
@@ -16,6 +16,7 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaTypeFactory;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -71,9 +72,18 @@ public class BookMediaController {
         return toImageResponse(bookService.getAudiobookCoverIfPresent(bookId));
     }
 
+    private MediaType getMediaType(Resource resource) {
+        return MediaTypeFactory.getMediaType(resource).orElse(MediaType.APPLICATION_OCTET_STREAM);
+    }
+
     private ResponseEntity<Resource> toImageResponse(Optional<Resource> image) {
         return image
-                .map(resource -> ResponseEntity.ok().cacheControl(IMAGE_CACHE).body(resource))
+                .map(
+                        resource -> ResponseEntity.ok()
+                                .contentType(getMediaType(resource))
+                                .cacheControl(IMAGE_CACHE)
+                                .body(resource)
+                )
                 .orElseGet(() -> ResponseEntity.notFound().cacheControl(CacheControl.noStore()).build());
     }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
currently the content type emitted as part of most responses is `null`.  because we are not returning `Resource` directly & use the `ResponseEntity` wrapper we have to manually specify the media type or the server will emit whatever the first `accept` is.

this is because by default the `ContentNegotiationConfigurer` uses the path extension (which does not exist for cover endpoints) and then the `Accept` header.  (this is per [the spring documentation](https://docs.spring.io/spring-framework/docs/4.3.20.RELEASE_to_4.3.21.RELEASE/Spring%20Framework%204.3.21.RELEASE/org/springframework/web/servlet/config/annotation/ContentNegotiationConfigurer.html))

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #407

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
updates our `BookMediaController` to read the media type of the cover resources and emit them

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

access cover directly in a browser and see an image rather than the image binary as "HTML"
view book covers in the app to see the covers continue to show

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Book images and other media now return the correct content type.
  * Media without a recognized type continues to load using a safe default.
  * Existing caching and not-found behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->