### PR TITLE
fix(api): use `Set` for `BookEntity.bookFiles` to mitigate duplicates

### DIFF
--- a/backend/src/main/java/org/booklore/mapper/BookMapper.java
+++ b/backend/src/main/java/org/booklore/mapper/BookMapper.java
@@ -11,6 +11,7 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -75,7 +76,7 @@ public interface BookMapper {
     }
 
     @Named("mapPrimaryFile")
-    default BookFile mapPrimaryFile(List<BookFileEntity> bookFiles) {
+    default BookFile mapPrimaryFile(Set<BookFileEntity> bookFiles) {
         if (bookFiles == null || bookFiles.isEmpty()) {
             return null;
         }
@@ -84,17 +85,18 @@ public interface BookMapper {
     }
 
     @Named("mapAlternativeFormats")
-    default List<BookFile> mapAlternativeFormats(List<BookFileEntity> bookFiles) {
+    default List<BookFile> mapAlternativeFormats(Set<BookFileEntity> bookFiles) {
         if (bookFiles == null) return null;
         return bookFiles.stream()
                 .filter(bf -> bf.isBook())
                 .filter(bf -> !bf.equals(getPrimaryBookFile(bookFiles)))
                 .map(this::toBookFile)
+                .sorted(Comparator.comparingLong(BookFile::getId))
                 .toList();
     }
 
     @Named("mapSupplementaryFiles")
-    default List<BookFile> mapSupplementaryFiles(List<BookFileEntity> bookFiles) {
+    default List<BookFile> mapSupplementaryFiles(Set<BookFileEntity> bookFiles) {
         if (bookFiles == null)
             return null;
         return bookFiles.stream()
@@ -103,11 +105,12 @@ public interface BookMapper {
                 .toList();
     }
 
-    default BookFileEntity getPrimaryBookFile(List<BookFileEntity> bookFiles) {
+    default BookFileEntity getPrimaryBookFile(Set<BookFileEntity> bookFiles) {
         if (bookFiles == null || bookFiles.isEmpty()) return null;
 
         List<BookFileEntity> bookFormats = bookFiles.stream()
                 .filter(BookFileEntity::isBook)
+                .sorted(Comparator.comparingLong(BookFileEntity::getId))
                 .toList();
 
         if (bookFormats.isEmpty()) return null;
@@ -180,7 +183,7 @@ public interface BookMapper {
         BookFileEntity audiobookFile = bookEntity.getBookFiles() != null
                 ? bookEntity.getBookFiles().stream()
                     .filter(bf -> bf.getBookType() == BookFileType.AUDIOBOOK && bf.isBook())
-                    .findFirst()
+                    .min(Comparator.comparingLong(BookFileEntity::getId))
                     .orElse(null)
                 : null;
 

--- a/backend/src/main/java/org/booklore/mapper/v2/BookMapperV2.java
+++ b/backend/src/main/java/org/booklore/mapper/v2/BookMapperV2.java
@@ -12,6 +12,7 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,7 +56,7 @@ public interface BookMapperV2 {
         BookFileEntity audiobookFile = bookEntity.getBookFiles() != null
                 ? bookEntity.getBookFiles().stream()
                     .filter(bf -> bf.getBookType() == BookFileType.AUDIOBOOK && bf.isBook())
-                    .findFirst()
+                    .min(Comparator.comparingLong(BookFileEntity::getId))
                     .orElse(null)
                 : null;
 
@@ -112,24 +113,25 @@ public interface BookMapperV2 {
     }
 
     @Named("mapPrimaryFile")
-    default BookFile mapPrimaryFile(List<BookFileEntity> bookFiles) {
+    default BookFile mapPrimaryFile(Set<BookFileEntity> bookFiles) {
         BookFileEntity primary = getPrimaryBookFile(bookFiles);
         return toBookFile(primary);
     }
 
     @Named("mapAlternativeFormats")
-    default List<BookFile> mapAlternativeFormats(List<BookFileEntity> bookFiles) {
+    default List<BookFile> mapAlternativeFormats(Set<BookFileEntity> bookFiles) {
         if (bookFiles == null) return null;
         BookFileEntity primary = getPrimaryBookFile(bookFiles);
         return bookFiles.stream()
                 .filter(BookFileEntity::isBook)
                 .filter(bf -> !bf.equals(primary))
                 .map(this::toBookFile)
+                .sorted(Comparator.comparingLong(BookFile::getId))
                 .toList();
     }
 
     @Named("mapSupplementaryFiles")
-    default List<BookFile> mapSupplementaryFiles(List<BookFileEntity> bookFiles) {
+    default List<BookFile> mapSupplementaryFiles(Set<BookFileEntity> bookFiles) {
         if (bookFiles == null) return null;
         return bookFiles.stream()
                 .filter(bf -> !bf.isBook())
@@ -137,11 +139,12 @@ public interface BookMapperV2 {
                 .toList();
     }
 
-    default BookFileEntity getPrimaryBookFile(List<BookFileEntity> bookFiles) {
+    default BookFileEntity getPrimaryBookFile(Set<BookFileEntity> bookFiles) {
         if (bookFiles == null || bookFiles.isEmpty()) return null;
 
         List<BookFileEntity> bookFormats = bookFiles.stream()
                 .filter(BookFileEntity::isBook)
+                .sorted(Comparator.comparingLong(BookFileEntity::getId))
                 .toList();
 
         if (bookFormats.isEmpty()) return null;

--- a/backend/src/main/java/org/booklore/model/entity/BookEntity.java
+++ b/backend/src/main/java/org/booklore/model/entity/BookEntity.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -92,9 +93,8 @@ public class BookEntity {
 
     @BatchSize(size = 20)
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    @OrderBy("id ASC")
     @Builder.Default
-    private List<BookFileEntity> bookFiles = new ArrayList<>();
+    private Set<BookFileEntity> bookFiles = new HashSet<>();
 
     @BatchSize(size = 20)
     @OneToMany(mappedBy = "book", fetch = FetchType.LAZY)
@@ -112,7 +112,7 @@ public class BookEntity {
 
     public BookFileEntity getPrimaryBookFile() {
         if (bookFiles == null) {
-            bookFiles = new ArrayList<>();
+            bookFiles = new HashSet<>();
         }
         if (bookFiles.isEmpty()) {
             return null;
@@ -121,13 +121,16 @@ public class BookEntity {
             for (BookFileType format : library.getFormatPriority()) {
                 var match = bookFiles.stream()
                         .filter(bf -> bf.isBookFormat() && bf.getBookType() == format)
-                        .findFirst();
+                        .min(Comparator.comparingLong(BookFileEntity::getId));
                 if (match.isPresent()) {
                     return match.get();
                 }
             }
         }
-        return bookFiles.getFirst();
+        return bookFiles
+                .stream()
+                .min(Comparator.comparingLong(BookFileEntity::getId))
+                .orElse(null);
     }
 
     public boolean hasFiles() {

--- a/backend/src/main/java/org/booklore/service/book/BookCreatorService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookCreatorService.java
@@ -91,7 +91,7 @@ public class BookCreatorService {
                 .library(libraryFile.getLibraryEntity())
                 .libraryPath(libraryFile.getLibraryPathEntity())
                 .addedOn(Instant.now())
-                .bookFiles(new ArrayList<>())
+                .bookFiles(new HashSet<>())
                 .build();
 
         BookFileEntity bookFileEntity = BookFileEntity.builder()

--- a/backend/src/main/java/org/booklore/service/book/BookDownloadService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookDownloadService.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -146,8 +147,16 @@ public class BookDownloadService {
         BookEntity bookEntity = bookRepository.findByIdWithBookFiles(bookId)
                 .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
 
-        List<BookFileEntity> allFiles = bookEntity.getBookFiles();
-        if (allFiles == null || allFiles.isEmpty()) {
+        if (bookEntity.getBookFiles() == null) {
+            throw ApiError.FILE_NOT_FOUND.createException(bookId);
+        }
+
+        List<BookFileEntity> allFiles = bookEntity.getBookFiles()
+                .stream()
+                .sorted(Comparator.comparingLong(BookFileEntity::getId))
+                .toList();
+
+        if (allFiles.isEmpty()) {
             throw ApiError.FILE_NOT_FOUND.createException(bookId);
         }
 

--- a/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookFileAttachmentService.java
@@ -64,10 +64,10 @@ public class BookFileAttachmentService {
             sourceBooks.add(sourceBook);
         }
 
-        BookFileEntity targetPrimaryFile = targetBook.getBookFiles().stream()
-                .filter(BookFileEntity::isBookFormat)
-                .findFirst()
-                .orElseThrow(() -> ApiError.GENERIC_BAD_REQUEST.createException("Target book has no primary file"));
+        BookFileEntity targetPrimaryFile = targetBook.getPrimaryBookFile();
+        if (targetPrimaryFile == null || !targetPrimaryFile.isBook()) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Target book has no primary book file");
+        }
 
         for (BookEntity sourceBook : sourceBooks) {
             if (!targetBook.getLibrary().getId().equals(sourceBook.getLibrary().getId())) {

--- a/backend/src/main/java/org/booklore/service/book/DuplicateDetectionService.java
+++ b/backend/src/main/java/org/booklore/service/book/DuplicateDetectionService.java
@@ -238,13 +238,8 @@ public class DuplicateDetectionService {
             if (alreadyGrouped.contains(book.getId())) continue;
             if (book.getLibraryPath() == null) continue;
 
-            List<BookFileEntity> bookFiles = book.getBookFiles();
-            if (bookFiles == null || bookFiles.isEmpty()) continue;
+            BookFileEntity primary = book.getPrimaryBookFile();
 
-            BookFileEntity primary = bookFiles.stream()
-                    .filter(BookFileEntity::isBookFormat)
-                    .findFirst()
-                    .orElse(null);
             if (primary == null) continue;
 
             String subPath = primary.getFileSubPath();
@@ -263,13 +258,7 @@ public class DuplicateDetectionService {
         for (BookEntity book : books) {
             if (alreadyGrouped.contains(book.getId())) continue;
 
-            List<BookFileEntity> bookFiles = book.getBookFiles();
-            if (bookFiles == null || bookFiles.isEmpty()) continue;
-
-            BookFileEntity primary = bookFiles.stream()
-                    .filter(BookFileEntity::isBookFormat)
-                    .findFirst()
-                    .orElse(null);
+            BookFileEntity primary = book.getPrimaryBookFile();
             if (primary == null || primary.getFileName() == null) continue;
 
             String fileName = primary.getFileName();

--- a/backend/src/main/java/org/booklore/service/book/PhysicalBookService.java
+++ b/backend/src/main/java/org/booklore/service/book/PhysicalBookService.java
@@ -56,7 +56,7 @@ public class PhysicalBookService {
                 .isPhysical(true)
                 .addedOn(Instant.now())
                 .scannedOn(Instant.now())
-                .bookFiles(new ArrayList<>())
+                .bookFiles(new HashSet<>())
                 .build();
 
         BookMetadataEntity metadata = BookMetadataEntity.builder()

--- a/backend/src/main/java/org/booklore/service/fileprocessor/AudiobookProcessor.java
+++ b/backend/src/main/java/org/booklore/service/fileprocessor/AudiobookProcessor.java
@@ -26,6 +26,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -80,7 +81,7 @@ public class AudiobookProcessor extends AbstractFileProcessor implements BookFil
     public boolean generateAudiobookCover(BookEntity bookEntity) {
         var audiobookFile = bookEntity.getBookFiles().stream()
                 .filter(f -> f.getBookType() == BookFileType.AUDIOBOOK)
-                .findFirst()
+                .min(Comparator.comparingLong(BookFileEntity::getId))
                 .orElse(null);
         if (audiobookFile == null) {
             return false;
@@ -252,7 +253,7 @@ public class AudiobookProcessor extends AbstractFileProcessor implements BookFil
 
         BookFileEntity audiobookFile = bookEntity.getBookFiles().stream()
                 .filter(bf -> bf.getBookType() == BookFileType.AUDIOBOOK && bf.isBook())
-                .findFirst()
+                .min(Comparator.comparingLong(BookFileEntity::getId))
                 .orElse(null);
 
         if (audiobookFile == null) {

--- a/backend/src/main/java/org/booklore/service/fileprocessor/EpubProcessor.java
+++ b/backend/src/main/java/org/booklore/service/fileprocessor/EpubProcessor.java
@@ -23,6 +23,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -171,7 +172,7 @@ public class EpubProcessor extends AbstractFileProcessor implements BookFileProc
 
         bookEntity.getBookFiles().stream()
             .filter(bf -> bf.getBookType() == BookFileType.EPUB && bf.isBook())
-            .findFirst()
+            .min(Comparator.comparingLong(BookFileEntity::getId))
             .ifPresent(ent -> ent.setFixedLayout(Boolean.TRUE.equals(epubMetadata.getIsFixedLayout())));
     }
 }

--- a/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
@@ -34,6 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -190,7 +191,7 @@ public class BookCoverService {
         // Find the audiobook file
         var audiobookFile = bookEntity.getBookFiles().stream()
                 .filter(f -> f.getBookType() == BookFileType.AUDIOBOOK)
-                .findFirst()
+                .min(Comparator.comparingLong(BookFileEntity::getId))
                 .orElseThrow(() -> ApiError.FAILED_TO_REGENERATE_COVER.createException("no audiobook file found"));
 
         BookFileProcessor processor = processorRegistry.getProcessorOrThrow(audiobookFile.getBookType());
@@ -282,7 +283,7 @@ public class BookCoverService {
                 }
                 var match = bookFiles.stream()
                         .filter(bf -> bf.isBookFormat() && bf.getBookType() == format)
-                        .findFirst();
+                        .min(Comparator.comparingLong(BookFileEntity::getId));
                 if (match.isPresent()) {
                     return match.get();
                 }
@@ -292,7 +293,7 @@ public class BookCoverService {
         // Fallback: return first non-audiobook file
         return bookFiles.stream()
                 .filter(f -> f.getBookType() != BookFileType.AUDIOBOOK)
-                .findFirst()
+                .min(Comparator.comparingLong(BookFileEntity::getId))
                 .orElse(null);
     }
 
@@ -609,7 +610,7 @@ public class BookCoverService {
         }
         var audiobookFile = bookEntity.getBookFiles().stream()
                 .filter(f -> f.getBookType() == BookFileType.AUDIOBOOK)
-                .findFirst()
+                .min(Comparator.comparingLong(BookFileEntity::getId))
                 .orElse(null);
 
         if (audiobookFile == null) {

--- a/backend/src/main/java/org/booklore/service/metadata/writer/AudiobookMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/AudiobookMetadataWriter.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -296,7 +297,7 @@ public class AudiobookMetadataWriter implements MetadataWriter {
         }
         return bookEntity.getBookFiles().stream()
                 .filter(bf -> bf.getBookType() == BookFileType.AUDIOBOOK)
-                .findFirst()
+                .min(Comparator.comparingLong(BookFileEntity::getId))
                 .orElse(null);
     }
 

--- a/backend/src/main/java/org/booklore/service/migration/migrations/MigrateProgressToFileProgressMigration.java
+++ b/backend/src/main/java/org/booklore/service/migration/migrations/MigrateProgressToFileProgressMigration.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,7 +97,11 @@ public class MigrateProgressToFileProgressMigration implements Migration {
             return Optional.empty();
         }
 
-        List<BookFileEntity> bookFiles = progress.getBook().getBookFiles();
+        List<BookFileEntity> bookFiles = progress.getBook().getBookFiles()
+                .stream()
+                .sorted(Comparator.comparingLong(BookFileEntity::getId))
+                .toList();
+
         if (bookFiles.isEmpty()) {
             return Optional.empty();
         }

--- a/backend/src/main/java/org/booklore/service/reader/AudiobookReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/AudiobookReaderService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -114,13 +115,13 @@ public class AudiobookReaderService {
             BookFileType requestedType = BookFileType.valueOf(bookType.toUpperCase());
             return bookEntity.getBookFiles().stream()
                     .filter(bf -> bf.getBookType() == requestedType)
-                    .findFirst()
+                    .min(Comparator.comparingLong(BookFileEntity::getId))
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
         }
 
         return bookEntity.getBookFiles().stream()
                 .filter(bf -> bf.getBookType() == BookFileType.AUDIOBOOK && bf.isBookFormat())
-                .findFirst()
+                .min(Comparator.comparingLong(BookFileEntity::getId))
                 .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No audiobook file found for book " + bookId));
     }
 }

--- a/backend/src/main/java/org/booklore/service/reader/CbxReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/CbxReaderService.java
@@ -413,7 +413,7 @@ public class CbxReaderService {
                     .orElseThrow(() -> ApiError.INVALID_INPUT.createException("Invalid book type: " + bookType));
             BookFileEntity bookFile = bookEntity.getBookFiles().stream()
                     .filter(bf -> bf.getBookType() == requestedType)
-                    .findFirst()
+                    .min(Comparator.comparingLong(BookFileEntity::getId))
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
             return bookFile.getFullFilePath();
         }

--- a/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/EpubReaderService.java
@@ -183,7 +183,7 @@ public class EpubReaderService {
             BookFileType requestedType = BookFileType.valueOf(bookType.toUpperCase());
             BookFileEntity bookFile = bookEntity.getBookFiles().stream()
                     .filter(bf -> bf.getBookType() == requestedType)
-                    .findFirst()
+                    .min(Comparator.comparingLong(BookFileEntity::getId))
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
             return bookFile.getFullFilePath();
         }

--- a/backend/src/main/java/org/booklore/service/reader/PdfReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/PdfReaderService.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -154,7 +155,7 @@ public class PdfReaderService {
                     .orElseThrow(() -> ApiError.INVALID_INPUT.createException("Invalid book type: " + bookType));
             BookFileEntity bookFile = bookEntity.getBookFiles().stream()
                     .filter(bf -> bf.getBookType() == requestedType)
-                    .findFirst()
+                    .min(Comparator.comparingLong(BookFileEntity::getId))
                     .orElseThrow(() -> ApiError.FILE_NOT_FOUND.createException("No file of type " + bookType + " found for book"));
             return bookFile.getFullFilePath();
         }

--- a/backend/src/main/java/org/booklore/service/watcher/PendingDeletionPool.java
+++ b/backend/src/main/java/org/booklore/service/watcher/PendingDeletionPool.java
@@ -95,8 +95,11 @@ public class PendingDeletionPool {
             }
             if (!fileSnapshots.isEmpty()) {
                 BookSnapshot bs = new BookSnapshot(
-                        book.getId(), book.getLibraryPath() != null ? book.getLibraryPath().getId() : null,
-                        book.getBookFiles().getFirst().getFileSubPath(), fileSnapshots);
+                        book.getId(),
+                        book.getLibraryPath() != null ? book.getLibraryPath().getId() : null,
+                        book.getPrimaryBookFile() != null ? book.getPrimaryBookFile().getFileSubPath() : null,
+                        fileSnapshots
+                );
                 affectedBooks.put(book.getId(), bs);
             }
         }

--- a/backend/src/test/java/org/booklore/app/service/AppSeriesServiceTest.java
+++ b/backend/src/test/java/org/booklore/app/service/AppSeriesServiceTest.java
@@ -471,13 +471,11 @@ class AppSeriesServiceTest {
                 .bookType(BookFileType.EPUB)
                 .build();
 
-        List<BookFileEntity> bookFiles = new ArrayList<>(List.of(bookFile));
-
         BookEntity book = BookEntity.builder()
                 .id(id)
                 .metadata(metadata)
                 .addedOn(Instant.now())
-                .bookFiles(bookFiles)
+                .bookFiles(Set.of(bookFile))
                 .build();
 
         metadata.setBook(book);

--- a/backend/src/test/java/org/booklore/mapper/BookMapperTest.java
+++ b/backend/src/test/java/org/booklore/mapper/BookMapperTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +41,7 @@ class BookMapperTest {
         primaryFile.setFileSubPath(".");
         primaryFile.setBookFormat(true);
         primaryFile.setBookType(BookFileType.EPUB);
-        entity.setBookFiles(List.of(primaryFile));
+        entity.setBookFiles(Set.of(primaryFile));
         entity.setLibrary(library);
         entity.setLibraryPath(libraryPath);
 

--- a/backend/src/test/java/org/booklore/mapper/komga/KomgaMapperTest.java
+++ b/backend/src/test/java/org/booklore/mapper/komga/KomgaMapperTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -74,7 +75,7 @@ class KomgaMapperTest {
         pdf.setBookType(BookFileType.PDF);
         pdf.setBookFormat(true);
 
-        book.setBookFiles(List.of(pdf));
+        book.setBookFiles(Set.of(pdf));
 
         // When: Converting to DTO
         KomgaBookDto dto = mapper.toKomgaBookDto(book);
@@ -105,7 +106,7 @@ class KomgaMapperTest {
         pdf.setBookType(BookFileType.PDF);
         pdf.setBookFormat(true);
 
-        book.setBookFiles(List.of(pdf));
+        book.setBookFiles(Set.of(pdf));
 
         // When: Converting to DTO
         KomgaBookDto dto = mapper.toKomgaBookDto(book);
@@ -142,7 +143,7 @@ class KomgaMapperTest {
         pdf.setBookType(BookFileType.PDF);
         pdf.setBookFormat(true);
 
-        book.setBookFiles(List.of(pdf));
+        book.setBookFiles(Set.of(pdf));
 
         // When: Converting to DTO
         KomgaBookDto dto = mapper.toKomgaBookDto(book);
@@ -175,7 +176,7 @@ class KomgaMapperTest {
         pdf.setBookType(BookFileType.PDF);
         pdf.setBookFormat(true);
 
-        book.setBookFiles(List.of(pdf));
+        book.setBookFiles(Set.of(pdf));
         
         // Book with metadata but empty fields
         BookMetadataEntity metadata = BookMetadataEntity.builder()
@@ -221,7 +222,7 @@ class KomgaMapperTest {
         pdf.setBookType(BookFileType.PDF);
         pdf.setBookFormat(true);
 
-        book.setBookFiles(List.of(pdf));
+        book.setBookFiles(Set.of(pdf));
         
         // Book with metadata but empty fields
         BookMetadataEntity metadata = BookMetadataEntity.builder()

--- a/backend/src/test/java/org/booklore/mapper/v2/BookMapperV2Test.java
+++ b/backend/src/test/java/org/booklore/mapper/v2/BookMapperV2Test.java
@@ -9,7 +9,7 @@ import org.booklore.model.enums.BookFileType;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
-import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,7 +46,7 @@ class BookMapperV2Test {
         supplementaryFile.setBookType(BookFileType.EPUB);
         supplementaryFile.setFileSizeKb(256L);
 
-        entity.setBookFiles(List.of(primaryFile, supplementaryFile));
+        entity.setBookFiles(Set.of(primaryFile, supplementaryFile));
         entity.setLibrary(library);
         entity.setLibraryPath(libraryPath);
 

--- a/backend/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
@@ -25,10 +25,11 @@ import org.springframework.http.ResponseEntity;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -74,7 +75,7 @@ class AdditionalFileServiceTest {
         fileEntity.setFileName("test-file.pdf");
         fileEntity.setFileSubPath(".");
         fileEntity.setBookFormat(true);
-        bookEntity.setBookFiles(new ArrayList<>(List.of(fileEntity)));
+        bookEntity.setBookFiles(Set.of(fileEntity));
 
         additionalFile = mock(BookFile.class);
     }
@@ -167,8 +168,8 @@ class AdditionalFileServiceTest {
         Long bookId = 100L;
         Long fileId = 1L;
         Path parentPath = fileEntity.getFullFilePath().getParent();
-        BookFileEntity primaryFile = createBookFile(2L, "primary.epub");
-        bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile, fileEntity)));
+        BookFileEntity primaryFile = createBookFile(0L, "primary.epub");
+        bookEntity.setBookFiles(new HashSet<>(Set.of(primaryFile, fileEntity)));
 
         when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
 
@@ -189,8 +190,8 @@ class AdditionalFileServiceTest {
         Long bookId = 100L;
         Long fileId = 1L;
         Path parentPath = fileEntity.getFullFilePath().getParent();
-        BookFileEntity primaryFile = createBookFile(2L, "primary.epub");
-        bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile, fileEntity)));
+        BookFileEntity primaryFile = createBookFile(0L, "primary.epub");
+        bookEntity.setBookFiles(new HashSet<>(Set.of(primaryFile, fileEntity)));
 
         when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
 
@@ -248,8 +249,8 @@ class AdditionalFileServiceTest {
         entityWithNonExistentFile.setBook(bookEntity);
         entityWithNonExistentFile.setFileName("non-existent.pdf");
         entityWithNonExistentFile.setFileSubPath(".");
-        BookFileEntity primaryFile = createBookFile(2L, "primary.epub");
-        bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile, entityWithNonExistentFile)));
+        BookFileEntity primaryFile = createBookFile(0L, "primary.epub");
+        bookEntity.setBookFiles(Set.of(primaryFile, entityWithNonExistentFile));
 
         when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(entityWithNonExistentFile));
 
@@ -270,8 +271,8 @@ class AdditionalFileServiceTest {
     void downloadAdditionalFile_WhenFileExists_ShouldReturnFileResource() throws Exception {
         Long bookId = 100L;
         Long fileId = 1L;
-        BookFileEntity primaryFile = createBookFile(2L, "primary.epub");
-        bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile, fileEntity)));
+        BookFileEntity primaryFile = createBookFile(0L, "primary.epub");
+        bookEntity.setBookFiles(Set.of(primaryFile, fileEntity));
         when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
 
         try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
@@ -311,7 +312,7 @@ class AdditionalFileServiceTest {
     void deleteAdditionalFile_WhenFileIsPrimaryBookFile_ShouldThrowException() {
         Long bookId = 100L;
         Long fileId = 1L;
-        bookEntity.setBookFiles(new ArrayList<>(List.of(fileEntity)));
+        bookEntity.setBookFiles(Set.of(fileEntity));
         when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
 
         IllegalArgumentException exception = assertThrows(
@@ -328,7 +329,7 @@ class AdditionalFileServiceTest {
     void downloadAdditionalFile_WhenFileIsPrimaryBookFile_ShouldThrowException() {
         Long bookId = 100L;
         Long fileId = 1L;
-        bookEntity.setBookFiles(new ArrayList<>(List.of(fileEntity)));
+        bookEntity.setBookFiles(Set.of(fileEntity));
         when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
 
         IllegalArgumentException exception = assertThrows(

--- a/backend/src/test/java/org/booklore/service/HibernateRegressionTest.java
+++ b/backend/src/test/java/org/booklore/service/HibernateRegressionTest.java
@@ -419,7 +419,7 @@ class HibernateRegressionTest {
 
             // Must NOT throw LazyInitializationException
             assertThat(loaded.getBookFiles()).hasSize(1);
-            assertThat(loaded.getBookFiles().get(0).getFileName()).isEqualTo("test.epub");
+            assertThat(loaded.getBookFiles().stream().toList().getFirst().getFileName()).isEqualTo("test.epub");
         }
     }
 
@@ -659,7 +659,7 @@ class HibernateRegressionTest {
                     .library(library)
                     .libraryPath(libraryPath)
                     .addedOn(Instant.now())
-                    .bookFiles(new ArrayList<>())
+                    .bookFiles(new HashSet<>())
                     .build();
 
             BookFileEntity bookFile = BookFileEntity.builder()
@@ -690,7 +690,7 @@ class HibernateRegressionTest {
             assertThat(loaded.getLibrary().getId()).isEqualTo(library.getId());
             assertThat(loaded.getLibraryPath().getId()).isEqualTo(libraryPath.getId());
             assertThat(loaded.getBookFiles()).hasSize(1);
-            assertThat(loaded.getBookFiles().get(0).getFileName()).isEqualTo("test.epub");
+            assertThat(loaded.getBookFiles().stream().toList().getFirst().getFileName()).isEqualTo("test.epub");
             assertThat(loaded.getMetadata().getTitle()).isEqualTo("Test Book Title");
             assertThat(loaded.getDeleted()).isFalse();
         }

--- a/backend/src/test/java/org/booklore/service/KoboEntitlementServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoboEntitlementServiceTest.java
@@ -48,8 +48,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import org.springframework.data.domain.PageImpl;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -64,7 +62,6 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import java.util.ArrayList;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -271,7 +268,7 @@ class KoboEntitlementServiceTest {
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.CBX);
         primaryFile.setFileSizeKb(1024L);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
 
         BookMetadataEntity metadata = new BookMetadataEntity();
         metadata.setTitle("Test CBX Book");
@@ -521,7 +518,7 @@ class KoboEntitlementServiceTest {
     private BookEntity createEpubBookEntity(Long id) {
         BookEntity book = new BookEntity();
         book.setId(id);
-        book.setBookFiles(new ArrayList<>());
+        book.setBookFiles(new HashSet<>());
 
         BookFileEntity bookFile = BookFileEntity.builder()
                 .book(book)
@@ -770,7 +767,7 @@ class KoboEntitlementServiceTest {
             primaryFile.setId(10L);
             primaryFile.setBook(book);
             primaryFile.setBookType(BookFileType.EPUB);
-            book.setBookFiles(List.of(primaryFile));
+            book.setBookFiles(Set.of(primaryFile));
 
             UserBookProgressEntity progress = new UserBookProgressEntity();
             progress.setBook(book);
@@ -825,7 +822,7 @@ class KoboEntitlementServiceTest {
             alternateAudiobook.setBook(book);
             alternateAudiobook.setBookType(BookFileType.AUDIOBOOK);
 
-            book.setBookFiles(List.of(primaryEpub, alternateAudiobook));
+            book.setBookFiles(Set.of(primaryEpub, alternateAudiobook));
 
             UserBookProgressEntity progress = new UserBookProgressEntity();
             progress.setBook(book);

--- a/backend/src/test/java/org/booklore/service/KoboReadingStateServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoboReadingStateServiceTest.java
@@ -40,6 +40,7 @@ import org.booklore.repository.UserBookFileProgressRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -126,7 +127,7 @@ class KoboReadingStateServiceTest {
         primaryFile.setId(bookFileId);
         primaryFile.setBook(testBook);
         primaryFile.setBookType(BookFileType.EPUB);
-        testBook.setBookFiles(List.of(primaryFile));
+        testBook.setBookFiles(Set.of(primaryFile));
         return primaryFile;
     }
 

--- a/backend/src/test/java/org/booklore/service/KoreaderServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/KoreaderServiceTest.java
@@ -36,9 +36,9 @@ import org.springframework.security.core.context.*;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -478,7 +478,7 @@ class KoreaderServiceTest {
         primaryFile.setBookType(bookFileType);
         primaryFile.setFileSubPath("subdir");
         primaryFile.setFileName("book.epub");
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
         return book;
     }
 }

--- a/backend/src/test/java/org/booklore/service/book/BookDownloadServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookDownloadServiceTest.java
@@ -17,8 +17,8 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.file.Files;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mockStatic;
@@ -98,7 +98,7 @@ public class BookDownloadServiceTest {
                 .build();
 
         BookEntity bookEntity = BookEntity.builder()
-                .bookFiles(List.of(bookFileEntity))
+                .bookFiles(Set.of(bookFileEntity))
                 .libraryPath(libraryPathEntity)
                 .build();
 

--- a/backend/src/test/java/org/booklore/service/book/BookFileAttachmentServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookFileAttachmentServiceTest.java
@@ -79,7 +79,7 @@ class BookFileAttachmentServiceTest {
                 .library(library)
                 .libraryPath(libraryPath)
                 .build();
-        book.setBookFiles(new ArrayList<>());
+        book.setBookFiles(new HashSet<>());
         return book;
     }
 
@@ -160,7 +160,7 @@ class BookFileAttachmentServiceTest {
 
             APIException ex = assertThrows(APIException.class,
                     () -> service.attachBookFiles(1L, List.of(2L), false));
-            assertTrue(ex.getMessage().contains("no primary file"));
+            assertTrue(ex.getMessage().contains("no primary book file"));
         }
     }
 
@@ -204,7 +204,7 @@ class BookFileAttachmentServiceTest {
                     .id(2L)
                     .library(otherLibrary)
                     .libraryPath(libraryPath)
-                    .bookFiles(new ArrayList<>())
+                    .bookFiles(new HashSet<>())
                     .build();
             createBookFile(20L, source, "source.epub", "sub2", true, false);
 
@@ -408,7 +408,7 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source = createBook(2L);
             createBookFile(20L, source, "source.pdf", "source_dir", true, false);
-            source.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source));
@@ -451,7 +451,7 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source = createBook(2L);
             createBookFile(20L, source, "source.pdf", "source_dir", true, false);
-            source.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source));
@@ -474,7 +474,7 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source = createBook(2L);
             createBookFile(20L, source, "source.pdf", "source_dir", true, false);
-            source.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source));
@@ -497,7 +497,7 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source = createBook(2L);
             createBookFile(20L, source, "source.pdf", "source_dir", true, false);
-            source.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source));
@@ -536,7 +536,7 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source = createBook(2L);
             createBookFile(20L, source, "source.pdf", "source_dir", true, false);
-            source.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source));
@@ -556,7 +556,7 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source = createBook(2L);
             createBookFile(20L, source, "source.pdf", "source_dir", true, false);
-            source.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source));
@@ -577,7 +577,7 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source = createBook(2L);
             createBookFile(20L, source, "source.pdf", "source_dir", true, false);
-            source.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source));
@@ -597,11 +597,11 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source1 = createBook(2L);
             createBookFile(20L, source1, "source1.pdf", "source_dir1", true, false);
-            source1.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source1.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             BookEntity source2 = createBook(3L);
             createBookFile(30L, source2, "source2.mobi", "source_dir2", true, false);
-            source2.getBookFiles().getFirst().setBookType(BookFileType.MOBI);
+            source2.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.MOBI);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source1));
@@ -748,7 +748,7 @@ class BookFileAttachmentServiceTest {
 
             BookEntity source = createBook(2L);
             createBookFile(20L, source, "source.pdf", "source_dir", true, false);
-            source.getBookFiles().getFirst().setBookType(BookFileType.PDF);
+            source.getBookFiles().stream().toList().getFirst().setBookType(BookFileType.PDF);
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(target));
             when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(source));
@@ -780,7 +780,7 @@ class BookFileAttachmentServiceTest {
                     .library(library)
                     .libraryPath(otherLibraryPath)
                     .build();
-            source.setBookFiles(new ArrayList<>());
+            source.setBookFiles(new HashSet<>());
             BookFileEntity sourceFile = BookFileEntity.builder()
                     .id(20L)
                     .book(source)

--- a/backend/src/test/java/org/booklore/service/book/BookFileDetachmentServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookFileDetachmentServiceTest.java
@@ -129,7 +129,7 @@ class BookFileDetachmentServiceTest {
 
         assertThat(response).isNotNull();
         assertThat(book.getBookFiles()).hasSize(1);
-        assertThat(book.getBookFiles().getFirst().getId()).isEqualTo(10L);
+        assertThat(book.getBookFiles().stream().toList().getFirst().getId()).isEqualTo(10L);
         verify(auditService).log(eq(AuditAction.BOOK_FILE_DETACHED), anyString(), eq(1L), anyString());
         verify(bookRepository, times(2)).saveAndFlush(argThat(newBook -> {
             assertThat(newBook.getMetadata().getTitle()).isEqualTo("Test Book 1");
@@ -206,8 +206,8 @@ class BookFileDetachmentServiceTest {
         service.detachBookFile(1L, 10L, false);
 
         assertThat(book.getBookFiles()).hasSize(1);
-        assertThat(book.getBookFiles().getFirst().getId()).isEqualTo(11L);
-        assertThat(book.getBookFiles().getFirst().isBookFormat()).isTrue();
+        assertThat(book.getBookFiles().stream().toList().getFirst().getId()).isEqualTo(11L);
+        assertThat(book.getBookFiles().stream().toList().getFirst().isBookFormat()).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookServiceTest.java
@@ -123,7 +123,7 @@ class BookServiceTest {
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setBook(entity);
         primaryFile.setBookType(BookFileType.EPUB);
-        entity.setBookFiles(List.of(primaryFile));
+        entity.setBookFiles(Set.of(primaryFile));
         LibraryPathEntity libPath = new LibraryPathEntity();
         libPath.setPath("/tmp/library");
         LibraryEntity library = new LibraryEntity();
@@ -151,7 +151,7 @@ class BookServiceTest {
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setBook(entity);
         primaryFile.setBookType(BookFileType.PDF);
-        entity.setBookFiles(List.of(primaryFile));
+        entity.setBookFiles(Set.of(primaryFile));
         LibraryPathEntity libPath = new LibraryPathEntity();
         libPath.setPath("/tmp/library");
         LibraryEntity library = new LibraryEntity();
@@ -186,7 +186,7 @@ class BookServiceTest {
         primaryFile.setId(1L);
         primaryFile.setBook(entity);
         primaryFile.setBookType(BookFileType.EPUB);
-        entity.setBookFiles(List.of(primaryFile));
+        entity.setBookFiles(Set.of(primaryFile));
         when(bookRepository.findByIdWithBookFiles(4L)).thenReturn(Optional.of(entity));
         EbookViewerPreferenceEntity epubPref = new EbookViewerPreferenceEntity();
         epubPref.setFontFamily("Arial");
@@ -227,7 +227,7 @@ class BookServiceTest {
         primaryFile.setId(1L);
         primaryFile.setBook(entity);
         primaryFile.setBookType(null);
-        entity.setBookFiles(List.of(primaryFile));
+        entity.setBookFiles(Set.of(primaryFile));
         when(bookRepository.findByIdWithBookFiles(5L)).thenReturn(Optional.of(entity));
         when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);
         assertThrows(APIException.class, () -> bookService.getBookViewerSetting(5L, 1L));
@@ -381,7 +381,7 @@ class BookServiceTest {
         primaryFile.setBook(entity);
         primaryFile.setFileSubPath("");
         primaryFile.setFileName("bookfile.txt");
-        entity.setBookFiles(List.of(primaryFile));
+        entity.setBookFiles(Set.of(primaryFile));
 
         Path filePath = Paths.get("/tmp/bookfile.txt");
         Files.createDirectories(filePath.getParent());
@@ -419,7 +419,7 @@ class BookServiceTest {
         primaryFile.setBook(entity);
         primaryFile.setFileSubPath("");
         primaryFile.setFileName("bookfile.txt");
-        entity.setBookFiles(List.of(primaryFile));
+        entity.setBookFiles(Set.of(primaryFile));
 
         Path filePath = Paths.get("/tmp/bookfile.txt");
         Files.createDirectories(filePath.getParent());
@@ -452,7 +452,7 @@ class BookServiceTest {
         primaryFile.setBook(entity);
         primaryFile.setFileSubPath("");
         primaryFile.setFileName("nonexistentfile.txt");
-        entity.setBookFiles(List.of(primaryFile));
+        entity.setBookFiles(Set.of(primaryFile));
 
         when(bookQueryService.findAllWithMetadataByIds(Set.of(13L))).thenReturn(List.of(entity));
         when(authenticationService.getAuthenticatedUser()).thenReturn(testUser);

--- a/backend/src/test/java/org/booklore/service/book/BookUpdateServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookUpdateServiceTest.java
@@ -79,7 +79,7 @@ class BookUpdateServiceTest {
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.PDF);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
         BookLoreUser user = mock(BookLoreUser.class);
         when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
         when(authenticationService.getAuthenticatedUser()).thenReturn(user);
@@ -109,7 +109,7 @@ class BookUpdateServiceTest {
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.EPUB);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
         BookLoreUser user = mock(BookLoreUser.class);
         when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
         when(authenticationService.getAuthenticatedUser()).thenReturn(user);
@@ -159,7 +159,7 @@ class BookUpdateServiceTest {
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setBook(book);
         primaryFile.setBookType(null);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
         when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
         when(authenticationService.getAuthenticatedUser()).thenReturn(mock(BookLoreUser.class));
         BookViewerSettings settings = BookViewerSettings.builder().build();
@@ -295,7 +295,7 @@ class BookUpdateServiceTest {
         bookFileEntity1.setBook(bookEntity1);
         bookFileEntity1.setFileSubPath("sub1");
         bookFileEntity1.setFileName("file1.pdf");
-        bookEntity1.setBookFiles(List.of(bookFileEntity1));
+        bookEntity1.setBookFiles(Set.of(bookFileEntity1));
 
         BookEntity bookEntity2 = spy(new BookEntity());
         bookEntity2.setId(2L);
@@ -307,7 +307,7 @@ class BookUpdateServiceTest {
         bookFileEntity2.setBook(bookEntity2);
         bookFileEntity2.setFileSubPath("sub2");
         bookFileEntity2.setFileName("file2.pdf");
-        bookEntity2.setBookFiles(List.of(bookFileEntity2));
+        bookEntity2.setBookFiles(Set.of(bookFileEntity2));
 
         when(bookQueryService.findAllWithMetadataByIds(bookIds)).thenReturn(Arrays.asList(bookEntity1, bookEntity2));
         ShelfEntity assignShelf = new ShelfEntity();

--- a/backend/src/test/java/org/booklore/service/book/DuplicateDetectionServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/DuplicateDetectionServiceTest.java
@@ -76,7 +76,7 @@ class DuplicateDetectionServiceTest {
                 .id(id)
                 .library(library)
                 .metadata(metadata)
-                .bookFiles(new ArrayList<>(List.of(file)))
+                .bookFiles(new HashSet<>(Set.of(file)))
                 .build();
 
         file.setBook(book);
@@ -458,11 +458,11 @@ class DuplicateDetectionServiceTest {
 
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
             book1.setLibraryPath(path);
-            book1.getBookFiles().getFirst().setFileSubPath("fiction/scifi");
+            book1.getBookFiles().stream().toList().getFirst().setFileSubPath("fiction/scifi");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
             book2.setLibraryPath(path);
-            book2.getBookFiles().getFirst().setFileSubPath("fiction/scifi");
+            book2.getBookFiles().stream().toList().getFirst().setFileSubPath("fiction/scifi");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyDirectory());
@@ -477,11 +477,11 @@ class DuplicateDetectionServiceTest {
 
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
             book1.setLibraryPath(path);
-            book1.getBookFiles().getFirst().setFileSubPath("fiction");
+            book1.getBookFiles().stream().toList().getFirst().setFileSubPath("fiction");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
             book2.setLibraryPath(path);
-            book2.getBookFiles().getFirst().setFileSubPath("nonfiction");
+            book2.getBookFiles().stream().toList().getFirst().setFileSubPath("nonfiction");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyDirectory());
@@ -496,11 +496,11 @@ class DuplicateDetectionServiceTest {
 
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
             book1.setLibraryPath(path1);
-            book1.getBookFiles().getFirst().setFileSubPath("shared");
+            book1.getBookFiles().stream().toList().getFirst().setFileSubPath("shared");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
             book2.setLibraryPath(path2);
-            book2.getBookFiles().getFirst().setFileSubPath("shared");
+            book2.getBookFiles().stream().toList().getFirst().setFileSubPath("shared");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyDirectory());
@@ -527,11 +527,11 @@ class DuplicateDetectionServiceTest {
 
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
             book1.setLibraryPath(path);
-            book1.getBookFiles().getFirst().setFileSubPath("  ");
+            book1.getBookFiles().stream().toList().getFirst().setFileSubPath("  ");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
             book2.setLibraryPath(path);
-            book2.getBookFiles().getFirst().setFileSubPath("  ");
+            book2.getBookFiles().stream().toList().getFirst().setFileSubPath("  ");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyDirectory());
@@ -548,10 +548,10 @@ class DuplicateDetectionServiceTest {
         @Test
         void groupsBooksWithSameBaseFilename() {
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
-            book1.getBookFiles().getFirst().setFileName("my_book.epub");
+            book1.getBookFiles().stream().toList().getFirst().setFileName("my_book.epub");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
-            book2.getBookFiles().getFirst().setFileName("my_book.mobi");
+            book2.getBookFiles().stream().toList().getFirst().setFileName("my_book.mobi");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyFilename());
@@ -563,10 +563,10 @@ class DuplicateDetectionServiceTest {
         @Test
         void normalizesUnderscoresHyphensCaseForMatching() {
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
-            book1.getBookFiles().getFirst().setFileName("My-Book_Title.epub");
+            book1.getBookFiles().stream().toList().getFirst().setFileName("My-Book_Title.epub");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
-            book2.getBookFiles().getFirst().setFileName("my book title.mobi");
+            book2.getBookFiles().stream().toList().getFirst().setFileName("my book title.mobi");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyFilename());
@@ -577,10 +577,10 @@ class DuplicateDetectionServiceTest {
         @Test
         void stripsPunctuationForMatching() {
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
-            book1.getBookFiles().getFirst().setFileName("book!@#title.epub");
+            book1.getBookFiles().stream().toList().getFirst().setFileName("book!@#title.epub");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
-            book2.getBookFiles().getFirst().setFileName("booktitle.mobi");
+            book2.getBookFiles().stream().toList().getFirst().setFileName("booktitle.mobi");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyFilename());
@@ -591,10 +591,10 @@ class DuplicateDetectionServiceTest {
         @Test
         void doesNotGroupDifferentFilenames() {
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
-            book1.getBookFiles().getFirst().setFileName("alpha.epub");
+            book1.getBookFiles().stream().toList().getFirst().setFileName("alpha.epub");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
-            book2.getBookFiles().getFirst().setFileName("beta.mobi");
+            book2.getBookFiles().stream().toList().getFirst().setFileName("beta.mobi");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyFilename());
@@ -605,9 +605,9 @@ class DuplicateDetectionServiceTest {
         @Test
         void skipsBooksWithNoBookFiles() {
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
-            book1.setBookFiles(new ArrayList<>());
+            book1.setBookFiles(Set.of());
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
-            book2.setBookFiles(new ArrayList<>());
+            book2.setBookFiles(Set.of());
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyFilename());
@@ -873,10 +873,10 @@ class DuplicateDetectionServiceTest {
         @Test
         void booksWithOnlyNonBookFilesAreSkippedInFilenameMatch() {
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
-            book1.getBookFiles().getFirst().setBookFormat(false);
+            book1.getBookFiles().stream().toList().getFirst().setBookFormat(false);
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
-            book2.getBookFiles().getFirst().setBookFormat(false);
+            book2.getBookFiles().stream().toList().getFirst().setBookFormat(false);
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyFilename());
@@ -905,7 +905,7 @@ class DuplicateDetectionServiceTest {
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
-            book2.getBookFiles().getFirst().setBookType(null);
+            book2.getBookFiles().stream().toList().getFirst().setBookType(null);
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyTitleAuthor());
@@ -917,10 +917,10 @@ class DuplicateDetectionServiceTest {
         @Test
         void handlesFilenameWithNoExtension() {
             BookEntity book1 = createBook(BookFileType.EPUB, "Book", "Author");
-            book1.getBookFiles().getFirst().setFileName("mybook");
+            book1.getBookFiles().stream().toList().getFirst().setFileName("mybook");
 
             BookEntity book2 = createBook(BookFileType.MOBI, "Book", "Author");
-            book2.getBookFiles().getFirst().setFileName("mybook");
+            book2.getBookFiles().stream().toList().getFirst().setFileName("mybook");
             stubBooks(book1, book2);
 
             List<DuplicateGroup> result = service.findDuplicates(onlyFilename());

--- a/backend/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/email/SendEmailV2ServiceTest.java
@@ -23,9 +23,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,7 +89,7 @@ class SendEmailV2ServiceTest {
         book.setId(10L);
         book.setMetadata(metadata);
         book.setLibraryPath(libraryPath);
-        book.setBookFiles(List.of(bookFile));
+        book.setBookFiles(Set.of(bookFile));
 
         emailProvider = EmailProviderV2Entity.builder()
                 .id(100L)

--- a/backend/src/test/java/org/booklore/service/file/FileMoveServiceOrderingTest.java
+++ b/backend/src/test/java/org/booklore/service/file/FileMoveServiceOrderingTest.java
@@ -118,7 +118,7 @@ class FileMoveServiceOrderingTest {
         file.setBookFormat(true);
         file.setBookType(BookFileType.EPUB);
 
-        book.setBookFiles(new ArrayList<>(List.of(file)));
+        book.setBookFiles(Set.of(file));
         return book;
     }
 
@@ -258,7 +258,7 @@ class FileMoveServiceOrderingTest {
         file2.setBookFormat(true);
         file2.setBookType(BookFileType.PDF);
 
-        book.setBookFiles(new ArrayList<>(List.of(file1, file2)));
+        book.setBookFiles(Set.of(file1, file2));
 
         Path target = Paths.get("/library/new/path/NewName.epub");
         mockStandardBehavior(book, target);

--- a/backend/src/test/java/org/booklore/service/file/FileMoveServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/file/FileMoveServiceTest.java
@@ -111,7 +111,7 @@ class FileMoveServiceTest {
         book.setLibrary(library);
         book.setLibraryPath(libraryPath);
         files.forEach(f -> f.setBook(book));
-        book.setBookFiles(new ArrayList<>(files));
+        book.setBookFiles(Set.copyOf(files));
         return book;
     }
 
@@ -735,7 +735,7 @@ class FileMoveServiceTest {
             bookWithEmptyFiles.setId(100L);
             bookWithEmptyFiles.setLibrary(library);
             bookWithEmptyFiles.setLibraryPath(libraryPath);
-            bookWithEmptyFiles.setBookFiles(new ArrayList<>());
+            bookWithEmptyFiles.setBookFiles(new HashSet<>());
 
             BookFileEntity epub = createBookFile(1L, "Book.epub", "path", true, false);
             BookEntity loadedBook = createBook(List.of(epub));

--- a/backend/src/test/java/org/booklore/service/kobo/KoboBookmarkLocationResolverTest.java
+++ b/backend/src/test/java/org/booklore/service/kobo/KoboBookmarkLocationResolverTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -194,7 +195,7 @@ class KoboBookmarkLocationResolverTest {
         bookFile.setCurrentHash("hash-123");
         bookFile.setFileName("book.epub");
         bookFile.setFileSubPath("");
-        book.setBookFiles(List.of(bookFile));
+        book.setBookFiles(Set.of(bookFile));
 
         return bookFile;
     }

--- a/backend/src/test/java/org/booklore/service/kobo/KoboCompatibilityServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/kobo/KoboCompatibilityServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -178,7 +178,7 @@ class KoboCompatibilityServiceTest {
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setBook(bookWithNullType);
         primaryFile.setBookType(null);
-        bookWithNullType.setBookFiles(List.of(primaryFile));
+        bookWithNullType.setBookFiles(Set.of(primaryFile));
 
 
         boolean isSupported = koboCompatibilityService.isBookSupportedForKobo(bookWithNullType);
@@ -300,7 +300,7 @@ class KoboCompatibilityServiceTest {
         primaryFile.setBook(book);
         primaryFile.setBookType(bookType);
         primaryFile.setFileSizeKb(fileSizeKb);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
 
         return book;
     }

--- a/backend/src/test/java/org/booklore/service/kobo/KoboLibrarySnapshotServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/kobo/KoboLibrarySnapshotServiceTest.java
@@ -86,7 +86,7 @@ class KoboLibrarySnapshotServiceTest {
 
         BookFileEntity ownersPrimaryFile = new BookFileEntity();
         ownersPrimaryFile.setBook(ownersBook);
-        ownersBook.setBookFiles(List.of(ownersPrimaryFile));
+        ownersBook.setBookFiles(Set.of(ownersPrimaryFile));
 
         otherUsersBook = BookEntity.builder()
                 .id(202L)
@@ -95,7 +95,7 @@ class KoboLibrarySnapshotServiceTest {
 
         BookFileEntity otherPrimaryFile = new BookFileEntity();
         otherPrimaryFile.setBook(otherUsersBook);
-        otherUsersBook.setBookFiles(List.of(otherPrimaryFile));
+        otherUsersBook.setBookFiles(Set.of(otherPrimaryFile));
 
         UserPermissions userPermissions = new UserPermissions();
         userPermissions.setAdmin(false);

--- a/backend/src/test/java/org/booklore/service/komga/KomgaServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/komga/KomgaServiceTest.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -99,7 +100,7 @@ class KomgaServiceTest {
             pdf.setBookType(BookFileType.PDF);
             pdf.setBookFormat(true);
 
-            book.setBookFiles(List.of(pdf));
+            book.setBookFiles(Set.of(pdf));
 
             seriesBooks.add(book);
         }

--- a/backend/src/test/java/org/booklore/service/library/LibraryFileHelperTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryFileHelperTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -429,7 +430,7 @@ class LibraryFileHelperTest {
     void detectDeletedBookIds_shouldIgnoreBooksWithoutFiles() {
         BookEntity book = BookEntity.builder()
                 .id(1L)
-                .bookFiles(Collections.emptyList())
+                .bookFiles(Collections.emptySet())
                 .build();
 
         List<Long> actual = libraryFileHelper.detectDeletedBookIds(Collections.emptyList(), List.of(book));
@@ -441,7 +442,7 @@ class LibraryFileHelperTest {
     void detectDeletedBookIds_shouldIgnoreDeletedBooks() {
         BookEntity book = BookEntity.builder()
                 .id(1L)
-                .bookFiles(List.of(BookFileEntity.builder().build()))
+                .bookFiles(Set.of(BookFileEntity.builder().build()))
                 .deleted(true)
                 .build();
 
@@ -472,7 +473,7 @@ class LibraryFileHelperTest {
         BookEntity book = BookEntity.builder()
                 .id(1L)
                 .libraryPath(libraryPathEntity)
-                .bookFiles(List.of(existing))
+                .bookFiles(Set.of(existing))
                 .build();
 
         existing.setBook(book);
@@ -505,7 +506,7 @@ class LibraryFileHelperTest {
         BookEntity book = BookEntity.builder()
                 .id(1L)
                 .libraryPath(libraryPathEntity)
-                .bookFiles(List.of(existing))
+                .bookFiles(Set.of(existing))
                 .build();
 
         existing.setBook(book);
@@ -518,7 +519,7 @@ class LibraryFileHelperTest {
         BookEntity expectedMissingBook = BookEntity.builder()
                 .id(2L)
                 .libraryPath(libraryPathEntity)
-                .bookFiles(List.of(expectedMissingBookFileEntity))
+                .bookFiles(Set.of(expectedMissingBookFileEntity))
                 .build();
 
         expectedMissingBookFileEntity.setBook(expectedMissingBook);
@@ -581,7 +582,7 @@ class LibraryFileHelperTest {
 
         BookEntity book = BookEntity.builder()
                 .libraryPath(libraryPathEntity)
-                .bookFiles(List.of(bookFile))
+                .bookFiles(Set.of(bookFile))
                 .build();
 
         bookFile.setBook(book);
@@ -622,7 +623,7 @@ class LibraryFileHelperTest {
 
         BookEntity audiobook = BookEntity.builder()
                 .libraryPath(libraryPathEntity)
-                .bookFiles(List.of(audiobookFolder))
+                .bookFiles(Set.of(audiobookFolder))
                 .build();
 
         audiobookFolder.setBook(audiobook);
@@ -666,7 +667,7 @@ class LibraryFileHelperTest {
 
         BookEntity book = BookEntity.builder()
                 .libraryPath(libraryPathEntity)
-                .bookFiles(List.of(bookFile))
+                .bookFiles(Set.of(bookFile))
                 .build();
 
         bookFile.setBook(book);

--- a/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceRegressionTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceRegressionTest.java
@@ -91,7 +91,7 @@ class LibraryProcessingServiceRegressionTest {
         BookEntity filelessBook = new BookEntity();
         filelessBook.setId(1L);
         filelessBook.setLibraryPath(pathEntity);
-        filelessBook.setBookFiles(Collections.emptyList());
+        filelessBook.setBookFiles(Collections.emptySet());
 
         libraryEntity.setBookEntities(List.of(filelessBook));
 

--- a/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
@@ -90,7 +90,7 @@ class LibraryProcessingServiceTest {
         existingBook.setLibraryPath(pathEntity);
         BookFileEntity existingBookFile = new BookFileEntity();
         existingBookFile.setBook(existingBook);
-        existingBook.setBookFiles(List.of(existingBookFile));
+        existingBook.setBookFiles(Set.of(existingBookFile));
         existingBook.getPrimaryBookFile().setFileSubPath("");
         existingBook.getPrimaryBookFile().setFileName("book1.epub");
         libraryEntity.setBookEntities(List.of(existingBook));
@@ -153,7 +153,7 @@ class LibraryProcessingServiceTest {
         existingBook.setLibraryPath(pathEntity);
         BookFileEntity existingBookFile = new BookFileEntity();
         existingBookFile.setBook(existingBook);
-        existingBook.setBookFiles(List.of(existingBookFile));
+        existingBook.setBookFiles(Set.of(existingBookFile));
         existingBook.getPrimaryBookFile().setFileSubPath("");
         existingBook.getPrimaryBookFile().setFileName("book1.epub");
         libraryEntity.setBookEntities(List.of(existingBook));
@@ -358,7 +358,7 @@ class LibraryProcessingServiceTest {
         image.setFileName("image.png");
         image.setBookFormat(false);
 
-        book.setBookFiles(List.of(epub, pdf, image));
+        book.setBookFiles(Set.of(epub, pdf, image));
         libraryEntity.setBookEntities(List.of(book));
 
         when(libraryRepository.findByIdWithPaths(libraryId)).thenReturn(Optional.of(libraryEntity));
@@ -434,7 +434,7 @@ class LibraryProcessingServiceTest {
         existingBook.setLibraryPath(pathEntity);
         BookFileEntity existingBookFile = new BookFileEntity();
         existingBookFile.setBook(existingBook);
-        existingBook.setBookFiles(List.of(existingBookFile));
+        existingBook.setBookFiles(Set.of(existingBookFile));
         existingBook.getPrimaryBookFile().setFileSubPath("");
         existingBook.getPrimaryBookFile().setFileName("book1.epub");
         libraryEntity.setBookEntities(List.of(existingBook));
@@ -473,7 +473,7 @@ class LibraryProcessingServiceTest {
         existingBook.setLibraryPath(pathEntity);
         BookFileEntity existingBookFile = new BookFileEntity();
         existingBookFile.setBook(existingBook);
-        existingBook.setBookFiles(List.of(existingBookFile));
+        existingBook.setBookFiles(Set.of(existingBookFile));
         existingBook.getPrimaryBookFile().setFileSubPath("");
         existingBook.getPrimaryBookFile().setFileName("book1.epub");
         libraryEntity.setBookEntities(List.of(existingBook));
@@ -547,7 +547,7 @@ class LibraryProcessingServiceTest {
         existingBook.setLibraryPath(pathEntity);
         BookFileEntity existingBookFile = new BookFileEntity();
         existingBookFile.setBook(existingBook);
-        existingBook.setBookFiles(new ArrayList<>(List.of(existingBookFile)));
+        existingBook.setBookFiles(Set.of(existingBookFile));
         existingBook.getPrimaryBookFile().setFileSubPath("");
         existingBook.getPrimaryBookFile().setFileName("book (with parens).epub");
 

--- a/backend/src/test/java/org/booklore/service/library/LibraryRescanHelperTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryRescanHelperTest.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -387,7 +388,7 @@ class LibraryRescanHelperTest {
         primaryFile.setFileName(fileName);
         primaryFile.setFileSubPath("");
         primaryFile.setBookType(bookType);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
         return book;
     }
 }

--- a/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
@@ -78,7 +78,7 @@ class BookCoverServiceTest {
         return BookEntity.builder()
                 .id(id)
                 .metadata(metadata)
-                .bookFiles(new ArrayList<>())
+                .bookFiles(new HashSet<>())
                 .build();
     }
 
@@ -91,7 +91,7 @@ class BookCoverServiceTest {
         return BookEntity.builder()
                 .id(id)
                 .metadata(metadata)
-                .bookFiles(new ArrayList<>())
+                .bookFiles(new HashSet<>())
                 .build();
     }
 
@@ -243,7 +243,7 @@ class BookCoverServiceTest {
                     .bookType(BookFileType.EPUB)
                     .isBookFormat(true)
                     .build();
-            book.setBookFiles(List.of(ebookFile));
+            book.setBookFiles(Set.of(ebookFile));
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
 
             BookFileProcessor processor = mock(BookFileProcessor.class);
@@ -262,7 +262,7 @@ class BookCoverServiceTest {
                     .bookType(BookFileType.EPUB)
                     .isBookFormat(true)
                     .build();
-            book.setBookFiles(List.of(ebookFile));
+            book.setBookFiles(Set.of(ebookFile));
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
 
             BookFileProcessor processor = mock(BookFileProcessor.class);
@@ -297,7 +297,7 @@ class BookCoverServiceTest {
             BookFileEntity audiobookFile = BookFileEntity.builder()
                     .bookType(BookFileType.AUDIOBOOK)
                     .build();
-            book.setBookFiles(List.of(audiobookFile));
+            book.setBookFiles(Set.of(audiobookFile));
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
 
             BookFileProcessor processor = mock(BookFileProcessor.class);
@@ -329,7 +329,7 @@ class BookCoverServiceTest {
                     .bookType(BookFileType.EPUB)
                     .isBookFormat(true)
                     .build();
-            book.setBookFiles(List.of(audiobookFile, pdfFile, epubFile));
+            book.setBookFiles(Set.of(audiobookFile, pdfFile, epubFile));
 
             LibraryEntity library = LibraryEntity.builder()
                     .formatPriority(List.of(BookFileType.AUDIOBOOK, BookFileType.EPUB, BookFileType.PDF))
@@ -358,7 +358,7 @@ class BookCoverServiceTest {
                     .bookType(BookFileType.PDF)
                     .isBookFormat(true)
                     .build();
-            book.setBookFiles(List.of(audiobookFile, pdfFile));
+            book.setBookFiles(Set.of(audiobookFile, pdfFile));
             book.setLibrary(LibraryEntity.builder().formatPriority(null).build());
 
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
@@ -381,7 +381,7 @@ class BookCoverServiceTest {
             BookEntity book = buildBook(1L, false);
             AuthorEntity author = AuthorEntity.builder().name("Jane Doe").build();
             book.getMetadata().setAuthors(List.of(author));
-            book.setBookFiles(new ArrayList<>());
+            book.setBookFiles(new HashSet<>());
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
             when(coverImageGenerator.generateCover("Test Book", "Jane Doe")).thenReturn(new byte[]{1, 2, 3});
             when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
@@ -615,7 +615,7 @@ class BookCoverServiceTest {
             BookFileEntity audiobookFile = BookFileEntity.builder()
                     .bookType(BookFileType.AUDIOBOOK)
                     .build();
-            book.setBookFiles(List.of(audiobookFile));
+            book.setBookFiles(Set.of(audiobookFile));
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
 
             BookFileProcessor processor = mock(BookFileProcessor.class);
@@ -688,7 +688,7 @@ class BookCoverServiceTest {
         @Test
         void delegatesToAsyncExecutorWithUnlockedBooks() {
             BookEntity unlocked = buildBook(1L, false);
-            unlocked.setBookFiles(List.of(BookFileEntity.builder().bookType(BookFileType.EPUB).isBookFormat(true).build()));
+            unlocked.setBookFiles(Set.of(BookFileEntity.builder().bookType(BookFileType.EPUB).isBookFormat(true).build()));
             unlocked.setLibrary(LibraryEntity.builder().build());
             BookEntity locked = buildBook(2L, true);
 
@@ -767,7 +767,7 @@ class BookCoverServiceTest {
             BookEntity book = buildBook(1L, false);
             BookFileEntity ebookFile = BookFileEntity.builder()
                     .bookType(BookFileType.EPUB).isBookFormat(true).build();
-            book.setBookFiles(List.of(ebookFile));
+            book.setBookFiles(Set.of(ebookFile));
             book.setLibrary(LibraryEntity.builder().build());
 
             when(bookQueryService.getAllFullBookEntitiesWithFiles()).thenReturn(List.of(book));
@@ -798,7 +798,7 @@ class BookCoverServiceTest {
             BookEntity locked = buildBook(1L, true);
             BookFileEntity ebookFile = BookFileEntity.builder()
                     .bookType(BookFileType.EPUB).isBookFormat(true).build();
-            locked.setBookFiles(List.of(ebookFile));
+            locked.setBookFiles(Set.of(ebookFile));
             locked.setLibrary(LibraryEntity.builder().build());
 
             when(bookQueryService.getAllFullBookEntitiesWithFiles()).thenReturn(List.of(locked));
@@ -819,14 +819,14 @@ class BookCoverServiceTest {
             withCover.setBookCoverHash("existingHash");
             BookFileEntity ebookFile1 = BookFileEntity.builder()
                     .bookType(BookFileType.EPUB).isBookFormat(true).build();
-            withCover.setBookFiles(List.of(ebookFile1));
+            withCover.setBookFiles(Set.of(ebookFile1));
             withCover.setLibrary(LibraryEntity.builder().build());
 
             BookEntity withoutCover = buildBook(2L, false);
             withoutCover.setBookCoverHash(null);
             BookFileEntity ebookFile2 = BookFileEntity.builder()
                     .bookType(BookFileType.EPUB).isBookFormat(true).build();
-            withoutCover.setBookFiles(List.of(ebookFile2));
+            withoutCover.setBookFiles(Set.of(ebookFile2));
             withoutCover.setLibrary(LibraryEntity.builder().build());
 
             when(bookQueryService.getAllFullBookEntitiesWithFiles()).thenReturn(List.of(withCover, withoutCover));
@@ -857,7 +857,7 @@ class BookCoverServiceTest {
         @Test
         void skipsBooksWithNoPrimaryFile() {
             BookEntity book = buildBook(1L, false);
-            book.setBookFiles(new ArrayList<>());
+            book.setBookFiles(new HashSet<>());
 
             when(bookQueryService.getAllFullBookEntitiesWithFiles()).thenReturn(List.of(book));
 
@@ -878,7 +878,7 @@ class BookCoverServiceTest {
             BookEntity book = BookEntity.builder()
                     .id(1L)
                     .metadata(null)
-                    .bookFiles(new ArrayList<>())
+                    .bookFiles(new HashSet<>())
                     .build();
 
             when(bookQueryService.getAllFullBookEntitiesWithFiles()).thenReturn(List.of(book));
@@ -940,7 +940,7 @@ class BookCoverServiceTest {
         @Test
         void returnsNullWhenBookFilesIsEmpty() {
             BookEntity book = buildBook(1L, false);
-            book.setBookFiles(new ArrayList<>());
+            book.setBookFiles(new HashSet<>());
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
 
             assertThatThrownBy(() -> service.regenerateCover(1L))
@@ -953,7 +953,7 @@ class BookCoverServiceTest {
             BookEntity book = buildBook(1L, false);
             BookFileEntity audiobookFile = BookFileEntity.builder()
                     .bookType(BookFileType.AUDIOBOOK).isBookFormat(false).build();
-            book.setBookFiles(List.of(audiobookFile));
+            book.setBookFiles(Set.of(audiobookFile));
             book.setLibrary(LibraryEntity.builder().formatPriority(null).build());
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
 
@@ -969,7 +969,7 @@ class BookCoverServiceTest {
                     .bookType(BookFileType.PDF).isBookFormat(true).build();
             BookFileEntity epubFile = BookFileEntity.builder()
                     .bookType(BookFileType.EPUB).isBookFormat(true).build();
-            book.setBookFiles(List.of(pdfFile, epubFile));
+            book.setBookFiles(Set.of(pdfFile, epubFile));
             book.setLibrary(LibraryEntity.builder()
                     .formatPriority(List.of(BookFileType.EPUB, BookFileType.PDF)).build());
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
@@ -988,7 +988,7 @@ class BookCoverServiceTest {
             BookEntity book = buildBook(1L, false);
             BookFileEntity pdfFile = BookFileEntity.builder()
                     .bookType(BookFileType.PDF).isBookFormat(true).build();
-            book.setBookFiles(List.of(pdfFile));
+            book.setBookFiles(Set.of(pdfFile));
             book.setLibrary(LibraryEntity.builder()
                     .formatPriority(List.of(BookFileType.EPUB)).build());
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
@@ -1007,7 +1007,7 @@ class BookCoverServiceTest {
             BookEntity book = buildBook(1L, false);
             BookFileEntity epubFile = BookFileEntity.builder()
                     .bookType(BookFileType.EPUB).isBookFormat(true).build();
-            book.setBookFiles(List.of(epubFile));
+            book.setBookFiles(Set.of(epubFile));
             book.setLibrary(LibraryEntity.builder().formatPriority(List.of()).build());
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
 
@@ -1031,7 +1031,7 @@ class BookCoverServiceTest {
                     .bookType(BookFileType.EPUB).isBookFormat(true)
                     .fileName("test.epub").fileSubPath("sub")
                     .build();
-            book.setBookFiles(List.of(primaryFile));
+            book.setBookFiles(Set.of(primaryFile));
             book.setLibrary(LibraryEntity.builder().build());
             book.setLibraryPath(LibraryPathEntity.builder().path("/lib").build());
 
@@ -1058,7 +1058,7 @@ class BookCoverServiceTest {
         @Test
         void skipsWriteWhenNoPrimaryFile() {
             BookEntity book = buildBook(1L, false);
-            book.setBookFiles(new ArrayList<>());
+            book.setBookFiles(new HashSet<>());
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
             when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
 
@@ -1142,7 +1142,7 @@ class BookCoverServiceTest {
                     .bookType(BookFileType.EPUB)
                     .isBookFormat(true)
                     .build();
-            book.setBookFiles(List.of(bookFile));
+            book.setBookFiles(Set.of(bookFile));
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
             when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
 
@@ -1160,7 +1160,7 @@ class BookCoverServiceTest {
             BookFileEntity audiobookFile = BookFileEntity.builder()
                     .bookType(BookFileType.AUDIOBOOK)
                     .build();
-            book.setBookFiles(List.of(audiobookFile));
+            book.setBookFiles(Set.of(audiobookFile));
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
             when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
 

--- a/backend/src/test/java/org/booklore/service/metadata/BookMetadataServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookMetadataServiceTest.java
@@ -460,7 +460,7 @@ class BookMetadataServiceTest {
 
         @Test
         void returnsNullWhenPrimaryFileIsNull() {
-            BookEntity bookEntity = BookEntity.builder().id(1L).bookFiles(new ArrayList<>()).build();
+            BookEntity bookEntity = BookEntity.builder().id(1L).bookFiles(new HashSet<>()).build();
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
             BookMetadata result = service.getComicInfoMetadata(1L);
@@ -471,7 +471,7 @@ class BookMetadataServiceTest {
         @Test
         void returnsNullWhenFileTypeIsNotCbx() {
             BookFileEntity file = BookFileEntity.builder().bookType(BookFileType.PDF).isBookFormat(true).build();
-            BookEntity bookEntity = BookEntity.builder().id(1L).bookFiles(List.of(file)).build();
+            BookEntity bookEntity = BookEntity.builder().id(1L).bookFiles(Set.of(file)).build();
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
             BookMetadata result = service.getComicInfoMetadata(1L);
@@ -493,7 +493,7 @@ class BookMetadataServiceTest {
 
         @Test
         void throwsWhenPrimaryFileIsNull() {
-            BookEntity bookEntity = BookEntity.builder().id(1L).bookFiles(new ArrayList<>()).build();
+            BookEntity bookEntity = BookEntity.builder().id(1L).bookFiles(new HashSet<>()).build();
             when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(bookEntity));
 
             assertThatThrownBy(() -> service.getFileMetadata(1L))

--- a/backend/src/test/java/org/booklore/service/metadata/BookMetadataUpdaterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookMetadataUpdaterTest.java
@@ -81,7 +81,7 @@ class BookMetadataUpdaterTest {
         bookEntity = BookEntity.builder()
                 .id(1L)
                 .metadata(metadataEntity)
-                .bookFiles(new ArrayList<>())
+                .bookFiles(new HashSet<>())
                 .build();
         metadataEntity.setBook(bookEntity);
     }
@@ -1749,7 +1749,7 @@ class BookMetadataUpdaterTest {
         void movesFile_whenSettingEnabled() {
             BookFileEntity primaryFile = BookFileEntity.builder()
                     .fileName("book.epub").bookType(BookFileType.EPUB).build();
-            bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile)));
+            bookEntity.setBookFiles(Set.of(primaryFile));
 
             BookMetadata newMeta = BookMetadata.builder().title("T").build();
             MetadataUpdateContext context = buildContext(newMeta, MetadataReplaceMode.REPLACE_ALL);
@@ -1782,7 +1782,7 @@ class BookMetadataUpdaterTest {
         void moveFileException_doesNotFailUpdate() {
             BookFileEntity primaryFile = BookFileEntity.builder()
                     .fileName("book.epub").bookType(BookFileType.EPUB).build();
-            bookEntity.setBookFiles(new ArrayList<>(List.of(primaryFile)));
+            bookEntity.setBookFiles(Set.of(primaryFile));
 
             BookMetadata newMeta = BookMetadata.builder().title("T").build();
             MetadataUpdateContext context = buildContext(newMeta, MetadataReplaceMode.REPLACE_ALL);
@@ -1859,7 +1859,7 @@ class BookMetadataUpdaterTest {
                     .bookType(BookFileType.EPUB)
                     .isBookFormat(true)
                     .build();
-            bookEntity.setBookFiles(new ArrayList<>(List.of(bookFile)));
+            bookEntity.setBookFiles(Set.of(bookFile));
 
             BookMetadata newMeta = BookMetadata.builder().title("New Title").build();
             MetadataUpdateContext context = buildContext(newMeta, MetadataReplaceMode.REPLACE_ALL);

--- a/backend/src/test/java/org/booklore/service/metadata/MetadataManagementServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/MetadataManagementServiceTest.java
@@ -234,7 +234,7 @@ class MetadataManagementServiceTest {
         libraryPath.setPath(tempDir.toString());
         BookEntity book = BookEntity.builder()
                 .id(1L)
-                .bookFiles(new ArrayList<>(List.of(bookFile)))
+                .bookFiles(Set.of(bookFile))
                 .libraryPath(libraryPath)
                 .build();
         BookMetadataEntity metadata = BookMetadataEntity.builder()
@@ -295,7 +295,7 @@ class MetadataManagementServiceTest {
         libraryPath.setPath(tempDir.toString());
         BookEntity book = BookEntity.builder()
                 .id(1L)
-                .bookFiles(new ArrayList<>(List.of(bookFile)))
+                .bookFiles(Set.of(bookFile))
                 .libraryPath(libraryPath)
                 .build();
         BookMetadataEntity metadata = BookMetadataEntity.builder()
@@ -465,7 +465,7 @@ class MetadataManagementServiceTest {
         libraryPath.setPath("/example");
         BookEntity book = BookEntity.builder()
                 .id(1L)
-                .bookFiles(List.of())
+                .bookFiles(Set.of())
                 .libraryPath(libraryPath)
                 .build();
         BookMetadataEntity metadata = BookMetadataEntity.builder()
@@ -500,7 +500,7 @@ class MetadataManagementServiceTest {
         libraryPath.setPath(tempDir.toString());
         BookEntity book = BookEntity.builder()
                 .id(1L)
-                .bookFiles(new ArrayList<>(List.of(bookFile)))
+                .bookFiles(Set.of(bookFile))
                 .libraryPath(libraryPath)
                 .build();
         BookMetadataEntity metadata = BookMetadataEntity.builder()
@@ -554,7 +554,7 @@ class MetadataManagementServiceTest {
         libraryPath.setPath(tempDir.toString());
         BookEntity book = BookEntity.builder()
                 .id(1L)
-                .bookFiles(new ArrayList<>(List.of(bookFile)))
+                .bookFiles(Set.of(bookFile))
                 .libraryPath(libraryPath)
                 .build();
         BookMetadataEntity metadata = BookMetadataEntity.builder()
@@ -600,7 +600,7 @@ class MetadataManagementServiceTest {
         libraryPath.setPath("/fake/path");
         BookEntity book = BookEntity.builder()
                 .id(1L)
-                .bookFiles(new ArrayList<>(List.of(bookFile)))
+                .bookFiles(Set.of(bookFile))
                 .libraryPath(libraryPath)
                 .build();
         BookMetadataEntity metadata = BookMetadataEntity.builder()
@@ -629,7 +629,7 @@ class MetadataManagementServiceTest {
         BookEntity physicalBook = BookEntity.builder()
                 .id(1L)
                 .isPhysical(true)
-                .bookFiles(new ArrayList<>())
+                .bookFiles(new HashSet<>())
                 .build();
         BookMetadataEntity metadata = BookMetadataEntity.builder()
                 .authors(new ArrayList<>(List.of(oldAuthor)))

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -31,9 +31,9 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -90,7 +90,7 @@ class EpubMetadataWriterTest {
         bookEntity.setLibraryPath(libraryPath);
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setBook(bookEntity);
-        bookEntity.setBookFiles(Collections.singletonList(primaryFile));
+        bookEntity.setBookFiles(Set.of(primaryFile));
         bookEntity.getPrimaryBookFile().setFileSubPath("");
         bookEntity.getPrimaryBookFile().setFileName("test.epub");
     }

--- a/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/progress/ReadingProgressServiceTest.java
@@ -179,7 +179,7 @@ class ReadingProgressServiceTest {
         primaryFile.setId(1L);
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.EPUB);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
 
         BookLoreUser user = mock(BookLoreUser.class);
         when(user.getId()).thenReturn(2L);
@@ -217,7 +217,7 @@ class ReadingProgressServiceTest {
         primaryFile.setId(1L);
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.EPUB);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
 
         BookLoreUser user = mock(BookLoreUser.class);
         when(user.getId()).thenReturn(2L);
@@ -260,7 +260,7 @@ class ReadingProgressServiceTest {
         primaryFile.setId(1L);
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.PDF);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
 
         BookLoreUser user = mock(BookLoreUser.class);
         when(user.getId()).thenReturn(2L);
@@ -298,7 +298,7 @@ class ReadingProgressServiceTest {
         primaryFile.setId(1L);
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.EPUB);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
 
         BookLoreUser user = mock(BookLoreUser.class);
         when(user.getId()).thenReturn(2L);
@@ -333,7 +333,7 @@ class ReadingProgressServiceTest {
         primaryFile.setId(1L);
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.PDF);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
 
         BookLoreUser user = mock(BookLoreUser.class);
         when(user.getId()).thenReturn(2L);
@@ -368,7 +368,7 @@ class ReadingProgressServiceTest {
         primaryFile.setId(1L);
         primaryFile.setBook(book);
         primaryFile.setBookType(BookFileType.EPUB);
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
 
         BookLoreUser user = mock(BookLoreUser.class);
         when(user.getId()).thenReturn(2L);

--- a/backend/src/test/java/org/booklore/service/reader/AudiobookReaderServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/reader/AudiobookReaderServiceTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -85,9 +86,7 @@ class AudiobookReaderServiceTest {
         when(folderAudiobookFileEntity.isBookFormat()).thenReturn(true);
         when(folderAudiobookFileEntity.getFullFilePath()).thenReturn(folderPath);
 
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(audiobookFileEntity);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(audiobookFileEntity));
     }
 
     // ==================== getAudiobookInfo tests ====================
@@ -117,10 +116,7 @@ class AudiobookReaderServiceTest {
         when(epubFile.getId()).thenReturn(30L);
         when(epubFile.getBookType()).thenReturn(BookFileType.EPUB);
 
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(audiobookFileEntity);
-        bookFiles.add(epubFile);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(audiobookFileEntity, epubFile));
 
         AudiobookInfo expectedInfo = AudiobookInfo.builder().bookId(1L).build();
 
@@ -146,9 +142,7 @@ class AudiobookReaderServiceTest {
         BookFileEntity epubFile = mock(BookFileEntity.class);
         when(epubFile.getBookType()).thenReturn(BookFileType.EPUB);
 
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(epubFile);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(epubFile));
 
         when(bookRepository.findByIdForAudiobook(1L)).thenReturn(Optional.of(bookEntity));
 
@@ -195,9 +189,7 @@ class AudiobookReaderServiceTest {
 
     @Test
     void getAudioFilePath_folderBased_returnsTrackPath() throws IOException {
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(folderAudiobookFileEntity);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(folderAudiobookFileEntity));
 
         Path track1 = folderPath.resolve("track1.mp3");
         Path track2 = folderPath.resolve("track2.mp3");
@@ -214,9 +206,7 @@ class AudiobookReaderServiceTest {
 
     @Test
     void getAudioFilePath_folderBased_defaultsToFirstTrack() throws IOException {
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(folderAudiobookFileEntity);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(folderAudiobookFileEntity));
 
         Path track1 = folderPath.resolve("track1.mp3");
         Files.createFile(track1);
@@ -231,9 +221,7 @@ class AudiobookReaderServiceTest {
 
     @Test
     void getAudioFilePath_folderBased_throwsExceptionForInvalidIndex() throws IOException {
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(folderAudiobookFileEntity);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(folderAudiobookFileEntity));
 
         Path track1 = folderPath.resolve("track1.mp3");
         Files.createFile(track1);
@@ -247,9 +235,7 @@ class AudiobookReaderServiceTest {
 
     @Test
     void getAudioFilePath_folderBased_throwsExceptionForNegativeIndex() throws IOException {
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(folderAudiobookFileEntity);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(folderAudiobookFileEntity));
 
         Path track1 = folderPath.resolve("track1.mp3");
         Files.createFile(track1);
@@ -308,9 +294,7 @@ class AudiobookReaderServiceTest {
 
     @Test
     void getEmbeddedCoverArt_folderBased_usesFirstAudioFile() throws IOException {
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(folderAudiobookFileEntity);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(folderAudiobookFileEntity));
 
         Path track1 = folderPath.resolve("track1.mp3");
         Files.createFile(track1);
@@ -352,9 +336,7 @@ class AudiobookReaderServiceTest {
 
     @Test
     void getCoverArtMimeType_folderBased_usesFirstAudioFile() throws IOException {
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(folderAudiobookFileEntity);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(folderAudiobookFileEntity));
 
         Path track1 = folderPath.resolve("track1.mp3");
         Files.createFile(track1);
@@ -389,10 +371,7 @@ class AudiobookReaderServiceTest {
         when(audiobookWithoutBookFormat.getBookType()).thenReturn(BookFileType.AUDIOBOOK);
         when(audiobookWithoutBookFormat.isBookFormat()).thenReturn(false);
 
-        List<BookFileEntity> bookFiles = new ArrayList<>();
-        bookFiles.add(audiobookFileEntity);
-        bookFiles.add(audiobookWithoutBookFormat);
-        when(bookEntity.getBookFiles()).thenReturn(bookFiles);
+        when(bookEntity.getBookFiles()).thenReturn(Set.of(audiobookFileEntity, audiobookWithoutBookFormat));
 
         AudiobookInfo expectedInfo = AudiobookInfo.builder().bookId(1L).build();
 

--- a/backend/src/test/java/org/booklore/service/upload/FileUploadServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/upload/FileUploadServiceTest.java
@@ -237,7 +237,7 @@ class FileUploadServiceTest {
         primaryFile.setFileName("primary.epub");
         primaryFile.setFileSubPath(".");
         primaryFile.setBookType(BookFileType.EPUB);
-        book.setBookFiles(new ArrayList<>(List.of(primaryFile)));
+        book.setBookFiles(Set.of(primaryFile));
 
         when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
 
@@ -280,7 +280,7 @@ class FileUploadServiceTest {
         primaryFile.setFileName("primary.epub");
         primaryFile.setFileSubPath(".");
         primaryFile.setBookType(BookFileType.EPUB);
-        book.setBookFiles(new ArrayList<>(List.of(primaryFile)));
+        book.setBookFiles(Set.of(primaryFile));
 
         when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));
 
@@ -355,7 +355,7 @@ class FileUploadServiceTest {
         book.setLibraryPath(libPath);
         BookFileEntity primaryFile = new BookFileEntity();
         primaryFile.setBook(book);
-        book.setBookFiles(new ArrayList<>(List.of(primaryFile)));
+        book.setBookFiles(Set.of(primaryFile));
         book.getPrimaryBookFile().setFileSubPath(".");
 
         when(bookRepository.findByIdWithBookFiles(bookId)).thenReturn(Optional.of(book));

--- a/backend/src/test/java/org/booklore/service/watcher/BookFilePersistenceServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/BookFilePersistenceServiceTest.java
@@ -74,7 +74,7 @@ class BookFilePersistenceServiceTest {
                 .library(library)
                 .libraryPath(libraryPath)
                 .deleted(false)
-                .bookFiles(new ArrayList<>())
+                .bookFiles(Set.of())
                 .build();
     }
 
@@ -150,7 +150,7 @@ class BookFilePersistenceServiceTest {
         void updatesPathWhenSubPathDiffers() {
             BookEntity book = buildBook(10L);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "hash123");
-            book.setBookFiles(new ArrayList<>(List.of(bookFile)));
+            book.setBookFiles(Set.of(bookFile));
 
             when(entityManager.merge(any(LibraryPathEntity.class))).thenReturn(libraryPath);
             fileUtilsMock.when(() -> FileUtils.getRelativeSubPath(anyString(), any(Path.class))).thenReturn("newsub");
@@ -165,7 +165,7 @@ class BookFilePersistenceServiceTest {
         void updatesPathWhenFileNameDiffers() {
             BookEntity book = buildBook(10L);
             BookFileEntity bookFile = buildBookFile(100L, book, "old.epub", "hash123");
-            book.setBookFiles(new ArrayList<>(List.of(bookFile)));
+            book.setBookFiles(Set.of(bookFile));
 
             when(entityManager.merge(any(LibraryPathEntity.class))).thenReturn(libraryPath);
 
@@ -180,7 +180,7 @@ class BookFilePersistenceServiceTest {
             BookEntity book = buildBook(10L);
             book.setDeleted(true);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "hash123");
-            book.setBookFiles(new ArrayList<>(List.of(bookFile)));
+            book.setBookFiles(Set.of(bookFile));
 
             when(entityManager.merge(any(LibraryPathEntity.class))).thenReturn(libraryPath);
 
@@ -196,7 +196,7 @@ class BookFilePersistenceServiceTest {
             BookEntity book = buildBook(10L);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "hash123");
             bookFile.setFileSubPath("sub");
-            book.setBookFiles(new ArrayList<>(List.of(bookFile)));
+            book.setBookFiles(Set.of(bookFile));
 
             when(entityManager.merge(any(LibraryPathEntity.class))).thenReturn(libraryPath);
 
@@ -210,7 +210,7 @@ class BookFilePersistenceServiceTest {
             BookEntity book = buildBook(10L);
             BookFileEntity primaryFile = buildBookFile(100L, book, "primary.epub", "primaryhash");
             BookFileEntity secondaryFile = buildBookFile(101L, book, "secondary.pdf", "hash123");
-            book.setBookFiles(new ArrayList<>(List.of(primaryFile, secondaryFile)));
+            book.setBookFiles(Set.of(primaryFile, secondaryFile));
 
             when(entityManager.merge(any(LibraryPathEntity.class))).thenReturn(libraryPath);
             fileUtilsMock.when(() -> FileUtils.getRelativeSubPath(anyString(), any(Path.class))).thenReturn("newsub");
@@ -227,7 +227,7 @@ class BookFilePersistenceServiceTest {
         void sendsNotificationAfterUpdate() {
             BookEntity book = buildBook(10L);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "hash123");
-            book.setBookFiles(new ArrayList<>(List.of(bookFile)));
+            book.setBookFiles(Set.of(bookFile));
 
             when(entityManager.merge(any(LibraryPathEntity.class))).thenReturn(libraryPath);
             fileUtilsMock.when(() -> FileUtils.getRelativeSubPath(anyString(), any(Path.class))).thenReturn("newsub");
@@ -346,7 +346,7 @@ class BookFilePersistenceServiceTest {
             BookEntity book = buildBook(10L);
             book.setDeleted(true);
             BookFileEntity bookFile = buildBookFile(100L, book, "old.epub", "filehash1");
-            book.setBookFiles(new ArrayList<>(List.of(bookFile)));
+            book.setBookFiles(Set.of(bookFile));
 
             var fileSnap = new FileSnapshot(100L, "old.epub", "sub", "filehash1", false, BookFileType.EPUB);
             var bookSnap = new BookSnapshot(10L, 1L, "sub", List.of(fileSnap));
@@ -384,7 +384,7 @@ class BookFilePersistenceServiceTest {
             book.setDeleted(true);
             BookFileEntity file1 = buildBookFile(100L, book, "a.epub", "hash1");
             BookFileEntity file2 = buildBookFile(101L, book, "b.epub", "hash2");
-            book.setBookFiles(new ArrayList<>(List.of(file1, file2)));
+            book.setBookFiles(Set.of(file1, file2));
 
             var snap1 = new FileSnapshot(100L, "a.epub", "sub", "hash1", false, BookFileType.EPUB);
             var snap2 = new FileSnapshot(101L, "b.epub", "sub", "hash2", false, BookFileType.EPUB);
@@ -411,7 +411,7 @@ class BookFilePersistenceServiceTest {
         void fileSnapshotWithNoHashMatch_leftUnchanged() {
             BookEntity book = buildBook(10L);
             BookFileEntity bookFile = buildBookFile(100L, book, "old.epub", "oldhash");
-            book.setBookFiles(new ArrayList<>(List.of(bookFile)));
+            book.setBookFiles(Set.of(bookFile));
 
             var fileSnap = new FileSnapshot(100L, "old.epub", "sub", "nomatch", false, BookFileType.EPUB);
             var bookSnap = new BookSnapshot(10L, 1L, "sub", List.of(fileSnap));

--- a/backend/src/test/java/org/booklore/service/watcher/BookFileTransactionalHandlerTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/BookFileTransactionalHandlerTest.java
@@ -1,7 +1,6 @@
 package org.booklore.service.watcher;
 
 import org.booklore.model.entity.*;
-import org.booklore.model.enums.BookFileExtension;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.model.enums.LibraryOrganizationMode;
 import org.booklore.repository.BookAdditionalFileRepository;
@@ -22,10 +21,9 @@ import org.mockito.MockitoAnnotations;
 
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 
@@ -103,7 +101,7 @@ class BookFileTransactionalHandlerTest {
                 .library(library)
                 .libraryPath(libraryPath)
                 .deleted(deleted)
-                .bookFiles(new ArrayList<>())
+                .bookFiles(Set.of())
                 .build();
     }
 
@@ -151,7 +149,7 @@ class BookFileTransactionalHandlerTest {
         void existingAtPath_deletedBook_restoresIt() {
             BookEntity book = buildBook(10L, true);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "oldhash");
-            book.setBookFiles(List.of(bookFile));
+            book.setBookFiles(Set.of(bookFile));
 
             when(bookFilePersistenceService.findBookFileByLibraryPathSubPathAndFileName(1L, "sub", "test.epub"))
                     .thenReturn(Optional.of(bookFile));
@@ -168,7 +166,7 @@ class BookFileTransactionalHandlerTest {
         void existingAtPath_sameHash_skipsProcessing() {
             BookEntity book = buildBook(10L, false);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "hash123");
-            book.setBookFiles(List.of(bookFile));
+            book.setBookFiles(Set.of(bookFile));
 
             when(bookFilePersistenceService.findBookFileByLibraryPathSubPathAndFileName(1L, "sub", "test.epub"))
                     .thenReturn(Optional.of(bookFile));
@@ -183,7 +181,7 @@ class BookFileTransactionalHandlerTest {
         void existingAtPath_hashChanged_updatesHash() {
             BookEntity book = buildBook(10L, false);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "oldhash");
-            book.setBookFiles(List.of(bookFile));
+            book.setBookFiles(Set.of(bookFile));
 
             when(bookFilePersistenceService.findBookFileByLibraryPathSubPathAndFileName(1L, "sub", "test.epub"))
                     .thenReturn(Optional.of(bookFile));
@@ -259,7 +257,7 @@ class BookFileTransactionalHandlerTest {
 
             BookEntity existingBook = buildBook(20L, false);
             BookFileEntity primaryFile = buildBookFile(200L, existingBook, "test.epub", "otherhash");
-            existingBook.setBookFiles(new ArrayList<>(List.of(primaryFile)));
+            existingBook.setBookFiles(Set.of(primaryFile));
             when(bookRepository.findAllByLibraryPathIdAndFileSubPath(1L, "sub")).thenReturn(List.of(existingBook));
 
             // Both files should produce the same grouping key (extension stripped)
@@ -313,7 +311,7 @@ class BookFileTransactionalHandlerTest {
 
             BookEntity existingBook = buildBook(20L, false);
             BookFileEntity primaryFile = buildBookFile(200L, existingBook, "existing.epub", "otherhash");
-            existingBook.setBookFiles(new ArrayList<>(List.of(primaryFile)));
+            existingBook.setBookFiles(Set.of(primaryFile));
             when(bookRepository.findAllByLibraryPathIdAndFileSubPath(1L, "sub")).thenReturn(List.of(existingBook));
 
             handler.handleNewBookFile(1L, Path.of("/library/sub/new.pdf"));
@@ -353,7 +351,7 @@ class BookFileTransactionalHandlerTest {
             BookEntity parentBook = buildBook(30L, false);
             BookFileEntity ebookFile = buildBookFile(300L, parentBook, "book.epub", "ebookhash");
             ebookFile.setBookType(BookFileType.EPUB);
-            parentBook.setBookFiles(new ArrayList<>(List.of(ebookFile)));
+            parentBook.setBookFiles(Set.of(ebookFile));
             when(bookRepository.findAllByLibraryPathIdAndFileSubPath(1L, "author/book")).thenReturn(List.of(parentBook));
 
             handler.handleNewBookFile(1L, Path.of("/library/author/book/audio/chapter1.m4b"));
@@ -417,11 +415,11 @@ class BookFileTransactionalHandlerTest {
 
             BookEntity book1 = buildBook(20L, false);
             BookFileEntity file1 = buildBookFile(200L, book1, "mybook.epub", "h1");
-            book1.setBookFiles(new ArrayList<>(List.of(file1)));
+            book1.setBookFiles(Set.of(file1));
 
             BookEntity book2 = buildBook(21L, false);
             BookFileEntity file2 = buildBookFile(201L, book2, "otherbook.epub", "h2");
-            book2.setBookFiles(new ArrayList<>(List.of(file2)));
+            book2.setBookFiles(Set.of(file2));
 
             when(bookRepository.findAllByLibraryPathIdAndFileSubPath(1L, "sub")).thenReturn(List.of(book1, book2));
             // Make groupingKey different to avoid exact match, but similarity high for book1
@@ -465,12 +463,12 @@ class BookFileTransactionalHandlerTest {
 
             BookEntity smallBook = buildBook(20L, false);
             BookFileEntity f1 = buildBookFile(200L, smallBook, "a.epub", "h1");
-            smallBook.setBookFiles(new ArrayList<>(List.of(f1)));
+            smallBook.setBookFiles(Set.of(f1));
 
             BookEntity bigBook = buildBook(21L, false);
             BookFileEntity f2 = buildBookFile(201L, bigBook, "b.epub", "h2");
             BookFileEntity f3 = buildBookFile(202L, bigBook, "b.pdf", "h3");
-            bigBook.setBookFiles(new ArrayList<>(List.of(f2, f3)));
+            bigBook.setBookFiles(Set.of(f2, f3));
 
             when(bookRepository.findAllByLibraryPathIdAndFileSubPath(1L, "sub")).thenReturn(List.of(smallBook, bigBook));
 
@@ -484,7 +482,7 @@ class BookFileTransactionalHandlerTest {
         void existingAtPath_deletedBook_matchesPendingDeletionHash() {
             BookEntity book = buildBook(10L, true);
             BookFileEntity bookFile = buildBookFile(100L, book, "test.epub", "oldhash");
-            book.setBookFiles(List.of(bookFile));
+            book.setBookFiles(Set.of(bookFile));
 
             when(bookFilePersistenceService.findBookFileByLibraryPathSubPathAndFileName(1L, "sub", "test.epub"))
                     .thenReturn(Optional.of(bookFile));
@@ -523,7 +521,7 @@ class BookFileTransactionalHandlerTest {
 
             BookEntity deletedBook = buildBook(20L, true);
             BookFileEntity file = buildBookFile(200L, deletedBook, "test.epub", "h1");
-            deletedBook.setBookFiles(new ArrayList<>(List.of(file)));
+            deletedBook.setBookFiles(Set.of(file));
             when(bookRepository.findAllByLibraryPathIdAndFileSubPath(1L, "sub")).thenReturn(List.of(deletedBook));
 
             handler.handleNewBookFile(1L, Path.of("/library/sub/test.pdf"));
@@ -584,7 +582,7 @@ class BookFileTransactionalHandlerTest {
 
             BookEntity existingBook = buildBook(20L, false);
             BookFileEntity primaryFile = buildBookFile(200L, existingBook, "audiobook.epub", "h1");
-            existingBook.setBookFiles(new ArrayList<>(List.of(primaryFile)));
+            existingBook.setBookFiles(Set.of(primaryFile));
             when(bookRepository.findAllByLibraryPathIdAndFileSubPath(anyLong(), anyString())).thenReturn(List.of(existingBook));
 
             // Folder name "audiobook" and file "audiobook.epub" should produce same grouping key
@@ -614,7 +612,7 @@ class BookFileTransactionalHandlerTest {
 
             BookEntity deletedBook = buildBook(20L, true);
             BookFileEntity file = buildBookFile(200L, deletedBook, "audiobook.epub", "h1");
-            deletedBook.setBookFiles(new ArrayList<>(List.of(file)));
+            deletedBook.setBookFiles(Set.of(file));
             when(bookRepository.findAllByLibraryPathIdAndFileSubPath(anyLong(), anyString())).thenReturn(List.of(deletedBook));
 
             handler.handleNewFolderAudiobook(1L, Path.of("/library/sub/audiobook"));

--- a/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/LibraryFileEventProcessorTest.java
@@ -304,14 +304,14 @@ class LibraryFileEventProcessorTest {
                     .library(library)
                     .libraryPath(libraryPath)
                     .deleted(false)
-                    .bookFiles(new ArrayList<>(List.of(BookFileEntity.builder()
+                    .bookFiles(Set.of(BookFileEntity.builder()
                             .id(100L)
                             .fileName("test.epub")
                             .fileSubPath("books")
                             .currentHash("hash")
                             .isBookFormat(true)
                             .bookType(BookFileType.EPUB)
-                            .build())))
+                            .build()))
                     .build();
 
             when(bookRepository.findBooksWithFilesUnderPath(eq(1L), anyString()))
@@ -348,7 +348,7 @@ class LibraryFileEventProcessorTest {
         void bookFileFound_addsToPool() throws Exception {
             BookEntity book = BookEntity.builder()
                     .id(10L).library(library).libraryPath(libraryPath).deleted(false)
-                    .bookFiles(new ArrayList<>()).build();
+                    .bookFiles(Set.of()).build();
             BookFileEntity bookFile = BookFileEntity.builder()
                     .id(100L).book(book).fileName("test.epub").fileSubPath("sub")
                     .currentHash("hash").isBookFormat(true).bookType(BookFileType.EPUB).build();

--- a/backend/src/test/java/org/booklore/service/watcher/PendingDeletionPoolTest.java
+++ b/backend/src/test/java/org/booklore/service/watcher/PendingDeletionPoolTest.java
@@ -103,7 +103,7 @@ class PendingDeletionPoolTest {
         BookFileEntity file2 = BookFileEntity.builder()
                 .id(101L).book(book).fileName("test2.epub").fileSubPath("subfolder")
                 .currentHash("def456").isBookFormat(true).folderBased(false).bookType(BookFileType.EPUB).build();
-        book.setBookFiles(List.of(bookFile, file2));
+        book.setBookFiles(Set.of(bookFile, file2));
 
         ScheduledFuture<?> timer = mock(ScheduledFuture.class);
         pool.addFolderDeletion(Path.of("/library/subfolder"), 1L, List.of(book), timer);
@@ -117,7 +117,7 @@ class PendingDeletionPoolTest {
         BookFileEntity file2 = BookFileEntity.builder()
                 .id(101L).book(book).fileName("test2.epub").fileSubPath("subfolder")
                 .currentHash("def456").isBookFormat(true).folderBased(false).bookType(BookFileType.EPUB).build();
-        book.setBookFiles(List.of(bookFile, file2));
+        book.setBookFiles(Set.of(bookFile, file2));
 
         ScheduledFuture<?> timer = mock(ScheduledFuture.class);
         pool.addFolderDeletion(Path.of("/library/subfolder"), 1L, List.of(book), timer);
@@ -135,7 +135,7 @@ class PendingDeletionPoolTest {
 
     @Test
     void matchFolderByHashes_rejectsLowOverlap() {
-        book.setBookFiles(List.of(bookFile));
+        book.setBookFiles(Set.of(bookFile));
 
         ScheduledFuture<?> timer = mock(ScheduledFuture.class);
         pool.addFolderDeletion(Path.of("/library/subfolder"), 1L, List.of(book), timer);
@@ -179,7 +179,7 @@ class PendingDeletionPoolTest {
 
     @Test
     void expireFolderDeletion_marksAllBooksDeleted() {
-        book.setBookFiles(List.of(bookFile));
+        book.setBookFiles(Set.of(bookFile));
 
         ScheduledFuture<?> timer = mock(ScheduledFuture.class);
         pool.addFolderDeletion(Path.of("/library/subfolder"), 1L, List.of(book), timer);

--- a/backend/src/test/java/org/booklore/util/FileUtilsTest.java
+++ b/backend/src/test/java/org/booklore/util/FileUtilsTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,7 +30,7 @@ class FileUtilsTest {
         bookFileEntity.setBook(bookEntity);
         bookFileEntity.setFileSubPath(subPath);
         bookFileEntity.setFileName(fileName);
-        bookEntity.setBookFiles(List.of(bookFileEntity));
+        bookEntity.setBookFiles(Set.of(bookFileEntity));
 
         return bookEntity;
     }

--- a/backend/src/test/java/org/booklore/util/PathPatternResolverTest.java
+++ b/backend/src/test/java/org/booklore/util/PathPatternResolverTest.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -248,7 +249,7 @@ class PathPatternResolverTest {
         primaryFile.setBook(book);
         primaryFile.setFileName("book.epub");
         primaryFile.setFileSubPath("");
-        book.setBookFiles(List.of(primaryFile));
+        book.setBookFiles(Set.of(primaryFile));
         book.setMetadata(metadata);
 
         String result = PathPatternResolver.resolvePattern(book, "{title}.{extension}");

--- a/backend/src/test/java/org/booklore/util/builder/LibraryTestBuilder.java
+++ b/backend/src/test/java/org/booklore/util/builder/LibraryTestBuilder.java
@@ -22,8 +22,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -199,7 +201,7 @@ public class LibraryTestBuilder {
                 .libraryPath(getLibraryEntity().getLibraryPaths().getLast())
                 .addedOn(Instant.now())
                 .metadata(metadata)
-                .bookFiles(new ArrayList<>())
+                .bookFiles(new HashSet<>())
                 .build();
 
         BookFileEntity primaryFile = BookFileEntity.builder()
@@ -303,7 +305,7 @@ public class LibraryTestBuilder {
                 .libraryPath(libraryFile.getLibraryPathEntity())
                 .addedOn(Instant.now())
                 .metadata(metadata)
-                .bookFiles(new ArrayList<>())
+                .bookFiles(Set.of())
                 .build();
 
         BookFileEntity primaryFile = BookFileEntity.builder()


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
With the way that we are doing eager loads of both `ShelfEntity` and `BookFileEnitty` we end up with duplicates of `BookFileEntity`.  This is painful as it leads to us having incorrect data throughout the application - and also makes removing values + saving them again confusing.

To mitigiate this (but not fully fix it) we can switch the `BookEntity.bookFiles` relationship to load as a `Set` instead of a `List`.  This means we lose the sorted order of the `List` but will remove any duplicate entities during the loading process.  to work around the lack of a sorted order, we can do the sorting in-memory when we actually need the values to be sorted by ID

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2292

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
switches `BookEntity.bookFiles` relationship to be a `Set`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

app loads, and metadata view + page view do not have duplicate file records
navigated throughout the app for a while with no unexpected errors or failure scenarios.

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
In the future we should probably update the loading mechanism to prefer `Lazy` loading + `SUBSELECT` fetch modes.  Those could lead to their own sets of problems, and have more unknowns than switching to `Set`, so this is a good mitigation untilw e make that shift.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Book and audiobook file selection is now deterministic, consistently choosing the lowest-ID matching file.
  * Primary-file selection respects library format priorities before applying a deterministic fallback.
  * Cover generation, metadata updates, readers, downloads, duplicate detection, and file attachments now use the correct primary file.
  * File deletion snapshots retain the primary file path when available.
  * Downloads now handle missing or empty book-file collections more reliably.

* **Refactor**
  * Book file collections now support unordered collections while preserving predictable selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->