### PR TITLE
fix(api): stricter SSRF protections

### DIFF
--- a/backend/src/main/java/org/booklore/security/RestrictedInetAddressMatcher.java
+++ b/backend/src/main/java/org/booklore/security/RestrictedInetAddressMatcher.java
@@ -1,0 +1,164 @@
+package org.booklore.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Component
+public class RestrictedInetAddressMatcher {
+    private record InetAddressRange(byte[] lower, byte[] upper) {
+        public boolean matches(InetAddress address) {
+            byte[] addressBytes = address.getAddress();
+            return addressBytes.length == lower.length && Arrays.compareUnsigned(lower, addressBytes) <= 0 && Arrays.compareUnsigned(addressBytes, upper) <= 0;
+        }
+
+        private static int parseCidrMask(String cidrPrefix) {
+            try {
+                return Integer.parseInt(cidrPrefix);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid CIDR prefix: " + cidrPrefix);
+            }
+        }
+
+        private static InetAddress parseCidrAddress(String cidrAddress) {
+            if (cidrAddress == null || cidrAddress.isBlank()) {
+                throw new IllegalArgumentException("Empty CIDR Address");
+            }
+
+            // If the first character is a digit, getByName uses `IPAddressUtil`
+            // and skips actual network calls.  Ensure we're properly skipping things
+            // so we avoid network lookups.
+            if (Character.digit(cidrAddress.charAt(0), 16) == -1 && cidrAddress.charAt(0) != ':') {
+                throw new IllegalArgumentException("Invalid CIDR Address: " + cidrAddress);
+            }
+
+            try {
+                return InetAddress.getByName(cidrAddress);
+            } catch (UnknownHostException e) {
+                throw new IllegalArgumentException("Invalid CIDR Address: " + cidrAddress);
+            }
+        }
+
+        private static InetAddressRange parse(String cidr) {
+            String[] parts = cidr.split("/");
+
+            if (parts.length != 2) {
+                throw new IllegalArgumentException("Invalid CIDR: " + cidr);
+            }
+
+            InetAddress address = parseCidrAddress(parts[0]);
+            int mask = parseCidrMask(parts[1]);
+
+            byte[] lower = address.getAddress();
+            byte[] upper = address.getAddress();
+
+            for (var i = 0; i < lower.length; i++) {
+                if (mask <= 0) {
+                    lower[i] = (byte) 0x00;
+                    upper[i] = (byte) 0xFF;
+                } else if (mask < 8) {
+                    lower[i] = (byte) (lower[i] & 0xFF << (8 - mask));
+                    upper[i] = (byte) (upper[i] | ~(0xFF << (8 - mask)));
+                }
+
+                mask -= 8;
+            }
+
+            return new InetAddressRange(lower, upper);
+        }
+    }
+
+    private static final List<InetAddressRange> RESTRICTED_RANGES = Set.of(
+            // IPv6 Addressing of IPv4/IPv6 Translators - RFC 6052 - https://datatracker.ietf.org/doc/html/rfc6052
+            "64:ff9b::/96",
+
+            // Local-Use IPv4/IPv6 Translation Prefix - RFC 8215 - https://datatracker.ietf.org/doc/html/rfc8215
+            "64:ff9b:1::/48",
+
+            // Connection of IPv6 Domains via IPv4 Clouds - RFC 3056 - https://datatracker.ietf.org/doc/html/rfc3056
+            "2002::/16",
+
+            // Initial IPv6 Sub-TLA ID Assignments - RFC 2928 - https://datatracker.ietf.org/doc/html/rfc2928
+            "2001::/23",
+
+            // Unique Local IPv6 Unicast Addresses - RFC 4193 - https://datatracker.ietf.org/doc/html/rfc4193
+            "fc00::/7",
+
+            // An Anycast Prefix for 6to4 Relay Routers - RFC 3068 - https://datatracker.ietf.org/doc/html/rfc3068
+            "192.88.99.0/24",
+
+            // Loopback - RFC 6890 - https://datatracker.ietf.org/doc/html/rfc6890
+            "127.0.0.0/8",
+
+            // Link Local - RFC 6890 - https://datatracker.ietf.org/doc/html/rfc6890
+            "169.254.0.0/16",
+
+            // Private Use - RFC 6890 - https://datatracker.ietf.org/doc/html/rfc6890
+            "172.16.0.0/12",
+
+            // Shared Address Space - RFC 6890 - https://datatracker.ietf.org/doc/html/rfc6890
+            "100.64.0.0/10",
+
+            // IETF Protocol Assignments - RFC 6890 - https://datatracker.ietf.org/doc/html/rfc6890
+            "192.0.0.0/24",
+
+            // This host on this network - RFC 6890 - https://datatracker.ietf.org/doc/html/rfc6890
+            "0.0.0.0/8",
+
+            // Private Use - RFC 6890 - https://datatracker.ietf.org/doc/html/rfc6890
+            "192.168.0.0/16",
+
+            // TEST-NET-1 - RFC 5737 - https://datatracker.ietf.org/doc/html/rfc5737
+            "192.0.2.0/24",
+
+            // TEST-NET-2 - RFC 5737 - https://datatracker.ietf.org/doc/html/rfc5737
+            "198.51.100.0/24",
+
+            // TEST-NET-3 - RFC 5737 - https://datatracker.ietf.org/doc/html/rfc5737
+            "203.0.113.0/24",
+
+            // Network Interconnect Device Benchmark Testing - RFC 2544 - https://datatracker.ietf.org/doc/html/rfc2544
+            "198.18.0.0/15",
+
+            // Limited Broadcast - RFC 0919 - https://datatracker.ietf.org/doc/html/rfc0919
+            "255.255.255.255/32"
+    ).stream().map(InetAddressRange::parse).toList();
+
+    private boolean isInRestrictedRange(InetAddress address) {
+        return RESTRICTED_RANGES.stream().anyMatch(r -> r.matches(address));
+    }
+
+    public boolean isRestrictedAddress(InetAddress address) {
+        return address.isLoopbackAddress() ||
+                address.isLinkLocalAddress() ||
+                address.isSiteLocalAddress() ||
+                address.isAnyLocalAddress() ||
+                isInRestrictedRange(address);
+    }
+
+    public boolean isRestrictedAddress(String host) throws IOException {
+        // Validate resolved IPs to block SSRF against internal networks
+        InetAddress[] inetAddresses = InetAddress.getAllByName(host);
+
+        if (inetAddresses.length == 0) {
+            throw new IOException("Unable to resolve host");
+        }
+
+        for (InetAddress inetAddress : inetAddresses) {
+            if (isRestrictedAddress(inetAddress)) {
+                log.debug("Address is restricted: {}", inetAddress);
+                return true;
+            }
+        }
+
+        return false;
+
+    }
+}

