### PR TITLE
Proposal to fix bug #2298

### DIFF
--- a/backend/src/main/java/org/booklore/service/bookdrop/BookDropService.java
+++ b/backend/src/main/java/org/booklore/service/bookdrop/BookDropService.java
@@ -40,7 +40,12 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.File;
@@ -76,6 +81,7 @@ public class BookDropService {
     private final FileMovingHelper fileMovingHelper;
     private final MonitoringRegistrationService monitoringRegistrationService;
     private final ApplicationEventPublisher eventPublisher;
+    private final PlatformTransactionManager transactionManager;
 
     private static final int CHUNK_SIZE = 100;
 
@@ -246,7 +252,7 @@ public class BookDropService {
                         totalFilesProcessed.incrementAndGet();
                         continue;
                     }
-                    processFile(file, metadataById.get(id), defaultLibraryId, defaultPathId, results, failedCount);
+                    processFileIsolated(file, metadataById.get(id), defaultLibraryId, defaultPathId, results, failedCount);
                     totalFilesProcessed.incrementAndGet();
                 }
             }
@@ -262,14 +268,19 @@ public class BookDropService {
                                                Long defaultPathId) {
         Set<Long> affectedLibraries = new HashSet<>();
 
-        List<BookdropFileEntity> files = bookdropFileRepository.findAllById(ids);
+        // Load the files in chunks to avoid a huge IN clause and to prevent a
+        // cross-chunk auto-flush of pending inserts (see issue #2298).
+        for (int i = 0; i < ids.size(); i += CHUNK_SIZE) {
+            List<Long> chunk = ids.subList(i, Math.min(i + CHUNK_SIZE, ids.size()));
+            List<BookdropFileEntity> files = bookdropFileRepository.findAllById(chunk);
 
-        for (BookdropFileEntity fileEntity : files) {
-            try {
-                FileProcessingContext context = prepareFileProcessingContext(fileEntity, metadataById.get(fileEntity.getId()), defaultLibraryId, defaultPathId);
-                affectedLibraries.add(context.libraryId());
-            } catch (Exception e) {
-                log.warn("Failed to determine library for file {}: {}", fileEntity.getId(), e.getMessage());
+            for (BookdropFileEntity fileEntity : files) {
+                try {
+                    FileProcessingContext context = prepareFileProcessingContext(fileEntity, metadataById.get(fileEntity.getId()), defaultLibraryId, defaultPathId);
+                    affectedLibraries.add(context.libraryId());
+                } catch (Exception e) {
+                    log.warn("Failed to determine library for file {}: {}", fileEntity.getId(), e.getMessage());
+                }
             }
         }
 
@@ -338,6 +349,41 @@ public class BookDropService {
             log.error(msg, e);
             notificationService.sendMessage(Topic.LOG, msg);
         }
+    }
+
+    private void processFileIsolated(BookdropFileEntity fileEntity,
+                                     BookdropFinalizeRequest.BookdropFinalizeFile fileReq,
+                                     Long defaultLibraryId,
+                                     Long defaultPathId,
+                                     BookdropFinalizeResult results,
+                                     AtomicInteger failedCount) {
+        // Each file is processed in its own REQUIRES_NEW transaction so that a
+        // commit-time flush failure (constraint violations, oversized values,
+        // relation conflicts) rolls back only that single file instead of the
+        // whole request.  See issue #2298.
+        AtomicInteger fileFailures = new AtomicInteger();
+        int resultsBefore = results.getResults().size();
+        try {
+            requiresNewTransactionTemplate().executeWithoutResult(
+                    status -> processFile(fileEntity, fileReq, defaultLibraryId, defaultPathId, results, fileFailures));
+        } catch (Exception e) {
+            while (results.getResults().size() > resultsBefore) {
+                results.getResults().remove(results.getResults().size() - 1);
+            }
+            if (fileFailures.get() == 0) {
+                failedCount.incrementAndGet();
+            }
+            String msg = String.format("Error finalizing file [id=%s, name=%s]: %s", fileEntity.getId(), fileEntity.getFileName(), e.getMessage());
+            log.error(msg, e);
+            notificationService.sendMessage(Topic.LOG, msg);
+        }
+        failedCount.addAndGet(fileFailures.get());
+    }
+
+    private TransactionTemplate requiresNewTransactionTemplate() {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return template;
     }
 
     private FileProcessingContext prepareFileProcessingContext(BookdropFileEntity fileEntity,
@@ -423,6 +469,11 @@ public class BookDropService {
             // Instead, we are using `Files.copy` directly
             Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
 
+            // If the transaction later rolls back (e.g. commit-time flush
+            // failure), remove the target copy again so it cannot turn into an
+            // orphaned file that blocks future imports (see issue #2298).
+            registerTargetRollbackCleanup(target, bookdropFile);
+
             log.info("Copied file id={}, name={} from '{}' to '{}'", bookdropFile.getId(), bookdropFile.getFileName(), source, target);
 
             BookdropFileResult result;
@@ -434,12 +485,9 @@ public class BookDropService {
             }
 
             if (result.isSuccess()) {
-                try {
-                    Files.delete(source);
-                    log.info("Successfully deleted source file '{}' after successful import for file id={}", source, bookdropFile.getId());
-                } catch (IOException e) {
-                    log.warn("Failed to delete source file '{}' after successful import for file id={}: {}", source, bookdropFile.getId(), e.getMessage());
-                }
+                // Delete the source only after the transaction committed so a
+                // rolled-back import keeps the source available for a retry.
+                deleteSourceAfterCommit(source, bookdropFile);
             } else {
                 cleanupTargetFile(target, bookdropFile.getId(), "logical failure");
             }
@@ -538,6 +586,42 @@ public class BookDropService {
             log.warn("Failed to cleanup target file '{}' after {} for file id={}: {}", 
                     target, reason, fileId, e.getMessage());
         }
+    }
+
+    private void deleteSourceAfterCommit(Path source, BookdropFileEntity bookdropFile) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            deleteSourceFile(source, bookdropFile);
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                deleteSourceFile(source, bookdropFile);
+            }
+        });
+    }
+
+    private void deleteSourceFile(Path source, BookdropFileEntity bookdropFile) {
+        try {
+            Files.delete(source);
+            log.info("Successfully deleted source file '{}' after successful import for file id={}", source, bookdropFile.getId());
+        } catch (IOException e) {
+            log.warn("Failed to delete source file '{}' after successful import for file id={}: {}", source, bookdropFile.getId(), e.getMessage());
+        }
+    }
+
+    private void registerTargetRollbackCleanup(Path target, BookdropFileEntity bookdropFile) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (status == TransactionSynchronization.STATUS_ROLLED_BACK) {
+                    cleanupTargetFile(target, bookdropFile.getId(), "transaction rollback");
+                }
+            }
+        });
     }
 
     private FileProcessResult processFileInLibrary(String fileName, LibraryEntity library, LibraryPathEntity path, File file, BookFileType type) {

--- a/backend/src/main/java/org/booklore/service/metadata/BookMetadataUpdater.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookMetadataUpdater.java
@@ -24,6 +24,8 @@ import org.booklore.service.metadata.writer.MetadataWriterFactory;
 import org.booklore.util.BookCoverUtils;
 import org.booklore.util.FileService;
 import org.booklore.util.MetadataChangeDetector;
+
+import static org.booklore.util.FileService.truncate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -80,6 +82,11 @@ public class BookMetadataUpdater {
             log.warn("Metadata is null for book ID {}. Skipping update.", bookId);
             return;
         }
+
+        // Normalize the incoming values to the database column widths so that
+        // oversized values cannot fail the transaction at flush time
+        // (see issue #2298).
+        truncateMetadata(newMetadata);
 
         MetadataClearFlags clearFlags = wrapper.getClearFlags();
         BookMetadataEntity metadata = bookEntity.getMetadata();
@@ -172,6 +179,47 @@ public class BookMetadataUpdater {
                 log.warn("Failed to move files for book ID {} after metadata update: {}", bookId, e.getMessage());
             }
         }
