### PR TITLE
fix(hardcover): use injected restclient with expected timeouts

### DIFF
--- a/backend/src/main/java/org/booklore/service/hardcover/HardcoverSyncService.java
+++ b/backend/src/main/java/org/booklore/service/hardcover/HardcoverSyncService.java
@@ -43,12 +43,14 @@ public class HardcoverSyncService {
     private final ThreadLocal<String> currentApiToken = new ThreadLocal<>();
 
     @Autowired
-    public HardcoverSyncService(HardcoverSyncSettingsService hardcoverSyncSettingsService, BookRepository bookRepository) {
+    public HardcoverSyncService(
+            HardcoverSyncSettingsService hardcoverSyncSettingsService,
+            BookRepository bookRepository,
+            RestClient restClient
+    ) {
         this.hardcoverSyncSettingsService = hardcoverSyncSettingsService;
         this.bookRepository = bookRepository;
-        this.restClient = RestClient.builder()
-                .baseUrl(HARDCOVER_API_URL)
-                .build();
+        this.restClient = restClient;
     }
 
     /**
@@ -795,7 +797,7 @@ public class HardcoverSyncService {
     private Map<String, Object> executeGraphQL(GraphQLRequest request) {
         try {
             return restClient.post()
-                    .uri("")
+                    .uri(HARDCOVER_API_URL)
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + getApiToken())
                     .body(request)

--- a/backend/src/main/java/org/booklore/service/metadata/parser/hardcover/HardcoverBookSearchService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/hardcover/HardcoverBookSearchService.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicLong;
 @Slf4j
 @Service
 public class HardcoverBookSearchService {
-
+    private static final String GRAPHQL_URI = "https://api.hardcover.app/v1/graphql";
     public static final int DEFAULT_PER_PAGE = 10;
     private static final long INITIAL_DELAY_MS = 1000;
     private static final long MAX_DELAY_MS = 15000;
@@ -27,11 +27,9 @@ public class HardcoverBookSearchService {
     private final AtomicLong lastRequestTime = new AtomicLong(0);
     private final AtomicLong successCount = new AtomicLong(0);
 
-    public HardcoverBookSearchService(AppSettingService appSettingService) {
+    public HardcoverBookSearchService(AppSettingService appSettingService, RestClient restClient) {
         this.appSettingService = appSettingService;
-        this.restClient = RestClient.builder()
-                .baseUrl("https://api.hardcover.app/v1/graphql")
-                .build();
+        this.restClient = restClient;
     }
 
     public List<GraphQLResponse.BookWithEditions> searchBookByIsbn(List<String> isbn) {
@@ -169,7 +167,7 @@ public class HardcoverBookSearchService {
 
         try {
             T response = restClient.post()
-                    .uri("")
+                    .uri(GRAPHQL_URI)
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiToken)
                     .body(body)

--- a/backend/src/test/java/org/booklore/service/hardcover/HardcoverSyncServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/hardcover/HardcoverSyncServiceTest.java
@@ -6,10 +6,10 @@ import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.repository.BookRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -48,6 +48,7 @@ class HardcoverSyncServiceTest {
     @Mock
     private RestClient.ResponseSpec responseSpec;
 
+    @InjectMocks
     private HardcoverSyncService service;
 
     private BookEntity testBook;
@@ -60,12 +61,7 @@ class HardcoverSyncServiceTest {
     @BeforeEach
     void setUp() throws Exception {
         // Create service with mocked dependencies
-        service = new HardcoverSyncService(hardcoverSyncSettingsService, bookRepository);
-        
-        // Inject our mocked restClient using reflection
-        Field restClientField = HardcoverSyncService.class.getDeclaredField("restClient");
-        restClientField.setAccessible(true);
-        restClientField.set(service, restClient);
+        service = new HardcoverSyncService(hardcoverSyncSettingsService, bookRepository, restClient);
 
         testBook = new BookEntity();
         testBook.setId(TEST_BOOK_ID);

--- a/backend/src/test/java/org/booklore/service/metadata/parser/hardcover/HardcoverBookSearchServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/hardcover/HardcoverBookSearchServiceTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.web.client.RestClient;
 
 import java.util.List;
 
@@ -20,12 +22,15 @@ class HardcoverBookSearchServiceTest {
     @Mock
     private AppSettingService appSettingService;
 
+    @Mock
+    private RestClient restClient;
+
+    @InjectMocks
     private HardcoverBookSearchService searchService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        searchService = new HardcoverBookSearchService(appSettingService);
     }
 
     private void setupAppSettingsWithToken(String token) {


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the current Hardcover integrations use a `RestClient` without any timeouts which leads to permanent timeouts

this changes the Hardcover services to inject the spring config `RestClient` with a default set of timeouts

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2319

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* updates `HardcoverSyncService` to inject `RestClient`
* updates `HardcoverBookSearchService` to inject `RestClient`
* updates tests to use more standard mock injecting

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Run hardcover metadata search and confirm results are still returned
2. Enable hardcover sync service 
3. Do some reading and see an attempt to send progress over hardcover sync

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
Depends on #2321 

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Hardcover book searches and synchronization by sending requests to the correct API endpoints.
  * Added consistent request timeout handling for external service calls.

* **Refactor**
  * Centralized HTTP client configuration to provide more predictable behavior across metadata and synchronization features.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->