### PR TITLE
feat(komga): support remember-me authentication cookies

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -113,7 +113,7 @@ public class SecurityConfig {
         http
                 .securityMatcher("/komga/api/v1/**", "/komga/api/v2/**")
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
+++ b/backend/src/main/java/org/booklore/config/security/SecurityConfig.java
@@ -2,6 +2,9 @@ package org.booklore.config.security;
 
 import org.booklore.config.security.filter.*;
 import org.booklore.config.security.service.OpdsUserDetailsService;
+import org.booklore.model.dto.settings.KomgaSettings;
+import org.booklore.service.appsettings.AppSettingService;
+
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
@@ -21,7 +24,10 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices;
+import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices.RememberMeTokenAlgorithm;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -102,7 +108,8 @@ public class SecurityConfig {
 
     @Bean
     @Order(2)
-    public SecurityFilterChain komgaBasicAuthSecurityChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain komgaBasicAuthSecurityChain(
+                HttpSecurity http, RememberMeServices komgaRememberMeServices) throws Exception {
         http
                 .securityMatcher("/komga/api/v1/**", "/komga/api/v2/**")
                 .csrf(AbstractHttpConfigurer::disable)
@@ -117,7 +124,9 @@ public class SecurityConfig {
                             response.setHeader("WWW-Authenticate", "Basic realm=\"Grimmory Komga API\"");
                             response.getWriter().write("HTTP Status 401 - " + authException.getMessage());
                         })
-                );
+                )
+                .rememberMe(rememberMe -> rememberMe
+                        .rememberMeServices(komgaRememberMeServices));
 
         return http.build();
     }
@@ -365,5 +374,19 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
 
         return source;
+    }
+
+    @Bean
+    public RememberMeServices komgaRememberMeServices(
+        OpdsUserDetailsService userDetailsService,
+        AppSettingService appSettingsService) {
+        KomgaSettings settings = appSettingsService.getAppSettings().getKomgaSettings();
+        TokenBasedRememberMeServices services = new TokenBasedRememberMeServices(
+            settings.getRememberMeKey(),
+            userDetailsService, 
+            RememberMeTokenAlgorithm.SHA256);
+        services.setCookieName("komga-remember-me");
+        services.setTokenValiditySeconds(settings.getRememberMeDurationInSeconds());
+        return services;
     }
 }

