### PR TITLE
fix(api): use `ApiException` instead of `EntityNotFoundExcepion`

### DIFF
--- a/backend/src/main/java/org/booklore/exception/ApiError.java
+++ b/backend/src/main/java/org/booklore/exception/ApiError.java
@@ -11,6 +11,7 @@ public enum ApiError {
     GENERIC_BAD_REQUEST(HttpStatus.BAD_REQUEST, "%s"),
     GENERIC_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "%s"),
 
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "%s not found with ID: %d"),
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "Book not found with ID: %d"),
     EMAIL_PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "Email provider with ID %s not found"),
     DEFAULT_EMAIL_PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "Default email provider not found"),

--- a/backend/src/main/java/org/booklore/service/book/AnnotationService.java
+++ b/backend/src/main/java/org/booklore/service/book/AnnotationService.java
@@ -2,6 +2,7 @@ package org.booklore.service.book;
 
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.exception.APIException;
+import org.booklore.exception.ApiError;
 import org.booklore.mapper.AnnotationMapper;
 import org.booklore.model.dto.Annotation;
 import org.booklore.model.dto.CreateAnnotationRequest;
@@ -12,7 +13,6 @@ import org.booklore.model.entity.BookLoreUserEntity;
 import org.booklore.repository.AnnotationRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -94,17 +94,17 @@ public class AnnotationService {
     private AnnotationEntity findAnnotationByIdAndUser(Long annotationId) {
         Long userId = getCurrentUserId();
         return annotationRepository.findByIdAndUserId(annotationId, userId)
-                .orElseThrow(() -> new EntityNotFoundException("Annotation not found: " + annotationId));
+                .orElseThrow(() -> ApiError.RESOURCE_NOT_FOUND.createException("Annotation", annotationId));
     }
 
     private BookEntity findBook(Long bookId) {
         return bookRepository.findById(bookId)
-                .orElseThrow(() -> new EntityNotFoundException("Book not found: " + bookId));
+                .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
     }
 
     private BookLoreUserEntity findUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
+                .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
     }
 
     private void validateNoDuplicateAnnotation(String cfi, Long bookId, Long userId) {

--- a/backend/src/main/java/org/booklore/service/book/BookMarkService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookMarkService.java
@@ -1,6 +1,7 @@
 package org.booklore.service.book;
 
 import org.booklore.config.BookmarkProperties;
+import org.booklore.exception.ApiError;
 import org.booklore.mapper.BookMarkMapper;
 import org.booklore.model.dto.BookMark;
 import org.booklore.model.dto.CreateBookMarkRequest;
@@ -13,7 +14,6 @@ import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserRepository;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.exception.APIException;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -111,17 +111,17 @@ public class BookMarkService {
     private BookMarkEntity findBookmarkByIdAndUser(Long bookmarkId) {
         Long userId = getCurrentUserId();
         return bookMarkRepository.findByIdAndUserId(bookmarkId, userId)
-                .orElseThrow(() -> new EntityNotFoundException("Bookmark not found: " + bookmarkId));
+                .orElseThrow(() -> ApiError.RESOURCE_NOT_FOUND.createException("Bookmark", bookmarkId));
     }
 
     private BookEntity findBook(Long bookId) {
         return bookRepository.findById(bookId)
-                .orElseThrow(() -> new EntityNotFoundException("Book not found: " + bookId));
+                .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
     }
 
     private BookLoreUserEntity findUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
+                .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
     }
 
     private void validateNoDuplicateBookmark(String cfi, Long bookId, Long userId) {

--- a/backend/src/main/java/org/booklore/service/book/BookNoteService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookNoteService.java
@@ -12,7 +12,6 @@ import org.booklore.model.entity.BookNoteEntity;
 import org.booklore.repository.BookNoteRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,13 +45,13 @@ public class BookNoteService {
                 .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(request.getBookId()));
 
         BookLoreUserEntity user = userRepository.findById(currentUser.getId())
-                .orElseThrow(() -> new EntityNotFoundException("User not found: " + currentUser.getId()));
+                .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(currentUser.getId()));
 
         BookNoteEntity noteEntity;
 
         if (request.getId() != null) {
             noteEntity = bookNoteRepository.findByIdAndUserId(request.getId(), currentUser.getId())
-                    .orElseThrow(() -> new EntityNotFoundException("Note not found: " + request.getId()));
+                    .orElseThrow(() -> ApiError.RESOURCE_NOT_FOUND.createException("Note", request.getId()));
             noteEntity.setTitle(request.getTitle());
             noteEntity.setContent(request.getContent());
         } else {
@@ -71,7 +70,8 @@ public class BookNoteService {
     @Transactional
     public void deleteNote(Long noteId) {
         BookLoreUser currentUser = authenticationService.getAuthenticatedUser();
-        BookNoteEntity note = bookNoteRepository.findByIdAndUserId(noteId, currentUser.getId()).orElseThrow(() -> new EntityNotFoundException("Note not found: " + noteId));
+        BookNoteEntity note = bookNoteRepository.findByIdAndUserId(noteId, currentUser.getId())
+                .orElseThrow(() -> ApiError.RESOURCE_NOT_FOUND.createException("Note", noteId));
         bookNoteRepository.delete(note);
     }
 }

--- a/backend/src/main/java/org/booklore/service/book/BookNoteV2Service.java
+++ b/backend/src/main/java/org/booklore/service/book/BookNoteV2Service.java
@@ -2,6 +2,7 @@ package org.booklore.service.book;
 
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.exception.APIException;
+import org.booklore.exception.ApiError;
 import org.booklore.mapper.BookNoteV2Mapper;
 import org.booklore.model.dto.BookNoteV2;
 import org.booklore.model.dto.CreateBookNoteV2Request;
@@ -12,7 +13,6 @@ import org.booklore.model.entity.BookNoteV2Entity;
 import org.booklore.repository.BookNoteV2Repository;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -92,17 +92,17 @@ public class BookNoteV2Service {
     private BookNoteV2Entity findNoteByIdAndUser(Long noteId) {
         Long userId = getCurrentUserId();
         return bookNoteV2Repository.findByIdAndUserId(noteId, userId)
-                .orElseThrow(() -> new EntityNotFoundException("Note not found: " + noteId));
+                .orElseThrow(() -> ApiError.RESOURCE_NOT_FOUND.createException("Note", noteId));
     }
 
     private BookEntity findBook(Long bookId) {
         return bookRepository.findById(bookId)
-                .orElseThrow(() -> new EntityNotFoundException("Book not found: " + bookId));
+                .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
     }
 
     private BookLoreUserEntity findUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
+                .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
     }
 
     private void validateNoDuplicateNote(String cfi, Long bookId, Long userId) {

--- a/backend/src/main/java/org/booklore/service/book/BookReviewService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookReviewService.java
@@ -1,9 +1,9 @@
 package org.booklore.service.book;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.exception.APIException;
 import org.booklore.exception.ApiError;
 import org.booklore.mapper.BookReviewMapper;
 import org.booklore.model.dto.BookLoreUser;
@@ -98,7 +98,7 @@ public class BookReviewService {
     @Transactional
     public void delete(Long id) {
         if (!bookReviewRepository.existsById(id)) {
-            throw new EntityNotFoundException("Review not found: " + id);
+            throw ApiError.RESOURCE_NOT_FOUND.createException("Review", id);
         }
         bookReviewRepository.deleteById(id);
     }

--- a/backend/src/main/java/org/booklore/service/book/PdfAnnotationPersistenceHandler.java
+++ b/backend/src/main/java/org/booklore/service/book/PdfAnnotationPersistenceHandler.java
@@ -2,13 +2,13 @@ package org.booklore.service.book;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.booklore.exception.ApiError;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookLoreUserEntity;
 import org.booklore.model.entity.PdfAnnotationEntity;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.PdfAnnotationRepository;
 import org.booklore.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,11 +53,11 @@ public class PdfAnnotationPersistenceHandler {
 
     private BookEntity findBook(Long bookId) {
         return bookRepository.findById(bookId)
-                .orElseThrow(() -> new EntityNotFoundException("Book not found: " + bookId));
+                .orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
     }
 
     private BookLoreUserEntity findUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
+                .orElseThrow(() -> ApiError.USER_NOT_FOUND.createException(userId));
     }
 }

--- a/backend/src/test/java/org/booklore/service/BookMarkServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/BookMarkServiceTest.java
@@ -15,7 +15,6 @@ import org.booklore.repository.BookMarkRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserRepository;
 import org.booklore.service.book.BookMarkService;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -130,7 +129,7 @@ class BookMarkServiceTest {
         when(bookMarkRepository.existsByCfiAndBookIdAndUserId("new-cfi", bookId, userId)).thenReturn(false); // No duplicate
         when(bookRepository.findById(bookId)).thenReturn(Optional.empty()); // Book doesn't exist
 
-        assertThrows(EntityNotFoundException.class, () -> bookMarkService.createBookmark(request));
+        assertThrows(APIException.class, () -> bookMarkService.createBookmark(request));
         verify(bookMarkRepository, never()).save(any());
     }
 
@@ -149,7 +148,7 @@ class BookMarkServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(userDto);
         when(bookMarkRepository.findByIdAndUserId(bookmarkId, userId)).thenReturn(Optional.empty());
 
-        assertThrows(EntityNotFoundException.class, () -> bookMarkService.deleteBookmark(bookmarkId));
+        assertThrows(APIException.class, () -> bookMarkService.deleteBookmark(bookmarkId));
         verify(bookMarkRepository, never()).delete(any());
     }
 
@@ -183,7 +182,7 @@ class BookMarkServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(userDto);
         when(bookMarkRepository.findByIdAndUserId(bookmarkId, userId)).thenReturn(Optional.empty());
 
-        assertThrows(EntityNotFoundException.class, () -> bookMarkService.updateBookmark(bookmarkId, updateRequest));
+        assertThrows(APIException.class, () -> bookMarkService.updateBookmark(bookmarkId, updateRequest));
         verify(bookMarkRepository, never()).save(any());
     }
 
@@ -205,7 +204,7 @@ class BookMarkServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(userDto);
         when(bookMarkRepository.findByIdAndUserId(bookmarkId, userId)).thenReturn(Optional.empty());
 
-        assertThrows(EntityNotFoundException.class, () -> bookMarkService.getBookmarkById(bookmarkId));
+        assertThrows(APIException.class, () -> bookMarkService.getBookmarkById(bookmarkId));
         verify(bookMarkRepository).findByIdAndUserId(bookmarkId, userId);
     }
 }

