### PR TITLE
refactor(amazon): use predefined domains

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -1,5 +1,6 @@
 package org.booklore.service.metadata.parser;
 
+import org.booklore.exception.ApiError;
 import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookMetadata;
 import org.booklore.model.dto.BookReview;
@@ -898,7 +899,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         }
 
         if (!BASE_URIS.containsKey(domain)) {
-            throw new IllegalArgumentException("Unsupported Amazon domain: " + domain);
+            throw ApiError.INVALID_INPUT.createException("Unsupported Amazon domain: " + domain);
         }
 
         return domain;

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -72,7 +72,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
             "yyyy/M/d", "yyyy/MM/dd", "yyyy年M月d日"
     };
 
-    private static final String DEFAULT_TLD = "com";
+    private static final String DEFAULT_DOMAIN = "com";
 
     private static final Map<String, String> BASE_URIS = Map.ofEntries(
             Map.entry("com", "https://www.amazon.com"),
@@ -123,8 +123,6 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
             Map.entry("eg", new LocaleInfo("en-US,en;q=0.9,ar;q=0.8", new Locale.Builder().setLanguage("en").setRegion("EG").build())),
             Map.entry("com.be", new LocaleInfo("en-GB,en;q=0.9,fr;q=0.8,nl;q=0.8", new Locale.Builder().setLanguage("fr").setRegion("BE").build()))
     );
-
-    private static final LocaleInfo DEFAULT_LOCALE_INFO = DOMAIN_LOCALE_MAP.get(DEFAULT_TLD);
 
     private final AppSettingService appSettingService;
 
@@ -667,7 +665,6 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     private List<BookReview> getReviews(Document doc, int maxReviews) {
         List<BookReview> reviews = new ArrayList<>();
-        LocaleInfo localeInfo = getLocaleInfoForDomain(getTld());
 
         try {
             Elements reviewElements = doc.select("li[data-hook=review]");
@@ -728,7 +725,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                             }
                         }
 
-                        LocalDate localDate = parseDate(datePart, localeInfo);
+                        LocalDate localDate = parseDate(datePart);
                         if (localDate != null) {
                             dateInstant = localDate.atStartOfDay(ZoneOffset.UTC).toInstant();
                         }
@@ -830,10 +827,9 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     private Document fetchDocument(String url) {
         try {
-            String tld = getTld();
-            String baseURI = BASE_URIS.get(tld);
+            String baseURI = getBaseURI();
             String amazonCookie = getAmazonCookie();
-            LocaleInfo localeInfo = getLocaleInfoForDomain(tld);
+            LocaleInfo localeInfo = getLocaleInfo();
 
             Connection connection = Jsoup.connect(url)
                     .header("accept", "text/html, application/json")
@@ -884,8 +880,14 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         }
     }
 
