### PR TITLE
fix(auth): honor FORCE_DISABLE_OIDC for OIDC-only mode

### DIFF
--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -185,18 +185,34 @@ public class AppSettingService {
                 .collect(Collectors.toMap(AppSettingEntity::getName, AppSettingEntity::getVal));
     }
 
+    // OIDC is only effectively enabled when the stored setting is on AND the FORCE_DISABLE_OIDC
+    // env override is not set. The override acts as an emergency escape hatch.
+    private boolean isOidcEffectivelyEnabled() {
+        boolean settingEnabled = Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_ENABLED, "false"));
+        Boolean forceDisable = appProperties.getForceDisableOidc();
+        return settingEnabled && (forceDisable == null || !forceDisable);
+    }
+
+    // OIDC-only mode must never be reported as active while OIDC is effectively disabled: doing so
+    // would block local login with no working OIDC to fall back on, locking every user out.
+    private boolean isOidcForceOnlyModeEffective(boolean oidcEffectivelyEnabled) {
+        boolean forceOnlyMode = Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_FORCE_ONLY_MODE, "false"));
+        return oidcEffectivelyEnabled && forceOnlyMode;
+    }
+
     private PublicAppSetting buildPublicSetting() {
         Map<String, String> settingsMap = getSettingsMap();
         PublicAppSetting.PublicAppSettingBuilder builder = PublicAppSetting.builder();
 
-        builder.oidcEnabled(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_ENABLED, "false")));
+        boolean oidcEnabled = isOidcEffectivelyEnabled();
+        builder.oidcEnabled(oidcEnabled);
         builder.remoteAuthEnabled(appProperties.getRemoteAuth().isEnabled());
         OidcProviderDetails details = settingPersistenceHelper.getJsonSetting(settingsMap, AppSettingKey.OIDC_PROVIDER_DETAILS, OidcProviderDetails.class, null, false);
         if (details != null) {
             details.setClientSecret(null);
         }
         builder.oidcProviderDetails(details);
-        builder.oidcForceOnlyMode(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_FORCE_ONLY_MODE, "false")));
+        builder.oidcForceOnlyMode(isOidcForceOnlyModeEffective(oidcEnabled));
 
         return builder.build();
     }
@@ -247,15 +263,13 @@ public class AppSettingService {
             }
         }
 
-        boolean settingEnabled = Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_ENABLED, "false"));
-        Boolean forceDisable = appProperties.getForceDisableOidc();
-        boolean finalEnabled = settingEnabled && (forceDisable == null || !forceDisable);
-        builder.oidcEnabled(finalEnabled);
+        boolean oidcEnabled = isOidcEffectivelyEnabled();
+        builder.oidcEnabled(oidcEnabled);
 
         builder.oidcGroupSyncMode(settingPersistenceHelper.getOrCreateSetting(
                 AppSettingKey.OIDC_GROUP_SYNC_MODE, "DISABLED"));
 
-        builder.oidcForceOnlyMode(Boolean.parseBoolean(settingPersistenceHelper.getOrCreateSetting(AppSettingKey.OIDC_FORCE_ONLY_MODE, "false")));
+        builder.oidcForceOnlyMode(isOidcForceOnlyModeEffective(oidcEnabled));
 
         builder.diskType(appProperties.getDiskType());
 