--- a/backend/src/test/java/org/booklore/service/BookNoteServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/BookNoteServiceTest.java
@@ -1,6 +1,7 @@
 package org.booklore.service;
 
 import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.exception.APIException;
 import org.booklore.mapper.BookNoteMapper;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.BookNote;
@@ -12,7 +13,6 @@ import org.booklore.repository.BookNoteRepository;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserRepository;
 import org.booklore.service.book.BookNoteService;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -149,7 +149,7 @@ class BookNoteServiceTest {
         when(bookRepository.findById(bookId)).thenReturn(Optional.of(BookEntity.builder().id(bookId).build()));
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        assertThrows(EntityNotFoundException.class, () -> service.createOrUpdateNote(req));
+        assertThrows(APIException.class, () -> service.createOrUpdateNote(req));
     }
 
     @Test
@@ -165,7 +165,7 @@ class BookNoteServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(BookLoreUserEntity.builder().id(userId).isDefaultPassword(false).build()));
         when(bookNoteRepository.findByIdAndUserId(noteId, userId)).thenReturn(Optional.empty());
 
-        assertThrows(EntityNotFoundException.class, () -> service.createOrUpdateNote(req));
+        assertThrows(APIException.class, () -> service.createOrUpdateNote(req));
     }
 
     @Test
