### PR TITLE
fix(audible): emit external Audible URL with region domain

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
@@ -36,6 +36,19 @@ import java.util.stream.Collectors;
 public class AudibleParser implements BookParser, DetailedMetadataProvider {
     private static final String DEFAULT_TLD = "com";
 
+    private static final Map<String, String> EXTERNAL_BASE_URIS = Map.of(
+            "com", "https://www.audible.com/",
+            "co.uk", "https://www.audible.co.uk/",
+            "de", "https://www.audible.de/",
+            "fr", "https://www.audible.fr/",
+            "it", "https://www.audible.it/",
+            "es", "https://www.audible.es/",
+            "ca", "https://www.audible.ca/",
+            "com.au", "https://www.audible.com.au/",
+            "co.jp", "https://www.audible.co.jp",
+            "in", "https://www.audible.in/"
+    );
+
     private static final Map<String, String> BASE_URIS = Map.of(
             "com", "https://api.audible.com/",
             "co.uk", "https://api.audible.co.uk/",
@@ -149,13 +162,32 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
             List<AudibleProduct> products
     ) {}
 
-    private String getBaseURI() {
+    private String getTld() {
         var settings = appSettingService.getAppSettings().getMetadataProviderSettings();
         String tld = DEFAULT_TLD;
         if (settings != null && settings.getAudible() != null && settings.getAudible().getDomain() != null) {
             tld = settings.getAudible().getDomain();
         }
-        return BASE_URIS.getOrDefault(tld, BASE_URIS.get(DEFAULT_TLD));
+        return tld;
+    }
+
+    private String getBaseURI() {
+        return BASE_URIS.getOrDefault(getTld(), BASE_URIS.get(DEFAULT_TLD));
+    }
+
+    private String getExternalBaseURI() {
+        return EXTERNAL_BASE_URIS.getOrDefault(getTld(), EXTERNAL_BASE_URIS.get(DEFAULT_TLD));
+    }
+
+    private String buildExternalURI(String asin) {
+        if (asin == null) {
+            return null;
+        }
+
+        return UriComponentsBuilder.fromUriString(getExternalBaseURI())
+                .path("/dp/{asin}")
+                .build(asin)
+                .toString();
     }
 
     private URI getURI(
@@ -417,6 +449,7 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
 
         return BookMetadata.builder()
                 .provider(MetadataProvider.Audible)
+                .externalUrl(buildExternalURI(product.asin))
                 .asin(product.asin)
                 .audibleId(product.asin)
                 .title(product.title)

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AudibleParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AudibleParserTest.java
@@ -150,6 +150,42 @@ public class AudibleParserTest {
     }
 
     @Test
+    public void fetchTopMetadata_includesExternalURLWithDomain() throws Exception {
+        mockHttpClientResponse(
+                "https://api.audible.co.jp/1.0/catalog/products/EXAMPLESKU",
+                200,
+                readFixture("example-asin-lookup.json")
+        );
+
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings( "co.jp"));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        BookMetadata actual = audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getExternalUrl()).isEqualTo("https://www.audible.co.jp/dp/1705047572");
+    }
+
+    @Test
+    public void fetchTopMetadata_includesExternalURL() throws Exception {
+        mockHttpClientResponse(
+                "https://api.audible.com/1.0/catalog/products/EXAMPLESKU",
+                200,
+                readFixture("example-asin-lookup.json")
+        );
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        BookMetadata actual = audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getExternalUrl()).isEqualTo("https://www.audible.com/dp/1705047572");
+    }
+
+    @Test
     public void fetchTopMetadata_removesExtraWhitespace() throws Exception {
         mockHttpClientResponse(
                 "https://api.audible.com/1.0/catalog/products/EXAMPLESKU",


### PR DESCRIPTION
> [!TIP]
> Visibility depends on https://github.com/grimmory-tools/grimmory/pull/2317

## Description

<!-- Required. Briefly explain what changed and why. -->
the audible metadata provider does not emit an `externalUrl` when fetching metadata.  instead, the UI hard codes the Audible domain - even if the URL is incorrect

this updates the Audible metadata provider to emit an expected audible domain during metadata searching

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2316 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* update audible metadata source internals to emit expected domain external URL
* update tests to match new behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. set Audible domain to IT
1. do metadata search in Audible metadata source
2. inspect HTTP requests and see `externalUrl` is returned with expected URL (including domain)

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.
