### PR TITLE
refactor(browse): extract shared pagination, scoping, and facet responses

### DIFF
--- a/backend/src/main/java/org/booklore/browse/BrowsePager.java
+++ b/backend/src/main/java/org/booklore/browse/BrowsePager.java
@@ -1,0 +1,53 @@
+package org.booklore.browse;
+
+import org.booklore.exception.ApiError;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class BrowsePager {
+
+    public static final int MAX_PAGE_SIZE = 100;
+
+    private final CursorCodec codec;
+    private final LinksBuilder linksBuilder;
+
+    public BrowsePager(CursorCodec codec, LinksBuilder linksBuilder) {
+        this.codec = codec;
+        this.linksBuilder = linksBuilder;
+    }
+
+    public record Window(long offset, int limit, String sort, String paramsHash) {
+    }
+
+    public Window resolve(String sort, String cursor, Pageable pageable, String paramsHash) {
+        long offset;
+        int limit;
+        String sortString;
+        if (cursor != null) {
+            CursorState state = codec.decode(cursor);
+            codec.verifyParamsMatch(state, paramsHash);
+            offset = state.offset();
+            limit = state.limit();
+            sortString = state.sort();
+        } else {
+            offset = pageable.getOffset();
+            limit = pageable.getPageSize();
+            sortString = sort;
+        }
+        if (limit <= 0) {
+            throw ApiError.INVALID_INPUT.createException("Page size must be positive.");
+        }
+        return new Window(offset, Math.min(limit, MAX_PAGE_SIZE), sortString, paramsHash);
+    }
+
+    public <T> BrowsePage<T> assemble(String pagePath, String facetPath, String preserved,
+                                      Window window, long total, List<T> content) {
+        CursorState baseState = new CursorState(window.offset(), window.limit(), window.sort(), window.paramsHash());
+        List<Link> links = linksBuilder.build(new LinksBuilder.Context(
+                pagePath, facetPath, preserved, window.offset(), window.limit(), total, baseState));
+        return BrowsePage.of(content, window.offset(), window.limit(), total, codec.encode(baseState), links);
+    }
+}

--- a/backend/src/main/java/org/booklore/browse/BrowsePager.java
+++ b/backend/src/main/java/org/booklore/browse/BrowsePager.java
@@ -1,0 +1,61 @@
+package org.booklore.browse;
+
+import org.booklore.exception.ApiError;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class BrowsePager {
+
+    public static final int MAX_PAGE_SIZE = 100;
+    private static final int MAX_RANDOM_SORT_SEED = 999;
+
+    private final CursorCodec codec;
+    private final LinksBuilder linksBuilder;
+
+    public BrowsePager(CursorCodec codec, LinksBuilder linksBuilder) {
+        this.codec = codec;
+        this.linksBuilder = linksBuilder;
+    }
+
+    public record Window(long offset, int limit, String sort, String paramsHash, Integer randomSeed) {
+    }
+
+    public static int newRandomSeed() {
+        return (int) (Math.random() * MAX_RANDOM_SORT_SEED);
+    }
+
+    public Window resolve(String sort, String cursor, Pageable pageable, String paramsHash) {
+        long offset;
+        int limit;
+        String sortString;
+        Integer randomSeed;
+        if (cursor != null) {
+            CursorState state = codec.decode(cursor);
+            codec.verifyParamsMatch(state, paramsHash);
+            offset = state.offset();
+            limit = state.limit();
+            sortString = state.sort();
+            randomSeed = state.randomSeed();
+        } else {
+            offset = pageable.getOffset();
+            limit = pageable.getPageSize();
+            sortString = sort;
+            randomSeed = newRandomSeed();
+        }
+        if (limit <= 0) {
+            throw ApiError.INVALID_INPUT.createException("Page size must be positive.");
+        }
+        return new Window(offset, Math.min(limit, MAX_PAGE_SIZE), sortString, paramsHash, randomSeed);
+    }
+
+    public <T> BrowsePage<T> assemble(String pagePath, String facetPath, String preserved,
+                                      Window window, long total, List<T> content) {
+        CursorState baseState = new CursorState(window.offset(), window.limit(), window.sort(), window.paramsHash(), window.randomSeed());
+        List<Link> links = linksBuilder.build(new LinksBuilder.Context(
+                pagePath, facetPath, preserved, window.offset(), window.limit(), total, baseState));
+        return BrowsePage.of(content, window.offset(), window.limit(), total, codec.encode(baseState), links);
+    }
+}

--- a/backend/src/main/java/org/booklore/model/dto/BookLoreUser.java
+++ b/backend/src/main/java/org/booklore/model/dto/BookLoreUser.java
@@ -10,6 +10,8 @@ import org.booklore.model.dto.settings.SidebarSortOption;
 import org.booklore.model.enums.*;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Data
 @Builder
