### PR TITLE
refactor(ui): add shelf menu remove-all option

### DIFF
--- a/frontend/src/app/shared/components/shelf-menu/shelf-membership-menu.component.spec.ts
+++ b/frontend/src/app/shared/components/shelf-menu/shelf-membership-menu.component.spec.ts
@@ -37,7 +37,7 @@ describe('ShelfMembershipMenuComponent', () => {
   }
 
   function menuElement(): HTMLElement {
-    return document.querySelector('app-menu[aria-label="Add to shelf"]') as HTMLElement;
+    return document.querySelector('app-menu[aria-label="Add to Shelf"]') as HTMLElement;
   }
 
   function rowLabels(): string[] {
@@ -58,8 +58,9 @@ describe('ShelfMembershipMenuComponent', () => {
 
   it('renders translated menu labels', async () => {
     await render(shelves(3));
-    expect(menuElement().getAttribute('aria-label')).toBe('Add to shelf');
-    expect(menuElement().querySelector('app-menu-item')?.textContent?.trim()).toBe('New shelf…');
+    expect(menuElement().getAttribute('aria-label')).toBe('Add to Shelf');
+    expect(Array.from(menuElement().querySelectorAll('app-menu-item'))
+      .map(item => item.textContent?.trim())).toEqual(['New Shelf', 'Remove from Your Shelves']);
   });
 
   it('hides the filter input for a short, scannable list', async () => {
@@ -105,7 +106,7 @@ describe('ShelfMembershipMenuComponent', () => {
     await render(shelves(12));
     const input = menuElement().querySelector('input') as HTMLInputElement;
     const rows = menuElement().querySelectorAll('app-menu-checkbox');
-    const newShelf = menuElement().querySelector('app-menu-item') as HTMLElement;
+    const removeAll = menuElement().querySelectorAll('app-menu-item')[1] as HTMLElement;
 
     input.focus();
     input.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: true, cancelable: true}));
@@ -113,7 +114,7 @@ describe('ShelfMembershipMenuComponent', () => {
 
     input.focus();
     input.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: true, cancelable: true}));
-    expect(document.activeElement).toBe(newShelf);
+    expect(document.activeElement).toBe(removeAll);
   });
 
   it('emits toggleShelf with the shelf id and next state', async () => {
@@ -157,22 +158,28 @@ describe('ShelfMembershipMenuComponent', () => {
     expect(menuElement().querySelector('input')).toBeNull();
   });
 
-  it('emits createShelf when the New shelf item is chosen', async () => {
+  it('emits both trailing shelf commands', async () => {
     await render(shelves(3));
-    const spy = vi.fn();
-    fixture.componentInstance.createShelf.subscribe(spy);
-    const newShelf = menuElement().querySelector('app-menu-item') as HTMLElement;
-    newShelf.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
-    expect(spy).toHaveBeenCalledTimes(1);
+    const create = vi.fn();
+    const removeAll = vi.fn();
+    fixture.componentInstance.createShelf.subscribe(create);
+    fixture.componentInstance.removeFromAllShelves.subscribe(removeAll);
+    const items = menuElement().querySelectorAll('app-menu-item');
+    items[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
+    items[1].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
+    expect(create).toHaveBeenCalledOnce();
+    expect(removeAll).toHaveBeenCalledOnce();
   });
 
-  it('renders the filter, rows and New shelf in logical order', async () => {
+  it('renders the filter, rows and commands in logical order', async () => {
     await render(shelves(12));
-    const order = Array.from(menuElement().querySelectorAll('input, app-menu-checkbox, app-menu-item')).map(el => {
-      const tag = el.tagName.toLowerCase();
-      return tag === 'input' ? 'filter' : tag === 'app-menu-item' ? 'newShelf' : 'row';
-    });
+    const order = Array.from(menuElement().querySelectorAll('input, app-menu-checkbox, app-menu-item'))
+      .map(el => el.tagName.toLowerCase() === 'input'
+        ? 'filter'
+        : el.tagName.toLowerCase() === 'app-menu-checkbox'
+          ? 'row'
+          : el.textContent?.trim());
     expect(order[0]).toBe('filter');
-    expect(order.at(-1)).toBe('newShelf');
+    expect(order.slice(-2)).toEqual(['New Shelf', 'Remove from Your Shelves']);
   });
 });

--- a/frontend/src/app/shared/components/shelf-menu/shelf-membership-menu.component.ts
+++ b/frontend/src/app/shared/components/shelf-menu/shelf-membership-menu.component.ts
@@ -57,7 +57,7 @@ const FILTER_THRESHOLD = 8;
           </div>
           <app-menu-separator />
         }
-        <div class="max-h-80 overflow-y-auto overscroll-contain">
+        <div class="max-h-80 overflow-x-hidden overflow-y-auto overscroll-contain">
           @for (shelf of filteredShelves(); track shelf.id) {
             <app-menu-checkbox
               [checked]="shelf.checked"
@@ -73,6 +73,10 @@ const FILTER_THRESHOLD = 8;
           <app-menu-separator />
         }
         <app-menu-item (selected)="createShelf.emit()">{{ 'shared.ui.shelfMenu.newShelf' | transloco }}</app-menu-item>
+        <app-menu-separator />
+        <app-menu-item (selected)="removeFromAllShelves.emit()">
+          {{ 'shared.ui.shelfMenu.removeFromAllShelves' | transloco }}
+        </app-menu-item>
       </ng-template>
     </app-menu>
   `,
@@ -82,6 +86,7 @@ export class ShelfMembershipMenuComponent {
 
   readonly toggleShelf = output<{shelfId: number; checked: boolean}>();
   readonly createShelf = output<void>();
+  readonly removeFromAllShelves = output<void>();
 
   readonly menu = viewChild.required(AppMenuComponent);
   readonly ariaMenu = viewChild.required(AppMenuComponent, {read: Menu});

--- a/frontend/src/i18n/en/shared.json
+++ b/frontend/src/i18n/en/shared.json
@@ -188,8 +188,9 @@
       "selectedCount": "{{ count }} selected"
     },
     "shelfMenu": {
-      "addToShelf": "Add to shelf",
-      "newShelf": "New shelf…"
+      "addToShelf": "Add to Shelf",
+      "newShelf": "New Shelf",
+      "removeFromAllShelves": "Remove from Your Shelves"
     },
     "spinner": {
       "loading": "Loading"


### PR DESCRIPTION
## Description

Small refinement to the shelf membership menu in the browser work. Adds "Remove from your shelves" to the menu options, meant to un-assign a book or bulk selection from the user's scoped shelves. 

## Linked Issue

N/A - Part of #2031

## Changes

- Adds "Remove from your shelf" item to the shelf assignment menu
- Updated specs

## Manual Testing Steps

N/A

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
<img width="209" height="167" alt="Screenshot 2026-08-10 at 13 10 45" src="https://github.com/user-attachments/assets/6cca49ac-7c90-4ded-9ab8-c4c4c48a30dd" />

## Additional Context (Optional)

This is only the component UI. The actual shelf wiring is part of the shelf membership command and wired up by its future users (the book context menu and the bulk action bar). 

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Remove from Your Shelves” command to the shelf membership menu.
  * The command lets users remove an item from all shelves at once.
  * Added a separator between shelf actions for clearer menu organization.

* **Style**
  * Prevented horizontal overflow in the shelf list menu.
  * Updated the “Add to Shelf” accessibility label capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->