### PR TITLE
fix(api): use `FORCE_DISABLE_OIDC` on all public / private OIDC flags

### DIFF
--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -189,14 +189,23 @@ public class AppSettingService {
         Map<String, String> settingsMap = getSettingsMap();
         PublicAppSetting.PublicAppSettingBuilder builder = PublicAppSetting.builder();
 
-        builder.oidcEnabled(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_ENABLED, "false")));
         builder.remoteAuthEnabled(appProperties.getRemoteAuth().isEnabled());
         OidcProviderDetails details = settingPersistenceHelper.getJsonSetting(settingsMap, AppSettingKey.OIDC_PROVIDER_DETAILS, OidcProviderDetails.class, null, false);
         if (details != null) {
             details.setClientSecret(null);
         }
+
+        boolean oidcEnabled = Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_ENABLED, "false"));
+        boolean oidcForceOnlyMode = Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_FORCE_ONLY_MODE, "false"));
+
+        if (appProperties.getForceDisableOidc() != null && appProperties.getForceDisableOidc()) {
+            oidcEnabled = false;
+            oidcForceOnlyMode = false;
+        }
+        builder.oidcEnabled(oidcEnabled);
+        builder.oidcForceOnlyMode(oidcForceOnlyMode);
+
         builder.oidcProviderDetails(details);
-        builder.oidcForceOnlyMode(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_FORCE_ONLY_MODE, "false")));
 
         return builder.build();
     }
@@ -247,15 +256,20 @@ public class AppSettingService {
             }
         }
 
-        boolean settingEnabled = Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_ENABLED, "false"));
-        Boolean forceDisable = appProperties.getForceDisableOidc();
-        boolean finalEnabled = settingEnabled && (forceDisable == null || !forceDisable);
-        builder.oidcEnabled(finalEnabled);
+        boolean oidcEnabled = Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_ENABLED, "false"));
+        boolean oidcForceOnlyMode = Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_FORCE_ONLY_MODE, "false"));
+
+        // Env var flag to force disable OIDC
+        if (appProperties.getForceDisableOidc() != null && appProperties.getForceDisableOidc()) {
+            oidcEnabled = false;
+            oidcForceOnlyMode = false;
+        }
+
+        builder.oidcEnabled(oidcEnabled);
+        builder.oidcForceOnlyMode(oidcForceOnlyMode);
 
         builder.oidcGroupSyncMode(settingPersistenceHelper.getOrCreateSetting(
                 AppSettingKey.OIDC_GROUP_SYNC_MODE, "DISABLED"));
-
-        builder.oidcForceOnlyMode(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_FORCE_ONLY_MODE, "false")));
 
         builder.diskType(appProperties.getDiskType());
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the `FORCE_DISABLE_OIDC` parameter only seems to apply to some flags, not all - and not in both public and private settings

this PR reworks the `AppSettingsService` to more reliably apply the parameter to the settings which allows users to log in again even when the "Only OIDC" mode is enabled

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2342

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
updates both `oidcEnabled` and `forceOidcMode` to off when `FORCE_DISABLE_OIDC` is `true`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. enable OIDC mode
2. enable force OIDC mode
3. log out
4. get automatically redirected to OIDC
5. try to log in via `curl` against the login and get an error
6. update `docker-compose` to set `FORCE_DISABLE_OIDC=true`
7. restart grimmory
8. log in fine with username / password

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected application settings so OIDC status and force-only mode are consistently reported together.
  * When OIDC is forcibly disabled, both related settings now correctly show as disabled across public and full settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->