### PR TITLE
fix(sidecar): import cover from sidecar files (#2234)

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
@@ -139,6 +139,24 @@ public class BookCoverService {
         notifyBookCoverUpdate(bookEntity);
     }
 
+    /**
+     * Update cover image from raw image bytes for a single book.
+     */
+    @Transactional
+    public void updateCoverFromBytes(Long bookId, byte[] coverBytes) {
+        BookEntity bookEntity = bookRepository.findByIdWithBookFiles(bookId).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
+
+        if (isCoverLocked(bookEntity)) {
+            throw ApiError.METADATA_LOCKED.createException();
+        }
+
+        fileService.createThumbnailFromBytes(bookId, coverBytes);
+        writeCoverToBookFile(bookEntity, (writer, book) -> writer.replaceCoverImageFromBytes(book, coverBytes));
+        updateBookCoverMetadata(bookEntity);
+        bookRepository.save(bookEntity);
+        notifyBookCoverUpdate(bookEntity);
+    }
+
     // =========================
     // SECTION: AUDIOBOOK COVER UPDATES
     // =========================

--- a/backend/src/main/java/org/booklore/service/metadata/sidecar/SidecarMetadataReader.java
+++ b/backend/src/main/java/org/booklore/service/metadata/sidecar/SidecarMetadataReader.java
@@ -6,6 +6,7 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.enums.SidecarSyncStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -47,14 +48,14 @@ public class SidecarMetadataReader {
         }
     }
 