--- a/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,7 +55,78 @@ class AppSettingServiceTest {
                 .permissions(permissions)
                 .build();
 
-        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        lenient().when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+    }
+
+    private static AppSettingEntity settingEntity(AppSettingKey key, String value) {
+        AppSettingEntity entity = new AppSettingEntity();
+        entity.setName(key.toString());
+        entity.setVal(value);
+        return entity;
+    }
+
+    @Test
+    void publicSettings_forceDisableOidc_reportsOidcAndOidcOnlyModeDisabled() {
+        when(appSettingsRepository.findAll()).thenReturn(List.of());
+        when(appProperties.getRemoteAuth()).thenReturn(new AppProperties.RemoteAuth());
+        when(appProperties.getForceDisableOidc()).thenReturn(true);
+        when(appSettingsRepository.findByName(AppSettingKey.OIDC_ENABLED.toString()))
+                .thenReturn(settingEntity(AppSettingKey.OIDC_ENABLED, "true"));
+        when(appSettingsRepository.findByName(AppSettingKey.OIDC_FORCE_ONLY_MODE.toString()))
+                .thenReturn(settingEntity(AppSettingKey.OIDC_FORCE_ONLY_MODE, "true"));
+
+        var publicSettings = appSettingService.getPublicSettings();
+
+        assertThat(publicSettings.isOidcEnabled()).isFalse();
+        assertThat(publicSettings.isOidcForceOnlyMode()).isFalse();
+    }
+
+    @Test
+    void appSettings_forceDisableOidc_disablesOidcOnlyModeSoLocalLoginWorks() {
+        when(appSettingsRepository.findAll()).thenReturn(List.of());
+        when(appProperties.getRemoteAuth()).thenReturn(new AppProperties.RemoteAuth());
+        when(appProperties.getForceDisableOidc()).thenReturn(true);
+        lenient().when(appSettingsRepository.findByName(AppSettingKey.OIDC_ENABLED.toString()))
+                .thenReturn(settingEntity(AppSettingKey.OIDC_ENABLED, "true"));
+        lenient().when(appSettingsRepository.findByName(AppSettingKey.OIDC_FORCE_ONLY_MODE.toString()))
+                .thenReturn(settingEntity(AppSettingKey.OIDC_FORCE_ONLY_MODE, "true"));
+
+        var appSettings = appSettingService.getAppSettings();
+
+        assertThat(appSettings.isOidcEnabled()).isFalse();
+        assertThat(appSettings.isOidcForceOnlyMode()).isFalse();
+    }
+
+    @Test
+    void appSettings_oidcEnabledWithForceOnlyMode_keepsOidcOnlyModeActive() {
+        when(appSettingsRepository.findAll()).thenReturn(List.of());
+        when(appProperties.getRemoteAuth()).thenReturn(new AppProperties.RemoteAuth());
+        when(appProperties.getForceDisableOidc()).thenReturn(false);
+        lenient().when(appSettingsRepository.findByName(AppSettingKey.OIDC_ENABLED.toString()))
+                .thenReturn(settingEntity(AppSettingKey.OIDC_ENABLED, "true"));
+        lenient().when(appSettingsRepository.findByName(AppSettingKey.OIDC_FORCE_ONLY_MODE.toString()))
+                .thenReturn(settingEntity(AppSettingKey.OIDC_FORCE_ONLY_MODE, "true"));
+
+        var appSettings = appSettingService.getAppSettings();
+
+        assertThat(appSettings.isOidcEnabled()).isTrue();
+        assertThat(appSettings.isOidcForceOnlyMode()).isTrue();
+    }
+
+    @Test
+    void appSettings_oidcDisabledButForceOnlyModeLeftOn_reportsOidcOnlyModeInactive() {
+        when(appSettingsRepository.findAll()).thenReturn(List.of());
+        when(appProperties.getRemoteAuth()).thenReturn(new AppProperties.RemoteAuth());
+        when(appProperties.getForceDisableOidc()).thenReturn(false);
+        lenient().when(appSettingsRepository.findByName(AppSettingKey.OIDC_ENABLED.toString()))
+                .thenReturn(settingEntity(AppSettingKey.OIDC_ENABLED, "false"));
+        lenient().when(appSettingsRepository.findByName(AppSettingKey.OIDC_FORCE_ONLY_MODE.toString()))
+                .thenReturn(settingEntity(AppSettingKey.OIDC_FORCE_ONLY_MODE, "true"));
+
+        var appSettings = appSettingService.getAppSettings();
+
+        assertThat(appSettings.isOidcEnabled()).isFalse();
+        assertThat(appSettings.isOidcForceOnlyMode()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Description

`FORCE_DISABLE_OIDC=true` is meant to be an emergency escape hatch that turns OIDC off completely. It correctly forced `oidcEnabled` to `false`, but the separate "OIDC-only mode" flag (`oidcForceOnlyMode`) was still read straight from the stored setting. If an admin had previously enabled OIDC-only mode, local login stayed blocked with *"Local login is disabled. Use OIDC to sign in."* while OIDC itself was disabled, locking every user out with no way back in.

This change enforces the invariant that OIDC-only mode can only be reported active while OIDC is effectively enabled.

## Linked Issue

Fixes #2342

## Changes

- Added `isOidcEffectivelyEnabled()` (stored `OIDC_ENABLED` **and** not `FORCE_DISABLE_OIDC`) and `isOidcForceOnlyModeEffective()` (only-mode **and** effectively enabled) helpers in `AppSettingService`.
- Applied both in `buildAppSettings` (used by `AuthenticationService`) and `buildPublicSetting` (read by the login page), so OIDC-only mode can no longer block local login when OIDC is force-disabled.
- The public `oidcEnabled` flag now also respects `FORCE_DISABLE_OIDC`, so the login page no longer offers or auto-redirects to a disabled provider.
- Added unit tests covering the force-disable case (both settings paths), the normal enabled + only-mode case, and the edge case of OIDC disabled with only-mode left on.

## Manual Testing Steps

1. In the admin auth settings, enable OIDC and turn on "OIDC-only mode".
2. Set the environment variable `FORCE_DISABLE_OIDC=true` and restart the stack.
3. Navigate to `/login` (or `/login?local=true`) and sign in with local admin credentials.
4. Expected: the local login form is shown (no auto-redirect to OIDC) and the login succeeds instead of returning "Local login is disabled. Use OIDC to sign in."

## AI Disclosure

Claude Code (Anthropic) investigated the issue, implemented the fix, and drafted the tests. All changes were reviewed before submitting.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`. (Ran the affected backend tests `AppSettingServiceTest` and `AuthenticationServiceTest` via Gradle; no UI changes, so `just ui check` is not applicable.)
- [ ] I have added screenshots if there were any UI changes. (No UI changes.)
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC settings now consistently respect forced-disable configuration.
  * OIDC-only mode is disabled automatically when OIDC is inactive.
  * Public and authenticated application settings now report accurate OIDC status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->