@@ -181,6 +181,6 @@ class BookNoteServiceTest {
     @Test
     void deleteNote_throwsIfNotFound() {
         when(bookNoteRepository.findByIdAndUserId(noteId, userId)).thenReturn(Optional.empty());
-        assertThrows(EntityNotFoundException.class, () -> service.deleteNote(noteId));
+        assertThrows(APIException.class, () -> service.deleteNote(noteId));
     }
 }

--- a/backend/src/test/java/org/booklore/service/BookNoteV2ServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/BookNoteV2ServiceTest.java
@@ -14,7 +14,6 @@ import org.booklore.repository.BookNoteV2Repository;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserRepository;
 import org.booklore.service.book.BookNoteV2Service;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -99,10 +98,10 @@ class BookNoteV2ServiceTest {
     }
 
     @Test
-    void getNoteById_throwsEntityNotFoundException_whenNotFound() {
+    void getNoteById_throwsAPIException_whenNotFound() {
         when(bookNoteV2Repository.findByIdAndUserId(noteId, userId)).thenReturn(Optional.empty());
 
-        EntityNotFoundException ex = assertThrows(EntityNotFoundException.class, () -> service.getNoteById(noteId));
+        APIException ex = assertThrows(APIException.class, () -> service.getNoteById(noteId));
 
         assertTrue(ex.getMessage().contains(String.valueOf(noteId)));
     }
@@ -213,7 +212,7 @@ class BookNoteV2ServiceTest {
     }
 
     @Test
-    void createNote_throwsEntityNotFoundException_whenBookNotFound() {
+    void createNote_throwssAPIException_whenBookNotFound() {
         CreateBookNoteV2Request request = CreateBookNoteV2Request.builder()
                 .bookId(bookId)
                 .cfi(cfi)
@@ -223,14 +222,14 @@ class BookNoteV2ServiceTest {
         when(bookNoteV2Repository.existsByCfiAndBookIdAndUserId(cfi, bookId, userId)).thenReturn(false);
         when(bookRepository.findById(bookId)).thenReturn(Optional.empty());
 
-        EntityNotFoundException ex = assertThrows(EntityNotFoundException.class, () -> service.createNote(request));
+        APIException ex = assertThrows(APIException.class, () -> service.createNote(request));
 
         assertTrue(ex.getMessage().contains(String.valueOf(bookId)));
         verify(bookNoteV2Repository, never()).save(any());
     }
 
     @Test
-    void createNote_throwsEntityNotFoundException_whenUserNotFound() {
+    void createNote_throwsAPIException_whenUserNotFound() {
         CreateBookNoteV2Request request = CreateBookNoteV2Request.builder()
                 .bookId(bookId)
                 .cfi(cfi)
@@ -243,7 +242,7 @@ class BookNoteV2ServiceTest {
         when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        EntityNotFoundException ex = assertThrows(EntityNotFoundException.class, () -> service.createNote(request));
+        APIException ex = assertThrows(APIException.class, () -> service.createNote(request));
 
         assertTrue(ex.getMessage().contains(String.valueOf(userId)));
         verify(bookNoteV2Repository, never()).save(any());
@@ -321,14 +320,14 @@ class BookNoteV2ServiceTest {
     }
 
     @Test
-    void updateNote_throwsEntityNotFoundException_whenNoteNotFound() {
+    void updateNote_throwsAPIException_whenNoteNotFound() {
         UpdateBookNoteV2Request request = UpdateBookNoteV2Request.builder()
                 .noteContent("Updated content")
                 .build();
 
         when(bookNoteV2Repository.findByIdAndUserId(noteId, userId)).thenReturn(Optional.empty());
 
-        EntityNotFoundException ex = assertThrows(EntityNotFoundException.class, () -> service.updateNote(noteId, request));
+        APIException ex = assertThrows(APIException.class, () -> service.updateNote(noteId, request));
 
         assertTrue(ex.getMessage().contains(String.valueOf(noteId)));
         verify(bookNoteV2Repository, never()).save(any());
@@ -345,10 +344,10 @@ class BookNoteV2ServiceTest {
     }
 
     @Test
-    void deleteNote_throwsEntityNotFoundException_whenNotFound() {
+    void deleteNote_throwsAPIException_whenNotFound() {
         when(bookNoteV2Repository.findByIdAndUserId(noteId, userId)).thenReturn(Optional.empty());
 
-        EntityNotFoundException ex = assertThrows(EntityNotFoundException.class, () -> service.deleteNote(noteId));
+        APIException ex = assertThrows(APIException.class, () -> service.deleteNote(noteId));
 
         assertTrue(ex.getMessage().contains(String.valueOf(noteId)));
         verify(bookNoteV2Repository, never()).delete(any());

--- a/backend/src/test/java/org/booklore/service/BookReviewServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/BookReviewServiceTest.java
@@ -1,7 +1,7 @@
 package org.booklore.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.exception.APIException;
 import org.booklore.mapper.BookReviewMapper;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.BookMetadata;
@@ -360,10 +360,10 @@ class BookReviewServiceTest {
 
         when(bookReviewRepository.existsById(reviewId)).thenReturn(false);
 
-        EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
+        APIException exception = assertThrows(APIException.class,
             () -> service.delete(reviewId));
 
-        assertEquals("Review not found: " + reviewId, exception.getMessage());
+        assertEquals("Review not found with ID: " + reviewId, exception.getMessage());
         verify(bookReviewRepository, never()).deleteById(reviewId);
     }
 }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
for annotations or other endpoints that bubble up the `EntityNotFoundException` from jakarta, failures to find records gets treated as an HTTP 500.  This is unwanted behavior.

instead, `ApiError.RESOURCE_NOT_FOUND` and other exceptions can be used which Grimmory natively understands which leads to the expected HTTP status codes

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1858

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* updates usages of `EntityNotFoundException` to be `APIException`
* updates tests to match

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. curl -v `http://localhost:6060/api/v1/annotations/12345`
2. Read status code as 404

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
```json
{
    "message":"Annotation not found with ID: 12345",
    "status":404,
    "timestamp":"2026-08-10T02:04:36.508959184"
}
```

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized missing-resource errors across annotations, bookmarks, notes, reviews, and PDF annotations.
  * Missing resources now return clear HTTP 404 responses identifying the resource type and ID.

* **Tests**
  * Updated service tests to verify consistent API error responses for missing books, users, notes, bookmarks, and reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->