+    }
+
+    private void truncateMetadata(BookMetadata metadata) {
+        metadata.setTitle(truncate(metadata.getTitle(), 1000));
+        metadata.setSubtitle(truncate(metadata.getSubtitle(), 1000));
+        metadata.setPublisher(truncate(metadata.getPublisher(), 1000));
+        metadata.setDescription(truncate(metadata.getDescription(), 2000));
+        metadata.setSeriesName(truncate(metadata.getSeriesName(), 1000));
+        metadata.setIsbn13(truncate(metadata.getIsbn13(), 64));
+        metadata.setIsbn10(truncate(metadata.getIsbn10(), 64));
+        metadata.setAsin(truncate(metadata.getAsin(), 20));
+        metadata.setLanguage(truncate(metadata.getLanguage(), 255));
+        metadata.setNarrator(truncate(metadata.getNarrator(), 500));
+        metadata.setContentRating(truncate(metadata.getContentRating(), 20));
+        metadata.setThumbnailUrl(truncate(metadata.getThumbnailUrl(), 2000));
+        metadata.setGoodreadsId(truncate(metadata.getGoodreadsId(), 100));
+        metadata.setComicvineId(truncate(metadata.getComicvineId(), 100));
+        metadata.setHardcoverId(truncate(metadata.getHardcoverId(), 100));
+        metadata.setHardcoverBookId(truncate(metadata.getHardcoverBookId(), 100));
+        metadata.setGoogleId(truncate(metadata.getGoogleId(), 100));
+        metadata.setLubimyczytacId(truncate(metadata.getLubimyczytacId(), 100));
+        metadata.setRanobedbId(truncate(metadata.getRanobedbId(), 100));
+        metadata.setAudibleId(truncate(metadata.getAudibleId(), 100));
+        metadata.setAuthors(truncateList(metadata.getAuthors(), 255));
+        metadata.setCategories(truncateSet(metadata.getCategories(), 255));
+        metadata.setTags(truncateSet(metadata.getTags(), 255));
+        metadata.setMoods(truncateSet(metadata.getMoods(), 255));
+    }
+
+    private List<String> truncateList(List<String> values, int maxLength) {
+        if (values == null) {
+            return null;
+        }
+        return values.stream().map(value -> truncate(value, maxLength)).toList();
+    }
+
+    private Set<String> truncateSet(Set<String> values, int maxLength) {
+        if (values == null) {
+            return null;
+        }
+        return values.stream().map(value -> truncate(value, maxLength)).collect(Collectors.toSet());
     }
 
     private void updateBasicFields(BookMetadata m, BookMetadataEntity e, MetadataClearFlags clear, MetadataReplaceMode replaceMode) {
@@ -410,6 +458,8 @@ public class BookMetadataUpdater {
             return;
         }
 
+        truncateComicMetadata(comicDto);
+
         ComicMetadataEntity comic = e.getComicMetadata();
         if (comic == null) {
             if (!hasComicData(comicDto) && !hasComicLocks(comicDto)) {
@@ -485,8 +535,19 @@ public class BookMetadataUpdater {
         comicCreatorRepository.deleteOrphaned();
     }
 
-    private boolean hasComicData(ComicMetadata dto) {
-        return StringUtils.hasText(dto.getIssueNumber())
+    private void truncateComicMetadata(ComicMetadata comicDto) {
+        comicDto.setIssueNumber(truncate(comicDto.getIssueNumber(), 50));
+        comicDto.setAlternateIssue(truncate(comicDto.getAlternateIssue(), 50));
+        comicDto.setFormat(truncate(comicDto.getFormat(), 50));
+        comicDto.setReadingDirection(truncate(comicDto.getReadingDirection(), 10));
+        comicDto.setVolumeName(truncate(comicDto.getVolumeName(), 255));
+        comicDto.setStoryArc(truncate(comicDto.getStoryArc(), 255));
+        comicDto.setAlternateSeries(truncate(comicDto.getAlternateSeries(), 255));
+        comicDto.setImprint(truncate(comicDto.getImprint(), 255));
+        comicDto.setWebLink(truncate(comicDto.getWebLink(), 1000));
+    }
+
+    private boolean hasComicData(ComicMetadata dto) {        return StringUtils.hasText(dto.getIssueNumber())
                 || StringUtils.hasText(dto.getVolumeName())
                 || dto.getVolumeNumber() != null
                 || StringUtils.hasText(dto.getStoryArc())

--- a/backend/src/test/java/org/booklore/service/bookdrop/BookDropServiceFinalizeTest.java
+++ b/backend/src/test/java/org/booklore/service/bookdrop/BookDropServiceFinalizeTest.java
@@ -1,7 +1,12 @@
 package org.booklore.service.bookdrop;
 
 import org.booklore.config.AppProperties;
+import org.booklore.model.dto.BookMetadata;
 import org.booklore.model.dto.request.BookdropFinalizeRequest;
+import org.booklore.model.entity.BookdropFileEntity;
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.entity.LibraryPathEntity;
+import org.booklore.model.websocket.Topic;
 import org.booklore.repository.BookdropFileRepository;
 import org.booklore.repository.LibraryRepository;
 import org.booklore.service.NotificationService;
@@ -10,14 +15,21 @@ import org.booklore.service.kobo.KoboAutoShelfService;
 import org.booklore.service.monitoring.MonitoringRegistrationService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
 import tools.jackson.databind.ObjectMapper;
 
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,6 +55,10 @@ class BookDropServiceFinalizeTest {
     private BookdropNotificationService bookdropNotificationService;
     @Mock
     private KoboAutoShelfService koboAutoShelfService;
+    @Mock
+    private PlatformTransactionManager transactionManager;
+    @Mock
+    private TransactionStatus transactionStatus;
 
     @InjectMocks
     private BookDropService bookDropService;
@@ -79,5 +95,74 @@ class BookDropServiceFinalizeTest {
 
         verify(bookdropFileRepository).findAllExcludingIdsFlat(List.of(3L));
         verify(bookdropFileRepository, never()).findAllIds();
+    }
+
+    @Test
+    void finalizeImport_commitFlushFailure_shouldNotThrowAndMarkFileFailed() {
+        BookdropFinalizeRequest request = new BookdropFinalizeRequest();
+        request.setSelectAll(false);
+        request.setDefaultLibraryId(1L);
+        request.setDefaultPathId(1L);
+        BookMetadata metadata = new BookMetadata();
+        metadata.setTitle("Test Book");
+        BookdropFinalizeRequest.BookdropFinalizeFile fileReq = new BookdropFinalizeRequest.BookdropFinalizeFile();
+        fileReq.setFileId(1L);
+        fileReq.setLibraryId(1L);
+        fileReq.setPathId(1L);
+        fileReq.setMetadata(metadata);
+        request.setFiles(List.of(fileReq));
+
+        BookdropFileEntity file = BookdropFileEntity.builder()
+                .id(1L)
+                .fileName("test.epub")
+                .filePath("/nonexistent/test.epub")
+                .build();
+
+        LibraryPathEntity libraryPath = LibraryPathEntity.builder()
+                .id(1L)
+                .path("/tmp")
+                .build();
+        LibraryEntity library = LibraryEntity.builder()
+                .name("Test Library")
+                .libraryPaths(List.of(libraryPath))
+                .build();
+
+        when(bookdropFileRepository.findAllById(anyList())).thenReturn(List.of(file));
+        when(libraryRepository.findByIdWithPaths(1L)).thenReturn(java.util.Optional.of(library));
+        when(fileMovingHelper.getFileNamingPattern(library)).thenReturn("{currentFilename}");
+        when(fileMovingHelper.generateNewFilePath(anyString(), any(BookMetadata.class), anyString(), anyString()))
+                .thenReturn(Path.of("/tmp/test.epub"));
+        when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
+        doThrow(new RuntimeException("simulated flush failure")).when(transactionManager).commit(any());
+
+        var result = bookDropService.finalizeImport(request);
+
+        assertEquals(1, result.getFailed());
+        assertEquals(1, result.getTotalFiles());
+        assertTrue(result.getResults().isEmpty());
+        verify(transactionManager).getTransaction(any());
+        verify(notificationService).sendMessage(eq(Topic.LOG), contains("Error finalizing file"));
+    }
+
+    @Test
+    void finalizeImport_selectAll_largeIdList_shouldChunkFindAllByIdQueries() {
+        BookdropFinalizeRequest request = new BookdropFinalizeRequest();
+        request.setSelectAll(true);
+        request.setExcludedIds(Collections.emptyList());
+        request.setDefaultLibraryId(1L);
+        request.setDefaultPathId(1L);
+
+        List<Long> ids = IntStream.range(0, 150).mapToLong(i -> i).boxed().toList();
+        when(bookdropFileRepository.findAllIds()).thenReturn(ids);
+        when(bookdropFileRepository.findAllById(anyList())).thenReturn(Collections.emptyList());
+
+        bookDropService.finalizeImport(request);
+
+        @SuppressWarnings("rawtypes")
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(bookdropFileRepository, atLeast(3)).findAllById(captor.capture());
+        for (List<?> chunk : captor.getAllValues()) {
+            assertTrue(chunk.size() <= 100);
+        }
     }
 }

--- a/backend/src/test/java/org/booklore/service/bookdrop/BookDropServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/bookdrop/BookDropServiceTest.java
@@ -41,6 +41,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -88,6 +90,10 @@ class BookDropServiceTest {
     private FileMovingHelper fileMovingHelper;
     @Mock
     private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private PlatformTransactionManager transactionManager;
+    @Mock
+    private TransactionStatus transactionStatus;
 
     @InjectMocks
     private BookDropService bookDropService;
@@ -101,6 +107,7 @@ class BookDropServiceTest {
 
     @BeforeEach
     void setUp() throws IOException {
+        lenient().when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
         LibraryPathEntity libraryPathEntity = new LibraryPathEntity();
         libraryPathEntity.setId(1L);
         libraryPathEntity.setPath(tempDir.toString());


### PR DESCRIPTION
## Description

The bookdrop import finalize flow (`POST /api/v1/bookdrop/imports/finalize`) returned `HTTP 500 "An unexpected error occurred"` and rolled back the **entire batch** whenever a commit-time flush failed (e.g. an over-long metadata value violating a database column width). Not a single file of the request was imported, and the already copied target files remained orphaned in the library while the source file was deleted.

This PR makes the finalize flow robust:

- Each file is processed in its **own transaction** (`REQUIRES_NEW`), so a failing file no longer discards the successful imports of the rest of the request. The response keeps its documented per-file `results` list.
- Incoming metadata (books and comic metadata) is **truncated to the database column widths** before it is written, eliminating the most common flush-time `DataIntegrityViolationException`.
- The **source file is deleted only after the transaction committed**, and the copied target file is cleaned up on rollback – failed imports keep the source for retry and no orphaned target files remain in the library.
- The affected-libraries lookup is processed **in chunks** instead of one huge `IN` clause.

## Linked Issue

Fixes #2298

## Changes

- `BookDropService`: run each file through `processFileIsolated(...)` inside a `REQUIRES_NEW` `TransactionTemplate`; on commit failure the per-file result is removed, the file is counted as failed and logged via `Topic.LOG` (no exception propagates to the controller).
- `BookDropService`: chunk the `collectAffectedLibraries` lookup by `CHUNK_SIZE` to avoid oversized queries.
- `BookDropService`: `deleteSourceAfterCommit(...)` – source file deletion is deferred to the commit phase via `TransactionSynchronization`; `registerTargetRollbackCleanup(...)` removes the copied target file on rollback.
- `BookMetadataUpdater`: `truncateMetadata(...)` / `truncateComicMetadata(...)` normalize all incoming values to the database column widths (e.g. title 1000, isbn 64, language 255, thumbnail 2000, names 255) before the change-detection and write path runs.
- Tests: new regression tests in `BookDropServiceFinalizeTest` (commit-flush failure isolation, chunked `findAllById` calls); `BookDropServiceTest` extended with transaction manager mocks.

## Manual Testing Steps

Note: I am a user of the application, not a maintainer – I could not run a live server with these changes. Verification was done with the unit tests below, which reproduce the exact failure modes.

1. `cd backend && ./gradlew test` – full backend suite passes, including the new tests.
2. `cd backend && ./gradlew check` – the `just api::check` equivalent (Gradle `check` lifecycle) passes.
3. Start the app, put a book into the bookdrop folder and finalize a small batch – it should import successfully.
4. To reproduce the previous failure: finalize a batch containing a file whose metadata value exceeds a column width – the request now returns `200` with per-file results, the failing file is reported as failed, and all other files of the batch are still imported.

## Screenshots (Optional)

None – backend-only change, no UI changes.

## Additional Context (Optional)

- `just ui check` was not run: the change is backend-only and no frontend toolchain is available on this machine.
- The fix intentionally keeps the class-level `@Transactional` on `BookDropService`; only the per-file processing runs in a `REQUIRES_NEW` scope, because wrapping the post-processing alone causes "Book ID missing after import" due to the REPEATABLE_READ snapshot (`BookDropService.java:466-470`).
- `BookdropFileEntity` is fully scalar (no lazy collections), so it is safe to use across the `REQUIRES_NEW` boundary.

## AI Disclosure

oc – analyzed the reported failure (issue #2298), proposed the root-cause fixes, implemented them and added the regression tests; all changes were reviewed and verified by me via the test suite.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


Hi @imnotjames,
This time, I quickly used an AI because I don't currently have the resources—and especially the time—to look into this in more detail. I hope this helps solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved book and comic metadata handling by safely limiting oversized text, IDs, URLs, and collection values.
  - BookDrop processing now handles files independently, reducing the impact of failures during finalization.
  - Source files are removed only after successful processing, while copied files are cleaned up when processing fails.
  - Large library scans are processed in smaller batches for improved reliability.

- **Tests**
  - Added coverage for transaction failures, rollback behavior, and large-batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->