### PR TITLE
refactor(browse): frontend browse extraction and author query service

### DIFF
--- a/frontend/src/app/core/data/browse-query-keys.spec.ts
+++ b/frontend/src/app/core/data/browse-query-keys.spec.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from 'vitest';
+
+import {
+  BrowseCollectionFilterParams,
+  BrowsePageParams,
+  BrowseQueryParams,
+  normalizeBrowseCollectionFilterParams,
+  normalizeBrowsePageParams,
+} from './browse-query-params';
+import {createBrowseQueryKeys} from './browse-query-keys';
+
+type TestCollectionParams = BrowseCollectionFilterParams<'genre'>;
+type TestQueryParams = BrowseQueryParams<'genre', 'title'>;
+type TestPageParams = BrowsePageParams<'genre', 'title'>;
+
+const query: TestQueryParams = {
+  query: 'dune',
+  facets: {genre: ['Fantasy']},
+  facetLogic: 'or',
+  sort: [{key: 'title', direction: 'asc'}],
+};
+const page = normalizeBrowsePageParams({...query, size: 20});
+const keys = createBrowseQueryKeys<
+  TestCollectionParams,
+  TestQueryParams,
+  TestPageParams
+>('items');
+
+describe('browse query keys', () => {
+  it('keeps bounded and infinite data shapes on different leaves', () => {
+    expect(keys.boundedPage(page)).not.toEqual(keys.infinitePage(page));
+    expect(keys.boundedPage(page).at(-1)).toBe(page);
+    expect(keys.infinitePage(page).at(-1)).toBe(page);
+  });
+
+  it('keeps facet selection as part of query identity', () => {
+    const genreSelected = normalizeBrowseCollectionFilterParams(query);
+    const unfiltered = normalizeBrowseCollectionFilterParams({...query, facets: {}});
+
+    expect(keys.facets(genreSelected)).not.toEqual(keys.facets(unfiltered));
+  });
+});

--- a/frontend/src/app/core/data/browse-query-keys.ts
+++ b/frontend/src/app/core/data/browse-query-keys.ts
@@ -1,0 +1,21 @@
+export function createBrowseQueryKeys<CollectionParams, QueryParams, PageParams>(resource: string) {
+  const all = () => [resource, 'query'] as const;
+  const collections = () => [...all(), 'collection'] as const;
+  const boundedPages = () => [...collections(), 'page', 'bounded'] as const;
+  const infinitePages = () => [...collections(), 'page', 'infinite'] as const;
+  const facetQueries = () => [...collections(), 'facets'] as const;
+  const idQueries = () => [...collections(), 'ids'] as const;
+
+  return {
+    all,
+    collections,
+    boundedPages,
+    boundedPage: (params: PageParams) => [...boundedPages(), params] as const,
+    infinitePages,
+    infinitePage: (params: PageParams) => [...infinitePages(), params] as const,
+    facetQueries,
+    facets: (params: CollectionParams) => [...facetQueries(), params] as const,
+    idQueries,
+    ids: (params: QueryParams) => [...idQueries(), params] as const,
+  };
+}

--- a/frontend/src/app/core/data/browse-query-params.spec.ts
+++ b/frontend/src/app/core/data/browse-query-params.spec.ts
@@ -1,17 +1,17 @@
 import {describe, expect, it} from 'vitest';
 
 import {
-  normalizeBookCollectionFilterParams,
-  normalizeBookQueryParams,
-  normalizeBookPageParams,
-  toCollectionHttpParams,
-  toIdsHttpParams,
-  toPageHttpParams,
-} from './book-query-params';
+  normalizeBrowseCollectionFilterParams,
+  normalizeBrowsePageParams,
+  normalizeBrowseQueryParams,
+  toBrowseCollectionHttpParams,
+  toBrowseIdsHttpParams,
+  toBrowsePageHttpParams,
+} from './browse-query-params';
 