@@ -30,6 +32,13 @@ public class BookLoreUser {
     private List<Library> assignedLibraries;
     private UserPermissions permissions;
     private UserSettings userSettings;
+
+    public Set<Long> assignedLibraryIds() {
+        if (assignedLibraries == null) {
+            return Set.of();
+        }
+        return assignedLibraries.stream().map(Library::getId).collect(Collectors.toSet());
+    }
 
     @Data
     public static class UserPermissions {

--- a/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
@@ -1,23 +1,18 @@
 package org.booklore.service.browse;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.booklore.browse.BrowsePage;
-import org.booklore.browse.CursorCodec;
-import org.booklore.browse.CursorState;
+import org.booklore.browse.BrowsePager;
 import org.booklore.browse.FacetLogic;
-import org.booklore.browse.Link;
-import org.booklore.browse.LinksBuilder;
 import org.booklore.browse.ParamsHash;
 import org.booklore.browse.SortParser;
 import org.booklore.browse.SortTerm;
 import org.booklore.config.security.service.AuthenticationService;
-import org.booklore.exception.ApiError;
 import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.entity.BookEntity;
@@ -44,72 +39,48 @@ public class BookBrowseService {
 
     private static final String PAGE_PATH = "/api/v1/books/page";
     private static final String FACET_PATH = "/api/v1/books/facets";
-    private static final int MAX_PAGE_SIZE = 100;
 
     private final AuthenticationService authenticationService;
     private final BookQueryService bookQueryService;
     private final ReadingProgressService readingProgressService;
     private final BookFilterSpecifications filterSpecifications;
     private final BookSortRegistry sortRegistry;
-    private final CursorCodec cursorCodec;
-    private final LinksBuilder linksBuilder;
-
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final BrowseScopeFactory scopeFactory;
+    private final BrowsePager pager;
+    private final EntityManager entityManager;
 
     public BrowsePage<Book> browse(String sort, List<String> facet, String facetLogicParam, String query, String cursor, Pageable pageable) {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
-        Long userId = user.getId();
-        boolean isAdmin = user.getPermissions().isAdmin();
+        BrowseScope scope = scopeFactory.from(user);
+        Long userId = scope.userId();
 
-        Map<String, List<String>> facets = BookFilterSpecifications.parseFacets(facet);
+        Map<String, List<String>> facets = BrowseParams.parseFacets(facet);
         FacetLogic facetLogic = FacetLogic.from(facetLogicParam);
         String paramsHash = ParamsHash.compute(query, facets, facetLogic);
 
-        long offset;
-        int limit;
-        String sortString;
-        if (cursor != null) {
-            CursorState state = cursorCodec.decode(cursor);
-            cursorCodec.verifyParamsMatch(state, paramsHash);
-            offset = state.offset();
-            limit = state.limit();
-            sortString = state.sort();
-        } else {
-            offset = pageable.getOffset();
-            limit = pageable.getPageSize();
-            sortString = sort;
-        }
-        if (limit <= 0) {
-            throw ApiError.INVALID_INPUT.createException("Page size must be positive.");
-        }
-        limit = Math.min(limit, MAX_PAGE_SIZE);
+        BrowsePager.Window window = pager.resolve(sort, cursor, pageable, paramsHash);
 
-        List<SortTerm> sortTerms = SortParser.parse(sortString, sortRegistry.registry().keys());
-        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, BookFilterSpecifications.libraryIds(user), null);
+        List<SortTerm> sortTerms = SortParser.parse(window.sort(), sortRegistry.registry().keys());
+        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, scope, null);
         Specification<BookEntity> spec = withSort(filter, sortTerms, userId);
 
-        Pageable pageRequest = PageRequest.of((int) (offset / limit), limit);
+        Pageable pageRequest = PageRequest.of((int) (window.offset() / window.limit()), window.limit());
         Page<Book> page = bookQueryService.findBooksPaged(spec, pageRequest, userId);
         enrich(page.getContent(), userId);
 
-        CursorState baseState = new CursorState(offset, limit, sortString, paramsHash);
-        String currentCursor = cursorCodec.encode(baseState);
-        List<Link> links = linksBuilder.build(new LinksBuilder.Context(
-                PAGE_PATH, FACET_PATH, BrowseParams.preserved(facet, facetLogicParam, query), offset, limit, page.getTotalElements(), baseState));
-
-        return BrowsePage.of(page.getContent(), offset, limit, page.getTotalElements(), currentCursor, links);
+        return pager.assemble(PAGE_PATH, FACET_PATH, BrowseParams.preserved(facet, facetLogicParam, query),
+                window, page.getTotalElements(), page.getContent());
     }
 
     public List<Long> findAllIds(String sort, List<String> facet, String facetLogicParam, String query) {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
-        Long userId = user.getId();
-        boolean isAdmin = user.getPermissions().isAdmin();
+        BrowseScope scope = scopeFactory.from(user);
+        Long userId = scope.userId();
 
-        Map<String, List<String>> facets = BookFilterSpecifications.parseFacets(facet);
+        Map<String, List<String>> facets = BrowseParams.parseFacets(facet);
         FacetLogic facetLogic = FacetLogic.from(facetLogicParam);
         List<SortTerm> sortTerms = SortParser.parse(sort, sortRegistry.registry().keys());
-        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, BookFilterSpecifications.libraryIds(user), null);
+        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, scope, null);
 
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<Long> cq = cb.createQuery(Long.class);
@@ -125,13 +96,9 @@ public class BookBrowseService {
     }
 
     public BrowsePage<Book> wrapLegacy(Page<Book> page, Pageable pageable) {
-        long offset = pageable.getOffset();
-        int limit = pageable.getPageSize();
         String paramsHash = ParamsHash.compute(null, Map.of(), FacetLogic.AND);
-        CursorState baseState = new CursorState(offset, limit, null, paramsHash);
-        List<Link> links = linksBuilder.build(new LinksBuilder.Context(
-                PAGE_PATH, FACET_PATH, "", offset, limit, page.getTotalElements(), baseState));
-        return BrowsePage.of(page.getContent(), offset, limit, page.getTotalElements(), cursorCodec.encode(baseState), links);
+        BrowsePager.Window window = new BrowsePager.Window(pageable.getOffset(), pageable.getPageSize(), null, paramsHash);
+        return pager.assemble(PAGE_PATH, FACET_PATH, "", window, page.getTotalElements(), page.getContent());
     }
 
     private Specification<BookEntity> withSort(Specification<BookEntity> filter, List<SortTerm> sortTerms, Long userId) {

--- a/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookBrowseService.java
@@ -1,23 +1,18 @@
 package org.booklore.service.browse;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.booklore.browse.BrowsePage;
-import org.booklore.browse.CursorCodec;
-import org.booklore.browse.CursorState;
+import org.booklore.browse.BrowsePager;
 import org.booklore.browse.FacetLogic;
-import org.booklore.browse.Link;
-import org.booklore.browse.LinksBuilder;
 import org.booklore.browse.ParamsHash;
 import org.booklore.browse.SortParser;
 import org.booklore.browse.SortTerm;
 import org.booklore.config.security.service.AuthenticationService;
-import org.booklore.exception.ApiError;
 import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.entity.BookEntity;
@@ -44,76 +39,48 @@ public class BookBrowseService {
 
     private static final String PAGE_PATH = "/api/v1/books/page";
     private static final String FACET_PATH = "/api/v1/books/facets";
-    private static final int MAX_PAGE_SIZE = 100;
-    private static final int MAX_RANDOM_SORT_SEED = 999;
 
     private final AuthenticationService authenticationService;
     private final BookQueryService bookQueryService;
     private final ReadingProgressService readingProgressService;
     private final BookFilterSpecifications filterSpecifications;
     private final BookSortRegistry sortRegistry;
-    private final CursorCodec cursorCodec;
-    private final LinksBuilder linksBuilder;
-
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final BrowseScopeFactory scopeFactory;
+    private final BrowsePager pager;
+    private final EntityManager entityManager;
 
     public BrowsePage<Book> browse(String sort, List<String> facet, String facetLogicParam, String query, String cursor, Pageable pageable) {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
-        Long userId = user.getId();
-        boolean isAdmin = user.getPermissions().isAdmin();
+        BrowseScope scope = scopeFactory.from(user);
+        Long userId = scope.userId();
 
-        Map<String, List<String>> facets = BookFilterSpecifications.parseFacets(facet);
+        Map<String, List<String>> facets = BrowseParams.parseFacets(facet);
         FacetLogic facetLogic = FacetLogic.from(facetLogicParam);
         String paramsHash = ParamsHash.compute(query, facets, facetLogic);
 
-        long offset;
-        int limit;
-        String sortString;
-        Integer randomSeed;
-        if (cursor != null) {
-            CursorState state = cursorCodec.decode(cursor);
-            cursorCodec.verifyParamsMatch(state, paramsHash);
-            offset = state.offset();
-            limit = state.limit();
-            sortString = state.sort();
-            randomSeed = state.randomSeed();
-        } else {
-            offset = pageable.getOffset();
-            limit = pageable.getPageSize();
-            sortString = sort;
-            randomSeed = (int) (Math.random() * MAX_RANDOM_SORT_SEED);
-        }
-        if (limit <= 0) {
-            throw ApiError.INVALID_INPUT.createException("Page size must be positive.");
-        }
-        limit = Math.min(limit, MAX_PAGE_SIZE);
+        BrowsePager.Window window = pager.resolve(sort, cursor, pageable, paramsHash);
 
-        List<SortTerm> sortTerms = SortParser.parse(sortString, sortRegistry.registry().keys());
-        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, BookFilterSpecifications.libraryIds(user), null);
-        Specification<BookEntity> spec = withSort(filter, sortTerms, userId, randomSeed);
+        List<SortTerm> sortTerms = SortParser.parse(window.sort(), sortRegistry.registry().keys());
+        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, scope, null);
+        Specification<BookEntity> spec = withSort(filter, sortTerms, userId, window.randomSeed());
 
-        Pageable pageRequest = PageRequest.of((int) (offset / limit), limit);
+        Pageable pageRequest = PageRequest.of((int) (window.offset() / window.limit()), window.limit());
         Page<Book> page = bookQueryService.findBooksPaged(spec, pageRequest, userId);
         enrich(page.getContent(), userId);
 
-        CursorState baseState = new CursorState(offset, limit, sortString, paramsHash, randomSeed);
-        String currentCursor = cursorCodec.encode(baseState);
-        List<Link> links = linksBuilder.build(new LinksBuilder.Context(
-                PAGE_PATH, FACET_PATH, BrowseParams.preserved(facet, facetLogicParam, query), offset, limit, page.getTotalElements(), baseState));
-
-        return BrowsePage.of(page.getContent(), offset, limit, page.getTotalElements(), currentCursor, links);
+        return pager.assemble(PAGE_PATH, FACET_PATH, BrowseParams.preserved(facet, facetLogicParam, query),
+                window, page.getTotalElements(), page.getContent());
     }
 
     public List<Long> findAllIds(String sort, List<String> facet, String facetLogicParam, String query) {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
-        Long userId = user.getId();
-        boolean isAdmin = user.getPermissions().isAdmin();
+        BrowseScope scope = scopeFactory.from(user);
+        Long userId = scope.userId();
 
-        Map<String, List<String>> facets = BookFilterSpecifications.parseFacets(facet);
+        Map<String, List<String>> facets = BrowseParams.parseFacets(facet);
         FacetLogic facetLogic = FacetLogic.from(facetLogicParam);
         List<SortTerm> sortTerms = SortParser.parse(sort, sortRegistry.registry().keys());
-        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, BookFilterSpecifications.libraryIds(user), null);
+        Specification<BookEntity> filter = filterSpecifications.base(query, facets, facetLogic, scope, null);
 
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<Long> cq = cb.createQuery(Long.class);
@@ -125,7 +92,7 @@ public class BookBrowseService {
         }
 
         // The `findAllIds` doesn't pass a cursor so it's a random seed every time.
