### PR TITLE
fix(books): remove stale facet cache

### DIFF
--- a/backend/src/main/java/org/booklore/service/browse/BookFacetService.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookFacetService.java
@@ -1,7 +1,5 @@
 package org.booklore.service.browse;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Tuple;
@@ -15,7 +13,6 @@ import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.booklore.browse.FacetLogic;
 import org.booklore.browse.Link;
-import org.booklore.browse.ParamsHash;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.browse.FacetGroupsResponse;
@@ -28,7 +25,6 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,11 +58,6 @@ public class BookFacetService {
     @PersistenceContext
     private EntityManager entityManager;
 
-    private final Cache<String, FacetGroupsResponse> cache = Caffeine.newBuilder()
-            .expireAfterWrite(Duration.ofSeconds(30))
-            .maximumSize(200)
-            .build();
-
     public FacetGroupsResponse getFacets(List<String> facet, String facetLogicParam, String query) {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
         Long userId = user.getId();
@@ -76,23 +67,15 @@ public class BookFacetService {
         Map<String, List<String>> facets = BookFilterSpecifications.parseFacets(facet);
         FacetLogic facetLogic = FacetLogic.from(facetLogicParam);
 
-        String cacheKey = userId + ":" + ParamsHash.compute(query, facets, facetLogic);
-        return cache.get(cacheKey, key -> {
-            String preserved = BrowseParams.preserved(facet, facetLogicParam, query);
-            List<FacetGroup> groups = new ArrayList<>();
-            groups.add(sortGroup(preserved));
-            for (FacetDef def : FACETS) {
-                Specification<BookEntity> base = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, libraryIds, def.key());
-                groups.add(toGroup(def, count(def, base), facet, preserved));
-            }
-            List<Link> links = List.of(Link.json(List.of("self"), href(FACET_PATH, preserved)));
-            return new FacetGroupsResponse(links, groups);
-        });
-    }
-
-    // Package-private: lets tests reset the shared singleton cache between runs.
-    void clearCache() {
-        cache.invalidateAll();
+        String preserved = BrowseParams.preserved(facet, facetLogicParam, query);
+        List<FacetGroup> groups = new ArrayList<>();
+        groups.add(sortGroup(preserved));
+        for (FacetDef def : FACETS) {
+            Specification<BookEntity> base = filterSpecifications.base(query, facets, facetLogic, userId, isAdmin, libraryIds, def.key());
+            groups.add(toGroup(def, count(def, base), facet, preserved));
+        }
+        List<Link> links = List.of(Link.json(List.of("self"), href(FACET_PATH, preserved)));
+        return new FacetGroupsResponse(links, groups);
     }
 
     private List<FacetCount> count(FacetDef def, Specification<BookEntity> base) {

--- a/backend/src/test/java/org/booklore/service/browse/BookFacetServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookFacetServiceTest.java
@@ -99,7 +99,6 @@ class BookFacetServiceTest {
 
     @BeforeEach
     void seed() {
-        facetService.clearCache();
         userEntity = BookLoreUserEntity.builder().username("reader").passwordHash("x").name("Reader").build();
         em.persist(userEntity);
         library = LibraryEntity.builder().name("Lib").icon("book").watch(false)
@@ -218,12 +217,19 @@ class BookFacetServiceTest {
     }
 
     @Test
-    void responseIsCachedPerParameters() {
+    void facetsReflectNewBooksImmediately() {
         book("A", "Horror", "Alice");
         em.flush();
         FacetGroupsResponse first = facetService.getFacets(null, null, null);
+        assertThat(count(group(first, "genre"), "Horror")).isEqualTo(1);
+
+        book("B", "Romance", "Bob");
+        em.flush();
         FacetGroupsResponse second = facetService.getFacets(null, null, null);
-        assertThat(first).isSameAs(second);
+
+        assertThat(count(group(second, "genre"), "Horror")).isEqualTo(1);
+        assertThat(count(group(second, "genre"), "Romance")).isEqualTo(1);
+        assertThat(group(second, "author").links()).extracting(FacetLink::value).contains("Alice", "Bob");
     }
 
     @Test


### PR DESCRIPTION
## Description

Removes the backend Caffeine cache from `BookFacetService` so `/api/v1/books/facets` always reflects the latest book and metadata state.

The frontend already caches facet requests through TanStack Query and can invalidate them after user actions. Keeping an additional backend cache could return stale facet/filter values for up to 30 seconds after book or metadata changes.

## Linked Issue

Fixes #2304

## Changes

- Removed the 30-second Caffeine cache from `BookFacetService`.
- Removed the test-only cache clearing helper.
- Updated facet service coverage to verify newly added books appear in facet results immediately.

## Manual Testing Steps

1. Ran `./gradlew test --tests org.booklore.service.browse.BookFacetServiceTest`
2. Ran `./gradlew check --no-daemon --parallel --build-cache`
3. Ran `git diff --check`

## Screenshots

No UI changes.

## Additional Context

I could not run `just api check` locally because `just` is not installed, so I ran the equivalent backend Gradle check from the `backend/Justfile`.

## AI Disclosure

Codex - helped implement and validate the cache removal and regression test; I reviewed all changes.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Book browsing facets now reflect newly added books immediately.
  * Updated genre counts and author values are shown without requiring cached data to expire or be cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->