### PR TITLE
fix(author): require a name match before applying an Audnexus quick-match result

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/AudnexusAuthorParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AudnexusAuthorParser.java
@@ -130,8 +130,7 @@ public class AudnexusAuthorParser implements AuthorParser {
         // Word-boundary placement varies across sources for compound surnames (e.g. "De Long"
         // vs "Delong"), so whitespace is stripped entirely rather than just collapsed.
         return name.toLowerCase(Locale.ROOT)
-                .replaceAll("[.,]", "")
-                .replaceAll("\\s+", "");
+                .replaceAll("(?U)[\\p{P}\\s]+", "");
     }
 
     @Override

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AudnexusAuthorParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AudnexusAuthorParser.java
@@ -101,8 +101,13 @@ public class AudnexusAuthorParser implements AuthorParser {
 
             if (response.statusCode() == 200) {
                 AudnexusAuthorResponse[] authors = objectMapper.readValue(response.body(), AudnexusAuthorResponse[].class);
-                if (authors.length == 0) return null;
-                return getAuthorByAsin(authors[0].getAsin(), region);
+                for (AudnexusAuthorResponse candidate : authors) {
+                    if (namesMatch(name, candidate.getName())) {
+                        return getAuthorByAsin(candidate.getAsin(), region);
+                    }
+                }
+                log.warn("Audnexus author quick search found no name match for: {}", name);
+                return null;
             }
 
             log.warn("Audnexus author quick search returned status {}", response.statusCode());
@@ -114,6 +119,19 @@ public class AudnexusAuthorParser implements AuthorParser {
             log.error("Audnexus author quick search failed for name: {}", name, e);
             return null;
         }
+    }
+
+    private boolean namesMatch(String queryName, String candidateName) {
+        if (queryName == null || candidateName == null) return false;
+        return normalizeName(queryName).equals(normalizeName(candidateName));
+    }
+
+    private String normalizeName(String name) {
+        // Word-boundary placement varies across sources for compound surnames (e.g. "De Long"
+        // vs "Delong"), so whitespace is stripped entirely rather than just collapsed.
+        return name.toLowerCase(Locale.ROOT)
+                .replaceAll("[.,]", "")
+                .replaceAll("\\s+", "");
     }
 
     @Override

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
@@ -265,6 +265,7 @@ class AudnexusAuthorParserTest {
         assertThat(result).isNotNull();
         assertThat(result.getAsin()).isEqualTo("B00ABCDEF0");
         assertThat(result.getName()).isEqualTo("Hayao Miyazaki");
+        verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B001I7AEI2")), any());
         verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B079XYL3FZ")), any());
         verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B00LATER99")), any());
     }

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
@@ -225,7 +225,8 @@ class AudnexusAuthorParserTest {
                 [
                   {"asin": "B001I7AEI2", "name": "Hayao Kawai"},
                   {"asin": "B079XYL3FZ", "name": "Yoshifumi Miyazaki"},
-                  {"asin": "B00ABCDEF0", "name": "Hayao Miyazaki"}
+                  {"asin": "B00ABCDEF0", "name": "Hayao Miyazaki"},
+                  {"asin": "B00LATER99", "name": "Hayao Miyazaki"}
                 ]
                 """;
         String wrongDetailJson = """
@@ -233,6 +234,9 @@ class AudnexusAuthorParserTest {
                 """;
         String detailJson = """
                 {"asin": "B00ABCDEF0", "name": "Hayao Miyazaki", "description": "Animator and filmmaker", "image": "https://img.com/miyazaki.jpg"}
+                """;
+        String laterMatchDetailJson = """
+                {"asin": "B00LATER99", "name": "Hayao Miyazaki"}
                 """;
 
         HttpResponse<String> searchResponse = mock(HttpResponse.class);
@@ -247,9 +251,14 @@ class AudnexusAuthorParserTest {
         when(detailResponse.statusCode()).thenReturn(200);
         when(detailResponse.body()).thenReturn(detailJson);
 
+        HttpResponse<String> laterMatchDetailResponse = mock(HttpResponse.class);
+        lenient().when(laterMatchDetailResponse.statusCode()).thenReturn(200);
+        lenient().when(laterMatchDetailResponse.body()).thenReturn(laterMatchDetailJson);
+
         doReturn(searchResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors?")), any());
         lenient().doReturn(wrongDetailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B001I7AEI2")), any());
         doReturn(detailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B00ABCDEF0")), any());
+        lenient().doReturn(laterMatchDetailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B00LATER99")), any());
 
         AuthorSearchResult result = parser.quickSearch("Hayao Miyazaki", "us");
 
@@ -257,6 +266,7 @@ class AudnexusAuthorParserTest {
         assertThat(result.getAsin()).isEqualTo("B00ABCDEF0");
         assertThat(result.getName()).isEqualTo("Hayao Miyazaki");
         verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B079XYL3FZ")), any());
+        verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B00LATER99")), any());
     }
 
     @Test
@@ -392,6 +402,7 @@ class AudnexusAuthorParserTest {
         String searchJson = """
                 [
                   {"asin": "B000NULL00"},
+                  {"asin": "B000EMPT00", "name": ""},
                   {"asin": "B001H6KOCK", "name": "Stephen King"}
                 ]
                 """;
@@ -415,6 +426,7 @@ class AudnexusAuthorParserTest {
         assertThat(result).isNotNull();
         assertThat(result.getAsin()).isEqualTo("B001H6KOCK");
         verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B000NULL00")), any());
+        verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B000EMPT00")), any());
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
@@ -345,6 +345,68 @@ class AudnexusAuthorParserTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    void quickSearch_matchIgnoresApostrophesAndHyphens() throws Exception {
+        // Sources disagree on whether names like "O'Connor" carry punctuation at all, so the
+        // match must tolerate an apostrophe (or hyphen) being present on only one side.
+        String searchJson = """
+                [
+                  {"asin": "B0131MUW2E", "name": "Flannery O'Connor"}
+                ]
+                """;
+        String detailJson = """
+                {"asin": "B0131MUW2E", "name": "Flannery O'Connor"}
+                """;
+
+        HttpResponse<String> searchResponse = mock(HttpResponse.class);
+        when(searchResponse.statusCode()).thenReturn(200);
+        when(searchResponse.body()).thenReturn(searchJson);
+
+        HttpResponse<String> detailResponse = mock(HttpResponse.class);
+        when(detailResponse.statusCode()).thenReturn(200);
+        when(detailResponse.body()).thenReturn(detailJson);
+
+        doReturn(searchResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors?")), any());
+        doReturn(detailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B0131MUW2E")), any());
+
+        AuthorSearchResult result = parser.quickSearch("Flannery OConnor", "us");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAsin()).isEqualTo("B0131MUW2E");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void quickSearch_skipsCandidateWithNullName() throws Exception {
+        String searchJson = """
+                [
+                  {"asin": "B000NULL00"},
+                  {"asin": "B001H6KOCK", "name": "Stephen King"}
+                ]
+                """;
+        String detailJson = """
+                {"asin": "B001H6KOCK", "name": "Stephen King"}
+                """;
+
+        HttpResponse<String> searchResponse = mock(HttpResponse.class);
+        when(searchResponse.statusCode()).thenReturn(200);
+        when(searchResponse.body()).thenReturn(searchJson);
+
+        HttpResponse<String> detailResponse = mock(HttpResponse.class);
+        when(detailResponse.statusCode()).thenReturn(200);
+        when(detailResponse.body()).thenReturn(detailJson);
+
+        doReturn(searchResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors?")), any());
+        doReturn(detailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B001H6KOCK")), any());
+
+        AuthorSearchResult result = parser.quickSearch("Stephen King", "us");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAsin()).isEqualTo("B001H6KOCK");
+        verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B000NULL00")), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     void quickSearch_returnsNullWhenNoResults() throws Exception {
         HttpResponse<String> mockResponse = mock(HttpResponse.class);
         when(mockResponse.statusCode()).thenReturn(200);

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
@@ -182,4 +182,177 @@ class AudnexusAuthorParserTest {
         assertThat(uri).contains("api.audnex.us/authors/B000APZGGS");
         assertThat(uri).contains("region=uk");
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void quickSearch_returnsNullWhenNoResultNameMatchesQuery() throws Exception {
+        // Reproduces the real Audnexus response for "Hayao Miyazaki": the top hit only
+        // shares a first name ("Hayao Kawai"), and nothing in the list is an actual match.
+        // The wrong top hit resolves to a real (but wrong) author detail, so a stray match
+        // here can only be explained by the buggy code actually taking it.
+        String searchJson = """
+                [
+                  {"asin": "B001I7AEI2", "name": "Hayao Kawai"},
+                  {"asin": "B079XYL3FZ", "name": "Yoshifumi Miyazaki"}
+                ]
+                """;
+        String wrongDetailJson = """
+                {"asin": "B001I7AEI2", "name": "Hayao Kawai", "description": "Psychologist"}
+                """;
+
+        HttpResponse<String> searchResponse = mock(HttpResponse.class);
+        when(searchResponse.statusCode()).thenReturn(200);
+        when(searchResponse.body()).thenReturn(searchJson);
+
+        HttpResponse<String> wrongDetailResponse = mock(HttpResponse.class);
+        lenient().when(wrongDetailResponse.statusCode()).thenReturn(200);
+        lenient().when(wrongDetailResponse.body()).thenReturn(wrongDetailJson);
+
+        doReturn(searchResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors?")), any());
+        lenient().doReturn(wrongDetailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B001I7AEI2")), any());
+
+        AuthorSearchResult result = parser.quickSearch("Hayao Miyazaki", "us");
+
+        assertThat(result).isNull();
+        verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B001I7AEI2")), any());
+        verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B079XYL3FZ")), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void quickSearch_skipsNonMatchingCandidatesAndReturnsFirstNameMatch() throws Exception {
+        String searchJson = """
+                [
+                  {"asin": "B001I7AEI2", "name": "Hayao Kawai"},
+                  {"asin": "B079XYL3FZ", "name": "Yoshifumi Miyazaki"},
+                  {"asin": "B00ABCDEF0", "name": "Hayao Miyazaki"}
+                ]
+                """;
+        String wrongDetailJson = """
+                {"asin": "B001I7AEI2", "name": "Hayao Kawai"}
+                """;
+        String detailJson = """
+                {"asin": "B00ABCDEF0", "name": "Hayao Miyazaki", "description": "Animator and filmmaker", "image": "https://img.com/miyazaki.jpg"}
+                """;
+
+        HttpResponse<String> searchResponse = mock(HttpResponse.class);
+        when(searchResponse.statusCode()).thenReturn(200);
+        when(searchResponse.body()).thenReturn(searchJson);
+
+        HttpResponse<String> wrongDetailResponse = mock(HttpResponse.class);
+        lenient().when(wrongDetailResponse.statusCode()).thenReturn(200);
+        lenient().when(wrongDetailResponse.body()).thenReturn(wrongDetailJson);
+
+        HttpResponse<String> detailResponse = mock(HttpResponse.class);
+        when(detailResponse.statusCode()).thenReturn(200);
+        when(detailResponse.body()).thenReturn(detailJson);
+
+        doReturn(searchResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors?")), any());
+        lenient().doReturn(wrongDetailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B001I7AEI2")), any());
+        doReturn(detailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B00ABCDEF0")), any());
+
+        AuthorSearchResult result = parser.quickSearch("Hayao Miyazaki", "us");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAsin()).isEqualTo("B00ABCDEF0");
+        assertThat(result.getName()).isEqualTo("Hayao Miyazaki");
+        verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B079XYL3FZ")), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void quickSearch_matchIsCaseAndPunctuationInsensitive() throws Exception {
+        // The real match is spelled differently (case + a period instead of a space) from the
+        // query, and is not the first candidate, so this exercises both normalization and skipping.
+        String searchJson = """
+                [
+                  {"asin": "B001I7AEI2", "name": "Hayao Kawai"},
+                  {"asin": "B00ABCDEF0", "name": "hayao.miyazaki"}
+                ]
+                """;
+        String wrongDetailJson = """
+                {"asin": "B001I7AEI2", "name": "Hayao Kawai"}
+                """;
+        String detailJson = """
+                {"asin": "B00ABCDEF0", "name": "hayao.miyazaki"}
+                """;
+
+        HttpResponse<String> searchResponse = mock(HttpResponse.class);
+        when(searchResponse.statusCode()).thenReturn(200);
+        when(searchResponse.body()).thenReturn(searchJson);
+
+        HttpResponse<String> wrongDetailResponse = mock(HttpResponse.class);
+        lenient().when(wrongDetailResponse.statusCode()).thenReturn(200);
+        lenient().when(wrongDetailResponse.body()).thenReturn(wrongDetailJson);
+
+        HttpResponse<String> detailResponse = mock(HttpResponse.class);
+        when(detailResponse.statusCode()).thenReturn(200);
+        when(detailResponse.body()).thenReturn(detailJson);
+
+        doReturn(searchResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors?")), any());
+        lenient().doReturn(wrongDetailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B001I7AEI2")), any());
+        doReturn(detailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B00ABCDEF0")), any());
+
+        AuthorSearchResult result = parser.quickSearch("Hayao Miyazaki", "us");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAsin()).isEqualTo("B00ABCDEF0");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void quickSearch_matchIgnoresWhitespaceDifferencesInCompoundSurnames() throws Exception {
+        // Real Audnexus response for "J. Bradford Delong": the genuine match is present in the
+        // list, but Audnexus spells the surname as two words ("De Long") where the query has it
+        // as one ("Delong"). That word-boundary difference must not defeat the match.
+        String searchJson = """
+                [
+                  {"asin": "B0131MUW2E", "name": "J. Bradford Hipps"},
+                  {"asin": "B07K1NLPWN", "name": "J.J. Arias"},
+                  {"asin": "B001H6KOCK", "name": "J. Bradford De Long"}
+                ]
+                """;
+        String wrongDetailJson = """
+                {"asin": "B0131MUW2E", "name": "J. Bradford Hipps"}
+                """;
+        String detailJson = """
+                {"asin": "B001H6KOCK", "name": "J. Bradford De Long", "description": "Economist"}
+                """;
+
+        HttpResponse<String> searchResponse = mock(HttpResponse.class);
+        when(searchResponse.statusCode()).thenReturn(200);
+        when(searchResponse.body()).thenReturn(searchJson);
+
+        HttpResponse<String> wrongDetailResponse = mock(HttpResponse.class);
+        lenient().when(wrongDetailResponse.statusCode()).thenReturn(200);
+        lenient().when(wrongDetailResponse.body()).thenReturn(wrongDetailJson);
+
+        HttpResponse<String> detailResponse = mock(HttpResponse.class);
+        when(detailResponse.statusCode()).thenReturn(200);
+        when(detailResponse.body()).thenReturn(detailJson);
+
+        doReturn(searchResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors?")), any());
+        lenient().doReturn(wrongDetailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B0131MUW2E")), any());
+        doReturn(detailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B001H6KOCK")), any());
+
+        AuthorSearchResult result = parser.quickSearch("J. Bradford Delong", "us");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAsin()).isEqualTo("B001H6KOCK");
+        assertThat(result.getName()).isEqualTo("J. Bradford De Long");
+        verify(httpClient, never()).send(argThat(req -> req.uri().toString().contains("/authors/B0131MUW2E")), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void quickSearch_returnsNullWhenNoResults() throws Exception {
+        HttpResponse<String> mockResponse = mock(HttpResponse.class);
+        when(mockResponse.statusCode()).thenReturn(200);
+        when(mockResponse.body()).thenReturn("[]");
+        doReturn(mockResponse).when(httpClient).send(any(HttpRequest.class), any());
+
+        AuthorSearchResult result = parser.quickSearch("Nobody", "us");
+
+        assertThat(result).isNull();
+    }
 }

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AudnexusAuthorParserTest.java
@@ -346,15 +346,19 @@ class AudnexusAuthorParserTest {
     @Test
     @SuppressWarnings("unchecked")
     void quickSearch_matchIgnoresApostrophesAndHyphens() throws Exception {
-        // Sources disagree on whether names like "O'Connor" carry punctuation at all, so the
-        // match must tolerate an apostrophe (or hyphen) being present on only one side.
+        // Sources disagree on whether names like "O'Connor" or "Anne-Marie" carry punctuation
+        // at all, so the match must tolerate an apostrophe or hyphen being present on only one side.
         String searchJson = """
                 [
-                  {"asin": "B0131MUW2E", "name": "Flannery O'Connor"}
+                  {"asin": "B0131MUW2E", "name": "Flannery O'Connor"},
+                  {"asin": "B0131MUW2F", "name": "Anne-Marie Smith"}
                 ]
                 """;
         String detailJson = """
                 {"asin": "B0131MUW2E", "name": "Flannery O'Connor"}
+                """;
+        String hyphenDetailJson = """
+                {"asin": "B0131MUW2F", "name": "Anne-Marie Smith"}
                 """;
 
         HttpResponse<String> searchResponse = mock(HttpResponse.class);
@@ -362,16 +366,24 @@ class AudnexusAuthorParserTest {
         when(searchResponse.body()).thenReturn(searchJson);
 
         HttpResponse<String> detailResponse = mock(HttpResponse.class);
-        when(detailResponse.statusCode()).thenReturn(200);
-        when(detailResponse.body()).thenReturn(detailJson);
+        lenient().when(detailResponse.statusCode()).thenReturn(200);
+        lenient().when(detailResponse.body()).thenReturn(detailJson);
+
+        HttpResponse<String> hyphenDetailResponse = mock(HttpResponse.class);
+        lenient().when(hyphenDetailResponse.statusCode()).thenReturn(200);
+        lenient().when(hyphenDetailResponse.body()).thenReturn(hyphenDetailJson);
 
         doReturn(searchResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors?")), any());
-        doReturn(detailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B0131MUW2E")), any());
+        lenient().doReturn(detailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B0131MUW2E")), any());
+        lenient().doReturn(hyphenDetailResponse).when(httpClient).send(argThat(req -> req.uri().toString().contains("/authors/B0131MUW2F")), any());
 
         AuthorSearchResult result = parser.quickSearch("Flannery OConnor", "us");
-
         assertThat(result).isNotNull();
         assertThat(result.getAsin()).isEqualTo("B0131MUW2E");
+
+        AuthorSearchResult hyphenResult = parser.quickSearch("AnneMarie Smith", "us");
+        assertThat(hyphenResult).isNotNull();
+        assertThat(hyphenResult.getAsin()).isEqualTo("B0131MUW2F");
     }
 
     @Test


### PR DESCRIPTION
## Description

Author automatch and the "Quick Match" button take Audnexus's search results and, previously, applied the *first* result unconditionally — even when it clearly wasn't the author being matched (Audnexus's search isn't ranked by relevance). This silently attached the wrong author's bio/photo/ASIN with no indication anything went wrong. This PR makes automatch require the candidate's name to actually match the query before applying it, and correctly report "no match" otherwise.

## Linked Issue

Fixes #2295

## Changes

- `AudnexusAuthorParser.quickSearch()` now iterates search results and only returns a candidate whose normalized name matches the query, instead of blindly taking the first result.
- Name comparison strips punctuation and **all** whitespace (not just collapsing it), since sources disagree on word-boundary placement for compound surnames — e.g. Audnexus spells the real "J. Bradford Delong" match as "J. Bradford De Long," and that difference shouldn't defeat an otherwise-correct match.
- Added `namesMatch()` / `normalizeName()` helpers.
- 5 new unit tests: no-match-found → returns null, skips non-matching candidates to find the real one, case/punctuation insensitivity, whitespace-insensitive compound-surname matching (the real Delong/De Long case), and the existing empty-results case.

## Manual Testing Steps

1. Built the image from this branch and ran it against my own real library/author data (`just image-build && just image-run`).
2. Quick Match on "Hannu Rajaniemi" — correctly applies the real Audnexus match (ASIN `B003VNOJY6`); no photo/bio appears only because Audnexus's own record has empty `description`/`image` fields for this author, not a bug.
3. Quick Match on "J. Bradford Delong" — previously silently applied an unrelated author ("J. Bradford Hipps"); now correctly finds and applies the real entry ("J. Bradford De Long") despite the differently-tokenized surname.
4. Quick Match on "Marshall McLuhan" — correctly reports no match, since Audnexus genuinely has no entry for this author (verified directly against the Audnexus API — no candidate even shares his surname).
5. Ran the backend test suite and `just api check` — all passing.

## Screenshots (Optional)

_(none — backend-only change, no UI diff)_

## Additional Context (Optional)

A related fix (re-ranking the *manual* author-search results by name similarity, addressing #2296) exists on a separate branch but hasn't been validated against real-world data yet, so it's being held for its own PR rather than bundled here.

## AI Disclosure

Claude (Claude Code) investigated the root cause — including live-tracing the actual Audnexus API responses that were producing wrong matches — wrote the fix and tests test-first (TDD), and iterated through a couple of rounds of debugging as real-world edge cases (Hannu Rajaniemi, Marshall McLuhan, the "De Long" spacing issue) surfaced during my own testing. I reviewed the code changes, ran the fix against my own production author data across multiple real cases, and verified the results myself before submitting.

## Checklist

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved author search accuracy by requiring an exact name match while ignoring differences in capitalization, punctuation, and spacing.
  * Prevented unnecessary detail lookups for unrelated search results.
  * Searches now safely return no result when no matching author is found.

* **Tests**
  * Added coverage for matching, non-matching, empty, and variably formatted author searches, including incomplete candidate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->