-    private static LocaleInfo getLocaleInfoForDomain(String domain) {
-        return DOMAIN_LOCALE_MAP.getOrDefault(domain, DEFAULT_LOCALE_INFO);
+    private LocaleInfo getLocaleInfo() {
+        String domain = getDomain();
+
+        if (!DOMAIN_LOCALE_MAP.containsKey(domain)) {
+            throw ApiError.INVALID_INPUT.createException("Unsupported Amazon domain: " + domain);
+        }
+
+        return DOMAIN_LOCALE_MAP.get(domain);
     }
 
     private Optional<AppSettings> getAppSettings() {
@@ -898,17 +900,13 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                 .map(MetadataProviderSettings::getAmazon);
     }
 
-    private String getTld() {
+    private String getDomain() {
         String domain = getAmazonSettings()
                 .map(MetadataProviderSettings.Amazon::getDomain)
-                .orElse(DEFAULT_TLD);
+                .orElse(DEFAULT_DOMAIN);
 
         if (domain.isBlank()) {
-            return DEFAULT_TLD;
-        }
-
-        if (!BASE_URIS.containsKey(domain)) {
-            throw ApiError.INVALID_INPUT.createException("Unsupported Amazon domain: " + domain);
+            return DEFAULT_DOMAIN;
         }
 
         return domain;
@@ -928,10 +926,18 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     }
 
     private String getBaseURI() {
-        return BASE_URIS.get(getTld());
+        String domain = getDomain();
+
+        if (!BASE_URIS.containsKey(domain)) {
+            throw ApiError.INVALID_INPUT.createException("Unsupported Amazon domain: " + domain);
+        }
+
+        return BASE_URIS.get(domain);
     }
 
-    private static LocalDate parseDate(String dateString, LocaleInfo localeInfo) {
+    private LocalDate parseDate(String dateString) {
+        LocaleInfo localeInfo = getLocaleInfo();
+
         if (dateString == null || dateString.trim().isEmpty()) {
             return null;
         }
@@ -956,10 +962,6 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
         log.warn("Failed to parse date '{}' with any known format for locale {}", dateString, localeInfo.locale());
         return null;
-    }
-
-    private LocalDate parseDate(String dateString) {
-        return parseDate(dateString, getLocaleInfoForDomain(getTld()));
     }
 
     private boolean isWhitespaceNode(Node node) {

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -887,8 +887,21 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     }
 
     private String getTld() {
-        String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
-        return domain != null && BASE_URIS.containsKey(domain) ? domain : DEFAULT_TLD;
+        String domain = Optional.ofNullable(appSettingService.getAppSettings())
+                .map(appSettings -> appSettings.getMetadataProviderSettings())
+                .map(metadataProviderSettings -> metadataProviderSettings.getAmazon())
+                .map(amazonSettings -> amazonSettings.getDomain())
+                .orElse(DEFAULT_TLD);
+
+        if (domain.isBlank()) {
+            return DEFAULT_TLD;
+        }
+
+        if (!BASE_URIS.containsKey(domain)) {
+            throw new IllegalArgumentException("Unsupported Amazon domain: " + domain);
+        }
+
+        return domain;
     }
 
     private String getBaseURI() {

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -68,6 +68,33 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
             "yyyy/M/d", "yyyy/MM/dd", "yyyy年M月d日"
     };
 
+    private static final String DEFAULT_TLD = "com";
+
+    private static final Map<String, String> BASE_URIS = Map.ofEntries(
+            Map.entry("com", "https://www.amazon.com"),
+            Map.entry("co.uk", "https://www.amazon.co.uk"),
+            Map.entry("de", "https://www.amazon.de"),
+            Map.entry("fr", "https://www.amazon.fr"),
+            Map.entry("it", "https://www.amazon.it"),
+            Map.entry("es", "https://www.amazon.es"),
+            Map.entry("ca", "https://www.amazon.ca"),
+            Map.entry("com.au", "https://www.amazon.com.au"),
+            Map.entry("co.jp", "https://www.amazon.co.jp"),
+            Map.entry("in", "https://www.amazon.in"),
+            Map.entry("com.br", "https://www.amazon.com.br"),
+            Map.entry("com.mx", "https://www.amazon.com.mx"),
+            Map.entry("nl", "https://www.amazon.nl"),
+            Map.entry("se", "https://www.amazon.se"),
+            Map.entry("pl", "https://www.amazon.pl"),
+            Map.entry("ae", "https://www.amazon.ae"),
+            Map.entry("sa", "https://www.amazon.sa"),
+            Map.entry("cn", "https://www.amazon.cn"),
+            Map.entry("sg", "https://www.amazon.sg"),
+            Map.entry("tr", "https://www.amazon.com.tr"),
+            Map.entry("eg", "https://www.amazon.eg"),
+            Map.entry("com.be", "https://www.amazon.com.be")
+    );
+
     private static final Map<String, LocaleInfo> DOMAIN_LOCALE_MAP = Map.ofEntries(
             Map.entry("com", new LocaleInfo("en-US,en;q=0.9", Locale.US)),
             Map.entry("co.uk", new LocaleInfo("en-GB,en;q=0.9", Locale.UK)),
@@ -93,7 +120,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
             Map.entry("com.be", new LocaleInfo("en-GB,en;q=0.9,fr;q=0.8,nl;q=0.8", new Locale.Builder().setLanguage("fr").setRegion("BE").build()))
     );
 
-    private static final LocaleInfo DEFAULT_LOCALE_INFO = new LocaleInfo("en-US,en;q=0.9", Locale.US);
+    private static final LocaleInfo DEFAULT_LOCALE_INFO = DOMAIN_LOCALE_MAP.get(DEFAULT_TLD);
 
     private final AppSettingService appSettingService;
 
@@ -270,10 +297,9 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     private BookMetadata getBookMetadata(String amazonBookId) {
         log.info("Amazon: Fetching metadata for: {}", amazonBookId);
 
-        String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
         Document doc;
         try {
-            doc = fetchDocument("https://www.amazon." + domain + BASE_BOOK_URL_SUFFIX + amazonBookId);
+            doc = fetchDocument(getBaseURI() + BASE_BOOK_URL_SUFFIX + amazonBookId);
         } catch (AmazonAntiScrapingException e) {
             log.debug("Aborting metadata fetch for ID {} due to status code (503).", amazonBookId);
             return null;
@@ -320,10 +346,10 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     }
 
     private String buildQueryUrl(FetchMetadataRequest fetchMetadataRequest, Book book) {
-        String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
+        String baseURI = getBaseURI();
         String isbnCleaned = ParserUtils.cleanIsbn(fetchMetadataRequest.getIsbn());
         if (isbnCleaned != null && !isbnCleaned.isEmpty()) {
-            String url = "https://www.amazon." + domain + "/s?k=" + fetchMetadataRequest.getIsbn();
+            String url = baseURI + "/s?k=" + fetchMetadataRequest.getIsbn();
             log.info("Amazon Query URL (ISBN): {}", url);
             return url;
         }
@@ -353,7 +379,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         }
 
         String encodedSearchTerm = searchTerm.toString().replace(" ", "+");
-        String url = "https://www.amazon." + domain + "/s?k=" + encodedSearchTerm;
+        String url = baseURI + "/s?k=" + encodedSearchTerm;
         log.info("Amazon Query URL: {}", url);
         return url;
     }
@@ -639,8 +665,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     private List<BookReview> getReviews(Document doc, int maxReviews) {
         List<BookReview> reviews = new ArrayList<>();
-        String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
-        LocaleInfo localeInfo = getLocaleInfoForDomain(domain);
+        LocaleInfo localeInfo = getLocaleInfoForDomain(getTld());
 
         try {
             Elements reviewElements = doc.select("li[data-hook=review]");
@@ -803,10 +828,10 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     private Document fetchDocument(String url) {
         try {
-            String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
+            String baseURI = getBaseURI();
             String amazonCookie = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getCookie();
 
-            LocaleInfo localeInfo = getLocaleInfoForDomain(domain);
+            LocaleInfo localeInfo = getLocaleInfoForDomain(getTld());
 
             Connection connection = Jsoup.connect(url)
                     .header("accept", "text/html, application/json")
@@ -816,7 +841,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
                     .header("downlink", "10")
                     .header("dpr", "2")
                     .header("ect", "4g")
-                    .header("origin", "https://www.amazon." + domain)
+                    .header("origin", baseURI)
                     .header("priority", "u=1, i")
                     .header("rtt", "50")
                     .header("sec-ch-device-memory", "8")
@@ -861,6 +886,15 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         return DOMAIN_LOCALE_MAP.getOrDefault(domain, DEFAULT_LOCALE_INFO);
     }
 
+    private String getTld() {
+        String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
+        return domain != null && BASE_URIS.containsKey(domain) ? domain : DEFAULT_TLD;
+    }
+
+    private String getBaseURI() {
+        return BASE_URIS.get(getTld());
+    }
+
     private static LocalDate parseDate(String dateString, LocaleInfo localeInfo) {
         if (dateString == null || dateString.trim().isEmpty()) {
             return null;
@@ -889,8 +923,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
     }
 
     private LocalDate parseDate(String dateString) {
-        String domain = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getDomain();
-        return parseDate(dateString, getLocaleInfoForDomain(domain));
+        return parseDate(dateString, getLocaleInfoForDomain(getTld()));
     }
 
     private boolean isWhitespaceNode(Node node) {

--- a/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AmazonBookParser.java
@@ -5,6 +5,9 @@ import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookMetadata;
 import org.booklore.model.dto.BookReview;
 import org.booklore.model.dto.request.FetchMetadataRequest;
+import org.booklore.model.dto.settings.AppSettings;
+import org.booklore.model.dto.settings.MetadataProviderSettings;
+import org.booklore.model.dto.settings.MetadataPublicReviewsSettings;
 import org.booklore.model.enums.MetadataProvider;
 import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.util.BookUtils;
@@ -306,9 +309,7 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
             return null;
         }
 
-        List<BookReview> reviews = appSettingService.getAppSettings()
-                .getMetadataPublicReviewsSettings()
-                .getProviders()
+        List<BookReview> reviews = getReviewProviderConfigs()
                 .stream()
                 .filter(cfg -> cfg.getProvider() == MetadataProvider.Amazon && cfg.isEnabled())
                 .findFirst()
@@ -829,10 +830,10 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
 
     private Document fetchDocument(String url) {
         try {
-            String baseURI = getBaseURI();
-            String amazonCookie = appSettingService.getAppSettings().getMetadataProviderSettings().getAmazon().getCookie();
-
-            LocaleInfo localeInfo = getLocaleInfoForDomain(getTld());
+            String tld = getTld();
+            String baseURI = BASE_URIS.get(tld);
+            String amazonCookie = getAmazonCookie();
+            LocaleInfo localeInfo = getLocaleInfoForDomain(tld);
 
             Connection connection = Jsoup.connect(url)
                     .header("accept", "text/html, application/json")
@@ -887,11 +888,19 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         return DOMAIN_LOCALE_MAP.getOrDefault(domain, DEFAULT_LOCALE_INFO);
     }
 
+    private Optional<AppSettings> getAppSettings() {
+        return Optional.ofNullable(appSettingService.getAppSettings());
+    }
+
+    private Optional<MetadataProviderSettings.Amazon> getAmazonSettings() {
+        return getAppSettings()
+                .map(AppSettings::getMetadataProviderSettings)
+                .map(MetadataProviderSettings::getAmazon);
+    }
+
     private String getTld() {
-        String domain = Optional.ofNullable(appSettingService.getAppSettings())
-                .map(appSettings -> appSettings.getMetadataProviderSettings())
-                .map(metadataProviderSettings -> metadataProviderSettings.getAmazon())
-                .map(amazonSettings -> amazonSettings.getDomain())
+        String domain = getAmazonSettings()
+                .map(MetadataProviderSettings.Amazon::getDomain)
                 .orElse(DEFAULT_TLD);
 
         if (domain.isBlank()) {
@@ -903,6 +912,19 @@ public class AmazonBookParser implements BookParser, DetailedMetadataProvider {
         }
 
         return domain;
+    }
+
+    private String getAmazonCookie() {
+        return getAmazonSettings()
+                .map(MetadataProviderSettings.Amazon::getCookie)
+                .orElse(null);
+    }
+
+    private Set<MetadataPublicReviewsSettings.ReviewProviderConfig> getReviewProviderConfigs() {
+        return getAppSettings()
+                .map(AppSettings::getMetadataPublicReviewsSettings)
+                .map(MetadataPublicReviewsSettings::getProviders)
+                .orElse(Collections.emptySet());
     }
 
     private String getBaseURI() {

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -412,6 +412,19 @@ public class AmazonBookParserTest {
     }
 
     @Test
+    public void fetchTopMetadata_fallsBackToDefaultDomainWhenDomainIsEmpty() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings(""));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
     public void fetchTopMetadata_removesExtraWhitespace() throws Exception {
         mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
 

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -1,6 +1,8 @@
 package org.booklore.service.metadata.parser;
 
 
+import org.booklore.exception.APIException;
+import org.booklore.exception.ApiError;
 import org.booklore.model.dto.Book;
 import org.booklore.model.dto.BookMetadata;
 import org.booklore.model.dto.request.FetchMetadataRequest;
@@ -393,8 +395,10 @@ public class AmazonBookParserTest {
         FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
 
         assertThatThrownBy(() -> amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Unsupported Amazon domain: com@evil.example");
+                .isInstanceOfSatisfying(APIException.class, exception -> {
+                    assertThat(exception.getStatus()).isEqualTo(ApiError.INVALID_INPUT.getStatus());
+                    assertThat(exception.getMessage()).isEqualTo("Unsupported Amazon domain: com@evil.example");
+                });
 
         mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com@evil.example/dp/EXAMPLESKU"), never());
     }

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -97,6 +97,20 @@ public class AmazonBookParserTest {
                 .build();
     }
 
+    private AppSettings getAppSettingsWithoutPublicReviewsSettings() {
+        MetadataProviderSettings.Amazon amazonSettings = new MetadataProviderSettings.Amazon();
+        amazonSettings.setEnabled(true);
+        amazonSettings.setDomain("com");
+
+        MetadataProviderSettings metadataProviderSettings = new MetadataProviderSettings();
+        metadataProviderSettings.setAmazon(amazonSettings);
+
+        return AppSettings
+                .builder()
+                .metadataProviderSettings(metadataProviderSettings)
+                .build();
+    }
+
     private Book getBook(String asin) {
         BookMetadata bookMetadata = BookMetadata.builder()
                 .asin(asin)
@@ -455,6 +469,19 @@ public class AmazonBookParserTest {
     }
 
     @Test
+    public void fetchTopMetadata_fallsBackToDefaultDomainWhenDomainIsBlank() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings("   "));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
     public void fetchTopMetadata_fallsBackToDefaultDomainWhenAppSettingsAreMissing() throws Exception {
         mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
         when(mockAppSettingService.getAppSettings()).thenReturn(null);
@@ -484,6 +511,19 @@ public class AmazonBookParserTest {
     public void fetchTopMetadata_fallsBackToDefaultDomainWhenAmazonSettingsAreMissing() throws Exception {
         mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
         when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettingsWithoutAmazonSettings());
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_fetchesMetadataWhenPublicReviewsSettingsAreMissing() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettingsWithoutPublicReviewsSettings());
 
         Book book = getBook("EXAMPLESKU");
         FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -72,6 +72,31 @@ public class AmazonBookParserTest {
                 .build();
     }
 
+    private AppSettings getAppSettingsWithoutMetadataProviderSettings() {
+        MetadataPublicReviewsSettings publicReviewsSettings = MetadataPublicReviewsSettings.builder()
+                .providers(Collections.emptySet())
+                .build();
+
+        return AppSettings
+                .builder()
+                .metadataPublicReviewsSettings(publicReviewsSettings)
+                .build();
+    }
+
+    private AppSettings getAppSettingsWithoutAmazonSettings() {
+        MetadataProviderSettings metadataProviderSettings = new MetadataProviderSettings();
+
+        MetadataPublicReviewsSettings publicReviewsSettings = MetadataPublicReviewsSettings.builder()
+                .providers(Collections.emptySet())
+                .build();
+
+        return AppSettings
+                .builder()
+                .metadataPublicReviewsSettings(publicReviewsSettings)
+                .metadataProviderSettings(metadataProviderSettings)
+                .build();
+    }
+
     private Book getBook(String asin) {
         BookMetadata bookMetadata = BookMetadata.builder()
                 .asin(asin)
@@ -420,6 +445,45 @@ public class AmazonBookParserTest {
     public void fetchTopMetadata_fallsBackToDefaultDomainWhenDomainIsEmpty() throws Exception {
         mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
         when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings(""));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_fallsBackToDefaultDomainWhenAppSettingsAreMissing() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(null);
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_fallsBackToDefaultDomainWhenMetadataProviderSettingsAreMissing() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettingsWithoutMetadataProviderSettings());
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
+    public void fetchTopMetadata_fallsBackToDefaultDomainWhenAmazonSettingsAreMissing() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettingsWithoutAmazonSettings());
 
         Book book = getBook("EXAMPLESKU");
         FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -385,6 +385,33 @@ public class AmazonBookParserTest {
     }
 
     @Test
+    public void fetchTopMetadata_fallsBackToDefaultDomainWhenDomainIsUnsupported() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings("com@evil.example"));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com@evil.example/dp/EXAMPLESKU"), never());
+    }
+
+    @Test
+    public void fetchTopMetadata_fallsBackToDefaultDomainWhenDomainIsNull() throws Exception {
+        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+        when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings(null));
+
+        Book book = getBook("EXAMPLESKU");
+        FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
+
+        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+
+        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
+    }
+
+    @Test
     public void fetchTopMetadata_removesExtraWhitespace() throws Exception {
         mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
 

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AmazonBookParserTest.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -385,16 +386,16 @@ public class AmazonBookParserTest {
     }
 
     @Test
-    public void fetchTopMetadata_fallsBackToDefaultDomainWhenDomainIsUnsupported() throws Exception {
-        mockJsoupConnect("https://www.amazon.com/dp/EXAMPLESKU", "<html />");
+    public void fetchTopMetadata_failsWhenDomainIsUnsupported() {
         when(mockAppSettingService.getAppSettings()).thenReturn(getAppSettings("com@evil.example"));
 
         Book book = getBook("EXAMPLESKU");
         FetchMetadataRequest fetchMetadataRequest = FetchMetadataRequest.builder().build();
 
-        amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest);
+        assertThatThrownBy(() -> amazonBookParser.fetchTopMetadata(book, fetchMetadataRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unsupported Amazon domain: com@evil.example");
 
-        mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com/dp/EXAMPLESKU"));
         mockJsoup.verify(() -> Jsoup.connect("https://www.amazon.com@evil.example/dp/EXAMPLESKU"), never());
     }
 


### PR DESCRIPTION
## Description

Refactors the Amazon metadata parser to resolve configured Amazon domains through a predefined base URI map instead of constructing URLs directly from the configured domain string.

Null or blank Amazon domain settings fall back to `amazon.com`. Unsupported non-empty domain values now fail loudly instead of silently using a different marketplace.

## Linked Issue

Fixes #2344

## Changes

- Added predefined Amazon marketplace domain resolution.
- Updated Amazon parser URL construction to use the resolved base URI.
- Made Amazon domain lookup null-safe for parent settings objects.
- Added fallback behavior for null and blank Amazon domain settings.
- Added explicit failure behavior for unsupported non-empty Amazon domain values.
- Added focused tests for supported, unsupported, null, and empty domain values.

## Manual Testing Steps

1. Ran `./gradlew test --tests org.booklore.service.metadata.parser.AmazonBookParserTest`
2. Ran `./gradlew check --no-daemon --parallel --build-cache`
3. Ran `git diff --check`

## Screenshots

No UI changes.

## Additional Context

I could not run `just api check` locally because `just` is not installed, so I ran the equivalent backend Gradle check from the `backend/Justfile`.

## AI Disclosure

Codex - helped implement and validate the parser refactor and draft tests; I reviewed all changes.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Amazon marketplace handling across metadata, search, reviews, requests, and date parsing.
  * Unsupported Amazon domains are now rejected safely with a clear validation error.
  * Missing, empty, or invalid marketplace settings now fall back to Amazon US.
  * Amazon URLs and locale-sensitive metadata now consistently use the validated marketplace, improving reliability across supported regions.
  * Metadata retrieval continues to work when optional review settings are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->