### PR TITLE
fix(archive): ignore directories when streaming entries from zip

### DIFF
--- a/backend/src/main/java/org/booklore/service/ArchiveService.java
+++ b/backend/src/main/java/org/booklore/service/ArchiveService.java
@@ -48,6 +48,7 @@ public class ArchiveService {
             return file.stream()
                     .toList()
                     .stream()
+                    .filter(e -> !e.isDirectory())
                     .map(e -> new Entry(e.getName(), e.getSize()));
         }
     }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
some zip files have headers with directories which caused problems - all other archive types in `ArchiveService` skip directories

this updates the ArchiveService wrapper for zip to also skip them

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2326

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* adds `isDirectory` filter when streaming entries from zip

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. edit epub
2. see no errors about entry extraction

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ZIP archive listings now exclude directory entries, providing consistent results with RAR archives.
  * File entries continue to display their names and sizes correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->