-    public byte[] readSidecarCover(Path bookPath) {
+    public byte[] readSidecarCover(Path bookPath, SidecarMetadata sidecar) {
         if (bookPath == null) {
             return null;
         }
 
-        Path coverPath = getCoverPath(bookPath);
-        if (!Files.exists(coverPath)) {
-            log.debug("No sidecar cover file found at: {}", coverPath);
+        Path coverPath = resolveCoverPath(bookPath, sidecar);
+        if (coverPath == null || !Files.exists(coverPath)) {
+            log.debug("No sidecar cover file found for book: {}", bookPath);
             return null;
         }
 
@@ -64,6 +65,18 @@ public class SidecarMetadataReader {
             log.warn("Failed to read sidecar cover from {}: {}", coverPath, e.getMessage());
             return null;
         }
+    }
+
+    private Path resolveCoverPath(Path bookPath, SidecarMetadata sidecar) {
+        if (sidecar != null && sidecar.getCover() != null && StringUtils.hasText(sidecar.getCover().getPath())) {
+            Path resolvedPath = bookPath.getParent().resolve(sidecar.getCover().getPath()).normalize();
+            if (resolvedPath.startsWith(bookPath.getParent())) {
+                return resolvedPath;
+            }
+            log.warn("Rejected sidecar cover path outside the book directory: {}", sidecar.getCover().getPath());
+            return null;
+        }
+        return getCoverPath(bookPath);
     }
 
     public SidecarSyncStatus getSyncStatus(BookEntity book) {

--- a/backend/src/main/java/org/booklore/service/metadata/sidecar/SidecarService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/sidecar/SidecarService.java
@@ -13,6 +13,7 @@ import org.booklore.model.enums.MetadataReplaceMode;
 import org.booklore.model.enums.SidecarSyncStatus;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.LibraryRepository;
+import org.booklore.service.metadata.BookCoverService;
 import org.booklore.service.metadata.BookMetadataUpdater;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ public class SidecarService {
     private final SidecarMetadataWriter sidecarWriter;
     private final SidecarMetadataMapper sidecarMapper;
     private final BookMetadataUpdater bookMetadataUpdater;
+    private final BookCoverService bookCoverService;
 
     public Optional<SidecarMetadata> getSidecarContent(Long bookId) {
         BookEntity book = bookRepository.findByIdWithBookFiles(bookId)
@@ -93,9 +95,19 @@ public class SidecarService {
             bookMetadataUpdater.setBookMetadata(context);
         }
 
-        byte[] coverBytes = sidecarReader.readSidecarCover(bookPath);
-        if (coverBytes != null) {
-            log.info("Sidecar cover found for book ID {} - cover import is a separate operation", bookId);
+        importSidecarCover(book, sidecar);
+    }
+
+    private void importSidecarCover(BookEntity book, SidecarMetadata sidecar) {
+        byte[] coverBytes = sidecarReader.readSidecarCover(book.getFullFilePath(), sidecar);
+        if (coverBytes == null) {
+            return;
+        }
+        try {
+            bookCoverService.updateCoverFromBytes(book.getId(), coverBytes);
+            log.info("Imported sidecar cover for book ID {}", book.getId());
+        } catch (Exception e) {
+            log.warn("Failed to import sidecar cover for book ID {}: {}", book.getId(), e.getMessage());
         }
     }
 
@@ -158,6 +170,8 @@ public class SidecarService {
                     bookMetadataUpdater.setBookMetadata(context);
                     imported++;
                 }
+
+                importSidecarCover(book, sidecar);
             } catch (Exception e) {
                 log.warn("Failed to import sidecar for book ID {}: {}", book.getId(), e.getMessage());
             }

--- a/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
@@ -553,6 +553,43 @@ class BookCoverServiceTest {
     }
 
     @Nested
+    class UpdateCoverFromBytes {
+
+        @Test
+        void successfullyUpdatesCoverFromBytes() {
+            BookEntity book = buildBook(1L, false);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
+            byte[] coverBytes = {1, 2, 3};
+
+            service.updateCoverFromBytes(1L, coverBytes);
+
+            verify(fileService).createThumbnailFromBytes(1L, coverBytes);
+            verify(bookRepository).save(book);
+            assertThat(book.getMetadata().getCoverUpdatedOn()).isNotNull();
+            assertThat(book.getBookCoverHash()).isNotNull();
+        }
+
+        @Test
+        void throwsWhenBookNotFound() {
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.updateCoverFromBytes(1L, new byte[]{1}))
+                    .isInstanceOf(APIException.class);
+        }
+
+        @Test
+        void throwsWhenCoverLocked() {
+            BookEntity book = buildBook(1L, true);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+
+            assertThatThrownBy(() -> service.updateCoverFromBytes(1L, new byte[]{1}))
+                    .isInstanceOf(APIException.class)
+                    .hasMessageContaining("locked");
+        }
+    }
+
+    @Nested
     class UpdateAudiobookCoverFromFile {
 
         @Test

--- a/backend/src/test/java/org/booklore/service/metadata/sidecar/SidecarMetadataReaderTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/sidecar/SidecarMetadataReaderTest.java
@@ -1,0 +1,110 @@
+package org.booklore.service.metadata.sidecar;
+
+import org.booklore.model.dto.sidecar.SidecarCoverInfo;
+import org.booklore.model.dto.sidecar.SidecarMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tools.jackson.databind.ObjectMapper;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SidecarMetadataReaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SidecarMetadataReader sidecarMetadataReader;
+
+    @BeforeEach
+    void setUp() {
+        sidecarMetadataReader = new SidecarMetadataReader(mock(SidecarMetadataMapper.class), new ObjectMapper());
+    }
+
+    @Test
+    void readSidecarCover_resolvesExplicitCoverPathFromJson() throws Exception {
+        Path bookDir = tempDir.resolve("books");
+        Files.createDirectories(bookDir);
+        Path bookPath = bookDir.resolve("libro.pdf");
+        Files.createFile(bookPath);
+        byte[] coverBytes = {1, 2, 3, 4};
+        Files.write(bookDir.resolve("portada.jpg"), coverBytes);
+
+        byte[] result = sidecarMetadataReader.readSidecarCover(bookPath, sidecarMetadataWithCoverPath("portada.jpg"));
+
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void readSidecarCover_resolvesExplicitCoverPathInSubdirectory() throws Exception {
+        Path bookDir = tempDir.resolve("books");
+        Files.createDirectories(bookDir.resolve("covers"));
+        Path bookPath = bookDir.resolve("libro.pdf");
+        Files.createFile(bookPath);
+        byte[] coverBytes = {7, 8, 9};
+        Files.write(bookDir.resolve("covers").resolve("portada.jpg"), coverBytes);
+
+        byte[] result = sidecarMetadataReader.readSidecarCover(bookPath, sidecarMetadataWithCoverPath("covers/portada.jpg"));
+
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void readSidecarCover_fallsBackToConventionWhenNoExplicitPath() throws Exception {
+        Path bookDir = tempDir.resolve("books");
+        Files.createDirectories(bookDir);
+        Path bookPath = bookDir.resolve("libro.pdf");
+        Files.createFile(bookPath);
+        byte[] coverBytes = {5, 6, 7};
+        Files.write(bookDir.resolve("libro.cover.jpg"), coverBytes);
+        SidecarMetadata sidecar = SidecarMetadata.builder()
+                .cover(SidecarCoverInfo.builder().source("external").build())
+                .build();
+
+        byte[] result = sidecarMetadataReader.readSidecarCover(bookPath, sidecar);
+
+        assertThat(result).isEqualTo(coverBytes);
+    }
+
+    @Test
+    void readSidecarCover_returnsNullWhenCoverFileMissing() throws Exception {
+        Path bookDir = tempDir.resolve("books");
+        Files.createDirectories(bookDir);
+        Path bookPath = bookDir.resolve("libro.pdf");
+        Files.createFile(bookPath);
+
+        byte[] result = sidecarMetadataReader.readSidecarCover(bookPath, sidecarMetadataWithCoverPath("portada.jpg"));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void readSidecarCover_rejectsPathOutsideBookDirectory() throws Exception {
+        Path bookDir = tempDir.resolve("books");
+        Files.createDirectories(bookDir);
+        Path bookPath = bookDir.resolve("libro.pdf");
+        Files.createFile(bookPath);
+        Files.write(tempDir.resolve("outside.jpg"), new byte[]{9, 9, 9});
+
+        byte[] result = sidecarMetadataReader.readSidecarCover(bookPath, sidecarMetadataWithCoverPath("../outside.jpg"));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void readSidecarCover_returnsNullWhenBookPathIsNull() {
+        byte[] result = sidecarMetadataReader.readSidecarCover(null, sidecarMetadataWithCoverPath("portada.jpg"));
+
+        assertThat(result).isNull();
+    }
+
+    private SidecarMetadata sidecarMetadataWithCoverPath(String path) {
+        return SidecarMetadata.builder()
+                .cover(SidecarCoverInfo.builder().source("external").path(path).build())
+                .build();
+    }
+}

--- a/backend/src/test/java/org/booklore/service/metadata/sidecar/SidecarServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/sidecar/SidecarServiceTest.java
@@ -1,0 +1,171 @@
+package org.booklore.service.metadata.sidecar;
+
+import org.booklore.model.dto.BookMetadata;
+import org.booklore.model.dto.sidecar.SidecarBookMetadata;
+import org.booklore.model.dto.sidecar.SidecarCoverInfo;
+import org.booklore.model.dto.sidecar.SidecarMetadata;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.repository.BookRepository;
+import org.booklore.repository.LibraryRepository;
+import org.booklore.service.metadata.BookCoverService;
+import org.booklore.service.metadata.BookMetadataUpdater;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SidecarServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private LibraryRepository libraryRepository;
+    @Mock
+    private SidecarMetadataReader sidecarReader;
+    @Mock
+    private SidecarMetadataWriter sidecarWriter;
+    @Mock
+    private SidecarMetadataMapper sidecarMapper;
+    @Mock
+    private BookMetadataUpdater bookMetadataUpdater;
+    @Mock
+    private BookCoverService bookCoverService;
+
+    @InjectMocks
+    private SidecarService sidecarService;
+
+    private BookEntity mockBook(long id) {
+        BookEntity book = mock(BookEntity.class);
+        lenient().when(book.getId()).thenReturn(id);
+        when(book.getFullFilePath()).thenReturn(Path.of("/books/repro/libro.pdf"));
+        return book;
+    }
+
+    private SidecarMetadata sidecarMetadata() {
+        return SidecarMetadata.builder()
+                .metadata(SidecarBookMetadata.builder().title("Libro de Prueba").build())
+                .cover(SidecarCoverInfo.builder().source("external").path("libro.cover.jpg").build())
+                .build();
+    }
+
+    @Nested
+    class ImportFromSidecar {
+
+        @Test
+        void importsMetadataAndAppliesCoverWhenCoverFileExists() {
+            BookEntity book = mockBook(1L);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(sidecarReader.readSidecarMetadata(any())).thenReturn(Optional.of(sidecarMetadata()));
+            when(sidecarMapper.toBookMetadata(any())).thenReturn(mock(BookMetadata.class));
+            byte[] coverBytes = {1, 2, 3};
+            when(sidecarReader.readSidecarCover(any(), any())).thenReturn(coverBytes);
+
+            sidecarService.importFromSidecar(1L);
+
+            verify(bookMetadataUpdater).setBookMetadata(any());
+            verify(bookCoverService).updateCoverFromBytes(1L, coverBytes);
+        }
+
+        @Test
+        void passesSidecarMetadataAndBookPathToCoverReader() {
+            BookEntity book = mockBook(1L);
+            SidecarMetadata sidecar = sidecarMetadata();
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(sidecarReader.readSidecarMetadata(any())).thenReturn(Optional.of(sidecar));
+            when(sidecarMapper.toBookMetadata(any())).thenReturn(mock(BookMetadata.class));
+            when(sidecarReader.readSidecarCover(any(), any())).thenReturn(new byte[]{1});
+
+            sidecarService.importFromSidecar(1L);
+
+            ArgumentCaptor<SidecarMetadata> captor = ArgumentCaptor.forClass(SidecarMetadata.class);
+            verify(sidecarReader).readSidecarCover(eq(Path.of("/books/repro/libro.pdf")), captor.capture());
+            assertThat(captor.getValue()).isSameAs(sidecar);
+        }
+
+        @Test
+        void importsMetadataButSkipsCoverWhenNoCoverFile() {
+            BookEntity book = mockBook(1L);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(sidecarReader.readSidecarMetadata(any())).thenReturn(Optional.of(sidecarMetadata()));
+            when(sidecarMapper.toBookMetadata(any())).thenReturn(mock(BookMetadata.class));
+            when(sidecarReader.readSidecarCover(any(), any())).thenReturn(null);
+
+            sidecarService.importFromSidecar(1L);
+
+            verify(bookMetadataUpdater).setBookMetadata(any());
+            verify(bookCoverService, never()).updateCoverFromBytes(any(), any());
+        }
+
+        @Test
+        void coverImportFailureDoesNotBreakMetadataImport() {
+            BookEntity book = mockBook(1L);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(sidecarReader.readSidecarMetadata(any())).thenReturn(Optional.of(sidecarMetadata()));
+            when(sidecarMapper.toBookMetadata(any())).thenReturn(mock(BookMetadata.class));
+            when(sidecarReader.readSidecarCover(any(), any())).thenReturn(new byte[]{1});
+            doThrow(new RuntimeException("cover locked"))
+                    .when(bookCoverService).updateCoverFromBytes(any(), any());
+
+            sidecarService.importFromSidecar(1L);
+
+            verify(bookMetadataUpdater).setBookMetadata(any());
+        }
+    }
+
+    @Nested
+    class BulkImport {
+
+        @Test
+        void importsCoverForEachBookWithSidecarCover() {
+            BookEntity book1 = mockBook(1L);
+            BookEntity book2 = mockBook(2L);
+            when(libraryRepository.findById(10L)).thenReturn(Optional.of(new LibraryEntity()));
+            when(bookRepository.findAllByLibraryIdWithFiles(10L)).thenReturn(List.of(book1, book2));
+            when(sidecarReader.readSidecarMetadata(any())).thenReturn(Optional.of(sidecarMetadata()));
+            when(sidecarMapper.toBookMetadata(any())).thenReturn(mock(BookMetadata.class));
+            when(sidecarReader.readSidecarCover(any(), any())).thenReturn(new byte[]{9, 9, 9});
+
+            int imported = sidecarService.bulkImport(10L);
+
+            assertThat(imported).isEqualTo(2);
+            verify(bookCoverService).updateCoverFromBytes(1L, new byte[]{9, 9, 9});
+            verify(bookCoverService).updateCoverFromBytes(2L, new byte[]{9, 9, 9});
+        }
+
+        @Test
+        void doesNotFailWholeBatchWhenCoverImportFails() {
+            BookEntity book = mockBook(1L);
+            when(libraryRepository.findById(10L)).thenReturn(Optional.of(new LibraryEntity()));
+            when(bookRepository.findAllByLibraryIdWithFiles(10L)).thenReturn(List.of(book));
+            when(sidecarReader.readSidecarMetadata(any())).thenReturn(Optional.of(sidecarMetadata()));
+            when(sidecarMapper.toBookMetadata(any())).thenReturn(mock(BookMetadata.class));
+            when(sidecarReader.readSidecarCover(any(), any())).thenReturn(new byte[]{1});
+            doThrow(new RuntimeException("boom"))
+                    .when(bookCoverService).updateCoverFromBytes(any(), any());
+
+            int imported = sidecarService.bulkImport(10L);
+
+            assertThat(imported).isEqualTo(1);
+            verify(bookCoverService).updateCoverFromBytes(1L, new byte[]{1});
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #2234: importing a sidecar (`.metadata.json`) applied the metadata but never the cover referenced by the sidecar, even when the cover file was present and its path was declared in the JSON.

`SidecarService` did read the sidecar cover bytes, but then only logged `"Sidecar cover found ... - cover import is a separate operation"` and never applied them â so imported books kept their old (or missing) cover. In addition, `SidecarMetadataReader` only looked for covers using the `<book>.cover.jpg` naming convention and ignored the explicit `cover.path` stored in the JSON, so any other cover filename was never found.

The fix wires cover import into the existing sidecar flows (`importFromSidecar` and `bulkImport`) and resolves the cover path from the sidecar's `cover.path` (relative to the book's directory), falling back to the filename convention when no explicit path is set. Cover import failures are logged and do not abort metadata import, and path resolution is validated to prevent traversal outside the book's directory.

## Linked Issue

Fixes #2234

## Changes

- `BookCoverService`: added `updateCoverFromBytes(Long bookId, byte[] coverBytes)` to apply raw cover bytes to a book (thumbnail creation, cover file write, metadata/hash update, change notification), respecting the existing cover-lock check.
- `SidecarMetadataReader`: `readSidecarCover` now takes the parsed `SidecarMetadata` and resolves the cover from its explicit `cover.path` (relative to the book's directory), with a fallback to the `<book>.cover.jpg` convention; rejects paths that resolve outside the book's directory.
- `SidecarService`: `importFromSidecar` and `bulkImport` now import the sidecar cover via `BookCoverService`, replacing the previous no-op log line (`"cover import is a separate operation"`); a failed cover import is caught and logged so it never breaks metadata import.
- Tests: new `SidecarMetadataReaderTest` (path resolution, fallback, missing file, traversal guard), new `SidecarServiceTest` (cover applied on single and bulk import, skipped when absent, failures don't break metadata), and `UpdateCoverFromBytes` cases in `BookCoverServiceTest`.

## Manual Testing Steps

1. Set up a folder with `test.pdf`, `test.metadata.json` (including `"cover": { "source": "external", "path": "test.cover.jpg" }`) and `test.cover.jpg`, scan the book into a library, then trigger "Import sidecar".
2. Confirm the cover now matches `test.cover.jpg` and the metadata matches the JSON (this previously did nothing for the cover).
3. Repeat with a sidecar whose `cover.path` points to a different filename or a subdirectory (e.g. `covers/front.jpg`) and confirm the cover is applied.
4. Import a sidecar with no cover file and confirm metadata still imports and no error is raised.
5. Ran the backend test suite, including the new `SidecarServiceTest`, `SidecarMetadataReaderTest` and `BookCoverServiceTest` cases (15 new tests, all passing), and the frontend `just ui check` steps â all green.

## Screenshots (Optional)

No UI changes.

## Additional Context (Optional)

- The original report log contained `SidecarService : Sidecar cover found for book ID 369 - cover import is a separate operation`, which was the exact no-op branch replaced by this fix.
- On this dev machine, `ng test` (vitest `threads` pool) crashes with an esbuild worker deadlock unrelated to this change; the frontend suite passes with `--pool=forks --maxWorkers=2` (1707 tests). This PR is backend-only.
- Branch is synced with the latest `upstream/develop` before pushing.

## AI Disclosure

Claude (opencode) â helped draft this PR description, review the diff, and set up the local test environment; I reviewed all changes and test results.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sidecar metadata imports now automatically apply associated book cover images.
  - Supports explicitly configured cover paths, nested paths, and conventional cover filenames.
  - Imported covers are validated, thumbnail-ready, and saved with updated book metadata.

- **Bug Fixes**
  - Invalid, missing, or unsafe cover paths are safely ignored.
  - Cover import failures no longer interrupt the rest of a metadata import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->