### PR TITLE
fix(api): book files cannot be left in a detached state

### DIFF
--- a/backend/src/main/java/org/booklore/service/book/BookFileDetachmentService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookFileDetachmentService.java
@@ -100,8 +100,8 @@ public class BookFileDetachmentService {
         sourceBook.getBookFiles().remove(targetFile);
         newBook.getBookFiles().add(targetFile);
 
-        bookRepository.saveAndFlush(sourceBook);
         newBook = bookRepository.saveAndFlush(newBook);
+        bookRepository.saveAndFlush(sourceBook);
 
         // Only save changes to the target file after the shift in relationship
         // via source & new book or else we get a hibernate error.

--- a/backend/src/test/java/org/booklore/service/book/BookFileDetachmentServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/BookFileDetachmentServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -185,6 +186,35 @@ class BookFileDetachmentServiceTest {
         assertThat(suppFile.getFileName()).isEqualTo("notes.txt");
         verify(bookRepository, times(2)).saveAndFlush(any(BookEntity.class));
         verify(bookFileRepository).saveAndFlush(any(BookFileEntity.class));
+    }
+
+    @Test
+    void detachSupplementaryFile_CorrectOrder() {
+        BookEntity oldBook = createBook(1L);
+        BookEntity newBook = createBook(2L);
+        createBookFile(10L, oldBook, true, BookFileType.EPUB);
+        BookFileEntity suppFile = createBookFile(11L, oldBook, false, BookFileType.PDF);
+        suppFile.setFileName("notes.txt");
+
+        when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(oldBook));
+        when(bookRepository.saveAndFlush(any(BookEntity.class))).thenAnswer(inv -> {
+            BookEntity saved = inv.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(2L);
+            }
+            return saved;
+        });
+
+        setupMocksForGetUpdatedBook();
+        when(bookRepository.findByIdWithBookFiles(2L)).thenReturn(Optional.of(newBook));
+
+        service.detachBookFile(1L, 11L, false);
+
+        //create inOrder object passing any mocks that need to be verified in order
+        InOrder inOrder = inOrder(bookRepository);
+
+        inOrder.verify(bookRepository).saveAndFlush(newBook);
+        inOrder.verify(bookRepository).saveAndFlush(oldBook);
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
with the way the `BookFileDetachmentService` was being called, the book files were being left - albeit temporarily - in a detached state.  this caused an `InvalidDataAccessApiUsageException` and failed the detach request.

instead, if we create & save the new book first, then save the old book, then save the file we get a correct state throughout the request

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2388

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
swaps order of book saves

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. find duplicates and attach books
2. change mind and try to detach books

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x]  I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when detaching supplementary book files by ensuring the newly created book is saved before the original book is updated.
  * Added validation to prevent persistence-order regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->