### PR TITLE
fix(epub): write epub3 title with refinement `main` for kindle compatibility

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -42,6 +42,8 @@ import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -94,11 +96,26 @@ public class EpubMetadataWriter implements MetadataWriter {
             MetadataCopyHelper helper = new MetadataCopyHelper(metadata);
 
             helper.copyTitle(clear != null && clear.isTitle(), val -> {
-                replaceAndTrackChange(opfDoc, metadataElement, "title", DC_NS, val, hasChanges);
-                if (StringUtils.isNotBlank(metadata.getSubtitle())) {
-                    addSubtitleToTitle(metadataElement, opfDoc, metadata.getSubtitle());
+                if (isEpub3(opfDoc)) {
+                    if (replaceEpub3Title(metadataElement, opfDoc, "main", val)) {
+                        hasChanges[0] = true;
+                    }
+                } else {
+                    replaceAndTrackChange(opfDoc, metadataElement, "title", DC_NS, val, hasChanges);
                 }
             });
+
+            helper.copySubtitle(clear != null && clear.isSubtitle(), val -> {
+                if (isEpub3(opfDoc)) {
+                    if (replaceEpub3Title(metadataElement, opfDoc, "subtitle", val)) {
+                        hasChanges[0] = true;
+                    }
+                }
+
+                // EPUB2: subtitle is stored only via booklore:subtitle metadata (written in addBookloreMetadata).
+                // No modification to dc:title is needed — this preserves round-trip fidelity.
+            });
+
             helper.copyDescription(clear != null && clear.isDescription(), val -> replaceAndTrackChange(opfDoc, metadataElement, "description", DC_NS, val, hasChanges));
             helper.copyPublisher(clear != null && clear.isPublisher(), val -> replaceAndTrackChange(opfDoc, metadataElement, "publisher", DC_NS, val, hasChanges));
             helper.copyPublishedDate(clear != null && clear.isPublishedDate(), val -> replaceAndTrackChange(opfDoc, metadataElement, "date", DC_NS, val != null ? val.toString() : null, hasChanges));
@@ -622,23 +639,53 @@ public class EpubMetadataWriter implements MetadataWriter {
             Element meta = (Element) metas.item(i);
             String refines = meta.getAttribute("refines");
 
-            if (refines.startsWith("#")) {
-                String refinesId = refines.substring(1);
-
-                if (!ids.contains(refinesId)) {
-                    metadataElement.removeChild(meta);
-                }
+            if (refines.isBlank()) {
+                // If this meta doesn't have `refines` or it's empty then
+                // we skip processing as that means they do not have a
+                // relationship with another specific element.
+                continue;
             }
+
+            if (!refines.startsWith("#")) {
+                // If the `refines` is a path-relative URL string it's possibly valid - but
+                // we cannot easily confirm it as valid here.  We only know about the contents
+                // of the current OPF and are not parsing the various pages.
+                //
+                // For now, we can skip it.
+                continue;
+            }
+
+            String refinesId = refines.substring(1);
+
+            if (ids.contains(refinesId)) {
+                continue;
+            }
+
+            metadataElement.removeChild(meta);
         }
     }
 
-    private void removeMetaByRefines(Element metadataElement, String refines) {
+    private List<Element> getMetaByRefines(Element metadataElement, String property, String id) {
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
-        for (int i = metas.getLength() - 1; i >= 0; i--) {
-            Element meta = (Element) metas.item(i);
-            if (refines.equals(meta.getAttribute("refines"))) {
-                metadataElement.removeChild(meta);
-            }
+
+        var refinesIndicator = "#".concat(id);
+
+        return IntStream.range(0, metas.getLength())
+                .mapToObj(metas::item)
+                .filter(Element.class::isInstance)
+                .map(Element.class::cast)
+                .filter(meta -> property == null || meta.getAttribute("property").equals(property))
+                .filter(meta -> refinesIndicator.equals(meta.getAttribute("refines")))
+                .toList();
+    }
+
+    private void removeMetaByRefines(Element metadataElement, String refines) {
+        removeMetaByRefines(metadataElement, null, refines);
+    }
+
+    private void removeMetaByRefines(Element metadataElement, String property, String refines) {
+        for (var child : getMetaByRefines(metadataElement, property, refines)) {
+            metadataElement.removeChild(child);
         }
     }
 
@@ -701,7 +748,7 @@ public class EpubMetadataWriter implements MetadataWriter {
             if (role.equalsIgnoreCase(creatorRole)) {
                 metadataElement.removeChild(creatorElement);
                 if (StringUtils.isNotBlank(id)) {
-                    removeMetaByRefines(metadataElement, "#".concat(id));
+                    removeMetaByRefines(metadataElement, id);
                 }
             }
         }
@@ -935,7 +982,7 @@ public class EpubMetadataWriter implements MetadataWriter {
                 String id = meta.getAttribute("id");
                 metadataElement.removeChild(meta);
                 if (StringUtils.isNotBlank(id)) {
-                    removeMetaByRefines(metadataElement, "#" + id);
+                    removeMetaByRefines(metadataElement, id);
                 }
             }
             // Also remove EPUB2-style series metas
@@ -998,49 +1045,111 @@ public class EpubMetadataWriter implements MetadataWriter {
         }
     }
 
-    private void addSubtitleToTitle(Element metadataElement, Document doc, String subtitle) {
-        final String DC_NS = "http://purl.org/dc/elements/1.1/";
-        boolean epub3 = isEpub3(doc);
-
-        // Remove existing subtitle elements (both EPUB2 and EPUB3 forms)
+    private Element getRefinesElement(Element metadataElement, String property, String content) {
         NodeList metas = metadataElement.getElementsByTagNameNS("*", "meta");
         for (int i = metas.getLength() - 1; i >= 0; i--) {
-            Element meta = (Element) metas.item(i);
-            String property = meta.getAttribute("property");
-            String refines = meta.getAttribute("refines");
-            if ("title-type".equals(property) && "subtitle".equals(meta.getTextContent())) {
-                if (StringUtils.isNotBlank(refines)) {
-                    NodeList titles = metadataElement.getElementsByTagNameNS(DC_NS, "title");
-                    for (int j = titles.getLength() - 1; j >= 0; j--) {
-                        Element title = (Element) titles.item(j);
-                        if (("#" + title.getAttribute("id")).equals(refines)) {
-                            metadataElement.removeChild(title);
-                            break;
-                        }
+            if (metas.item(i) instanceof Element meta) {
+                if (meta.getAttribute("property").equals(property) && meta.getTextContent().equals(content)) {
+                    return meta;
+                }
+            }
+        }
+        return null;
+    }
+
+    private Element createRefinesElement(Document doc, String property, String content, String target) {
+        Element element = doc.createElementNS(OPF_NS, "meta");
+        element.setPrefix("opf");
+        element.setAttribute("refines", "#" + target);
+        element.setAttribute("property", property);
+        element.setTextContent(content);
+        return element;
+    }
+
+    private boolean replaceEpub3Title(Element metadataElement, Document doc, String titleType, String value) {
+        final String DC_NS = "http://purl.org/dc/elements/1.1/";
+
+        Element refineElement = getRefinesElement(metadataElement, "title-type", titleType);
+        String refines = refineElement == null ? "" : refineElement.getAttribute("refines");
+
+        Element titleElement = null;
+
+        if (!refines.isBlank()) {
+            NodeList titles = metadataElement.getElementsByTagNameNS(DC_NS, "title");
+            for (int i = titles.getLength() - 1; i >= 0; i--) {
+                if (titles.item(i) instanceof Element title) {
+                    if (("#" + title.getAttribute("id")).equals(refines)) {
+                        titleElement = title;
+                        break;
                     }
                 }
-                metadataElement.removeChild(meta);
             }
         }
 
-        if (epub3) {
-            // EPUB3: add subtitle as separate dc:title with title-type refinement
-            String subtitleId = "subtitle-" + UUID.randomUUID().toString().substring(0, 8);
-            Element subtitleElement = doc.createElementNS(DC_NS, "title");
-            subtitleElement.setPrefix("dc");
-            subtitleElement.setAttribute("id", subtitleId);
-            subtitleElement.setTextContent(subtitle);
-            metadataElement.appendChild(subtitleElement);
+        // If no exact match exists, we choose the first title (per epub3 spec) as the main title
+        if (titleElement == null && "main".equals(titleType)) {
+            NodeList titles = metadataElement.getElementsByTagNameNS(DC_NS, "title");
+            if (titles.getLength() > 0 && titles.item(0) instanceof Element title) {
+                var id = title.getAttribute("id");
 
-            Element typeMeta = doc.createElementNS(OPF_NS, "meta");
-            typeMeta.setPrefix("opf");
-            typeMeta.setAttribute("refines", "#" + subtitleId);
-            typeMeta.setAttribute("property", "title-type");
-            typeMeta.setTextContent("subtitle");
-            metadataElement.appendChild(typeMeta);
+                // Except we can't select an existing subtitle
+                if (id.isBlank() || getMetaByRefines(metadataElement, "title-type", id).isEmpty()) {
+                    titleElement = title;
+                }
+            }
         }
-        // EPUB2: subtitle is stored only via booklore:subtitle metadata (written in addBookloreMetadata).
-        // No modification to dc:title is needed — this preserves round-trip fidelity.
+
+        boolean hasChanges = false;
+
+        if (value == null) {
+            // If we are removing the title but have found a relevant
+            // title value we should remove it.
+            if (titleElement != null) {
+                metadataElement.removeChild(titleElement);
+                hasChanges = true;
+            }
+
+            if (refineElement != null) {
+                metadataElement.removeChild(refineElement);
+                hasChanges = true;
+            }
+
+            return hasChanges;
+        }
+
+        String titleId = titleType + "-" + UUID.randomUUID().toString().substring(0, 8);
+
+        if (titleElement == null) {
+            hasChanges = true;
+            titleElement = doc.createElementNS(DC_NS, "title");
+            titleElement.setPrefix("dc");
+            titleElement.setAttribute("id", titleId);
+            titleElement.setTextContent(value);
+            metadataElement.appendChild(titleElement);
+        } else {
+            if (titleElement.getAttribute("id").isBlank()) {
+                hasChanges = true;
+                titleElement.setAttribute("id", titleId);
+            } else {
+                titleId = titleElement.getAttribute("id");
+            }
+
+            if (!value.equals(titleElement.getTextContent())) {
+                hasChanges = true;
+                titleElement.setTextContent(value);
+            }
+        }
+
+        if (refineElement == null) {
+            hasChanges = true;
+            refineElement = createRefinesElement(doc, "title-type", titleType, titleId);
+            metadataElement.appendChild(refineElement);
+        } else if (!refineElement.getAttribute("refines").equals("#" + titleId)) {
+            hasChanges = true;
+            refineElement.setAttribute("refines", "#" + titleId);
+        }
+
+        return hasChanges;
     }
 
     private void addBookloreMetadata(Element metadataElement, Document doc, BookMetadataEntity metadata) {
@@ -1183,7 +1292,7 @@ public class EpubMetadataWriter implements MetadataWriter {
                 String id = contributor.getAttribute("id");
                 metadataElement.removeChild(contributor);
                 if (StringUtils.isNotBlank(id)) {
-                    removeMetaByRefines(metadataElement, "#" + id);
+                    removeMetaByRefines(metadataElement, id);
                 }
             }
         }

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -468,6 +468,141 @@ class EpubMetadataWriterTest {
     }
 
     @Nested
+    @DisplayName("EPUB3 Title Tests")
+    class Epub3TitleTests {
+        @Test
+        @DisplayName("Should add title dc:title with title-type refinement in EPUB3")
+        void epub3_shouldAddTitleWithRefinement() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                        </metadata>
+                    </package>""";
+
+            metadata.setTitle("Main Title");
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-title-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains("Main Title");
+            assertThat(content).contains("property=\"title-type\"");
+            assertThat(content).contains(">main</opf:meta>");
+        }
+
+        @Test
+        @DisplayName("Should edit title dc:title when subtitle exists in EPUB3")
+        void epub3_shouldEditTitleWhenTitleAndSubtitleExist() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title>Test Book</dc:title>
+                            <dc:title id="subtitle-12b45ebf">My Subtitle</dc:title>
+                            <opf:meta xmlns:opf="http://www.idpf.org/2007/opf" property="title-type" refines="#subtitle-12b45ebf">subtitle</opf:meta>
+                        </metadata>
+                    </package>""";
+
+            metadata.setTitle("Main Title");
+            metadata.setSubtitle("My Subtitle");
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-title-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains("Main Title");
+            assertThat(content).contains("property=\"title-type\"");
+            assertThat(content).contains(">main</opf:meta>");
+            assertThat(content).contains(">subtitle</opf:meta>");
+        }
+
+        @Test
+        @DisplayName("Should add title dc:title when no title-type refinement in EPUB3")
+        void epub3_shouldAddTitleWhenNoRefinement() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title>Main Title</dc:title>
+                        </metadata>
+                    </package>""";
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-title-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains(">Test Book<");
+            assertThat(content).doesNotContain(">Main Title<");
+            assertThat(content).contains("property=\"title-type\"");
+            assertThat(content).contains(">main</opf:meta>");
+        }
+
+        @Test
+        @DisplayName("Should update title dc:title with title-type refinement in EPUB3")
+        void epub3_shouldUpdateTitleWithRefinement() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title id="title-12b45ebf">Main Title</dc:title>
+                            <opf:meta xmlns:opf="http://www.idpf.org/2007/opf" property="title-type" refines="#title-12b45ebf">main</opf:meta>
+                        </metadata>
+                    </package>""";
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-title-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).contains(">Test Book<");
+            assertThat(content).doesNotContain(">Main Title<");
+            assertThat(content).contains("property=\"title-type\"");
+            assertThat(content).contains(">main</opf:meta>");
+        }
+
+        @Test
+        @DisplayName("Should remove refinement when title is removed")
+        void epub3_shouldRemoveRefinementWhenRemovingTitle() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title id="title-12b45ebf">Main Title</dc:title>
+                            <opf:meta xmlns:opf="http://www.idpf.org/2007/opf" property="title-type" refines="#title-12b45ebf">main</opf:meta>
+                        </metadata>
+                    </package>""";
+
+            var clearFlags = new MetadataClearFlags();
+            clearFlags.setTitle(true);
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-title-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, clearFlags);
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).doesNotContain(">main</opf:meta>");
+        }
+
+        @Test
+        @DisplayName("Should do nothing when no title and title is removed")
+        void epub3_shouldSaveNoTitleWhenAlreadyNoTitle() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                        </metadata>
+                    </package>""";
+
+            metadata.setTitle(null);
+
+            File epubFile = createEpubWithOpf(opfContent, "test-epub3-title-" + System.nanoTime() + ".epub");
+            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+
+            String content = readOpfContent(epubFile);
+            assertThat(content).doesNotContain(">main</opf:meta>");
+        }
+    }
+
+    @Nested
     @DisplayName("EPUB3 Subtitle Tests")
     class Epub3SubtitleTests {
 
@@ -501,15 +636,16 @@ class EpubMetadataWriterTest {
                     <?xml version="1.0" encoding="UTF-8"?>
                     <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
                         <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-                            <dc:title id="#subtitle-12b45ebf">Subtitle</dc:title>
+                            <dc:title id="subtitle-12b45ebf">Subtitle</dc:title>
                             <opf:meta xmlns:opf="http://www.idpf.org/2007/opf" property="title-type" refines="#subtitle-12b45ebf">subtitle</opf:meta>
                         </metadata>
                     </package>""";
 
-            metadata.setSubtitle(null);
+            var clearFlags = new MetadataClearFlags();
+            clearFlags.setSubtitle(true);
 
             File epubFile = createEpubWithOpf(opfContent, "test-epub3-subtitle-" + System.nanoTime() + ".epub");
-            writer.saveMetadataToFile(epubFile, metadata, null, new MetadataClearFlags());
+            writer.saveMetadataToFile(epubFile, metadata, null, clearFlags);
 
             String content = readOpfContent(epubFile);
             assertThat(content).doesNotContain(">subtitle</opf:meta>");


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->

### Context

 For epub3 documents per the [epub 3.3 specification](https://www.w3.org/TR/epub-33/), the main title has multiple ways of being provided.

One way, as defined [in 5.5.3.1.2 `dc:title`](https://www.w3.org/TR/epub-33/#sec-opf-dctitle) is the first `title` element:

> The first dc:title element in document order is the main title of the EPUB publication (i.e., the primary one reading systems present to users).

Another way for this to be provided is [defined in D.3.13 `title-type`](https://www.w3.org/TR/epub-33/#sec-title-type) as a refinement of type `title-type` with the value `main`:

> When the title-type value is drawn from a code list or other formal enumeration, [EPUB creators](https://www.w3.org/TR/epub-33/#dfn-epub-creator) SHOULD attach a [scheme attribute](https://www.w3.org/TR/epub-33/#attrdef-scheme) to identify its source. When a scheme is not specified, [reading systems](https://www.w3.org/TR/epub-33/#dfn-epub-reading-system) SHOULD recognize the following title type values: main, subtitle, short, collection, edition and expanded.

Today we only do the former.  

### Problem

Amazon's web to kindle flow is picky about what it supports and what it doesn't. The Kindle compatibility seems to require the epub3 title to always have a refinement when there are multiple epub3 titles available.

If we want to push our epub3 files to Amazon, we should conform to these more explicit formats of the title.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2323

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* Reworks the subtitle code to properly use the subtitle copy helper (splitting it from title)
* Updates the title code to safely write new titles with `main` refinements
* Updates tests to validate behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

### Send to Kindle email

1. upload epub3 to Grimmory
2. enable write-to-epub
3. add subtitle to book in Grimmory
4. use send-to-email to send to kindle web
5. see doc show up in kindle library
6. delete from kindle library to reset

### Upload to Amazon

1. upload epub3 to Grimmory
2. enable write to epub
3. add subtitle to book in grimmory
4. download epub3 file
5. upload at Amazon's [send-to-kindle URL](https://www.amazon.com/sendtokindle)
6. see doc show u p in kindle library



## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
N/A

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
The "requirement" of an explicit epub3 title is an assumption - there is no documentation that I have found that define what is actually supported and what is not.  Instead, this was found by trial-and-error and manual verification.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved EPUB 3 metadata support for titles and subtitles.
  * Titles and subtitles are now correctly created, updated, preserved, or removed using EPUB 3 refinement metadata.
  * EPUB 2 subtitle handling remains compatible without altering the main title.

* **Bug Fixes**
  * Improved cleanup of invalid or incomplete metadata references.
  * Corrected subtitle removal behavior when clearing subtitle metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->