### PR TITLE
refactor(ui): app-menu positioning and styling refinements

### DIFF
--- a/frontend/src/app/shared/ui/menu/app-menu-item.component.ts
+++ b/frontend/src/app/shared/ui/menu/app-menu-item.component.ts
@@ -24,6 +24,7 @@ import {
   appMenuLabelClass,
   appMenuLeadingSlotClass,
   appMenuShortcutClass,
+  appMenuTrailingTextClass,
   appMenuSpinnerClass,
   appMenuSubmenuIconClass,
   appMenuTrailingIconClass,
@@ -48,6 +49,8 @@ import {
         #anchor
         [routerLink]="link()"
         [queryParams]="queryParams()"
+        [target]="target() || undefined"
+        [attr.rel]="target() === '_blank' ? 'noopener' : null"
         tabindex="-1"
         class="flex min-h-full w-full items-center gap-2 no-underline text-inherit outline-none">
         <ng-container [ngTemplateOutlet]="body" />
@@ -76,6 +79,9 @@ import {
       @if (trailingIcon(); as iconData) {
         <svg [lucideIcon]="iconData" [class]="trailingIconClass" aria-hidden="true"></svg>
       }
+      @if (trailingText()) {
+        <span [class]="trailingTextClass" aria-hidden="true">{{ trailingText() }}</span>
+      }
       @if (shortcut()) {
         <span [class]="shortcutClass" aria-hidden="true">{{ shortcut() }}</span>
       }
@@ -92,9 +98,11 @@ export class AppMenuItemComponent {
   readonly loading = input(false, { transform: booleanAttribute });
   readonly inset = input(false, { transform: booleanAttribute });
   readonly shortcut = input('');
+  readonly trailingText = input('');
   readonly variant = input<AppMenuItemVariant>('default');
   readonly closeOnSelect = input(true, { transform: booleanAttribute });
   readonly link = input<string | readonly unknown[] | null>(null);
+  readonly target = input('');
   readonly queryParams = input<Record<string, unknown> | null>(null);
   readonly searchLabel = input('');
 
@@ -112,6 +120,7 @@ export class AppMenuItemComponent {
   protected readonly labelClass = appMenuLabelClass;
   protected readonly trailingIconClass = appMenuTrailingIconClass;
   protected readonly shortcutClass = appMenuShortcutClass;
+  protected readonly trailingTextClass = appMenuTrailingTextClass;
   protected readonly submenuIconClass = appMenuSubmenuIconClass;
   protected readonly rowClass = computed(() => appMenuItemRowClass(this.variant()));
   protected readonly inert = computed(() => this.loading() || this.menuItem.disabled());

--- a/frontend/src/app/shared/ui/menu/app-menu.component.ts
+++ b/frontend/src/app/shared/ui/menu/app-menu.component.ts
@@ -54,6 +54,23 @@ import { AppMenuContentDirective } from './app-menu-content.directive';
 
 const menuByElement = new WeakMap<Element, AppMenuComponent>();
 
+export interface ContextMenuRequest {
+  origin: HTMLElement;
+  cursor: {x: number; y: number} | null;
+  contextmenu: boolean;
+}
+
+export function contextMenuRequest(event: MouseEvent): ContextMenuRequest {
+  const contextmenu = event.type === 'contextmenu';
+  return {
+    origin: event.currentTarget as HTMLElement,
+    cursor: contextmenu && (event.clientX !== 0 || event.clientY !== 0)
+      ? {x: event.clientX, y: event.clientY}
+      : null,
+    contextmenu,
+  };
+}
+
 type MenuPresentation = 'popup' | 'sheet' | 'push';
 
 const SUBMENU_GAP = 4;
@@ -212,6 +229,14 @@ export class AppMenuComponent {
     this.anchor = origin;
     this.contextZone = null;
     this.show();
+  }
+
+  openFrom(request: ContextMenuRequest): void {
+    if (request.cursor) {
+      this.openAt(request.cursor.x, request.cursor.y, request.origin);
+    } else {
+      this.open(request.origin);
+    }
   }
 
   openAt(x: number, y: number, contextZone?: HTMLElement, fromPointer = true): void {

--- a/frontend/src/app/shared/ui/menu/menu.styles.ts
+++ b/frontend/src/app/shared/ui/menu/menu.styles.ts
@@ -19,7 +19,7 @@ export const appMenuSheetPanelClass =
   'rounded-t-xl rounded-b-none border-x-0 border-b-0 ' +
   'pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]';
 
-export const appMenuScrollRegionClass = 'flex min-h-0 flex-col overflow-y-auto overscroll-contain';
+export const appMenuScrollRegionClass = 'flex min-h-0 flex-col overflow-x-hidden overflow-y-auto overscroll-contain';
 
 export const appMenuSheetPaneClass = 'will-change-transform animate-in-sheet slide-in-from-bottom-full';
 
@@ -51,14 +51,16 @@ export function appMenuItemRowClass(variant: AppMenuItemVariant): string {
   );
 }
 
-export const appMenuLeadingSlotClass = 'flex size-4 shrink-0 items-center justify-center text-text-muted';
-export const appMenuBadgeSlotClass = cn(appMenuLeadingSlotClass, 'text-xs font-medium tabular-nums');
+const menuIconToneClass = 'text-surface-400 dark:text-text-muted';
+export const appMenuLeadingSlotClass = cn('flex size-4 shrink-0 items-center justify-center', menuIconToneClass);
+export const appMenuBadgeSlotClass = cn(appMenuLeadingSlotClass, 'text-xs font-medium tabular-nums text-text-muted');
 export const appMenuIconClass = 'size-3.5 shrink-0';
 export const appMenuSpinnerClass = 'size-4 shrink-0 border-2';
 export const appMenuLabelClass = 'min-w-0 flex-1 truncate leading-5';
 export const appMenuShortcutClass = overlayListShortcutClass;
-export const appMenuTrailingIconClass = 'size-4 shrink-0';
-export const appMenuSubmenuIconClass = 'ml-auto size-4 shrink-0 text-text-muted';
+export const appMenuTrailingTextClass = 'text-xs text-text-muted';
+export const appMenuTrailingIconClass = cn('ml-2 size-3.5 shrink-0', menuIconToneClass);
+export const appMenuSubmenuIconClass = cn(appMenuTrailingIconClass, 'ml-auto');
 export const appMenuCheckIconClass = 'size-4 shrink-0 text-primary';
 export const appMenuSectionClass = cn(overlayListSectionLabelClass, 'text-text-muted');
 export const appMenuSeparatorClass = overlayListSeparatorClass;


### PR DESCRIPTION
## Description

Small follow-up to enhance the menu component with trailing text support, updating icon sizes and positioning to keep consistency, and included context menu positioning handling. 

## Linked Issue

N/A - Part of #2031 

## Changes

- Add support for trailing icon + text
- Updated icon sizes to match text sizes, change icon colours to a more subtle grey, and add a minimum gap between text + icon. 
- Add context menu positioning logic for the possible open triggers (static button, long press/right click). Without this, each individual page would have to reimplement this logic, so I extracted this from the browser page work and included in the menu itself. 

## Manual Testing Steps

N/A

## Screenshots (Optional)

Example of the WIP book menu with trailing text + icon + consistent icon formatting. 
<img width="832" height="812" alt="image" src="https://github.com/user-attachments/assets/e1899b68-4e08-4df3-9ab9-69605430a587" />

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Menu items can now display trailing text and icons.
  * Links support configurable targets, with improved security for new-tab links.
  * Context menus open at the pointer location or on the associated menu item.

* **Style**
  * Improved menu icon sizing, muted styling, and overflow handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->