### PR TITLE
fix(audible): use expected URL patterns for product links

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/AudibleParser.java
@@ -185,7 +185,7 @@ public class AudibleParser implements BookParser, DetailedMetadataProvider {
         }
 
         return UriComponentsBuilder.fromUriString(getExternalBaseURI())
-                .path("/dp/{asin}")
+                .path("/pd/{asin}")
                 .build(asin)
                 .toString();
     }

--- a/backend/src/test/java/org/booklore/service/metadata/parser/AudibleParserTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/parser/AudibleParserTest.java
@@ -165,7 +165,7 @@ public class AudibleParserTest {
         BookMetadata actual = audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
 
         assertThat(actual).isNotNull();
-        assertThat(actual.getExternalUrl()).isEqualTo("https://www.audible.co.jp/dp/1705047572");
+        assertThat(actual.getExternalUrl()).isEqualTo("https://www.audible.co.jp/pd/1705047572");
     }
 
     @Test
@@ -182,7 +182,7 @@ public class AudibleParserTest {
         BookMetadata actual = audibleParser.fetchTopMetadata(book, fetchMetadataRequest);
 
         assertThat(actual).isNotNull();
-        assertThat(actual.getExternalUrl()).isEqualTo("https://www.audible.com/dp/1705047572");
+        assertThat(actual.getExternalUrl()).isEqualTo("https://www.audible.com/pd/1705047572");
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
Audible external URIs seem to require `/pd/` instead of `/dp/` like Amazon.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2316

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
Updates the audible external URI helper to emit URIs with `/pd/`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. search on audible for "How to Talk to Your Cat About Gun Safety"
2. click "Audible" link
3. See audible URI as expected

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
This may have been mixed up because of the similar amazon change being made

Bad: https://www.audible.com/dp/0593151496

Good: https://www.audible.com/pd/0593151496

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Audible book links to use the correct product URL format.
  - Improved locale-specific Audible links, including Japanese URLs.
  - Preserved existing behavior when an ASIN is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->