--- a/backend/src/main/java/org/booklore/service/UntrustedHttpRequestService.java
+++ b/backend/src/main/java/org/booklore/service/UntrustedHttpRequestService.java
@@ -1,0 +1,139 @@
+package org.booklore.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.booklore.security.RestrictedInetAddressMatcher;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UntrustedHttpRequestService {
+    private static final int MAX_REDIRECTS = 5;
+
+    private static final String USER_AGENT = "Grimmory/1.0 (Book and Comic Metadata Fetcher; +https://github.com/grimmory-tools/grimmory)";
+
+    private final RestTemplate noRedirectRestTemplate;
+
+    private final RestrictedInetAddressMatcher restrictedInetAddressMatcher;
+
+    public byte[] request(String url) throws IOException {
+        return request(HttpMethod.GET, url, HttpHeaders.EMPTY, byte[].class);
+    }
+
+    public byte[] request(HttpMethod method, String url) throws IOException {
+        return request(method, url, HttpHeaders.EMPTY, byte[].class);
+    }
+
+    public byte[] request(HttpMethod method, String url, HttpHeaders extraHeaders) throws IOException {
+        return request(method, url, extraHeaders, byte[].class);
+    }
+
+    public <T> T request(HttpMethod method, String url, HttpHeaders extraHeaders, Class<T> responseClass) throws IOException {
+        String currentUrl = url;
+        int redirectCount = 0;
+
+        while (redirectCount <= MAX_REDIRECTS) {
+            URI uri = URI.create(currentUrl);
+            if (!"http".equalsIgnoreCase(uri.getScheme()) && !"https".equalsIgnoreCase(uri.getScheme())) {
+                throw new IOException("Only HTTP and HTTPS protocols are allowed");
+            }
+
+            String host = uri.getHost();
+            if (host == null) {
+                throw new IOException("Invalid URL: no host found in " + currentUrl);
+            }
+
+            if (restrictedInetAddressMatcher.isRestrictedAddress(host)) {
+                throw new SecurityException("URL points to a restricted network address: " + host);
+            }
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set(HttpHeaders.USER_AGENT, USER_AGENT);
+            headers.addAll(extraHeaders);
+
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            log.debug("Downloading data from: {}", currentUrl);
+
+            ResponseEntity<T> response = noRedirectRestTemplate.exchange(
+                    currentUrl,
+                    method,
+                    entity,
+                    responseClass
+            );
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return response.getBody();
+            }
+
+            if (response.getStatusCode().is3xxRedirection()) {
+                String location = response.getHeaders().getFirst(HttpHeaders.LOCATION);
+                if (location == null) {
+                    throw new IOException("Redirection response without Location header");
+                }
+                URI redirectUri = uri.resolve(location);
+
+                // When a CDN redirects to a raw IP (e.g. CloudFront -> 3.168.64.124),
+                // the Host header would become the bare IP, which the CDN rejects with
+                // 400. Rewrite the URL to keep the previous hostname so the JDK
+                // HttpClient sets the correct Host header automatically.
+                if (isRawIpAddress(redirectUri.getHost())) {
+                    try {
+                        redirectUri = new URI(
+                                redirectUri.getScheme(),
+                                redirectUri.getUserInfo(),
+                                host,
+                                redirectUri.getPort(),
+                                redirectUri.getPath(),
+                                redirectUri.getQuery(),
+                                redirectUri.getFragment()
+                        );
+                    } catch (URISyntaxException e) {
+                        throw new IOException("Invalid redirect URI: " + e.getMessage(), e);
+                    }
+                }
+
+                currentUrl = redirectUri.toString();
+                redirectCount++;
+                continue;
+            }
+
+            throw new IOException("Failed to download data. HTTP Status: " + response.getStatusCode());
+        }
+
+        throw new IOException("Too many redirects (max " + MAX_REDIRECTS + ")");
+    }
+
+    private boolean isRawIpAddress(String host) {
+        if (host == null) {
+            return false;
+        }
+        // IPv6 in URI brackets
+        if (host.startsWith("[")) {
+            return true;
+        }
+        // IPv4: all segments are digits
+        String[] parts = host.split("\\.");
+        if (parts.length == 4) {
+            for (String part : parts) {
+                if (!part.chars().allMatch(Character::isDigit)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/backend/src/main/java/org/booklore/util/FileService.java
+++ b/backend/src/main/java/org/booklore/util/FileService.java
@@ -5,15 +5,11 @@ import org.booklore.exception.ApiError;
 import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.settings.CoverCroppingSettings;
 import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.service.UntrustedHttpRequestService;
 import org.booklore.service.appsettings.AppSettingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.imageio.ImageIO;
@@ -25,9 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -36,7 +29,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Stream;
-import java.net.UnknownHostException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -44,12 +36,8 @@ import java.net.UnknownHostException;
 public class FileService {
 
     private final AppProperties appProperties;
-    private final RestTemplate restTemplate;
     private final AppSettingService appSettingService;
-    private final RestTemplate noRedirectRestTemplate;
-
-    private static final int MAX_REDIRECTS = 5;
-
+    private final UntrustedHttpRequestService untrustedHttpRequestService;
 
     private static final double TARGET_COVER_ASPECT_RATIO = 1.5;
     private static final int SMART_CROP_COLOR_TOLERANCE = 30;
@@ -293,7 +281,7 @@ public class FileService {
 
     public BufferedImage downloadImageFromUrl(String imageUrl) throws IOException {
         try {
-            return downloadImageFromUrlInternal(imageUrl);
+            return readImage(untrustedHttpRequestService.request(imageUrl));
         } catch (Exception e) {
             log.warn("Failed to download image from {}: {}", imageUrl, e.getMessage());
             if (e instanceof IOException ioException) {
@@ -301,144 +289,6 @@ public class FileService {
             }
             throw new IOException("Failed to download image from " + imageUrl + ": " + e.getMessage(), e);
         }
-    }
-
-    private BufferedImage downloadImageFromUrlInternal(String imageUrl) throws IOException {
-        String currentUrl = imageUrl;
-        int redirectCount = 0;
-
-        while (redirectCount <= MAX_REDIRECTS) {
-            URI uri = URI.create(currentUrl);
-            if (!"http".equalsIgnoreCase(uri.getScheme()) && !"https".equalsIgnoreCase(uri.getScheme())) {
-                throw new IOException("Only HTTP and HTTPS protocols are allowed");
-            }
-
-            String host = uri.getHost();
-            if (host == null) {
-                throw new IOException("Invalid URL: no host found in " + currentUrl);
-            }
-
-            // Validate resolved IPs to block SSRF against internal networks
-            InetAddress[] inetAddresses = InetAddress.getAllByName(host);
-            if (inetAddresses.length == 0) {
-                throw new IOException("Could not resolve host: " + host);
-            }
-            for (InetAddress inetAddress : inetAddresses) {
-                if (isInternalAddress(inetAddress)) {
-                    throw new SecurityException("URL points to a local or private internal network address: " + host + " (" + inetAddress.getHostAddress() + ")");
-                }
-            }
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.set(HttpHeaders.USER_AGENT, "Grimmory/1.0 (Book and Comic Metadata Fetcher; +https://github.com/grimmory-tools/grimmory)");
-            headers.set(HttpHeaders.ACCEPT, "image/*");
-
-            HttpEntity<String> entity = new HttpEntity<>(headers);
-
-            log.debug("Downloading image from: {}", currentUrl);
-
-            ResponseEntity<byte[]> response = noRedirectRestTemplate.exchange(
-                    currentUrl,
-                    HttpMethod.GET,
-                    entity,
-                    byte[].class
-            );
-
-            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-                return readImage(response.getBody());
-            } else if (response.getStatusCode().is3xxRedirection()) {
-                String location = response.getHeaders().getFirst(HttpHeaders.LOCATION);
-                if (location == null) {
-                    throw new IOException("Redirection response without Location header");
-                }
-                URI redirectUri = uri.resolve(location);
-
-                // When a CDN redirects to a raw IP (e.g. CloudFront -> 3.168.64.124),
-                // the Host header would become the bare IP, which the CDN rejects with
-                // 400. Rewrite the URL to keep the previous hostname so the JDK
-                // HttpClient sets the correct Host header automatically.
-                if (isRawIpAddress(redirectUri.getHost())) {
-                    try {
-                        redirectUri = new URI(
-                                redirectUri.getScheme(),
-                                redirectUri.getUserInfo(),
-                                host,
-                                redirectUri.getPort(),
-                                redirectUri.getPath(),
-                                redirectUri.getQuery(),
-                                redirectUri.getFragment()
-                        );
-                    } catch (URISyntaxException e) {
-                        throw new IOException("Invalid redirect URI: " + e.getMessage(), e);
-                    }
-                }
-
-                currentUrl = redirectUri.toString();
-                redirectCount++;
-            } else {
-                throw new IOException("Failed to download image. HTTP Status: " + response.getStatusCode());
-            }
-        }
-
-        throw new IOException("Too many redirects (max " + MAX_REDIRECTS + ")");
-    }
-
-    private boolean isRawIpAddress(String host) {
-        if (host == null) {
-            return false;
-        }
-        // IPv6 in URI brackets
-        if (host.startsWith("[")) {
-            return true;
-        }
-        // IPv4: all segments are digits
-        String[] parts = host.split("\\.");
-        if (parts.length == 4) {
-            for (String part : parts) {
-                if (!part.chars().allMatch(Character::isDigit)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-        return false;
-    }
-
-    private boolean isInternalAddress(InetAddress address) {
-        if (address.isLoopbackAddress() || address.isLinkLocalAddress() ||
-            address.isSiteLocalAddress() || address.isAnyLocalAddress()) {
-            return true;
-        }
-
-        byte[] addr = address.getAddress();
-        // Check for IPv6 Unique Local Address (fc00::/7)
-        if (addr.length == 16) {
-            if ((addr[0] & 0xFE) == (byte) 0xFC) {
-                return true;
-            }
-        }
-
-        // Handle IPv4-mapped IPv6 addresses (::ffff:127.0.0.1)
-        if (isIpv4MappedAddress(addr)) {
-            try {
-                byte[] ipv4Bytes = new byte[4];
-                System.arraycopy(addr, 12, ipv4Bytes, 0, 4);
-                InetAddress ipv4Addr = InetAddress.getByAddress(ipv4Bytes);
-                return isInternalAddress(ipv4Addr);
-            } catch (UnknownHostException e) {
-                return false;
-            }
-        }
-
-        return false;
-    }
-
-    private boolean isIpv4MappedAddress(byte[] addr) {
-        if (addr.length != 16) return false;
-        for (int i = 0; i < 10; i++) {
-            if (addr[i] != 0) return false;
-        }
-        return (addr[10] == (byte) 0xFF) && (addr[11] == (byte) 0xFF);
     }
 
     // ========================================

--- a/backend/src/test/java/org/booklore/security/RestrictedInetAddressMatcherTest.java
+++ b/backend/src/test/java/org/booklore/security/RestrictedInetAddressMatcherTest.java
@@ -1,0 +1,98 @@
+package org.booklore.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+
+public class RestrictedInetAddressMatcherTest {
+    private final RestrictedInetAddressMatcher restrictedInetAddressMatcher = new RestrictedInetAddressMatcher();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "192.168.1.1",
+            "192.0.0.1",
+            "127.0.0.1",
+            "169.254.169.254",
+            "198.18.0.1",
+            "255.255.255.255",
+            "64:ff9b::c0a8:0101",
+            "2002:c0a8:0101::1",
+            "2001:0000:4136:e378:8000:63bf:3f57:fefe",
+            "0.0.0.0",
+            "0.0.0.1",
+    })
+    void isRestrictedAddress_handlesLocalAddresses(String address) throws Exception {
+        assertThat(restrictedInetAddressMatcher.isRestrictedAddress(InetAddress.getByName(address))).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "4.2.2.1",
+            "8.8.8.8",
+            "2606:4700::6810:85e5",
+            "2607:f8b0:4007:804::200e",
+    })
+    void isRestrictedAddress_handlesKnownSafeExternalAddresses(String address) throws Exception {
+        assertThat(restrictedInetAddressMatcher.isRestrictedAddress(InetAddress.getByName(address))).isFalse();
+    }
+
+    @Test
+    void isRestrictedAddress_byHostThrowsExceptionWhenNoResolvedHosts() throws Exception {
+        var addresses = new InetAddress[]{};
+
+        try (var inetMock = mockStatic(InetAddress.class)) {
+            inetMock.when(() -> InetAddress.getAllByName("example.com")).thenReturn(addresses);
+
+            var exception = assertThrows(IOException.class, () -> restrictedInetAddressMatcher.isRestrictedAddress("example.com"));
+            assertThat(exception).hasMessage("Unable to resolve host");
+        }
+    }
+
+    @Test
+    void isRestrictedAddress_byHostHandlesUnsafeAddress() throws Exception {
+        var addresses = new InetAddress[]{
+                InetAddress.getByName("0.0.0.0"),
+        };
+
+        try (var inetMock = mockStatic(InetAddress.class)) {
+            inetMock.when(() -> InetAddress.getAllByName("example.com")).thenReturn(addresses);
+
+            assertThat(restrictedInetAddressMatcher.isRestrictedAddress("example.com")).isTrue();
+        }
+    }
+
+    @Test
+    void isRestrictedAddress_byHostHandlesKnownSafeAddress() throws Exception {
+        var addresses = new InetAddress[]{
+                InetAddress.getByName("8.8.8.8"),
+        };
+
+        try (var inetMock = mockStatic(InetAddress.class)) {
+            inetMock.when(() -> InetAddress.getAllByName("example.com")).thenReturn(addresses);
+
+            assertThat(restrictedInetAddressMatcher.isRestrictedAddress("example.com")).isFalse();
+        }
+    }
+
+    @Test
+    void isRestrictedAddress_byHostHandlesMixOfSafeAndUnsafeAddresses() throws Exception {
+        var addresses = new InetAddress[]{
+                InetAddress.getByName("8.8.8.8"),
+                InetAddress.getByName("0.0.0.0"),
+                InetAddress.getByName("1.1.1.1"),
+        };
+
+        try (var inetMock = mockStatic(InetAddress.class)) {
+            inetMock.when(() -> InetAddress.getAllByName("example.com")).thenReturn(addresses);
+
+            assertThat(restrictedInetAddressMatcher.isRestrictedAddress("example.com")).isTrue();
+        }
+    }
+}

--- a/backend/src/test/java/org/booklore/service/UntrustedHttpRequestServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/UntrustedHttpRequestServiceTest.java
@@ -1,0 +1,230 @@
+package org.booklore.service;
+
+import org.booklore.security.RestrictedInetAddressMatcher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UntrustedHttpRequestServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private RestrictedInetAddressMatcher restrictedInetAddressMatcher;
+
+    @InjectMocks
+    private UntrustedHttpRequestService untrustedHttpRequestService;
+
+    @Test
+    @DisplayName("throws exception when response body is null")
+    void request_nullBody_throwsException() {
+        String exampleUrl = "http://1.1.1.1/image.jpg";
+        ResponseEntity<byte[]> responseEntity = ResponseEntity.ok(null);
+        when(restTemplate.exchange(
+                anyString(),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(byte[].class)
+        )).thenReturn(responseEntity);
+
+        assertThrows(IOException.class, () -> untrustedHttpRequestService.request(exampleUrl));
+    }
+
+    @Test
+    @DisplayName("throws exception on HTTP error status")
+    void request_httpError_throwsException() {
+        String url = "http://1.1.1.1/image.jpg";
+        ResponseEntity<byte[]> responseEntity = ResponseEntity.notFound().build();
+        when(restTemplate.exchange(
+                anyString(),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(byte[].class)
+        )).thenReturn(responseEntity);
+
+        assertThrows(IOException.class, () -> untrustedHttpRequestService.request(url));
+    }
+
+    @Test
+    @DisplayName("rewrites redirect URL to preserve hostname when CDN redirects to raw IP")
+    void request_redirectToRawIp_rewritesUrlWithOriginalHost() throws IOException {
+        String originalUrl = "http://example.com/cover.jpg";
+        String cdnIpRedirect = "http://3.168.64.124/cover.jpg";
+        byte[] responseBytes = new byte[]{0x01, 0x02, 0x03};
+
+        ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(302)
+                .header("Location", cdnIpRedirect).build();
+        ResponseEntity<byte[]> finalResponse = ResponseEntity.ok(responseBytes);
+
+        var urlCaptor = ArgumentCaptor.forClass(String.class);
+        when(
+                restTemplate.exchange(
+                    urlCaptor.capture(),
+                    eq(HttpMethod.GET),
+                    any(HttpEntity.class),
+                    eq(byte[].class)
+        )).thenReturn(redirectResponse).thenReturn(finalResponse);
+
+        untrustedHttpRequestService.request(originalUrl);
+
+        assertEquals(originalUrl, urlCaptor.getAllValues().get(0));
+        assertEquals("http://example.com/cover.jpg", urlCaptor.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("preserves redirect path when rewriting raw IP URL back to hostname")
+    void request_redirectToRawIpDifferentPath_preservesPath() throws IOException {
+        String originalUrl = "http://example.com/images/cover.jpg";
+        String cdnIpRedirect = "http://3.168.64.124/cdn/optimized/cover.jpg?token=abc";
+        byte[] responseBytes = new byte[]{0x01, 0x02, 0x03};
+
+        ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(302)
+                .header("Location", cdnIpRedirect).build();
+        ResponseEntity<byte[]> finalResponse = ResponseEntity.ok(responseBytes);
+
+        var urlCaptor = ArgumentCaptor.forClass(String.class);
+        when(restTemplate.exchange(
+                urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
+        )).thenReturn(redirectResponse).thenReturn(finalResponse);
+
+        untrustedHttpRequestService.request(originalUrl);
+
+        assertEquals("http://example.com/cdn/optimized/cover.jpg?token=abc", urlCaptor.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("does not rewrite URL when redirect target is a hostname")
+    void request_redirectToHostname_keepsRedirectUrl() throws IOException {
+        String originalUrl = "http://example.com/cover.jpg";
+        String hostnameRedirect = "http://www.example.com/cover.jpg";
+        byte[] responseBytes = new byte[]{0x01, 0x02, 0x03};
+
+        ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(301)
+                .header("Location", hostnameRedirect).build();
+        ResponseEntity<byte[]> finalResponse = ResponseEntity.ok(responseBytes);
+
+        var urlCaptor = ArgumentCaptor.forClass(String.class);
+        when(restTemplate.exchange(
+                urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
+        )).thenReturn(redirectResponse).thenReturn(finalResponse);
+
+        untrustedHttpRequestService.request(originalUrl);
+
+        assertEquals(hostnameRedirect, urlCaptor.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("chain: hostname -> hostname -> raw IP uses last hostname for rewrite")
+    void request_multipleRedirectsToRawIp_usesLastHostname() throws IOException {
+        String originalUrl = "http://example.com/cover.jpg";
+        String hostnameRedirect = "http://www.example.com/cover.jpg";
+        String ipRedirect = "http://52.84.12.99/cover.jpg";
+        byte[] responseBytes = new byte[]{0x01, 0x02, 0x03};
+
+        ResponseEntity<byte[]> redirect1 = ResponseEntity.status(301)
+                .header("Location", hostnameRedirect).build();
+        ResponseEntity<byte[]> redirect2 = ResponseEntity.status(302)
+                .header("Location", ipRedirect).build();
+        ResponseEntity<byte[]> finalResponse = ResponseEntity.ok(responseBytes);
+
+        var urlCaptor = ArgumentCaptor.forClass(String.class);
+        when(restTemplate.exchange(
+                urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
+        )).thenReturn(redirect1).thenReturn(redirect2).thenReturn(finalResponse);
+
+        untrustedHttpRequestService.request(originalUrl);
+
+        assertEquals(originalUrl, urlCaptor.getAllValues().get(0));
+        assertEquals(hostnameRedirect, urlCaptor.getAllValues().get(1));
+        assertEquals("http://www.example.com/cover.jpg", urlCaptor.getAllValues().get(2));
+    }
+
+    @Test
+    @DisplayName("throws exception when redirect exceeds max limit")
+    void request_tooManyRedirects_throwsException() {
+        String imageUrl = "http://1.1.1.1/cover.jpg";
+
+        ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(302)
+                .header("Location", "http://2.2.2.2/cover.jpg")
+                .build();
+
+        when(restTemplate.exchange(
+                anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
+        )).thenReturn(redirectResponse);
+
+        IOException ex = assertThrows(IOException.class, () ->
+                untrustedHttpRequestService.request(imageUrl));
+        assertTrue(ex.getMessage().contains("Too many redirects"));
+    }
+
+    @Test
+    @DisplayName("throws exception when redirect has no Location header")
+    void request_redirectWithoutLocation_throwsException() {
+        String imageUrl = "http://1.1.1.1/image.jpg";
+
+        ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(302).build();
+        when(restTemplate.exchange(
+                anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
+        )).thenReturn(redirectResponse);
+
+        IOException ex = assertThrows(IOException.class, () ->
+                untrustedHttpRequestService.request(imageUrl));
+        assertTrue(ex.getMessage().contains("Location"));
+    }
+
+    @Test
+    @DisplayName("throws exception when address is restricted")
+    void request_restrictedInetAddress_throwsException() throws Exception{
+        String originalUrl = "http://example.com/cover.jpg";
+
+        when(restrictedInetAddressMatcher.isRestrictedAddress(anyString())).thenReturn(true);
+
+        assertThrows(SecurityException.class, () -> untrustedHttpRequestService.request(originalUrl));
+        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(byte[].class));
+    }
+
+    @Test
+    @DisplayName("throws exception when address in redirect is restricted")
+    void request_restrictedInetAddressInRedirect_throwsException() throws Exception {
+        String originalUrl = "http://example.com/cover.jpg";
+        String hostnameRedirect = "http://www.example2.com/cover.jpg";
+
+        ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(301)
+                .header("Location", hostnameRedirect).build();
+
+        when(restTemplate.exchange(
+                anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
+        )).thenReturn(redirectResponse);
+
+        when(restrictedInetAddressMatcher.isRestrictedAddress(anyString()))
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertThrows(SecurityException.class, () -> untrustedHttpRequestService.request(originalUrl));
+        verify(restTemplate, atMostOnce()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(byte[].class));
+    }
+
+}

--- a/backend/src/test/java/org/booklore/util/FileServiceTest.java
+++ b/backend/src/test/java/org/booklore/util/FileServiceTest.java
@@ -4,6 +4,7 @@ import org.booklore.config.AppProperties;
 import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.settings.CoverCroppingSettings;
 import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.service.UntrustedHttpRequestService;
 import org.booklore.service.appsettings.AppSettingService;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,6 +14,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -47,6 +49,10 @@ class FileServiceTest {
     @Mock
     private AppSettingService appSettingService;
 
+    @Mock
+    private UntrustedHttpRequestService untrustedHttpRequestService;
+
+    @InjectMocks
     private FileService fileService;
 
     @TempDir
@@ -63,10 +69,6 @@ class FileServiceTest {
                 .coverCroppingSettings(coverCroppingSettings)
                 .build();
         lenient().when(appSettingService.getAppSettings()).thenReturn(appSettings);
-
-        RestTemplate mockRestTemplate = mock(RestTemplate.class);
-        RestTemplate mockNoRedirectRestTemplate = mock(RestTemplate.class);
-        fileService = new FileService(appProperties, mockRestTemplate, appSettingService, mockNoRedirectRestTemplate);
     }
 
     @Nested
@@ -1217,14 +1219,6 @@ class FileServiceTest {
     @DisplayName("Network Operations")
     class NetworkOperationsTests {
 
-        @Mock
-        private RestTemplate restTemplate;
-
-        @Mock
-        private AppSettingService appSettingServiceForNetwork;
-
-        private FileService fileService;
-
         @BeforeEach
         void setup() {
             lenient().when(appProperties.getPathConfig()).thenReturn(tempDir.toString());
@@ -1237,9 +1231,7 @@ class FileServiceTest {
             AppSettings appSettings = AppSettings.builder()
                     .coverCroppingSettings(coverCroppingSettings)
                     .build();
-            lenient().when(appSettingServiceForNetwork.getAppSettings()).thenReturn(appSettings);
-
-            fileService = new FileService(appProperties, restTemplate, appSettingServiceForNetwork, restTemplate);
+            lenient().when(appSettingService.getAppSettings()).thenReturn(appSettings);
         }
 
         @Nested
@@ -1248,25 +1240,15 @@ class FileServiceTest {
 
             @Test
             @DisplayName("downloads and returns valid image")
-            @Timeout(5)
             void downloadImageFromUrl_validImage_returnsBufferedImage() throws IOException {
                 String imageUrl = "http://1.1.1.1/image.jpg";
                 BufferedImage testImage = createTestImage(100, 100);
                 byte[] imageBytes = imageToBytes(testImage);
 
-                RestTemplate mockRestTemplate = mock(RestTemplate.class);
-                AppSettingService mockAppSettingService = mock(AppSettingService.class);
-                FileService testFileService = new FileService(appProperties, mockRestTemplate, mockAppSettingService, mockRestTemplate);
-
                 ResponseEntity<byte[]> responseEntity = ResponseEntity.ok(imageBytes);
-                when(mockRestTemplate.exchange(
-                        anyString(),
-                        eq(HttpMethod.GET),
-                        any(HttpEntity.class),
-                        eq(byte[].class)
-                )).thenReturn(responseEntity);
+                when(untrustedHttpRequestService.request(imageUrl)).thenReturn(imageBytes);
 
-                BufferedImage result = testFileService.downloadImageFromUrl(imageUrl);
+                BufferedImage result = fileService.downloadImageFromUrl(imageUrl);
 
                 assertNotNull(result);
                 assertEquals(100, result.getWidth());
@@ -1275,16 +1257,10 @@ class FileServiceTest {
 
             @Test
             @DisplayName("throws exception when response body is null")
-            @Timeout(5)
-            void downloadImageFromUrl_nullBody_throwsException() {
+            void downloadImageFromUrl_nullBody_throwsException() throws Exception {
                 String imageUrl = "http://1.1.1.1/image.jpg";
                 ResponseEntity<byte[]> responseEntity = ResponseEntity.ok(null);
-                when(restTemplate.exchange(
-                        anyString(),
-                        eq(HttpMethod.GET),
-                        any(HttpEntity.class),
-                        eq(byte[].class)
-                )).thenReturn(responseEntity);
+                when(untrustedHttpRequestService.request("http://1.1.1.1/image.jpg")).thenReturn(null);
 
                 assertThrows(IOException.class, () ->
                         fileService.downloadImageFromUrl(imageUrl));
@@ -1292,187 +1268,13 @@ class FileServiceTest {
 
             @Test
             @DisplayName("throws IOException when ImageIO cannot read bytes")
-            @Timeout(5)
             void downloadImageFromUrl_invalidImageData_throwsException() throws IOException {
                 String imageUrl = "http://1.1.1.1/image.jpg";
                 byte[] invalidBytes = "not an image".getBytes();
-                ResponseEntity<byte[]> responseEntity = ResponseEntity.ok(invalidBytes);
-                RestTemplate noRedirectMock = (RestTemplate) ReflectionTestUtils.getField(fileService, "noRedirectRestTemplate");
 
-                when(noRedirectMock.exchange(
-                        anyString(),
-                        eq(HttpMethod.GET),
-                        any(HttpEntity.class),
-                        eq(byte[].class)
-                )).thenReturn(responseEntity);
+                when(untrustedHttpRequestService.request("http://1.1.1.1/image.jpg")).thenReturn(invalidBytes);
 
                 assertThrows(IOException.class, () -> fileService.downloadImageFromUrl(imageUrl));
-            }
-
-            @Test
-            @DisplayName("throws exception on HTTP error status")
-            @Timeout(5)
-            void downloadImageFromUrl_httpError_throwsException() {
-                String imageUrl = "http://1.1.1.1/image.jpg";
-                ResponseEntity<byte[]> responseEntity = ResponseEntity.notFound().build();
-                when(restTemplate.exchange(
-                        anyString(),
-                        eq(HttpMethod.GET),
-                        any(HttpEntity.class),
-                        eq(byte[].class)
-                )).thenReturn(responseEntity);
-
-                assertThrows(IOException.class, () ->
-                        fileService.downloadImageFromUrl(imageUrl));
-            }
-
-            @Test
-            @DisplayName("rewrites redirect URL to preserve hostname when CDN redirects to raw IP")
-            @Timeout(5)
-            void downloadImageFromUrl_redirectToRawIp_rewritesUrlWithOriginalHost() throws IOException {
-                String originalUrl = "http://example.com/cover.jpg";
-                String cdnIpRedirect = "http://3.168.64.124/cover.jpg";
-                BufferedImage testImage = createTestImage(100, 100);
-                byte[] imageBytes = imageToBytes(testImage);
-
-                RestTemplate mockRestTemplate = mock(RestTemplate.class);
-                FileService testFileService = new FileService(appProperties, mockRestTemplate, appSettingServiceForNetwork, mockRestTemplate);
-
-                ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(302)
-                        .header("Location", cdnIpRedirect).build();
-                ResponseEntity<byte[]> imageResponse = ResponseEntity.ok(imageBytes);
-
-                var urlCaptor = ArgumentCaptor.forClass(String.class);
-                when(mockRestTemplate.exchange(
-                        urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
-                )).thenReturn(redirectResponse, imageResponse);
-
-                BufferedImage result = testFileService.downloadImageFromUrl(originalUrl);
-
-                assertNotNull(result);
-                assertEquals(originalUrl, urlCaptor.getAllValues().get(0));
-                assertEquals("http://example.com/cover.jpg", urlCaptor.getAllValues().get(1));
-            }
-
-            @Test
-            @DisplayName("preserves redirect path when rewriting raw IP URL back to hostname")
-            @Timeout(5)
-            void downloadImageFromUrl_redirectToRawIpDifferentPath_preservesPath() throws IOException {
-                String originalUrl = "http://example.com/images/cover.jpg";
-                String cdnIpRedirect = "http://3.168.64.124/cdn/optimized/cover.jpg?token=abc";
-                BufferedImage testImage = createTestImage(100, 100);
-                byte[] imageBytes = imageToBytes(testImage);
-
-                RestTemplate mockRestTemplate = mock(RestTemplate.class);
-                FileService testFileService = new FileService(appProperties, mockRestTemplate, appSettingServiceForNetwork, mockRestTemplate);
-
-                ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(302)
-                        .header("Location", cdnIpRedirect).build();
-                ResponseEntity<byte[]> imageResponse = ResponseEntity.ok(imageBytes);
-
-                var urlCaptor = ArgumentCaptor.forClass(String.class);
-                when(mockRestTemplate.exchange(
-                        urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
-                )).thenReturn(redirectResponse, imageResponse);
-
-                testFileService.downloadImageFromUrl(originalUrl);
-
-                assertEquals("http://example.com/cdn/optimized/cover.jpg?token=abc", urlCaptor.getAllValues().get(1));
-            }
-
-            @Test
-            @DisplayName("does not rewrite URL when redirect target is a hostname")
-            @Timeout(5)
-            void downloadImageFromUrl_redirectToHostname_keepsRedirectUrl() throws IOException {
-                String originalUrl = "http://example.com/cover.jpg";
-                String hostnameRedirect = "http://www.example.com/cover.jpg";
-                BufferedImage testImage = createTestImage(100, 100);
-                byte[] imageBytes = imageToBytes(testImage);
-
-                RestTemplate mockRestTemplate = mock(RestTemplate.class);
-                FileService testFileService = new FileService(appProperties, mockRestTemplate, appSettingServiceForNetwork, mockRestTemplate);
-
-                ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(301)
-                        .header("Location", hostnameRedirect).build();
-                ResponseEntity<byte[]> imageResponse = ResponseEntity.ok(imageBytes);
-
-                var urlCaptor = ArgumentCaptor.forClass(String.class);
-                when(mockRestTemplate.exchange(
-                        urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
-                )).thenReturn(redirectResponse, imageResponse);
-
-                testFileService.downloadImageFromUrl(originalUrl);
-
-                assertEquals(hostnameRedirect, urlCaptor.getAllValues().get(1));
-            }
-
-            @Test
-            @DisplayName("chain: hostname -> hostname -> raw IP uses last hostname for rewrite")
-            @Timeout(5)
-            void downloadImageFromUrl_multipleRedirectsToRawIp_usesLastHostname() throws IOException {
-                String originalUrl = "http://example.com/cover.jpg";
-                String hostnameRedirect = "http://www.example.com/cover.jpg";
-                String ipRedirect = "http://52.84.12.99/cover.jpg";
-                BufferedImage testImage = createTestImage(100, 100);
-                byte[] imageBytes = imageToBytes(testImage);
-
-                RestTemplate mockRestTemplate = mock(RestTemplate.class);
-                FileService testFileService = new FileService(appProperties, mockRestTemplate, appSettingServiceForNetwork, mockRestTemplate);
-
-                ResponseEntity<byte[]> redirect1 = ResponseEntity.status(301)
-                        .header("Location", hostnameRedirect).build();
-                ResponseEntity<byte[]> redirect2 = ResponseEntity.status(302)
-                        .header("Location", ipRedirect).build();
-                ResponseEntity<byte[]> imageResponse = ResponseEntity.ok(imageBytes);
-
-                var urlCaptor = ArgumentCaptor.forClass(String.class);
-                when(mockRestTemplate.exchange(
-                        urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
-                )).thenReturn(redirect1, redirect2, imageResponse);
-
-                testFileService.downloadImageFromUrl(originalUrl);
-
-                assertEquals(originalUrl, urlCaptor.getAllValues().get(0));
-                assertEquals(hostnameRedirect, urlCaptor.getAllValues().get(1));
-                assertEquals("http://www.example.com/cover.jpg", urlCaptor.getAllValues().get(2));
-            }
-
-            @Test
-            @DisplayName("throws exception when redirect exceeds max limit")
-            @Timeout(5)
-            void downloadImageFromUrl_tooManyRedirects_throwsException() {
-                String imageUrl = "http://1.1.1.1/cover.jpg";
-
-                RestTemplate mockRestTemplate = mock(RestTemplate.class);
-                FileService testFileService = new FileService(appProperties, mockRestTemplate, appSettingServiceForNetwork, mockRestTemplate);
-
-                ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(302)
-                        .header("Location", "http://2.2.2.2/cover.jpg")
-                        .build();
-
-                when(mockRestTemplate.exchange(
-                        anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
-                )).thenReturn(redirectResponse);
-
-                IOException ex = assertThrows(IOException.class, () ->
-                        testFileService.downloadImageFromUrl(imageUrl));
-                assertTrue(ex.getMessage().contains("Too many redirects"));
-            }
-
-            @Test
-            @DisplayName("throws exception when redirect has no Location header")
-            @Timeout(5)
-            void downloadImageFromUrl_redirectWithoutLocation_throwsException() {
-                String imageUrl = "http://1.1.1.1/image.jpg";
-
-                ResponseEntity<byte[]> redirectResponse = ResponseEntity.status(302).build();
-                when(restTemplate.exchange(
-                        anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(byte[].class)
-                )).thenReturn(redirectResponse);
-
-                IOException ex = assertThrows(IOException.class, () ->
-                        fileService.downloadImageFromUrl(imageUrl));
-                assertTrue(ex.getMessage().contains("Location"));
             }
         }
 
@@ -1482,20 +1284,13 @@ class FileServiceTest {
 
             @Test
             @DisplayName("downloads and saves cover images successfully")
-            @Timeout(5)
             void createThumbnailFromUrl_validImage_createsCoverAndThumbnail() throws IOException {
                 String imageUrl = "http://1.1.1.1/cover.jpg";
                 long bookId = 42L;
                 BufferedImage testImage = createTestImage(800, 1200); // Portrait image
                 byte[] imageBytes = imageToBytes(testImage);
 
-                ResponseEntity<byte[]> responseEntity = ResponseEntity.ok(imageBytes);
-                when(restTemplate.exchange(
-                        anyString(),
-                        eq(HttpMethod.GET),
-                        any(HttpEntity.class),
-                        eq(byte[].class)
-                )).thenReturn(responseEntity);
+                when(untrustedHttpRequestService.request(imageUrl)).thenReturn(imageBytes);
 
                 assertDoesNotThrow(() ->
                         fileService.createThumbnailFromUrl(bookId, imageUrl));
@@ -1511,17 +1306,12 @@ class FileServiceTest {
 
             @Test
             @DisplayName("throws ApiError.FILE_READ_ERROR on download failure")
-            @Timeout(5)
-            void createThumbnailFromUrl_downloadFails_throwsApiError() {
+            void createThumbnailFromUrl_downloadFails_throwsApiError() throws Exception {
                 String imageUrl = "http://example.com/invalid.jpg";
                 long bookId = 42L;
 
-                when(restTemplate.exchange(
-                        anyString(),
-                        eq(HttpMethod.GET),
-                        any(HttpEntity.class),
-                        eq(byte[].class)
-                )).thenThrow(new RuntimeException("Network error"));
+                when(untrustedHttpRequestService.request("http://example.com/invalid.jpg"))
+                        .thenThrow(new RuntimeException("Network error"));
 
                 // FileService wraps exceptions in RuntimeException via ApiError
                 RuntimeException exception = assertThrows(RuntimeException.class, () ->


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->

> [!CAUTION]
> If you are hosting Grimmory in an untrusted environment with untrusted
> users and need the strictest security guarantees an egress gateway such as 
> [Istio][istio] or [Cilium][cilium] should be utilized.


in some cases (mostly enterprise cloud environments) our SSRF protections were not protecting users as well as they could be.  in particular, we allowed IPs in CGNat, v4-to-v6 translation gateways, IPv6 addressing of IPv4 translators, as well as access to addresses considered generally unsafe to allow access to.

This PR introduces:

* a new `RestrictedInetAddressMatcher` component which has a list of restricted ranges (along with comments as to why they are restricted)
* an `UntrustedHttpRequestService` which takes special care over other HTTP clients we utilize which uses `RestrictedInetAddressMatcher` 
* refactoring of the `FileService` to use the new `UntrustedHttpRequestService`

The `RestrictedInetAddressMatcher` detects the following:

- IPv6 Addressing of IPv4/IPv6 Translators - [RFC 6052](https://datatracker.ietf.org/doc/html/rfc6052)
- Local-Use IPv4/IPv6 Translation Prefix - [RFC 8215](https://datatracker.ietf.org/doc/html/rfc8215)
- Connection of IPv6 Domains via IPv4 Clouds - [RFC 3056](https://datatracker.ietf.org/doc/html/rfc3056)
- Initial IPv6 Sub-TLA ID Assignments - [RFC 2928](https://datatracker.ietf.org/doc/html/rfc2928)
- Unique Local IPv6 Unicast Addresses - [RFC 4193](https://datatracker.ietf.org/doc/html/rfc4193)
- Anycast Prefix for 6to4 Relay Routers - [RFC 3068](https://datatracker.ietf.org/doc/html/rfc3068)
- Loopback - [RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)
- Link Local - [RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)
- Private Use - [RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)
- Shared Address Space [RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)
- IETF Protocol Assignments - [RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)
- This host on this network - [RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)
- Private Use - [RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)
- TEST-NET-1 - [RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737)
- TEST-NET-2 - [RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737)
- TEST-NET-3 - [RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737)
- Network Interconnect Device Benchmark Testing - [RFC 2544](https://datatracker.ietf.org/doc/html/rfc2544)
- Limited Broadcast - [RFC 0919](https://datatracker.ietf.org/doc/html/rfc0919)

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
Adds `UntrustedHttpRequestService`
Adds `RestrictedInetAddressMatcher`
Updates `FileService`
Updates related tests

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. Go to book edit metadata
2. Select new cover
3. See new cover get downloaded via new untrusted HTTP Client

Unhappy Path

1. Add `0.0.0.1 m.media-amazon.com` to the container's `/etc/hosts`
2. Select same new cover again
3. See HTTP 500 emitted

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

[istio]: https://istio.io/latest/docs/tasks/traffic-management/egress/egress-gateway
[cilium]: https://cilium.io/use-cases/egress-gateway/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure HTTP and HTTPS requests for downloading remote content.
  - Blocks requests to restricted, private, loopback, and reserved network addresses.
  - Supports controlled redirect handling, including relative redirects, with a five-redirect limit.
  - Validates URLs, hosts, schemes, response statuses, and redirect destinations.

- **Bug Fixes**
  - Improved protection against unsafe image and thumbnail downloads.

- **Tests**
  - Added coverage for address restrictions, hostname resolution, redirects, errors, and download failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->