-describe('book query parameters', () => {
+describe('browse query parameters', () => {
   it('normalizes equivalent queries and facet selections', () => {
-    const first = normalizeBookPageParams({
+    const first = normalizeBrowsePageParams({
       query: '  dune  ',
       facets: {
         language: [' French ', 'English'],
@@ -21,7 +21,7 @@ describe('book query parameters', () => {
       sort: [{key: 'title', direction: 'asc'}],
       size: 40,
     });
-    const second = normalizeBookPageParams({
+    const second = normalizeBrowsePageParams({
       query: 'dune',
       facets: {
         genre: ['Fantasy', 'Science Fiction'],
@@ -40,7 +40,7 @@ describe('book query parameters', () => {
   });
 
   it('passes an empty sort through without imposing a default', () => {
-    const normalized = normalizeBookQueryParams({
+    const normalized = normalizeBrowseQueryParams({
       facets: {},
       facetLogic: 'or',
       sort: [],
@@ -50,14 +50,14 @@ describe('book query parameters', () => {
   });
 
   it.each(['and'] as const)('preserves explicit %s facet logic', facetLogic => {
-    const normalized = normalizeBookQueryParams({facets: {}, facetLogic, sort: []});
+    const normalized = normalizeBrowseQueryParams({facets: {}, facetLogic, sort: []});
 
     expect(normalized.facetLogic).toBe(facetLogic);
-    expect(toIdsHttpParams(normalized).get('facet_logic')).toBe(facetLogic);
+    expect(toBrowseIdsHttpParams(normalized).get('facet_logic')).toBe(facetLogic);
   });
 
   it('serializes page parameters using the backend vocabulary', () => {
-    const params = toPageHttpParams(normalizeBookPageParams({
+    const params = toBrowsePageHttpParams(normalizeBrowsePageParams({
       query: 'dune',
       facets: {
         genre: ['Science Fiction'],
@@ -80,7 +80,7 @@ describe('book query parameters', () => {
   });
 
   it('excludes sort and size from facet requests', () => {
-    const params = toCollectionHttpParams(normalizeBookCollectionFilterParams({
+    const params = toBrowseCollectionHttpParams(normalizeBrowseCollectionFilterParams({
       query: 'dune',
       facets: {genre: ['Fantasy']},
       facetLogic: 'and',
@@ -94,7 +94,7 @@ describe('book query parameters', () => {
   });
 
   it('does not emit facet parameters for an empty selection', () => {
-    const params = toCollectionHttpParams(normalizeBookCollectionFilterParams({
+    const params = toBrowseCollectionHttpParams(normalizeBrowseCollectionFilterParams({
       facets: {},
       facetLogic: 'or',
     }));
@@ -103,7 +103,7 @@ describe('book query parameters', () => {
   });
 
   it('includes sort but excludes size from ID requests', () => {
-    const params = toIdsHttpParams(normalizeBookQueryParams({
+    const params = toBrowseIdsHttpParams(normalizeBrowseQueryParams({
       facets: {},
       facetLogic: 'or',
       sort: [{key: 'title', direction: 'desc'}],

--- a/frontend/src/app/core/data/browse-query-params.ts
+++ b/frontend/src/app/core/data/browse-query-params.ts
@@ -1,0 +1,132 @@
+import {HttpParams} from '@angular/common/http';
+
+import {
+  BrowseFacetLogic,
+  BrowseSortTerm,
+} from './browse.models';
+
+export type BrowseFacetValueMap<Key extends string> =
+  Readonly<Partial<Record<Key, readonly string[]>>>;
+
+export interface BrowseCollectionFilterParams<FacetKey extends string> {
+  query?: string;
+  facets: BrowseFacetValueMap<FacetKey>;
+  facetLogic: BrowseFacetLogic;
+}
+
+export interface BrowseQueryParams<FacetKey extends string, SortKey extends string>
+  extends BrowseCollectionFilterParams<FacetKey> {
+  sort: readonly BrowseSortTerm<SortKey>[];
+}
+
+export interface BrowsePageParams<FacetKey extends string, SortKey extends string>
+  extends BrowseQueryParams<FacetKey, SortKey> {
+  size: number;
+}
+
+export function normalizeBrowsePageParams<FacetKey extends string, SortKey extends string>(
+  params: BrowsePageParams<FacetKey, SortKey>,
+): BrowsePageParams<FacetKey, SortKey> {
+  return {
+    ...normalizeBrowseQueryParams(params),
+    size: params.size,
+  };
+}
+
+export function normalizeBrowseQueryParams<FacetKey extends string, SortKey extends string>(
+  params: BrowseQueryParams<FacetKey, SortKey>,
+): BrowseQueryParams<FacetKey, SortKey> {
+  return {
+    ...normalizeBrowseCollectionFilterParams(params),
+    sort: params.sort,
+  };
+}
+
+export function normalizeBrowseCollectionFilterParams<FacetKey extends string>(
+  params: BrowseCollectionFilterParams<FacetKey>,
+): BrowseCollectionFilterParams<FacetKey> {
+  const query = params.query?.trim();
+  const facets = normalizeFacetValueMap(params.facets);
+
+  return {
+    ...(query ? {query} : {}),
+    facets,
+    facetLogic: params.facetLogic,
+  };
+}
+
+export function toBrowsePageHttpParams<FacetKey extends string, SortKey extends string>(
+  params: BrowsePageParams<FacetKey, SortKey>,
+): HttpParams {
+  return appendSortParam(toBrowseCollectionHttpParams(params), params.sort)
+    .set('size', params.size.toString());
+}
+
+export function toBrowseIdsHttpParams<FacetKey extends string, SortKey extends string>(
+  params: BrowseQueryParams<FacetKey, SortKey>,
+): HttpParams {
+  return appendSortParam(toBrowseCollectionHttpParams(params), params.sort);
+}
+
+export function toBrowseCollectionHttpParams<FacetKey extends string>(
+  params: BrowseCollectionFilterParams<FacetKey>,
+): HttpParams {
+  let httpParams = new HttpParams().set('facet_logic', params.facetLogic);
+
+  if (params.query) {
+    httpParams = httpParams.set('query', params.query);
+  }
+
+  return appendFacetParams(httpParams, params.facets);
+}
+
+function appendSortParam<SortKey extends string>(
+  httpParams: HttpParams,
+  sort: readonly BrowseSortTerm<SortKey>[],
+): HttpParams {
+  return sort.length === 0 ? httpParams : httpParams.set('sort', serializeSort(sort));
+}
+
+function normalizeFacetValueMap<Key extends string>(
+  facets: BrowseFacetValueMap<Key>,
+): BrowseFacetValueMap<Key> {
+  const normalized: Partial<Record<Key, readonly string[]>> = {};
+  const keys = (Object.keys(facets) as Key[]).sort(compareCodeUnits);
+
+  for (const key of keys) {
+    const values = [...new Set((facets[key] ?? [])
+      .map(value => value.trim())
+      .filter(Boolean))].sort(compareCodeUnits);
+    if (values.length > 0) {
+      normalized[key] = values;
+    }
+  }
+
+  return normalized;
+}
+
+function appendFacetParams<Key extends string>(
+  httpParams: HttpParams,
+  facets: BrowseFacetValueMap<Key>,
+): HttpParams {
+  let result = httpParams;
+  for (const key of Object.keys(facets) as Key[]) {
+    for (const value of facets[key] ?? []) {
+      result = result.append('facet', `${key}:${value}`);
+    }
+  }
+
+  return result;
+}
+
+function serializeSort<SortKey extends string>(
+  sort: readonly BrowseSortTerm<SortKey>[],
+): string {
+  return sort
+    .map(term => `${term.direction === 'desc' ? '-' : ''}${term.key}`)
+    .join(',');
+}
+
+function compareCodeUnits(first: string, second: string): number {
+  return first < second ? -1 : first > second ? 1 : 0;
+}

--- a/frontend/src/app/core/data/browse-query.service.spec.ts
+++ b/frontend/src/app/core/data/browse-query.service.spec.ts
@@ -1,0 +1,220 @@
+import {HttpClient} from '@angular/common/http';
+import {HttpTestingController} from '@angular/common/http/testing';
+import {Injectable, inject} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {injectInfiniteQuery, QueryClient} from '@tanstack/angular-query-experimental';
+import {afterEach, beforeEach, describe, expect, expectTypeOf, it, vi} from 'vitest';
+
+import {API_CONFIG} from '../config/api-config';
+import {
+  createAuthServiceStub,
+  createQueryClientHarness,
+  flushSignalAndQueryEffects,
+} from '../testing/query-testing';
+import {AuthService} from '../../shared/service/auth.service';
+import {createBrowseQueryKeys} from './browse-query-keys';
+import {BrowsePageParams} from './browse-query-params';
+import {BrowsePage} from './browse.models';
+import {BrowseQueryService} from './browse-query.service';
+
+type TestFacetKey = 'genre';
+type TestSortKey = 'name';
+
+interface TestSummary {
+  id: string;
+  name: string;
+}
+
+type TestPageParams = BrowsePageParams<TestFacetKey, TestSortKey>;
+
+const PARAMS: TestPageParams = {
+  query: '  earthsea  ',
+  facets: {genre: ['Fantasy']},
+  facetLogic: 'or',
+  sort: [{key: 'name', direction: 'asc'}],
+  size: 20,
+};
+
+const testQueryKeys = createBrowseQueryKeys<
+  Omit<TestPageParams, 'sort' | 'size'>,
+  Omit<TestPageParams, 'size'>,
+  TestPageParams
+>('test-items');
+
+function page(ids: string[]): BrowsePage<TestSummary> {
+  return {
+    content: ids.map(id => ({id, name: id})),
+    page: {
+      number: 0,
+      size: 20,
+      totalElements: ids.length,
+      totalPages: ids.length === 0 ? 0 : 1,
+      cursor: 'opaque-cursor',
+    },
+    links: [],
+  };
+}
+
+@Injectable()
+class TestBrowseQueryService extends BrowseQueryService<
+  TestSummary,
+  TestFacetKey,
+  TestSortKey
+> {
+  constructor() {
+    super(
+      inject(HttpClient),
+      inject(AuthService),
+      inject(QueryClient),
+      `${API_CONFIG.BASE_URL}/api/v1/test-items`,
+      testQueryKeys,
+    );
+  }
+}
+
+@Injectable()
+class InfiniteQueryHost {
+  private readonly service = inject(TestBrowseQueryService);
+  readonly query = injectInfiniteQuery(() => this.service.infinitePage(PARAMS));
+}
+
+describe('BrowseQueryService', () => {
+  let service: TestBrowseQueryService;
+  let queryClient: QueryClient;
+  let authService: ReturnType<typeof createAuthServiceStub>;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    const harness = createQueryClientHarness();
+    queryClient = harness.queryClient;
+    authService = createAuthServiceStub();
+    queryClient.setDefaultOptions({queries: {retry: false}});
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...harness.providers,
+        {provide: AuthService, useValue: authService},
+        TestBrowseQueryService,
+        InfiniteQueryHost,
+      ],
+    });
+
+    service = TestBed.inject(TestBrowseQueryService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+    vi.restoreAllMocks();
+  });
+
+  it('removes its resource cache when the authenticated session ends', () => {
+    const key = testQueryKeys.boundedPage(PARAMS);
+    queryClient.setQueryData(key, page(['earthsea']));
+
+    authService.token.set(null);
+    flushSignalAndQueryEffects();
+
+    expect(queryClient.getQueryData(key)).toBeUndefined();
+  });
+
+  it('fetches one normalized bounded page', async () => {
+    const resultPromise = queryClient.fetchQuery(service.page(PARAMS));
+    const request = http.expectOne(
+      `${API_CONFIG.BASE_URL}/api/v1/test-items/page?facet_logic=or&query=earthsea&facet=genre:Fantasy&sort=name&size=20`,
+    );
+    request.flush(page(['earthsea']));
+
+    await expect(resultPromise).resolves.toMatchObject({content: [{id: 'earthsea'}]});
+  });
+
+  it('maps facet responses without page-only parameters', async () => {
+    const resultPromise = queryClient.fetchQuery(service.facets(PARAMS));
+    const request = http.expectOne(
+      `${API_CONFIG.BASE_URL}/api/v1/test-items/facets?facet_logic=or&query=earthsea&facet=genre:Fantasy`,
+    );
+    request.flush({
+      facets: [{
+        metadata: {rel: 'facet', key: 'genre', title: 'Genre'},
+        links: [{
+          rel: ['self', 'facet'],
+          href: '/api/v1/test-items/page?facet=genre%3AFantasy',
+          type: 'application/json',
+          title: 'Fantasy',
+          value: 'Fantasy',
+          properties: {numberOfItems: 4},
+        }],
+      }],
+    });
+
+    await expect(resultPromise).resolves.toEqual([{
+      rel: 'facet',
+      key: 'genre',
+      title: 'Genre',
+      values: [{value: 'Fantasy', title: 'Fantasy', count: 4, selected: true}],
+    }]);
+  });
+
+  it('supports string resource IDs and excludes page size from ID requests', async () => {
+    const resultPromise = queryClient.fetchQuery(service.ids(PARAMS));
+    expectTypeOf(resultPromise).toEqualTypeOf<Promise<string[]>>();
+    const request = http.expectOne(
+      `${API_CONFIG.BASE_URL}/api/v1/test-items/ids?facet_logic=or&query=earthsea&facet=genre:Fantasy&sort=name`,
+    );
+    request.flush(['earthsea', 'the-expanse']);
+
+    await expect(resultPromise).resolves.toEqual(['earthsea', 'the-expanse']);
+  });
+
+  it('follows the exact next href for an infinite query', async () => {
+    const host = TestBed.inject(InfiniteQueryHost);
+    flushSignalAndQueryEffects();
+
+    const firstRequest = http.expectOne(
+      `${API_CONFIG.BASE_URL}/api/v1/test-items/page?facet_logic=or&query=earthsea&facet=genre:Fantasy&sort=name&size=20`,
+    );
+    firstRequest.flush({
+      ...page(['earthsea']),
+      links: [{
+        rel: 'next',
+        href: '/api/v1/test-items/page?facet=genre%3AFantasy&cursor=opaque',
+        type: 'application/json',
+      }],
+    });
+    await vi.waitFor(() => expect(host.query.isSuccess()).toBe(true));
+
+    const nextPromise = host.query.fetchNextPage();
+    http.expectOne(
+      `${API_CONFIG.BASE_URL}/api/v1/test-items/page?facet=genre%3AFantasy&cursor=opaque`,
+    ).flush(page(['the-expanse']));
+    const nextResult = await nextPromise;
+
+    expect(nextResult.data?.pages.flatMap(current => current.content.map(item => item.id)))
+      .toEqual(['earthsea', 'the-expanse']);
+  });
+
+  it('stops paging when the backend emits no next link', async () => {
+    const host = TestBed.inject(InfiniteQueryHost);
+    flushSignalAndQueryEffects();
+
+    http.expectOne(
+      `${API_CONFIG.BASE_URL}/api/v1/test-items/page?facet_logic=or&query=earthsea&facet=genre:Fantasy&sort=name&size=20`,
+    ).flush(page(['earthsea']));
+    await vi.waitFor(() => expect(host.query.isSuccess()).toBe(true));
+
+    expect(host.query.hasNextPage()).toBe(false);
+  });
+
+  it('cancels an active HTTP request through the query signal', async () => {
+    const options = service.page(PARAMS);
+    const resultPromise = queryClient.fetchQuery(options);
+    const request = http.expectOne(
+      `${API_CONFIG.BASE_URL}/api/v1/test-items/page?facet_logic=or&query=earthsea&facet=genre:Fantasy&sort=name&size=20`,
+    );
+
+    await queryClient.cancelQueries({queryKey: options.queryKey});
+
+    expect(request.cancelled).toBe(true);
+    await expect(resultPromise).rejects.toBeDefined();
+  });
+});

--- a/frontend/src/app/core/data/browse-query.service.ts
+++ b/frontend/src/app/core/data/browse-query.service.ts
@@ -1,0 +1,144 @@
+import {HttpClient, HttpParams} from '@angular/common/http';
+import {effect} from '@angular/core';
+import {
+  infiniteQueryOptions,
+  queryOptions,
+  QueryClient,
+} from '@tanstack/angular-query-experimental';
+import {lastValueFrom, takeUntil} from 'rxjs';
+
+import {API_CONFIG} from '../config/api-config';
+import {AuthService} from '../../shared/service/auth.service';
+import {
+  BrowseCollectionFilterParams,
+  BrowsePageParams,
+  BrowseQueryParams,
+  normalizeBrowseCollectionFilterParams,
+  normalizeBrowsePageParams,
+  normalizeBrowseQueryParams,
+  toBrowseCollectionHttpParams,
+  toBrowseIdsHttpParams,
+  toBrowsePageHttpParams,
+} from './browse-query-params';
+import {BrowsePage, findBrowsePageLink} from './browse.models';
+import {mapBrowseFacetGroups, mapBrowsePage} from './browse-response';
+import {abortSignal, QUERY_DEFAULTS} from './query-transport';
+
+interface BrowseQueryKeys<CollectionParams, QueryParams, PageParams> {
+  all: () => readonly unknown[];
+  boundedPage: (params: PageParams) => readonly unknown[];
+  infinitePage: (params: PageParams) => readonly unknown[];
+  facets: (params: CollectionParams) => readonly unknown[];
+  ids: (params: QueryParams) => readonly unknown[];
+}
+
+export abstract class BrowseQueryService<
+  Summary extends {id: string | number},
+  FacetKey extends string,
+  SortKey extends string,
+> {
+  protected constructor(
+    protected readonly http: HttpClient,
+    authService: AuthService,
+    queryClient: QueryClient,
+    private readonly baseUrl: string,
+    private readonly keys: BrowseQueryKeys<
+      BrowseCollectionFilterParams<FacetKey>,
+      BrowseQueryParams<FacetKey, SortKey>,
+      BrowsePageParams<FacetKey, SortKey>
+    >,
+  ) {
+    effect(() => {
+      if (authService.token() === null) {
+        queryClient.removeQueries({queryKey: keys.all()});
+      }
+    });
+  }
+
+  page(params: BrowsePageParams<FacetKey, SortKey>) {
+    const normalized = normalizeBrowsePageParams(params);
+
+    return queryOptions({
+      queryKey: this.keys.boundedPage(normalized),
+      queryFn: ({signal}) => this.fetchPage(normalized, null, signal),
+      ...QUERY_DEFAULTS,
+    });
+  }
+
+  infinitePage(params: BrowsePageParams<FacetKey, SortKey>) {
+    const normalized = normalizeBrowsePageParams(params);
+
+    return infiniteQueryOptions({
+      queryKey: this.keys.infinitePage(normalized),
+      queryFn: ({pageParam, signal}) => this.fetchPage(normalized, pageParam, signal),
+      initialPageParam: null as string | null,
+      getNextPageParam: page => findBrowsePageLink(page, 'next')?.href,
+      ...QUERY_DEFAULTS,
+    });
+  }
+
+  facets(params: BrowseCollectionFilterParams<FacetKey>) {
+    const normalized = normalizeBrowseCollectionFilterParams(params);
+
+    return queryOptions({
+      queryKey: this.keys.facets(normalized),
+      queryFn: ({signal}) => this.getMapped(
+        `${this.baseUrl}/facets`,
+        signal,
+        mapBrowseFacetGroups,
+        toBrowseCollectionHttpParams(normalized),
+      ),
+      ...QUERY_DEFAULTS,
+    });
+  }
+
+  ids(params: BrowseQueryParams<FacetKey, SortKey>) {
+    const normalized = normalizeBrowseQueryParams(params);
+
+    return queryOptions({
+      queryKey: this.keys.ids(normalized),
+      queryFn: ({signal}) => this.get<Summary['id'][]>(
+        `${this.baseUrl}/ids`,
+        signal,
+        toBrowseIdsHttpParams(normalized),
+      ),
+      ...QUERY_DEFAULTS,
+      staleTime: 0,
+      gcTime: 0,
+    });
+  }
+
+  protected get<T>(url: string, signal: AbortSignal, params?: HttpParams): Promise<T> {
+    return lastValueFrom(this.http.get<T>(url, {params}).pipe(takeUntil(abortSignal(signal))));
+  }
+
+  private fetchPage(
+    params: BrowsePageParams<FacetKey, SortKey>,
+    nextHref: string | null,
+    signal: AbortSignal,
+  ): Promise<BrowsePage<Summary>> {
+    if (nextHref !== null) {
+      return this.getMapped(
+        `${API_CONFIG.BASE_URL}${nextHref}`,
+        signal,
+        mapBrowsePage<Summary>,
+      );
+    }
+
+    return this.getMapped(
+      `${this.baseUrl}/page`,
+      signal,
+      mapBrowsePage<Summary>,
+      toBrowsePageHttpParams(params),
+    );
+  }
+
+  private getMapped<Raw, Result>(
+    url: string,
+    signal: AbortSignal,
+    project: (value: Raw) => Result,
+    params?: HttpParams,
+  ): Promise<Result> {
+    return this.get<Raw>(url, signal, params).then(project);
+  }
+}

--- a/frontend/src/app/core/data/query-transport.spec.ts
+++ b/frontend/src/app/core/data/query-transport.spec.ts
@@ -1,0 +1,18 @@
+import {HttpErrorResponse} from '@angular/common/http';
+import {describe, expect, it} from 'vitest';
+
+import {retryTransientQueryError} from './query-transport';
+
+describe('query transport', () => {
+  it('retries only transient failures and only twice', () => {
+    const networkError = new HttpErrorResponse({status: 0});
+    const badRequest = new HttpErrorResponse({status: 400});
+    const serverError = new HttpErrorResponse({status: 503});
+
+    expect(retryTransientQueryError(0, networkError)).toBe(true);
+    expect(retryTransientQueryError(0, badRequest)).toBe(false);
+    expect(retryTransientQueryError(0, serverError)).toBe(true);
+    expect(retryTransientQueryError(0, new Error('Unexpected failure'))).toBe(false);
+    expect(retryTransientQueryError(2, serverError)).toBe(false);
+  });
+});

--- a/frontend/src/app/features/author-browser/data/author-query-keys.ts
+++ b/frontend/src/app/features/author-browser/data/author-query-keys.ts
@@ -1,0 +1,18 @@
+import {createBrowseQueryKeys} from '../../../core/data/browse-query-keys';
+import {
+  AuthorCollectionFilterParams,
+  AuthorPageParams,
+  AuthorQueryParams,
+} from './author-query-params';
+
+const browseAuthorQueryKeys = createBrowseQueryKeys<
+  AuthorCollectionFilterParams,
+  AuthorQueryParams,
+  AuthorPageParams
+>('authors');
+
+export const authorQueryKeys = {
+  ...browseAuthorQueryKeys,
+  details: () => [...authorQueryKeys.all(), 'detail'] as const,
+  detail: (authorId: number) => [...authorQueryKeys.details(), authorId] as const,
+};

--- a/frontend/src/app/features/author-browser/data/author-query-params.ts
+++ b/frontend/src/app/features/author-browser/data/author-query-params.ts
@@ -1,0 +1,45 @@
+import {
+  BrowseCollectionFilterParams,
+  BrowseFacetValueMap,
+  BrowsePageParams,
+  BrowseQueryParams,
+} from '../../../core/data/browse-query-params';
+import {BrowseSortTerm} from '../../../core/data/browse.models';
+
+export const AUTHOR_QUERY_FACET_KEYS = [
+  'has_asin',
+  'has_photo',
+  'has_description',
+  'read_status',
+  'book_count',
+  'library',
+  'genre',
+  'language',
+] as const;
+
+export const AUTHOR_QUERY_SORT_KEYS = [
+  'name',
+  'sortName',
+  'bookCount',
+  'seriesCount',
+  'addedOn',
+  'lastReadTime',
+  'personalRating',
+  'amazonRating',
+  'goodreadsRating',
+  'hardcoverRating',
+  'ranobedbRating',
+] as const;
+
+export type AuthorQueryFacetKey = typeof AUTHOR_QUERY_FACET_KEYS[number];
+export type AuthorQuerySortKey = typeof AUTHOR_QUERY_SORT_KEYS[number];
+export type AuthorFacetValueMap = BrowseFacetValueMap<AuthorQueryFacetKey>;
+export type AuthorSortTerm = BrowseSortTerm<AuthorQuerySortKey>;
+export type AuthorCollectionFilterParams = BrowseCollectionFilterParams<AuthorQueryFacetKey>;
+export type AuthorQueryParams = BrowseQueryParams<AuthorQueryFacetKey, AuthorQuerySortKey>;
+export type AuthorPageParams = BrowsePageParams<AuthorQueryFacetKey, AuthorQuerySortKey>;
+
+export const EMPTY_AUTHOR_FACET_SELECTION: AuthorFacetValueMap = {};
+export const DEFAULT_AUTHOR_SORT_TERMS: readonly AuthorSortTerm[] = [
+  {key: 'name', direction: 'asc'},
+];

--- a/frontend/src/app/features/author-browser/data/author-query.models.ts
+++ b/frontend/src/app/features/author-browser/data/author-query.models.ts
@@ -1,0 +1,5 @@
+import {BrowseFacetGroup, BrowsePage} from '../../../core/data/browse.models';
+import {AuthorSummary} from './author-response.models';
+
+export type AuthorPage = BrowsePage<AuthorSummary>;
+export type AuthorFacetGroup = BrowseFacetGroup;

--- a/frontend/src/app/features/author-browser/data/author-query.service.spec.ts
+++ b/frontend/src/app/features/author-browser/data/author-query.service.spec.ts
@@ -1,0 +1,94 @@
+import {HttpTestingController} from '@angular/common/http/testing';
+import {TestBed} from '@angular/core/testing';
+import {QueryClient} from '@tanstack/angular-query-experimental';
+import {afterEach, beforeEach, describe, expect, expectTypeOf, it} from 'vitest';
+
+import {API_CONFIG} from '../../../core/config/api-config';
+import {
+  createAuthServiceStub,
+  createQueryClientHarness,
+} from '../../../core/testing/query-testing';
+import {AuthService} from '../../../shared/service/auth.service';
+import {AuthorPageParams} from './author-query-params';
+import {AuthorPage} from './author-query.models';
+import {AuthorQueryService} from './author-query.service';
+import {AuthorDetail} from './author-response.models';
+
+const PARAMS: AuthorPageParams = {
+  query: '  le guin  ',
+  facets: {has_photo: ['true']},
+  facetLogic: 'or',
+  sort: [{key: 'name', direction: 'asc'}],
+  size: 20,
+};
+
+function page(): AuthorPage {
+  return {
+    content: [{id: 7, name: 'Ursula K. Le Guin', bookCount: 4, hasPhoto: true}],
+    page: {
+      number: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+      cursor: 'opaque-cursor',
+    },
+    links: [],
+  };
+}
+
+describe('AuthorQueryService', () => {
+  let service: AuthorQueryService;
+  let queryClient: QueryClient;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    const harness = createQueryClientHarness();
+    queryClient = harness.queryClient;
+    queryClient.setDefaultOptions({queries: {retry: false}});
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...harness.providers,
+        {provide: AuthService, useValue: createAuthServiceStub()},
+        AuthorQueryService,
+      ],
+    });
+
+    service = TestBed.inject(AuthorQueryService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('binds a normalized author request to the shared browse page contract', async () => {
+    const resultPromise = queryClient.fetchQuery(service.page(PARAMS));
+    expectTypeOf(resultPromise).toEqualTypeOf<Promise<AuthorPage>>();
+
+    http.expectOne(
+      `${API_CONFIG.BASE_URL}/api/v1/authors/page?facet_logic=or&query=le%20guin&facet=has_photo:true&sort=name&size=20`,
+    ).flush(page());
+
+    await expect(resultPromise).resolves.toMatchObject({
+      content: [{id: 7, name: 'Ursula K. Le Guin'}],
+    });
+  });
+
+  it('fetches author detail', async () => {
+    const resultPromise = queryClient.fetchQuery(service.detail(7));
+    expectTypeOf(resultPromise).toEqualTypeOf<Promise<AuthorDetail>>();
+
+    const response: AuthorDetail = {
+      id: 7,
+      name: 'Ursula K. Le Guin',
+      description: 'American author.',
+      asin: 'B000AQ1X2C',
+      nameLocked: false,
+      descriptionLocked: false,
+      asinLocked: false,
+      photoLocked: false,
+    };
+    http.expectOne(`${API_CONFIG.BASE_URL}/api/v1/authors/7`).flush(response);
+
+    await expect(resultPromise).resolves.toEqual(response);
+  });
+});

--- a/frontend/src/app/features/author-browser/data/author-query.service.ts
+++ b/frontend/src/app/features/author-browser/data/author-query.service.ts
@@ -1,0 +1,44 @@
+import {HttpClient} from '@angular/common/http';
+import {inject, Injectable} from '@angular/core';
+import {queryOptions, QueryClient} from '@tanstack/angular-query-experimental';
+
+import {API_CONFIG} from '../../../core/config/api-config';
+import {BrowseQueryService} from '../../../core/data/browse-query.service';
+import {QUERY_DEFAULTS} from '../../../core/data/query-transport';
+import {AuthService} from '../../../shared/service/auth.service';
+import {authorQueryKeys} from './author-query-keys';
+import {
+  AuthorQueryFacetKey,
+  AuthorQuerySortKey,
+} from './author-query-params';
+import {AuthorDetail, AuthorSummary} from './author-response.models';
+
+@Injectable({providedIn: 'root'})
+export class AuthorQueryService extends BrowseQueryService<
+  AuthorSummary,
+  AuthorQueryFacetKey,
+  AuthorQuerySortKey
+> {
+  private static readonly BASE_URL = `${API_CONFIG.BASE_URL}/api/v1/authors`;
+
+  constructor() {
+    super(
+      inject(HttpClient),
+      inject(AuthService),
+      inject(QueryClient),
+      AuthorQueryService.BASE_URL,
+      authorQueryKeys,
+    );
+  }
+
+  detail(authorId: number) {
+    return queryOptions({
+      queryKey: authorQueryKeys.detail(authorId),
+      queryFn: ({signal}): Promise<AuthorDetail> => this.get<AuthorDetail>(
+        `${AuthorQueryService.BASE_URL}/${authorId}`,
+        signal,
+      ),
+      ...QUERY_DEFAULTS,
+    });
+  }
+}

--- a/frontend/src/app/features/author-browser/data/author-response.models.ts
+++ b/frontend/src/app/features/author-browser/data/author-response.models.ts
@@ -1,0 +1,18 @@
+export interface AuthorSummary {
+  id: number;
+  name: string;
+  asin?: string;
+  bookCount: number;
+  hasPhoto: boolean;
+}
+
+export interface AuthorDetail {
+  id: number;
+  name: string;
+  description?: string;
+  asin?: string;
+  nameLocked: boolean;
+  descriptionLocked: boolean;
+  asinLocked: boolean;
+  photoLocked: boolean;
+}

--- a/frontend/src/app/features/book/data/book-query-cache.spec.ts
+++ b/frontend/src/app/features/book/data/book-query-cache.spec.ts
@@ -1,17 +1,17 @@
 import {QueryClient, QueryObserver} from '@tanstack/angular-query-experimental';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
+import {normalizeBrowsePageParams} from '../../../core/data/browse-query-params';
 import {
   invalidateAllBookQueries,
   invalidateBookCollections,
   applyBookQueryChangeSet,
 } from './book-query-cache';
 import {bookQueryKeys} from './book-query-keys';
-import {normalizeBookPageParams} from './book-query-params';
 
 const firstBook = {id: 1};
 const secondBook = {id: 2};
-const pageKey = bookQueryKeys.boundedPage(normalizeBookPageParams({
+const pageKey = bookQueryKeys.boundedPage(normalizeBrowsePageParams({
   facets: {},
   facetLogic: 'or',
   sort: [],

--- a/frontend/src/app/features/book/data/book-query-keys.spec.ts
+++ b/frontend/src/app/features/book/data/book-query-keys.spec.ts
@@ -1,10 +1,10 @@
 import {describe, expect, it} from 'vitest';
 
 import {
-  normalizeBookCollectionFilterParams,
-  normalizeBookQueryParams,
-  normalizeBookPageParams,
-} from './book-query-params';
+  normalizeBrowseCollectionFilterParams,
+  normalizeBrowsePageParams,
+  normalizeBrowseQueryParams,
+} from '../../../core/data/browse-query-params';
 import {bookQueryKeys} from './book-query-keys';
 
 describe('book query keys', () => {
@@ -14,14 +14,14 @@ describe('book query keys', () => {
     facetLogic: 'or' as const,
     sort: [{key: 'title', direction: 'asc'}] as const,
   };
-  const page = normalizeBookPageParams({...query, size: 20});
+  const page = normalizeBrowsePageParams({...query, size: 20});
 
   it('roots every read under the unified book-query prefix', () => {
     const keys = [
       bookQueryKeys.boundedPage(page),
       bookQueryKeys.infinitePage(page),
-      bookQueryKeys.facets(normalizeBookCollectionFilterParams(query)),
-      bookQueryKeys.ids(normalizeBookQueryParams(query)),
+      bookQueryKeys.facets(normalizeBrowseCollectionFilterParams(query)),
+      bookQueryKeys.ids(normalizeBrowseQueryParams(query)),
       bookQueryKeys.detail(12, true),
       bookQueryKeys.recommendation(12, 20),
     ];
@@ -30,19 +30,6 @@ describe('book query keys', () => {
     for (const key of keys) {
       expect(key.slice(0, 2)).toEqual(bookQueryKeys.all());
     }
-  });
-
-  it('keeps bounded and infinite data shapes on different leaves', () => {
-    expect(bookQueryKeys.boundedPage(page)).not.toEqual(bookQueryKeys.infinitePage(page));
-    expect(bookQueryKeys.boundedPage(page).at(-1)).toBe(page);
-    expect(bookQueryKeys.infinitePage(page).at(-1)).toBe(page);
-  });
-
-  it('keeps facet selection as part of query identity', () => {
-    const genreSelected = normalizeBookCollectionFilterParams(query);
-    const unfiltered = normalizeBookCollectionFilterParams({...query, facets: {}});
-
-    expect(bookQueryKeys.facets(genreSelected)).not.toEqual(bookQueryKeys.facets(unfiltered));
   });
 
   it('nests every leaf under the prefix its invalidation targets', () => {

--- a/frontend/src/app/features/book/data/book-query-keys.ts
+++ b/frontend/src/app/features/book/data/book-query-keys.ts
@@ -1,24 +1,18 @@
+import {createBrowseQueryKeys} from '../../../core/data/browse-query-keys';
 import {
   BookCollectionFilterParams,
   BookPageParams,
   BookQueryParams,
 } from './book-query-params';
 
+const browseBookQueryKeys = createBrowseQueryKeys<
+  BookCollectionFilterParams,
+  BookQueryParams,
+  BookPageParams
+>('books');
+
 export const bookQueryKeys = {
-  all: () => ['books', 'query'] as const,
-  collections: () => [...bookQueryKeys.all(), 'collection'] as const,
-  boundedPages: () => [...bookQueryKeys.collections(), 'page', 'bounded'] as const,
-  boundedPage: (params: BookPageParams) =>
-    [...bookQueryKeys.boundedPages(), params] as const,
-  infinitePages: () => [...bookQueryKeys.collections(), 'page', 'infinite'] as const,
-  infinitePage: (params: BookPageParams) =>
-    [...bookQueryKeys.infinitePages(), params] as const,
-  facetQueries: () => [...bookQueryKeys.collections(), 'facets'] as const,
-  facets: (params: BookCollectionFilterParams) =>
-    [...bookQueryKeys.facetQueries(), params] as const,
-  idQueries: () => [...bookQueryKeys.collections(), 'ids'] as const,
-  ids: (params: BookQueryParams) =>
-    [...bookQueryKeys.idQueries(), params] as const,
+  ...browseBookQueryKeys,
   details: () => [...bookQueryKeys.all(), 'detail'] as const,
   detailQueries: (bookId: number) =>
     [...bookQueryKeys.details(), bookId] as const,

--- a/frontend/src/app/features/book/data/book-query-params.ts
+++ b/frontend/src/app/features/book/data/book-query-params.ts
@@ -1,10 +1,15 @@
-import {HttpParams} from '@angular/common/http';
-
+import {
+  BrowseCollectionFilterParams,
+  BrowseFacetValueMap,
+  BrowsePageParams as SharedBrowsePageParams,
+  BrowseQueryParams as SharedBrowseQueryParams,
+} from '../../../core/data/browse-query-params';
 import {
   BrowseFacetLogic,
   BrowseSortDirection,
   BrowseSortTerm,
 } from '../../../core/data/browse.models';
+
 export const BOOK_QUERY_FACET_KEYS = [
   'author',
   'series',
@@ -62,26 +67,18 @@ export const BOOK_QUERY_SORT_KEYS = [
 export type BookQueryFacetKey = typeof BOOK_QUERY_FACET_KEYS[number];
 export type BookQuerySortKey = typeof BOOK_QUERY_SORT_KEYS[number];
 export type FacetLogic = BrowseFacetLogic;
-export type FacetValueMap = Readonly<Partial<Record<BookQueryFacetKey, readonly string[]>>>;
+export type FacetValueMap = BrowseFacetValueMap<BookQueryFacetKey>;
 export type SortDirection = BrowseSortDirection;
 
 export const EMPTY_FACET_SELECTION: FacetValueMap = {};
 
 export type BookSortTerm = BrowseSortTerm<BookQuerySortKey>;
 
-export interface BookCollectionFilterParams {
-  query?: string;
-  facets: FacetValueMap;
-  facetLogic: FacetLogic;
-}
+export type BookCollectionFilterParams = BrowseCollectionFilterParams<BookQueryFacetKey>;
 
-export interface BookQueryParams extends BookCollectionFilterParams {
-  sort: readonly BookSortTerm[];
-}
+export type BookQueryParams = SharedBrowseQueryParams<BookQueryFacetKey, BookQuerySortKey>;
 
-export interface BookPageParams extends BookQueryParams {
-  size: number;
-}
+export type BookPageParams = SharedBrowsePageParams<BookQueryFacetKey, BookQuerySortKey>;
 
 export interface BookDescriptionOptions {
   withDescription: boolean;
@@ -97,86 +94,4 @@ export function isBookQueryFacetKey(value: string): value is BookQueryFacetKey {
 
 export function isBookQuerySortKey(value: string): value is BookQuerySortKey {
   return BOOK_QUERY_SORT_KEY_SET.has(value);
-}
-
-export function normalizeBookPageParams(params: BookPageParams): BookPageParams {
-  return {
-    ...normalizeBookQueryParams(params),
-    size: params.size,
-  };
-}
-
-export function toPageHttpParams(params: BookPageParams): HttpParams {
-  return appendSortParam(toCollectionHttpParams(params), params.sort)
-    .set('size', params.size.toString());
-}
-
-export function toIdsHttpParams(params: BookQueryParams): HttpParams {
-  return appendSortParam(toCollectionHttpParams(params), params.sort);
-}
-
-function appendSortParam(httpParams: HttpParams, sort: readonly BookSortTerm[]): HttpParams {
-  return sort.length === 0 ? httpParams : httpParams.set('sort', serializeSort(sort));
-}
-
-export function normalizeBookQueryParams(params: BookQueryParams): BookQueryParams {
-  return {
-    ...normalizeBookCollectionFilterParams(params),
-    sort: params.sort,
-  };
-}
-
-export function normalizeBookCollectionFilterParams(
-  params: BookCollectionFilterParams,
-): BookCollectionFilterParams {
-  const query = params.query?.trim();
-  const facets = normalizeFacetValueMap(params.facets);
-
-  return {
-    ...(query ? {query} : {}),
-    facets,
-    facetLogic: params.facetLogic,
-  };
-}
-
-export function toCollectionHttpParams(params: BookCollectionFilterParams): HttpParams {
-  let httpParams = new HttpParams().set('facet_logic', params.facetLogic);
-
-  if (params.query) {
-    httpParams = httpParams.set('query', params.query);
-  }
-
-  return appendFacetParams(httpParams, params.facets);
-}
-
-function compareCodeUnits(first: string, second: string): number {
-  return first < second ? -1 : first > second ? 1 : 0;
-}
-
-function normalizeFacetValueMap(facets: FacetValueMap): FacetValueMap {
-  const normalized = Object.entries(facets)
-    .sort(([first], [second]) => compareCodeUnits(first, second))
-    .map(([key, values]) => [key, [...new Set(values
-      .map(value => value.trim())
-      .filter(Boolean))].sort(compareCodeUnits)] as const)
-    .filter(([, values]) => values.length > 0);
-
-  return Object.fromEntries(normalized);
-}
-
-function appendFacetParams(httpParams: HttpParams, facets: FacetValueMap): HttpParams {
-  let result = httpParams;
-  for (const [key, values] of Object.entries(facets)) {
-    for (const value of values) {
-      result = result.append('facet', `${key}:${value}`);
-    }
-  }
-
-  return result;
-}
-
-function serializeSort(sort: readonly BookSortTerm[]): string {
-  return sort
-    .map(term => `${term.direction === 'desc' ? '-' : ''}${term.key}`)
-    .join(',');
 }

--- a/frontend/src/app/features/book/data/book-query.service.spec.ts
+++ b/frontend/src/app/features/book/data/book-query.service.spec.ts
@@ -1,70 +1,32 @@
-import {HttpErrorResponse} from '@angular/common/http';
 import {HttpTestingController} from '@angular/common/http/testing';
-import {Injectable, inject} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {injectInfiniteQuery, QueryClient} from '@tanstack/angular-query-experimental';
-import {afterEach, beforeEach, describe, expect, expectTypeOf, it, vi} from 'vitest';
+import {QueryClient} from '@tanstack/angular-query-experimental';
+import {afterEach, beforeEach, describe, expect, expectTypeOf, it} from 'vitest';
 
 import {API_CONFIG} from '../../../core/config/api-config';
 import {
   createAuthServiceStub,
   createQueryClientHarness,
-  flushSignalAndQueryEffects,
 } from '../../../core/testing/query-testing';
 import {AuthService} from '../../../shared/service/auth.service';
-import {bookQueryKeys} from './book-query-keys';
-import {BookPageParams} from './book-query-params';
-import {BookPage} from './book-query.models';
 import {BookDetail, BookRecommendation} from './book-response.models';
-import {retryTransientQueryError} from '../../../core/data/query-transport';
 import {BookQueryService} from './book-query.service';
-
-const PARAMS: BookPageParams = {
-  query: 'dune',
-  facets: {genre: ['Science Fiction']},
-  facetLogic: 'or',
-  sort: [{key: 'title', direction: 'asc'}],
-  size: 20,
-};
-
-function page(ids: number[]): BookPage {
-  return {
-    content: ids.map(id => ({id, libraryId: 1, libraryName: 'Library'})),
-    page: {
-      number: 0,
-      size: 20,
-      totalElements: ids.length,
-      totalPages: ids.length === 0 ? 0 : 1,
-      cursor: 'opaque-cursor',
-    },
-    links: [],
-  };
-}
-
-@Injectable()
-class InfiniteQueryHost {
-  private readonly books = inject(BookQueryService);
-  readonly query = injectInfiniteQuery(() => this.books.infinitePage(PARAMS));
-}
 
 describe('BookQueryService', () => {
   let service: BookQueryService;
   let queryClient: QueryClient;
-  let authService: ReturnType<typeof createAuthServiceStub>;
   let http: HttpTestingController;
 
   beforeEach(() => {
     const harness = createQueryClientHarness();
     queryClient = harness.queryClient;
-    authService = createAuthServiceStub();
     queryClient.setDefaultOptions({queries: {retry: false}});
 
     TestBed.configureTestingModule({
       providers: [
         ...harness.providers,
-        {provide: AuthService, useValue: authService},
+        {provide: AuthService, useValue: createAuthServiceStub()},
         BookQueryService,
-        InfiniteQueryHost,
       ],
     });
 
@@ -72,127 +34,7 @@ describe('BookQueryService', () => {
     http = TestBed.inject(HttpTestingController);
   });
 
-  afterEach(() => {
-    http.verify();
-    vi.restoreAllMocks();
-  });
-
-  it('removes its cached book queries when the authenticated session ends', () => {
-    const key = bookQueryKeys.detail(7, false);
-    queryClient.setQueryData(key, {id: 7});
-
-    authService.token.set(null);
-    flushSignalAndQueryEffects();
-
-    expect(queryClient.getQueryData(key)).toBeUndefined();
-  });
-
-  it('fetches one bounded summary page with normalized parameters', async () => {
-    const resultPromise = queryClient.fetchQuery(service.page(PARAMS));
-    const request = http.expectOne(`${API_CONFIG.BASE_URL}/api/v1/books/page?facet_logic=or&query=dune&facet=genre:Science%20Fiction&sort=title&size=20`);
-    request.flush(page([1, 2]));
-
-    await expect(resultPromise).resolves.toMatchObject({
-      content: [{id: 1}, {id: 2}],
-    });
-  });
-
-  it('sends every selected facet value as a repeated facet parameter', async () => {
-    const resultPromise = queryClient.fetchQuery(service.page({
-      ...PARAMS,
-      facets: {
-        genre: ['Science Fiction'],
-        language: ['English'],
-      },
-    }));
-    const request = http.expectOne(
-      `${API_CONFIG.BASE_URL}/api/v1/books/page?facet_logic=or&query=dune&facet=genre:Science%20Fiction&facet=language:English&sort=title&size=20`,
-    );
-    request.flush(page([1]));
-
-    await expect(resultPromise).resolves.toMatchObject({content: [{id: 1}]});
-  });
-
-  it('fetches facets without sort or size', async () => {
-    const resultPromise = queryClient.fetchQuery(service.facets(PARAMS));
-    const request = http.expectOne(`${API_CONFIG.BASE_URL}/api/v1/books/facets?facet_logic=or&query=dune&facet=genre:Science%20Fiction`);
-    request.flush({
-      links: [{rel: 'self', href: '/api/v1/books/facets?query=dune', type: 'application/json'}],
-      facets: [{
-        metadata: {rel: 'facet', key: 'genre', title: 'Genre'},
-        links: [{
-          rel: ['self', 'facet'],
-          href: '/api/v1/books/page?facet=genre%3AFantasy',
-          type: 'application/json',
-          title: 'Fantasy',
-          value: 'Fantasy',
-          properties: {numberOfItems: 4},
-        }],
-      }],
-    });
-
-    await expect(resultPromise).resolves.toEqual([{
-      rel: 'facet',
-      key: 'genre',
-      title: 'Genre',
-      values: [{value: 'Fantasy', title: 'Fantasy', count: 4, selected: true}],
-    }]);
-  });
-
-  it('fetches matching IDs with sort but no size', async () => {
-    const resultPromise = queryClient.fetchQuery(service.ids(PARAMS));
-    const request = http.expectOne(`${API_CONFIG.BASE_URL}/api/v1/books/ids?facet_logic=or&query=dune&facet=genre:Science%20Fiction&sort=title`);
-    request.flush([3, 1, 2]);
-
-    await expect(resultPromise).resolves.toEqual([3, 1, 2]);
-  });
-
-  it('follows the exact next href for an infinite query', async () => {
-    const host = TestBed.inject(InfiniteQueryHost);
-    flushSignalAndQueryEffects();
-
-    const firstRequest = http.expectOne(`${API_CONFIG.BASE_URL}/api/v1/books/page?facet_logic=or&query=dune&facet=genre:Science%20Fiction&sort=title&size=20`);
-    expect(firstRequest.request.params.has('cursor')).toBe(false);
-    firstRequest.flush({
-      ...page([1]),
-      links: [
-        {
-          rel: 'self',
-          href: '/api/v1/books/page?cursor=origin',
-          type: 'application/json',
-        },
-        {
-          rel: 'next',
-          href: '/api/v1/books/page?facet=genre%3AScience%20Fiction&cursor=opaque',
-          type: 'application/json',
-        },
-      ],
-    });
-    await vi.waitFor(() => expect(host.query.isSuccess()).toBe(true));
-
-    const nextPromise = host.query.fetchNextPage();
-    const nextRequest = http.expectOne(`${API_CONFIG.BASE_URL}/api/v1/books/page?facet=genre%3AScience%20Fiction&cursor=opaque`);
-    nextRequest.flush(page([2]));
-    const nextResult = await nextPromise;
-
-    expect(nextResult.data?.pages.flatMap(current => current.content.map(book => book.id)))
-      .toEqual([1, 2]);
-  });
-
-  it('stops paging when the backend emits no next link', async () => {
-    const host = TestBed.inject(InfiniteQueryHost);
-    flushSignalAndQueryEffects();
-
-    http.expectOne(`${API_CONFIG.BASE_URL}/api/v1/books/page?facet_logic=or&query=dune&facet=genre:Science%20Fiction&sort=title&size=20`)
-      .flush(page([1]));
-    await vi.waitFor(() => expect(host.query.isSuccess()).toBe(true));
-
-    expect(host.query.hasNextPage()).toBe(false);
-  });
-
-  it('keys an infinite query by its normalized parameters alone so the cache is shared', () => {
-    expect(service.infinitePage(PARAMS).queryKey).toEqual(service.infinitePage(PARAMS).queryKey);
-  });
+  afterEach(() => http.verify());
 
   it('fetches full book detail with the description flag', async () => {
     const resultPromise = queryClient.fetchQuery(service.detail(42, {withDescription: true}));
@@ -226,28 +68,5 @@ describe('BookQueryService', () => {
       {book: {id: 8}, similarityScore: 0.4},
       {book: {id: 5}, similarityScore: 0.9},
     ]);
-  });
-
-  it('cancels an active HTTP request through the query signal', async () => {
-    const options = service.detail(42, {withDescription: false});
-    const resultPromise = queryClient.fetchQuery(options);
-    const request = http.expectOne(`${API_CONFIG.BASE_URL}/api/v1/books/42?withDescription=false`);
-
-    await queryClient.cancelQueries({queryKey: options.queryKey});
-
-    expect(request.cancelled).toBe(true);
-    await expect(resultPromise).rejects.toBeDefined();
-  });
-
-  it('retries only transient failures and only twice', () => {
-    const networkError = new HttpErrorResponse({status: 0});
-    const badRequest = new HttpErrorResponse({status: 400});
-    const serverError = new HttpErrorResponse({status: 503});
-
-    expect(retryTransientQueryError(0, networkError)).toBe(true);
-    expect(retryTransientQueryError(0, badRequest)).toBe(false);
-    expect(retryTransientQueryError(0, serverError)).toBe(true);
-    expect(retryTransientQueryError(0, new Error('Unexpected failure'))).toBe(false);
-    expect(retryTransientQueryError(2, serverError)).toBe(false);
   });
 });

--- a/frontend/src/app/features/book/data/book-query.service.ts
+++ b/frontend/src/app/features/book/data/book-query.service.ts
@@ -1,106 +1,42 @@
 import {HttpClient, HttpParams} from '@angular/common/http';
-import {effect, inject, Injectable} from '@angular/core';
-import {
-  infiniteQueryOptions,
-  queryOptions,
-  QueryClient,
-} from '@tanstack/angular-query-experimental';
-import {lastValueFrom, Observable, map, takeUntil} from 'rxjs';
+import {inject, Injectable} from '@angular/core';
+import {queryOptions, QueryClient} from '@tanstack/angular-query-experimental';
 
 import {API_CONFIG} from '../../../core/config/api-config';
-import {findBrowsePageLink} from '../../../core/data/browse.models';
-import {mapBrowseFacetGroups, mapBrowsePage} from '../../../core/data/browse-response';
+import {BrowseQueryService} from '../../../core/data/browse-query.service';
+import {QUERY_DEFAULTS} from '../../../core/data/query-transport';
+import {AuthService} from '../../../shared/service/auth.service';
 import {bookQueryKeys} from './book-query-keys';
 import {
-  BookCollectionFilterParams,
   BookDescriptionOptions,
-  BookPageParams,
-  BookQueryParams,
-  normalizeBookCollectionFilterParams,
-  normalizeBookPageParams,
-  normalizeBookQueryParams,
-  toCollectionHttpParams,
-  toIdsHttpParams,
-  toPageHttpParams,
+  BookQueryFacetKey,
+  BookQuerySortKey,
 } from './book-query-params';
-import {BookFacetGroup, BookPage} from './book-query.models';
 import {BookDetail, BookRecommendation, BookSummary} from './book-response.models';
-import {abortSignal, QUERY_DEFAULTS} from '../../../core/data/query-transport';
-import {AuthService} from '../../../shared/service/auth.service';
 
 @Injectable({providedIn: 'root'})
-export class BookQueryService {
-  private readonly http = inject(HttpClient);
-  private readonly authService = inject(AuthService);
-  private readonly queryClient = inject(QueryClient);
-  private readonly baseUrl = `${API_CONFIG.BASE_URL}/api/v1/books`;
+export class BookQueryService extends BrowseQueryService<
+  BookSummary,
+  BookQueryFacetKey,
+  BookQuerySortKey
+> {
+  private static readonly BASE_URL = `${API_CONFIG.BASE_URL}/api/v1/books`;
 
   constructor() {
-    effect(() => {
-      if (this.authService.token() === null) {
-        this.queryClient.removeQueries({queryKey: bookQueryKeys.all()});
-      }
-    });
-  }
-
-  page(params: BookPageParams) {
-    const normalized = normalizeBookPageParams(params);
-
-    return queryOptions({
-      queryKey: bookQueryKeys.boundedPage(normalized),
-      queryFn: ({signal}) => this.fetchPage(normalized, null, signal),
-      ...QUERY_DEFAULTS,
-    });
-  }
-
-  infinitePage(params: BookPageParams) {
-    const normalized = normalizeBookPageParams(params);
-
-    return infiniteQueryOptions({
-      queryKey: bookQueryKeys.infinitePage(normalized),
-      queryFn: ({pageParam, signal}) => this.fetchPage(normalized, pageParam, signal),
-      initialPageParam: null as string | null,
-      getNextPageParam: page => findBrowsePageLink(page, 'next')?.href,
-      ...QUERY_DEFAULTS,
-    });
-  }
-
-  facets(params: BookCollectionFilterParams) {
-    const normalized = normalizeBookCollectionFilterParams(params);
-
-    return queryOptions({
-      queryKey: bookQueryKeys.facets(normalized),
-      queryFn: ({signal}): Promise<BookFacetGroup[]> => this.getMapped(
-        `${this.baseUrl}/facets`,
-        signal,
-        mapBrowseFacetGroups,
-        toCollectionHttpParams(normalized),
-      ),
-      ...QUERY_DEFAULTS,
-    });
-  }
-
-  ids(params: BookQueryParams) {
-    const normalized = normalizeBookQueryParams(params);
-
-    return queryOptions({
-      queryKey: bookQueryKeys.ids(normalized),
-      queryFn: ({signal}) => this.get<number[]>(
-        `${this.baseUrl}/ids`,
-        signal,
-        toIdsHttpParams(normalized),
-      ),
-      ...QUERY_DEFAULTS,
-      staleTime: 0,
-      gcTime: 0,
-    });
+    super(
+      inject(HttpClient),
+      inject(AuthService),
+      inject(QueryClient),
+      BookQueryService.BASE_URL,
+      bookQueryKeys,
+    );
   }
 
   detail(bookId: number, {withDescription}: BookDescriptionOptions) {
     return queryOptions({
       queryKey: bookQueryKeys.detail(bookId, withDescription),
       queryFn: ({signal}): Promise<BookDetail> => this.get<BookDetail>(
-        `${this.baseUrl}/${bookId}`,
+        `${BookQueryService.BASE_URL}/${bookId}`,
         signal,
         new HttpParams().set('withDescription', withDescription.toString()),
       ),
@@ -112,49 +48,11 @@ export class BookQueryService {
     return queryOptions({
       queryKey: bookQueryKeys.recommendation(bookId, limit),
       queryFn: ({signal}): Promise<BookRecommendation[]> => this.get<BookRecommendation[]>(
-        `${this.baseUrl}/${bookId}/recommendations`,
+        `${BookQueryService.BASE_URL}/${bookId}/recommendations`,
         signal,
         new HttpParams().set('limit', limit.toString()),
       ),
       ...QUERY_DEFAULTS,
     });
-  }
-
-  private fetchPage(
-    params: BookPageParams,
-    nextHref: string | null,
-    signal: AbortSignal,
-  ): Promise<BookPage> {
-    if (nextHref !== null) {
-      return this.getMapped(
-        `${API_CONFIG.BASE_URL}${nextHref}`,
-        signal,
-        mapBrowsePage<BookSummary>,
-      );
-    }
-
-    return this.getMapped(
-      `${this.baseUrl}/page`,
-      signal,
-      mapBrowsePage<BookSummary>,
-      toPageHttpParams(params),
-    );
-  }
-
-  private get<T>(url: string, signal: AbortSignal, params?: HttpParams): Promise<T> {
-    return this.finalize(this.http.get<T>(url, {params}), signal);
-  }
-
-  private getMapped<TRaw, T>(
-    url: string,
-    signal: AbortSignal,
-    project: (value: TRaw) => T,
-    params?: HttpParams,
-  ): Promise<T> {
-    return this.finalize(this.http.get<TRaw>(url, {params}).pipe(map(project)), signal);
-  }
-
-  private finalize<T>(source: Observable<T>, signal: AbortSignal): Promise<T> {
-    return lastValueFrom(source.pipe(takeUntil(abortSignal(signal))));
   }
 }


### PR DESCRIPTION
## Description

Extracts the core of the `BookQueryService` into a generic browse query layer, and creates small book and author query services using this and the paginated endpoints. 

## Linked Issue

N/A - Part of the stack

## Changes

- New `browse-query` service and related files - Generic tanstack query setup for any endpoints that follow the backend's browse system. 
- Author and book query services set up as thin users of the browse layer, both identically set up, same models, pagination, facet, and tanstack query cache handling. 

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

Mainly handled via Cursor to keep parity across book + authors and extract code into the shared browse files. 

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.
