### PR TITLE
fix(ui): logout needs access token before clearing session

### DIFF
--- a/frontend/src/app/shared/service/auth.service.spec.ts
+++ b/frontend/src/app/shared/service/auth.service.spec.ts
@@ -185,8 +185,8 @@ describe('AuthService', () => {
     const logoutRequest = httpTestingController.expectOne(`${API_CONFIG.BASE_URL}/api/v1/auth/logout`);
     expect(logoutRequest.request.body).toEqual({ refreshToken: 'refresh-token' });
 
-    refreshRequest.flush({ accessToken: 'late-access', refreshToken: 'late-refresh' });
     logoutRequest.flush({ logoutUrl: null });
+    refreshRequest.flush({ accessToken: 'late-access', refreshToken: 'late-refresh' });
 
     await expect(refresh).rejects.toThrow('Refresh response belongs to a stale session');
     expect(service.getInternalAccessToken()).toBeNull();

--- a/frontend/src/app/shared/service/auth.service.ts
+++ b/frontend/src/app/shared/service/auth.service.ts
@@ -177,14 +177,14 @@ export class AuthService {
     this._logoutInProgress.set(true);
 
     const refreshToken = this.getInternalRefreshToken();
-    this.clearSession();
-
     this.http.post<{ logoutUrl: string | null }>(`${this.apiUrl}/logout`, { refreshToken })
       .pipe(finalize(() => {
         this._logoutInProgress.set(false);
       }))
       .subscribe({
         next: (response) => {
+          this.clearSession();
+
           if (response.logoutUrl) {
             this.redirectTo(response.logoutUrl, true);
           } else {
@@ -192,6 +192,8 @@ export class AuthService {
           }
         },
         error: () => {
+          this.clearSession();
+
           this.redirectTo('/login', true);
         }
       });


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
The logout button clears the user's session so the auth token is removed before we make the request. This causes the logout request to fail, because the `logout` request _requires_ the login token.

We can actually call the `logout` endpoint properly by waiting to clear the session until after the request completes

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2339

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
moves `clearSession` to after logout request completes

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Logout
2. See request complete with 200

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
It's possible the endpoint isn't working as expected but a log out request requiring a valid access token makes sense to me.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout handling by clearing the local session whether the logout request succeeds or fails.
  * Ensured users are redirected to the login screen after logout.
  * Updated refresh-session behavior to handle logout responses in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->