### PR TITLE
fix(books): prevent duplicate book file entries

### DIFF
--- a/backend/src/main/java/org/booklore/repository/BookRepository.java
+++ b/backend/src/main/java/org/booklore/repository/BookRepository.java
@@ -85,12 +85,8 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
     @Query("SELECT b FROM BookEntity b WHERE (b.deleted IS NULL OR b.deleted = false)")
     List<BookEntity> findAllWithMetadata();
 
-    @EntityGraph(attributePaths = {
-        "metadata", "metadata.comicMetadata",
-        "metadata.comicMetadata.characters", "metadata.comicMetadata.teams", "metadata.comicMetadata.locations", "metadata.comicMetadata.creatorMappings",
-        "metadata.authors", "metadata.categories", "metadata.moods", "metadata.tags",
-        "shelves", "libraryPath", "library", "bookFiles"
-    })
+    // Only ToOne paths in EntityGraph; collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
+    @EntityGraph(attributePaths = {"metadata", "metadata.comicMetadata", "libraryPath", "library"})
     @Query("SELECT b FROM BookEntity b WHERE b.id IN :bookIds AND (b.deleted IS NULL OR b.deleted = false)")
     List<BookEntity> findAllWithMetadataByIds(@Param("bookIds") Set<Long> bookIds);
 


### PR DESCRIPTION
## Description

Fixes an issue with duplicate info returned from the paginated endpoint. With the findAllWithMetadataByIds as one big SQL query, hibernate couldn't de-duplicate the files list when multiple files were tied to a single book. 

## Linked Issue

Fixes #2288 

## Changes

- Removed collection paths from `findAllWithMetadataByIds` to avoid an eager-join of more than one collection in a single query. Those now load in separate queries afterwards. 

## Manual Testing Steps

Check row output for a book with multiple tags, moods, and specifically multiple files. confirm rows are 1 to 1 with unique files and no duplicates are shown. 

## Screenshots (Optional)

N/A

## Additional Context (Optional)

No issues with general use of the endpoint or performance concerns. Fetch time per-page was approx 35ms before and after the fix. 

Looking at the rest of `BookRepository` this was a similar approach to other queries anyway, so this feels more conventional and fixes a bug. 

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved book loading performance by fetching only the metadata needed for book details.
  * Reduced unnecessary related data loading when retrieving books.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->