-        int randomSeed = (int) (Math.random() * MAX_RANDOM_SORT_SEED);
+        int randomSeed = BrowsePager.newRandomSeed();
 
         cq.orderBy(sortRegistry.registry().toOrders(sortTerms, root, cq, cb, userId, randomSeed));
 
@@ -133,18 +100,12 @@ public class BookBrowseService {
     }
 
     public BrowsePage<Book> wrapLegacy(Page<Book> page, Pageable pageable) {
-        long offset = pageable.getOffset();
-        int limit = pageable.getPageSize();
-
         String paramsHash = ParamsHash.compute(null, Map.of(), FacetLogic.AND);
 
         // Pass a null random seed for the legacy case - we don't actually store a seed value and
         // this is good enough for most use cases.
-        CursorState baseState = new CursorState(offset, limit, null, paramsHash, null);
-
-        List<Link> links = linksBuilder.build(new LinksBuilder.Context(
-                PAGE_PATH, FACET_PATH, "", offset, limit, page.getTotalElements(), baseState));
-        return BrowsePage.of(page.getContent(), offset, limit, page.getTotalElements(), cursorCodec.encode(baseState), links);
+        BrowsePager.Window window = new BrowsePager.Window(pageable.getOffset(), pageable.getPageSize(), null, paramsHash, null);
+        return pager.assemble(PAGE_PATH, FACET_PATH, "", window, page.getTotalElements(), page.getContent());
     }
 
     private Specification<BookEntity> withSort(Specification<BookEntity> filter, List<SortTerm> sortTerms, Long userId, Integer randomSeed) {

--- a/backend/src/main/java/org/booklore/service/browse/BookFacetService.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookFacetService.java
@@ -3,7 +3,6 @@ package org.booklore.service.browse;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -14,15 +13,11 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.booklore.browse.FacetLogic;
-import org.booklore.browse.Link;
 import org.booklore.browse.ParamsHash;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.browse.FacetGroupsResponse;
 import org.booklore.model.dto.browse.FacetGroupsResponse.FacetGroup;
-import org.booklore.model.dto.browse.FacetGroupsResponse.FacetLink;
-import org.booklore.model.dto.browse.FacetGroupsResponse.Metadata;
-import org.booklore.model.dto.browse.FacetGroupsResponse.Properties;
 import org.booklore.model.entity.BookEntity;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
@@ -32,7 +27,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 @Service
@@ -58,9 +52,8 @@ public class BookFacetService {
     private final AuthenticationService authenticationService;
     private final BookFilterSpecifications filterSpecifications;
     private final BookSortRegistry sortRegistry;
-
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final BrowseScopeFactory scopeFactory;
+    private final EntityManager entityManager;
 
     private final Cache<String, FacetGroupsResponse> cache = Caffeine.newBuilder()
             .expireAfterWrite(Duration.ofSeconds(30))
@@ -69,24 +62,22 @@ public class BookFacetService {
 
     public FacetGroupsResponse getFacets(List<String> facet, String facetLogicParam, String query) {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
-        Long userId = user.getId();
-        boolean isAdmin = user.getPermissions().isAdmin();
-        Set<Long> libraryIds = BookFilterSpecifications.libraryIds(user);
+        BrowseScope scope = scopeFactory.from(user);
 
-        Map<String, List<String>> facets = BookFilterSpecifications.parseFacets(facet);
+        Map<String, List<String>> facets = BrowseParams.parseFacets(facet);
         FacetLogic facetLogic = FacetLogic.from(facetLogicParam);
 
-        String cacheKey = userId + ":" + ParamsHash.compute(query, facets, facetLogic);
+        String cacheKey = scope.userId() + ":" + ParamsHash.compute(query, facets, facetLogic);
         return cache.get(cacheKey, key -> {
             String preserved = BrowseParams.preserved(facet, facetLogicParam, query);
+            FacetResponseBuilder builder = new FacetResponseBuilder(PAGE_PATH, FACET_PATH, preserved, facet);
             List<FacetGroup> groups = new ArrayList<>();
-            groups.add(sortGroup(preserved));
+            groups.add(builder.sortGroup(sortRegistry.registry().keys()));
             for (FacetDef def : FACETS) {
-                Specification<BookEntity> base = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, libraryIds, def.key());
-                groups.add(toGroup(def, count(def, base), facet, preserved));
+                Specification<BookEntity> base = filterSpecifications.base(query, facets, facetLogic, scope, def.key());
+                groups.add(builder.group(def.key(), def.title(), count(def, base)));
             }
-            List<Link> links = List.of(Link.json(List.of("self"), href(FACET_PATH, preserved)));
-            return new FacetGroupsResponse(links, groups);
+            return new FacetGroupsResponse(builder.selfLinks(), groups);
         });
     }
 
@@ -95,7 +86,7 @@ public class BookFacetService {
         cache.invalidateAll();
     }
 
-    private List<FacetCount> count(FacetDef def, Specification<BookEntity> base) {
+    private List<FacetResponseBuilder.FacetCount> count(FacetDef def, Specification<BookEntity> base) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<Tuple> cq = cb.createTupleQuery();
         Root<BookEntity> root = cq.from(BookEntity.class);
@@ -115,42 +106,8 @@ public class BookFacetService {
         cq.orderBy(cb.desc(count), cb.asc(value));
 
         return entityManager.createQuery(cq).setMaxResults(MAX_VALUES).getResultList().stream()
-                .map(tuple -> new FacetCount(String.valueOf(tuple.get("value")), ((Number) tuple.get("count")).longValue()))
+                .map(tuple -> new FacetResponseBuilder.FacetCount(String.valueOf(tuple.get("value")), ((Number) tuple.get("count")).longValue()))
                 .toList();
-    }
-
-    private FacetGroup toGroup(FacetDef def, List<FacetCount> counts, List<String> facet, String preserved) {
-        List<FacetLink> links = counts.stream()
-                .map(c -> {
-                    boolean active = BrowseParams.hasFacet(facet, def.key(), c.value());
-                    List<String> rel = active ? List.of("self", "facet") : List.of("facet");
-                    String href = active
-                            ? href(PAGE_PATH, preserved)
-                            : pageLink(preserved, "facet=" + BrowseParams.encode(def.key() + ":" + c.value()));
-                    return new FacetLink(rel, href, Link.JSON_TYPE, c.value(), c.value(), new Properties(c.count()));
-                })
-                .toList();
-        return new FacetGroup(new Metadata("facet", def.key(), def.title()), links);
-    }
-
-    private FacetGroup sortGroup(String preserved) {
-        List<FacetLink> links = new ArrayList<>();
-        for (String key : sortRegistry.registry().keys()) {
-            if (key.equals("id")) {
-                continue;
-            }
-            links.add(new FacetLink(List.of("sort"), pageLink(preserved, "sort=" + BrowseParams.encode(key)), Link.JSON_TYPE, key + " ascending", key, null));
-            links.add(new FacetLink(List.of("sort"), pageLink(preserved, "sort=-" + BrowseParams.encode(key)), Link.JSON_TYPE, key + " descending", "-" + key, null));
-        }
-        return new FacetGroup(new Metadata("sort", "sort", "Sort"), links);
-    }
-
-    private static String pageLink(String preserved, String param) {
-        return preserved.isBlank() ? PAGE_PATH + "?" + param : PAGE_PATH + "?" + preserved + "&" + param;
-    }
-
-    private static String href(String path, String preserved) {
-        return preserved.isBlank() ? path : path + "?" + preserved;
     }
 
     private static Join<?, ?> metadata(Root<BookEntity> root) {
@@ -158,8 +115,5 @@ public class BookFacetService {
     }
 
     private record FacetDef(String key, String title, Function<Root<BookEntity>, Expression<?>> value) {
-    }
-
-    private record FacetCount(String value, long count) {
     }
 }

--- a/backend/src/main/java/org/booklore/service/browse/BookFilterSpecifications.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookFilterSpecifications.java
@@ -4,37 +4,25 @@ import lombok.RequiredArgsConstructor;
 import org.booklore.app.specification.AppBookSpecification;
 import org.booklore.browse.FacetLogic;
 import org.booklore.exception.ApiError;
-import org.booklore.model.dto.BookLoreUser;
-import org.booklore.model.dto.Library;
 import org.booklore.model.entity.BookEntity;
-import org.booklore.repository.UserContentRestrictionRepository;
-import org.booklore.security.policy.ContentRestrictionSpecification;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class BookFilterSpecifications {
 
     private final BookFacetRegistry facetRegistry;
-    private final UserContentRestrictionRepository restrictionRepository;
 
     public Specification<BookEntity> base(String query, Map<String, List<String>> facets, FacetLogic facetLogic,
-                                          Long userId, boolean isAdmin, Set<Long> libraryIds, String omitFacet) {
+                                          BrowseScope scope, String omitFacet) {
         List<Specification<BookEntity>> specs = new ArrayList<>();
-        specs.add(AppBookSpecification.notDeleted());
-        if (!isAdmin) {
-            specs.add(inLibraries(libraryIds));
-            specs.add(ContentRestrictionSpecification.from(restrictionRepository.findByUserId(userId)));
-        }
+        specs.add(scope.visibleBooks());
         if (query != null && !query.isBlank()) {
             specs.add(BookSearchSpecification.matching(query));
         }
@@ -45,39 +33,8 @@ public class BookFilterSpecifications {
             if (!facetRegistry.has(entry.getKey())) {
                 throw ApiError.INVALID_FACET.createException("Unknown facet: " + entry.getKey());
             }
-            specs.add(facetRegistry.toSpecification(entry.getKey(), entry.getValue(), facetLogic, userId));
+            specs.add(facetRegistry.toSpecification(entry.getKey(), entry.getValue(), facetLogic, scope.userId()));
         }
         return AppBookSpecification.combine(specs.toArray(Specification[]::new));
-    }
-
-    private static Specification<BookEntity> inLibraries(Set<Long> libraryIds) {
-        return (root, query, cb) -> libraryIds.isEmpty()
-                ? cb.disjunction()
-                : root.get("library").get("id").in(libraryIds);
-    }
-
-    public static Set<Long> libraryIds(BookLoreUser user) {
-        if (user.getAssignedLibraries() == null) {
-            return Set.of();
-        }
-        return user.getAssignedLibraries().stream().map(Library::getId).collect(Collectors.toSet());
-    }
-
-    public static Map<String, List<String>> parseFacets(List<String> facet) {
-        Map<String, List<String>> facets = new LinkedHashMap<>();
-        if (facet == null) {
-            return facets;
-        }
-        for (String entry : facet) {
-            if (entry == null || entry.isBlank()) {
-                continue;
-            }
-            int colon = entry.indexOf(':');
-            if (colon <= 0 || colon == entry.length() - 1) {
-                throw ApiError.INVALID_FACET.createException("Facet must be in key:value form: " + entry);
-            }
-            facets.computeIfAbsent(entry.substring(0, colon), k -> new ArrayList<>()).add(entry.substring(colon + 1));
-        }
-        return facets;
     }
 }

--- a/backend/src/main/java/org/booklore/service/browse/BrowseParams.java
+++ b/backend/src/main/java/org/booklore/service/browse/BrowseParams.java
@@ -1,13 +1,35 @@
 package org.booklore.service.browse;
 
+import org.booklore.exception.ApiError;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 final class BrowseParams {
 
     private BrowseParams() {
+    }
+
+    static Map<String, List<String>> parseFacets(List<String> facet) {
+        Map<String, List<String>> facets = new LinkedHashMap<>();
+        if (facet == null) {
+            return facets;
+        }
+        for (String entry : facet) {
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+            int colon = entry.indexOf(':');
+            if (colon <= 0 || colon == entry.length() - 1) {
+                throw ApiError.INVALID_FACET.createException("Facet must be in key:value form: " + entry);
+            }
+            facets.computeIfAbsent(entry.substring(0, colon), k -> new ArrayList<>()).add(entry.substring(colon + 1));
+        }
+        return facets;
     }
 
     static String preserved(List<String> facet, String facetLogic, String query) {

--- a/backend/src/main/java/org/booklore/service/browse/BrowseScope.java
+++ b/backend/src/main/java/org/booklore/service/browse/BrowseScope.java
@@ -1,0 +1,41 @@
+package org.booklore.service.browse;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.booklore.model.entity.BookEntity;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public record BrowseScope(
+        Long userId,
+        boolean isAdmin,
+        Set<Long> libraryIds,
+        Specification<BookEntity> contentRestriction
+) {
+
+    public Predicate visibleBook(Root<BookEntity> book, CriteriaQuery<?> query, CriteriaBuilder cb) {
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.or(cb.isNull(book.get("deleted")), cb.equal(book.get("deleted"), false)));
+        if (!isAdmin) {
+            predicates.add(libraryIds.isEmpty()
+                    ? cb.disjunction()
+                    : book.get("library").get("id").in(libraryIds));
+            if (contentRestriction != null) {
+                Predicate restriction = contentRestriction.toPredicate(book, query, cb);
+                if (restriction != null) {
+                    predicates.add(restriction);
+                }
+            }
+        }
+        return cb.and(predicates.toArray(Predicate[]::new));
+    }
+
+    public Specification<BookEntity> visibleBooks() {
+        return this::visibleBook;
+    }
+}

--- a/backend/src/main/java/org/booklore/service/browse/BrowseScopeFactory.java
+++ b/backend/src/main/java/org/booklore/service/browse/BrowseScopeFactory.java
@@ -1,0 +1,23 @@
+package org.booklore.service.browse;
+
+import lombok.RequiredArgsConstructor;
+import org.booklore.model.dto.BookLoreUser;
+import org.booklore.repository.UserContentRestrictionRepository;
+import org.booklore.security.policy.ContentRestrictionSpecification;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BrowseScopeFactory {
+
+    private final UserContentRestrictionRepository restrictionRepository;
+
+    public BrowseScope from(BookLoreUser user) {
+        boolean isAdmin = user.getPermissions().isAdmin();
+        return new BrowseScope(
+                user.getId(),
+                isAdmin,
+                user.assignedLibraryIds(),
+                isAdmin ? null : ContentRestrictionSpecification.from(restrictionRepository.findByUserId(user.getId())));
+    }
+}

--- a/backend/src/main/java/org/booklore/service/browse/FacetResponseBuilder.java
+++ b/backend/src/main/java/org/booklore/service/browse/FacetResponseBuilder.java
@@ -1,0 +1,68 @@
+package org.booklore.service.browse;
+
+import org.booklore.browse.Link;
+import org.booklore.browse.SortParser;
+import org.booklore.model.dto.browse.FacetGroupsResponse.FacetGroup;
+import org.booklore.model.dto.browse.FacetGroupsResponse.FacetLink;
+import org.booklore.model.dto.browse.FacetGroupsResponse.Metadata;
+import org.booklore.model.dto.browse.FacetGroupsResponse.Properties;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+final class FacetResponseBuilder {
+
+    record FacetCount(String value, long count) {
+    }
+
+    private final String pagePath;
+    private final String facetPath;
+    private final String preserved;
+    private final List<String> selectedFacets;
+
+    FacetResponseBuilder(String pagePath, String facetPath, String preserved, List<String> selectedFacets) {
+        this.pagePath = pagePath;
+        this.facetPath = facetPath;
+        this.preserved = preserved;
+        this.selectedFacets = selectedFacets;
+    }
+
+    FacetGroup sortGroup(Set<String> sortKeys) {
+        List<FacetLink> links = new ArrayList<>();
+        for (String key : sortKeys) {
+            if (key.equals(SortParser.TIEBREAKER_KEY)) {
+                continue;
+            }
+            links.add(new FacetLink(List.of("sort"), pageLink("sort=" + BrowseParams.encode(key)), Link.JSON_TYPE, key + " ascending", key, null));
+            links.add(new FacetLink(List.of("sort"), pageLink("sort=-" + BrowseParams.encode(key)), Link.JSON_TYPE, key + " descending", "-" + key, null));
+        }
+        return new FacetGroup(new Metadata("sort", "sort", "Sort"), links);
+    }
+
+    FacetGroup group(String key, String title, List<FacetCount> counts) {
+        List<FacetLink> links = counts.stream()
+                .map(c -> {
+                    boolean active = BrowseParams.hasFacet(selectedFacets, key, c.value());
+                    List<String> rel = active ? List.of("self", "facet") : List.of("facet");
+                    String href = active
+                            ? href(pagePath)
+                            : pageLink("facet=" + BrowseParams.encode(key + ":" + c.value()));
+                    return new FacetLink(rel, href, Link.JSON_TYPE, c.value(), c.value(), new Properties(c.count()));
+                })
+                .toList();
+        return new FacetGroup(new Metadata("facet", key, title), links);
+    }
+
+    List<Link> selfLinks() {
+        return List.of(Link.json(List.of("self"), href(facetPath)));
+    }
+
+    private String pageLink(String param) {
+        return preserved.isBlank() ? pagePath + "?" + param : pagePath + "?" + preserved + "&" + param;
+    }
+
+    private String href(String path) {
+        return preserved.isBlank() ? path : path + "?" + preserved;
+    }
+}

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
@@ -16,7 +16,10 @@ import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.entity.CategoryEntity;
 import org.booklore.model.entity.LibraryEntity;
 import org.booklore.model.entity.LibraryPathEntity;
+import org.booklore.model.entity.UserContentRestrictionEntity;
 import org.booklore.model.enums.BookFileType;
+import org.booklore.model.enums.ContentRestrictionMode;
+import org.booklore.model.enums.ContentRestrictionType;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.task.TaskCronService;
 import org.flywaydb.core.Flyway;
@@ -297,5 +300,44 @@ class BookBrowseServiceTest {
         BrowsePage<Book> result = browse(null, null, null, null, 0, 20);
         assertThat(result.content()).hasSize(1);
         assertThat(result.content().get(0).getId()).isNotEqualTo(outside.getId());
+    }
+
+    @Test
+    void nonAdminWithNoLibrariesSeesNothing() {
+        book("Alpha", List.of());
+        em.flush();
+        when(authenticationService.getAuthenticatedUser()).thenReturn(noLibrariesUser());
+
+        BrowsePage<Book> result = browse(null, null, null, null, 0, 20);
+        assertThat(result.content()).isEmpty();
+        assertThat(result.page().totalElements()).isZero();
+        assertThat(browseService.findAllIds(null, null, null, null)).isEmpty();
+    }
+
+    @Test
+    void contentRestrictionsExcludeBooks() {
+        em.persist(UserContentRestrictionEntity.builder()
+                .user(userEntity)
+                .restrictionType(ContentRestrictionType.CATEGORY)
+                .mode(ContentRestrictionMode.EXCLUDE)
+                .value("Horror")
+                .build());
+        Long romance = book("R", List.of("Romance")).getId();
+        book("H", List.of("Horror"));
+        em.flush();
+
+        assertThat(browse(null, null, null, null, 0, 20).content().stream().map(Book::getId))
+                .containsExactly(romance);
+        assertThat(browseService.findAllIds(null, null, null, null)).containsExactly(romance);
+    }
+
+    private BookLoreUser noLibrariesUser() {
+        BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();
+        permissions.setAdmin(false);
+        return BookLoreUser.builder()
+                .id(userEntity.getId())
+                .assignedLibraries(List.of())
+                .permissions(permissions)
+                .build();
     }
 }

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
@@ -17,7 +17,10 @@ import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.entity.CategoryEntity;
 import org.booklore.model.entity.LibraryEntity;
 import org.booklore.model.entity.LibraryPathEntity;
+import org.booklore.model.entity.UserContentRestrictionEntity;
 import org.booklore.model.enums.BookFileType;
+import org.booklore.model.enums.ContentRestrictionMode;
+import org.booklore.model.enums.ContentRestrictionType;
 import org.booklore.repository.BookRepository;
 import org.booklore.service.task.TaskCronService;
 import org.flywaydb.core.Flyway;
@@ -324,5 +327,44 @@ class BookBrowseServiceTest {
         BrowsePage<Book> result = browse(null, null, null, null, 0, 20);
         assertThat(result.content()).hasSize(1);
         assertThat(result.content().get(0).getId()).isNotEqualTo(outside.getId());
+    }
+
+    @Test
+    void nonAdminWithNoLibrariesSeesNothing() {
+        book("Alpha", List.of());
+        em.flush();
+        when(authenticationService.getAuthenticatedUser()).thenReturn(noLibrariesUser());
+
+        BrowsePage<Book> result = browse(null, null, null, null, 0, 20);
+        assertThat(result.content()).isEmpty();
+        assertThat(result.page().totalElements()).isZero();
+        assertThat(browseService.findAllIds(null, null, null, null)).isEmpty();
+    }
+
+    @Test
+    void contentRestrictionsExcludeBooks() {
+        em.persist(UserContentRestrictionEntity.builder()
+                .user(userEntity)
+                .restrictionType(ContentRestrictionType.CATEGORY)
+                .mode(ContentRestrictionMode.EXCLUDE)
+                .value("Horror")
+                .build());
+        Long romance = book("R", List.of("Romance")).getId();
+        book("H", List.of("Horror"));
+        em.flush();
+
+        assertThat(browse(null, null, null, null, 0, 20).content().stream().map(Book::getId))
+                .containsExactly(romance);
+        assertThat(browseService.findAllIds(null, null, null, null)).containsExactly(romance);
+    }
+
+    private BookLoreUser noLibrariesUser() {
+        BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();
+        permissions.setAdmin(false);
+        return BookLoreUser.builder()
+                .id(userEntity.getId())
+                .assignedLibraries(List.of())
+                .permissions(permissions)
+                .build();
     }
 }

--- a/backend/src/test/java/org/booklore/service/browse/BookFacetServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookFacetServiceTest.java
@@ -17,7 +17,10 @@ import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.entity.CategoryEntity;
 import org.booklore.model.entity.LibraryEntity;
 import org.booklore.model.entity.LibraryPathEntity;
+import org.booklore.model.entity.UserContentRestrictionEntity;
 import org.booklore.model.enums.BookFileType;
+import org.booklore.model.enums.ContentRestrictionMode;
+import org.booklore.model.enums.ContentRestrictionType;
 import org.booklore.service.task.TaskCronService;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.BeforeEach;
@@ -365,5 +368,42 @@ class BookFacetServiceTest {
         assertThat(json).contains("\"rel\":[\"self\",\"facet\"]");
         assertThat(json).doesNotContain("\"rel\":[\"self\"]");
         assertThat(json).doesNotContain("\"rel\":[\"facet\"]");
+    }
+
+    @Test
+    void nonAdminWithNoLibrariesGetsNoFacetValues() {
+        book("A", "Horror", "Alice");
+        em.flush();
+        BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();
+        permissions.setAdmin(false);
+        when(authenticationService.getAuthenticatedUser()).thenReturn(BookLoreUser.builder()
+                .id(userEntity.getId())
+                .assignedLibraries(List.of())
+                .permissions(permissions)
+                .build());
+
+        FacetGroupsResponse response = facetService.getFacets(null, null, null);
+
+        assertThat(group(response, "genre").links()).isEmpty();
+        assertThat(group(response, "author").links()).isEmpty();
+    }
+
+    @Test
+    void contentRestrictionsExcludeBooksFromCounts() {
+        em.persist(UserContentRestrictionEntity.builder()
+                .user(userEntity)
+                .restrictionType(ContentRestrictionType.CATEGORY)
+                .mode(ContentRestrictionMode.EXCLUDE)
+                .value("Horror")
+                .build());
+        book("H", "Horror", "Alice");
+        book("R", "Romance", "Bob");
+        em.flush();
+
+        FacetGroupsResponse response = facetService.getFacets(null, null, null);
+
+        assertThat(count(group(response, "genre"), "Romance")).isEqualTo(1);
+        assertThat(count(group(response, "genre"), "Horror")).isNull();
+        assertThat(count(group(response, "author"), "Alice")).isNull();
     }
 }


### PR DESCRIPTION
## Description

This PR pulls out some of the shared, entity-neutral elements of the browse pattern out of the book specific code, so the future browse endpoints for authors/series can reduce code duplication.

The current endpoints for `/page`, `/facets`, and `/ids` behave identically before/after this PR.

## Linked Issue

Part of https://github.com/grimmory-tools/grimmory/issues/1845

## Changes

- `BrowseScope` and the `BrowseScopeFactory` have been pulled out so they can be reused across entities. This isn't a comprehensive scoping solution platform wide, just a consistent solution we can use here for now
  - also has the added benefit or cutting down facet calls from making 9 restriction checks to just 1
- `BrowsePager` handles the cursor and page resolution, and builds the `BrowsePage` response w/ relevant links + cursors
- added a `FacetResponseBuilder` to build generalize the code for constructing facet responses
- generalized available library IDs out of `BookFilterSpecifications` and onto the user for reuse elsewhere

## Manual Testing Steps

1. Verify all tests continue to pass
2. Verify that restricted content, and libraries continue to be filtered appropriately

## Screenshots (Optional)

N/A

## Additional Context (Optional)

Most of this is cleanup that seemed pertinent when I played with adding the author paginated browse endpoints.

## AI Disclosure

Rebase help

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination with validated page sizes, navigation links, and result metadata.
  * Improved browsing visibility for administrators and users with library-specific access.
  * Added structured facet and sort links while preserving search parameters.
  * Added grouped facet filters with validation for malformed entries.

* **Bug Fixes**
  * Prevented deleted or inaccessible books from appearing in browse results, ID lookups, and facet counts.
  * Correctly handles users without assigned libraries.
  * Applied content restrictions consistently across browsing and facet results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->