### PR TITLE
fix(amazon): emit external Amazon URL with region domain

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -19,6 +19,7 @@ import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -297,6 +298,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
         return BookMetadata.builder()
                 .provider(MetadataProvider.Amazon)
+                .externalUrl(buildExternalUrl(amazonBookId))
                 .title(titleInfo.title())
                 .subtitle(titleInfo.subtitle())
                 .authors(new ArrayList<>(getAuthors(doc)))
@@ -319,7 +321,17 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                 .build();
     }
 
-    private String buildQueryUrl(FetchMetadataRequest fetchMetadataRequest, Book book) {
+    private String buildExternalUrl(String asin) {
+        String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
+
+        return UriComponentsBuilder.fromUriString("https://www.amazon." + domain)
+                .path("/dp/{asin}")
+                .build(asin)
+                .toString();
+    }
+
+
+        private String buildQueryUrl(FetchMetadataRequest fetchMetadataRequest, Book book) {
         String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
         String isbnCleaned = ParserUtils.cleanIsbn(fetchMetadataRequest.getIsbn());
         if (isbnCleaned != null && !isbnCleaned.isEmpty()) {

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -23,6 +23,7 @@ import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -323,6 +324,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
         return BookMetadata.builder()
                 .provider(MetadataProvider.Amazon)
+                .externalUrl(buildExternalUrl(amazonBookId))
                 .title(titleInfo.title())
                 .subtitle(titleInfo.subtitle())
                 .authors(new ArrayList<>(getAuthors(doc)))
@@ -343,6 +345,15 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                 .amazonReviewCount(getReviewCount(doc))
                 .bookReviews(reviews)
                 .build();
+    }
+
+    private String buildExternalUrl(String asin) {
+        String baseUri = getBaseURI();
+
+        return UriComponentsBuilder.fromUriString(baseUri)
+                .path("/dp/{asin}")
+                .build(asin)
+                .toString();
     }
 
     private String buildQueryUrl(FetchMetadataRequest fetchMetadataRequest, Book book) {

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -385,6 +385,33 @@ public class AmazonBookParserTest {
     }
 
     @Test
+    public void fetchTopMetadata_includesExternalURLWithDomain() throws Exception {
+        mockJsoupConnect("https://www.amazon.de/dp/EXAMPLESKU", readFixture("book-de.html"));
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings( "de"));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        var metadata = amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getExternalUrl()).isEqualTo("https://www.amazon.de/dp/EXAMPLESKU");
+    }
+
+    @Test
+    public void fetchTopMetadata_includeExternalURL() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", readFixture("ebook-us.html"));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        var metadata = amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getExternalUrl()).isEqualTo("https://www.amazon.com/dp/EXAMPLESKU");
+    }
+
+    @Test
     public void fetchTopMetadata_removesExtraWhitespace() throws Exception {
         mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
 

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -427,6 +427,20 @@ public class AmazonBookParserTest {
     }
 
     @Test
+    public void fetchTopMetadata_includesExternalURLWithDomain() throws Exception {
+        mockJsoupConnect("https://www.amazon.de/dp/EXAMPLESKU", readFixture("book-de.html"));
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings( "de"));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        var metadata = amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getExternalUrl()).isEqualTo("https://www.amazon.de/dp/EXAMPLESKU");
+    }
+
+    @Test
     public void fetchTopMetadata_failsWhenDomainIsUnsupported() {
         when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings("com@evil.example"));
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the amazon metadata provider does not emit an externalUrl when fetching metadata. instead, the UI hard codes the Amazon.com domain - even if the URL is incorrect

this updates the Amazon metadata provider to emit an expected audible domain during metadata searching

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2316

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* update audible metadata source internals to emit expected domain external URL
* update tests to match new behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

* set Amazon domain to IT
* do metadata search in Amazon metadata source
* inspect HTTP requests and see externalUrl is returned with expected URL (including domain)

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Amazon-sourced book metadata now includes a direct link to the corresponding product page.
  * Links are generated using the configured Amazon regional domain, including German and US sites.

* **Tests**
  * Added coverage confirming that regional metadata results include correctly formatted Amazon product links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->