--- a/backend/src/main/java/org/booklore/model/dto/settings/AppSettingKey.java
+++ b/backend/src/main/java/org/booklore/model/dto/settings/AppSettingKey.java
@@ -17,6 +17,7 @@ public enum AppSettingKey {
     OIDC_GROUP_SYNC_MODE                ("oidc_group_sync_mode",                 false, false, List.of(PermissionType.ADMIN)),
     OIDC_FORCE_ONLY_MODE                ("oidc_force_only_mode",                 false, true,  List.of(PermissionType.ADMIN)),
     KOBO_SETTINGS                       ("kobo_settings",                        true,  false, List.of(PermissionType.ADMIN)),
+    KOMGA_SETTINGS                     ("komga_settings",                        true,  false, List.of(PermissionType.ADMIN)),
     OPDS_SERVER_ENABLED                 ("opds_server_enabled",                  false, false, List.of(PermissionType.ADMIN)),
     KOMGA_API_ENABLED                     ("komga_api_enabled",                  false, false, List.of(PermissionType.ADMIN)),
     KOMGA_GROUP_UNKNOWN                 ("komga_group_unknown",                  false, false, List.of(PermissionType.ADMIN)),

--- a/backend/src/main/java/org/booklore/model/dto/settings/AppSettings.java
+++ b/backend/src/main/java/org/booklore/model/dto/settings/AppSettings.java
@@ -34,6 +34,7 @@ public class AppSettings {
     private MetadataPersistenceSettings metadataPersistenceSettings;
     private MetadataPublicReviewsSettings metadataPublicReviewsSettings;
     private KoboSettings koboSettings;
+    private KomgaSettings komgaSettings;
     private CoverCroppingSettings coverCroppingSettings;
     private MetadataProviderSpecificFields metadataProviderSpecificFields;
     private Integer oidcSessionDurationHours;

--- a/backend/src/main/java/org/booklore/model/dto/settings/KomgaSettings.java
+++ b/backend/src/main/java/org/booklore/model/dto/settings/KomgaSettings.java
@@ -1,0 +1,15 @@
+package org.booklore.model.dto.settings;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class KomgaSettings {
+   private String rememberMeKey; 
+   private Integer rememberMeDurationInSeconds;
+}

--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -42,12 +42,12 @@ public class AppSettingService {
     private final AuditService auditService;
     private final ObjectMapper objectMapper;
 
-    public AppSettingService(AppProperties appProperties, SettingPersistenceHelper settingPersistenceHelper, @Lazy AuthenticationService authenticationService, @Lazy AuditService auditService) {
+    public AppSettingService(AppProperties appProperties, SettingPersistenceHelper settingPersistenceHelper, @Lazy AuthenticationService authenticationService, @Lazy AuditService auditService, ObjectMapper objectMapper) {
         this.appProperties = appProperties;
         this.settingPersistenceHelper = settingPersistenceHelper;
         this.authenticationService = authenticationService;
         this.auditService = auditService;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = objectMapper;
     }
 
     @Cacheable("appSettings")

--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -219,6 +219,7 @@ public class AppSettingService {
         builder.metadataPersistenceSettings(settingPersistenceHelper.getJsonSetting(settingsMap, AppSettingKey.METADATA_PERSISTENCE_SETTINGS, MetadataPersistenceSettings.class, settingPersistenceHelper.getDefaultMetadataPersistenceSettings(), true));
         builder.metadataPublicReviewsSettings(settingPersistenceHelper.getJsonSetting(settingsMap, AppSettingKey.METADATA_PUBLIC_REVIEWS_SETTINGS, MetadataPublicReviewsSettings.class, settingPersistenceHelper.getDefaultMetadataPublicReviewsSettings(), true));
         builder.koboSettings(settingPersistenceHelper.getJsonSetting(settingsMap, AppSettingKey.KOBO_SETTINGS, KoboSettings.class, settingPersistenceHelper.getDefaultKoboSettings(), true));
+        builder.komgaSettings(settingPersistenceHelper.getJsonSetting(settingsMap, AppSettingKey.KOMGA_SETTINGS, KomgaSettings.class, settingPersistenceHelper.getDefaultKomgaSettings(), true));
         builder.coverCroppingSettings(settingPersistenceHelper.getJsonSetting(settingsMap, AppSettingKey.COVER_CROPPING_SETTINGS, CoverCroppingSettings.class, settingPersistenceHelper.getDefaultCoverCroppingSettings(), true));
         builder.metadataProviderSpecificFields(
             settingPersistenceHelper.getJsonSetting(

--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -70,6 +70,10 @@ public class AppSettingService {
             validateOidcForceOnlyMode(val);
         }
 
+        if (key == AppSettingKey.KOMGA_SETTINGS) {
+            validateKomgaSettings(val);
+        }
+
         var setting = settingPersistenceHelper.appSettingsRepository.findByName(key.toString());
         if (setting == null) {
             setting = new AppSettingEntity();
@@ -98,6 +102,32 @@ public class AppSettingService {
         if (details == null || details.getIssuerUri() == null || details.getIssuerUri().isBlank()
                 || details.getClientId() == null || details.getClientId().isBlank()) {
             throw ApiError.GENERIC_BAD_REQUEST.createException("Cannot enable OIDC-only mode: OIDC must be configured with issuer URI and client ID");
+        }
+    }
+
+    private void validateKomgaSettings(Object val) {
+        if (val == null) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Komga settings cannot be null");
+        }
+
+        if (!(val instanceof KomgaSettings)) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Komga settings must be a valid KomgaSettings object");
+        }
+
+        KomgaSettings settings = (KomgaSettings) val;
+
+        // Validate rememberMeKey
+        if (settings.getRememberMeKey() == null || settings.getRememberMeKey().isBlank()) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Komga rememberMeKey cannot be null or blank");
+        }
+
+        // Validate remmeberMeDurationInSeconds
+        if (settings.getRememberMeDurationInSeconds() == null) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Komga rememberMeDurationInSeconds cannot be null");
+        }
+
+        if (settings.getRememberMeDurationInSeconds() <= 0) {
+            throw ApiError.GENERIC_BAD_REQUEST.createException("Komga rememberMeDurationInSeconds must be a positive integer");
         }
     }
 

--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -21,6 +21,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.net.URI;
 import java.util.LinkedHashSet;
@@ -39,12 +40,14 @@ public class AppSettingService {
     private final SettingPersistenceHelper settingPersistenceHelper;
     private final AuthenticationService authenticationService;
     private final AuditService auditService;
+    private final ObjectMapper objectMapper;
 
     public AppSettingService(AppProperties appProperties, SettingPersistenceHelper settingPersistenceHelper, @Lazy AuthenticationService authenticationService, @Lazy AuditService auditService) {
         this.appProperties = appProperties;
         this.settingPersistenceHelper = settingPersistenceHelper;
         this.authenticationService = authenticationService;
         this.auditService = auditService;
+        this.objectMapper = new ObjectMapper();
     }
 
     @Cacheable("appSettings")
@@ -71,6 +74,7 @@ public class AppSettingService {
         }
 
         if (key == AppSettingKey.KOMGA_SETTINGS) {
+            val = objectMapper.convertValue(val, KomgaSettings.class);
             validateKomgaSettings(val);
         }
 

--- a/backend/src/main/java/org/booklore/service/appsettings/SettingPersistenceHelper.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/SettingPersistenceHelper.java
@@ -13,6 +13,8 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Set;
 
@@ -318,6 +320,15 @@ public class SettingPersistenceHelper {
                 .conversionImageCompressionPercentage(85)
                 .forceEnableHyphenation(false)
                 .forwardToKoboStore(true)
+                .build();
+    }
+
+    public KomgaSettings getDefaultKomgaSettings() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return KomgaSettings.builder()
+                .rememberMeKey(Base64.getEncoder().encodeToString(bytes))
+                .rememberMeDurationInSeconds(2592000) // 30 days
                 .build();
     }
 

--- a/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
@@ -1,10 +1,21 @@
 package org.booklore.service.appsettings;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
 import org.booklore.config.AppProperties;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.model.dto.BookLoreUser;
-import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.settings.AppSettingKey;
+import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.settings.KomgaSettings;
 import org.booklore.model.entity.AppSettingEntity;
 import org.booklore.model.enums.AuditAction;
@@ -20,17 +31,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import tools.jackson.databind.ObjectMapper;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -218,5 +218,126 @@ class AppSettingServiceTest {
         assertThat(second.getRememberMeKey()).isNotBlank();
         assertThat(first.getRememberMeKey()).isNotEqualTo(second.getRememberMeKey());
         assertThat(first.getRememberMeDurationInSeconds()).isEqualTo(2592000);
+    }
+
+    @Test
+    void updateSetting_rejectsNullKomgaSettings() {
+        assertThatThrownBy(() -> appSettingService.updateSetting(
+                AppSettingKey.KOMGA_SETTINGS,
+                null
+        ))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("Komga settings cannot be null");
+
+        verify(appSettingsRepository, never()).save(any());
+    }
+
+    @Test
+    void updateSetting_rejectsInvalidKomgaSettingsType() {
+        assertThatThrownBy(() -> appSettingService.updateSetting(
+                AppSettingKey.KOMGA_SETTINGS,
+                "invalid string"
+        ))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("Komga settings must be a valid KomgaSettings object");
+
+        verify(appSettingsRepository, never()).save(any());
+    }
+
+    @Test
+    void updateSetting_rejectsKomgaSettingsWithNullKey() {
+        KomgaSettings settings = new KomgaSettings();
+        settings.setRememberMeKey(null);
+        settings.setRememberMeDurationInSeconds(86400);
+
+        assertThatThrownBy(() -> appSettingService.updateSetting(
+                AppSettingKey.KOMGA_SETTINGS,
+                settings
+        ))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("rememberMeKey");
+
+        verify(appSettingsRepository, never()).save(any());
+    }
+
+    @Test
+    void updateSetting_rejectsKomgaSettingsWithBlankKey() {
+        KomgaSettings settings = new KomgaSettings();
+        settings.setRememberMeKey("   ");
+        settings.setRememberMeDurationInSeconds(86400);
+
+        assertThatThrownBy(() -> appSettingService.updateSetting(
+                AppSettingKey.KOMGA_SETTINGS,
+                settings
+        ))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("rememberMeKey");
+
+        verify(appSettingsRepository, never()).save(any());
+    }
+
+    @Test
+    void updateSetting_rejectsKomgaSettingsWithNullDuration() {
+        KomgaSettings settings = new KomgaSettings();
+        settings.setRememberMeKey("validKey123");
+        settings.setRememberMeDurationInSeconds(null);
+
+        assertThatThrownBy(() -> appSettingService.updateSetting(
+                AppSettingKey.KOMGA_SETTINGS,
+                settings
+        ))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("rememberMeDurationInSeconds");
+
+        verify(appSettingsRepository, never()).save(any());
+    }
+
+    @Test
+    void updateSetting_rejectsKomgaSettingsWithZeroDuration() {
+        KomgaSettings settings = new KomgaSettings();
+        settings.setRememberMeKey("validKey123");
+        settings.setRememberMeDurationInSeconds(0);
+
+        assertThatThrownBy(() -> appSettingService.updateSetting(
+                AppSettingKey.KOMGA_SETTINGS,
+                settings
+        ))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("positive");
+
+        verify(appSettingsRepository, never()).save(any());
+    }
+
+    @Test
+    void updateSetting_rejectsKomgaSettingsWithNegativeDuration() {
+        KomgaSettings settings = new KomgaSettings();
+        settings.setRememberMeKey("validKey123");
+        settings.setRememberMeDurationInSeconds(-1);
+
+        assertThatThrownBy(() -> appSettingService.updateSetting(
+                AppSettingKey.KOMGA_SETTINGS,
+                settings
+        ))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("positive");
+
+        verify(appSettingsRepository, never()).save(any());
+    }
+
+    @Test
+    void updateSetting_acceptsValidKomgaSettings() throws Exception {
+        KomgaSettings settings = new KomgaSettings();
+        settings.setRememberMeKey("validKey123");
+        settings.setRememberMeDurationInSeconds(86400);
+
+        appSettingService.updateSetting(AppSettingKey.KOMGA_SETTINGS, settings);
+
+        ArgumentCaptor<AppSettingEntity> settingCaptor = ArgumentCaptor.forClass(AppSettingEntity.class);
+        verify(appSettingsRepository).save(settingCaptor.capture());
+
+        AppSettingEntity savedSetting = settingCaptor.getValue();
+        assertThat(savedSetting.getName()).isEqualTo(AppSettingKey.KOMGA_SETTINGS.toString());
+        assertThat(savedSetting.getVal()).contains("validKey123");
+        assertThat(savedSetting.getVal()).contains("86400");
     }
 }

--- a/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
@@ -53,7 +53,7 @@ class AppSettingServiceTest {
     @BeforeEach
     void setUp() {
         settingPersistenceHelper = new SettingPersistenceHelper(appSettingsRepository, new ObjectMapper());
-        appSettingService = new AppSettingService(appProperties, settingPersistenceHelper, authenticationService, auditService);
+        appSettingService = new AppSettingService(appProperties, settingPersistenceHelper, authenticationService, auditService, new ObjectMapper());
 
         var permissions = new BookLoreUser.UserPermissions();
         permissions.setAdmin(true);

--- a/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 
 import org.booklore.config.AppProperties;
 import org.booklore.config.security.service.AuthenticationService;
@@ -233,18 +234,6 @@ class AppSettingServiceTest {
     }
 
     @Test
-    void updateSetting_rejectsInvalidKomgaSettingsType() {
-        assertThatThrownBy(() -> appSettingService.updateSetting(
-                AppSettingKey.KOMGA_SETTINGS,
-                "invalid string"
-        ))
-        .isInstanceOf(Exception.class)
-        .hasMessageContaining("Komga settings must be a valid KomgaSettings object");
-
-        verify(appSettingsRepository, never()).save(any());
-    }
-
-    @Test
     void updateSetting_rejectsKomgaSettingsWithNullKey() {
         KomgaSettings settings = new KomgaSettings();
         settings.setRememberMeKey(null);
@@ -340,4 +329,42 @@ class AppSettingServiceTest {
         assertThat(savedSetting.getVal()).contains("validKey123");
         assertThat(savedSetting.getVal()).contains("86400");
     }
+
+    @Test
+    void updateSetting_acceptsKomgaSettingsAsMap() throws Exception {
+        Map<String, Object> settings = Map.of(
+                "rememberMeKey", "validKey123",
+                "rememberMeDurationInSeconds", 86400
+        );
+
+        appSettingService.updateSetting(
+                AppSettingKey.KOMGA_SETTINGS,
+                settings
+        );
+
+        ArgumentCaptor<AppSettingEntity> captor =
+                ArgumentCaptor.forClass(AppSettingEntity.class);
+
+        verify(appSettingsRepository).save(captor.capture());
+
+        assertThat(captor.getValue().getName())
+                .isEqualTo(AppSettingKey.KOMGA_SETTINGS.toString());
+        assertThat(captor.getValue().getVal()).contains("validKey123");
+        assertThat(captor.getValue().getVal()).contains("86400");
+    }
+
+	@Test
+	void updateSetting_rejectsIncompleteKomgaSettingsMap() {
+		Map<String, Object> settings = Map.of(
+				"rememberMeKey", "validKey123"
+		);
+
+		assertThatThrownBy(() -> appSettingService.updateSetting(
+				AppSettingKey.KOMGA_SETTINGS,
+				settings
+		))
+				.hasMessageContaining("rememberMeDurationInSeconds");
+
+		verify(appSettingsRepository, never()).save(any());
+	}
 }

--- a/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
@@ -3,7 +3,9 @@ package org.booklore.service.appsettings;
 import org.booklore.config.AppProperties;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.settings.AppSettingKey;
+import org.booklore.model.dto.settings.KomgaSettings;
 import org.booklore.model.entity.AppSettingEntity;
 import org.booklore.model.enums.AuditAction;
 import org.booklore.repository.AppSettingsRepository;
@@ -14,6 +16,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
@@ -24,8 +29,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AppSettingServiceTest {
 
     @Mock
@@ -164,5 +172,51 @@ class AppSettingServiceTest {
                 .hasMessageContaining("Redirect URI must include a scheme");
 
         verify(appSettingsRepository, never()).save(any());
+    }
+
+    @Test
+    void getAppSettings_buildsKomgaSettingsDefault_whenNoRowsExist() throws Exception{
+        when(appSettingsRepository.findAll()).thenReturn(List.of());
+        when(appSettingsRepository.findByName(anyString())).thenReturn(null);
+        when(appProperties.getRemoteAuth()).thenReturn(new AppProperties.RemoteAuth());
+
+        AppSettings result = appSettingService.getAppSettings();
+
+        assertThat(result.getKomgaSettings()).isNotNull();
+        assertThat(result.getKomgaSettings().getRememberMeKey()).isNotBlank();
+        assertThat(result.getKomgaSettings().getRememberMeDurationInSeconds()).isEqualTo(2592000);
+
+        ArgumentCaptor<AppSettingEntity> captor = ArgumentCaptor.forClass(AppSettingEntity.class);
+        verify(appSettingsRepository, atLeastOnce()).save(captor.capture());
+        assertThat(captor.getAllValues())
+                .anyMatch(e -> "komga_settings".equals(e.getName()));
+    }
+
+    @Test
+    void getAppSettings_readsPersistedKomgaSettings() throws Exception {
+        AppSettingEntity komgaRow = new AppSettingEntity();
+        komgaRow.setName("komga_settings");
+        komgaRow.setVal("{\"rememberMeKey\":\"persistedKey\",\"rememberMeDurationInSeconds\":86400}");
+
+        when(appSettingsRepository.findAll()).thenReturn(List.of(komgaRow));
+        when(appSettingsRepository.findByName(anyString())).thenReturn(null);
+        when(appProperties.getRemoteAuth()).thenReturn(new AppProperties.RemoteAuth());
+
+        AppSettings result = appSettingService.getAppSettings();
+
+        assertThat(result.getKomgaSettings()).isNotNull();
+        assertThat(result.getKomgaSettings().getRememberMeKey()).isEqualTo("persistedKey");
+        assertThat(result.getKomgaSettings().getRememberMeDurationInSeconds()).isEqualTo(86400);
+    }
+
+    @Test
+    void defaultKomgaSettings_generatesUniqueKeys() {
+        KomgaSettings first = settingPersistenceHelper.getDefaultKomgaSettings();
+        KomgaSettings second = settingPersistenceHelper.getDefaultKomgaSettings();
+
+        assertThat(first.getRememberMeKey()).isNotBlank();
+        assertThat(second.getRememberMeKey()).isNotBlank();
+        assertThat(first.getRememberMeKey()).isNotEqualTo(second.getRememberMeKey());
+        assertThat(first.getRememberMeDurationInSeconds()).isEqualTo(2592000);
     }
 }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->

- Adds remember-me authentication to the Komga API security chain, matching how real
  Komga handles Komelia logins. Previously the chain was fully stateless and never
  issued a cookie, so Komelia's post-login request for libraries (sent with no
  credentials) got a 401 and showed "invalid credentials" even though login worked.

 - This change issues a signed `komga-remember-me` cookie on login and enables session
  support (`JSESSIONID`), so Komelia can talk to the API using cookies alone.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
Refs #164 — implements the "Remember Me" authentication cookies checklist item.

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
- New `KomgaSettings` DTO with a random `rememberMeKey` generated on first boot and
  persisted via the existing `KOMGA_SETTINGS` key, so it stays stable across restarts.
- New `komgaRememberMeServices` bean (`TokenBasedRememberMeServices`) in the Komga
  chain, cookie name `komga-remember-me` (matches real Komga and Komelia's client).
- Komga chain session policy changed from `STATELESS` to `IF_REQUIRED`, so the
  remember-me login creates a `JSESSIONID` that Komelia replays. Basic auth
  (Tachiyomi/OPDS) is unchanged.
- Wired the new settings into `SettingPersistenceHelper` and `AppSettingService`.
- 3 new tests in `AppSettingServiceTest` (defaults persisted, persisted values read
  back, unique key generation).

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

Tested against a live instance on localhost:6060 with tcpdump on port 6060:

  1. Login: `GET /komga/api/v2/users/me?remember-me=true` with Basic auth → 200 with
  `Set-Cookie: komga-remember-me=...` and `Set-Cookie: JSESSIONID=...`
  2. Libraries: `GET /komga/api/v1/libraries` with only those cookies (no Basic) → 200
  3. Basic auth alone → still 200 (no regression)
  4. No auth at all → 401 (still protected)
  5. Full backend suite passes via `just api check

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

- A separate schema issue remains on the library endpoint: the response is missing
  `scanDirectoryExclusions` and `oneshotsDirectory`, which Komelia's `KomgaLibrary`
  DTO requires (JsonConvertException). That's a different fix, not part of this auth
  change.
- The remember-me key is random per install on first boot; admins can override it
  via the settings API.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
Omniroute helped with the implementation, analyzing Komelia's client source, and the settings wiring. I reviewed and verified all code, tests, and the tcpdump evidence myself.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Remember me” authentication for Komga access.
  - Administrators can configure the remember-me security key and session duration.
  - New installations receive secure defaults, including a 30-day duration.

- **Bug Fixes**
  - Improved Komga session handling for persistent authentication.
  - Added validation to prevent invalid or incomplete authentication settings.

- **Tests**
  - Added coverage for default settings, saved configurations, unique keys, durations, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->