### PR TITLE
fix: use Apache Commons Compress for ZIP/CBZ handling

### DIFF
--- a/backend/src/main/java/org/booklore/service/ArchiveService.java
+++ b/backend/src/main/java/org/booklore/service/ArchiveService.java
@@ -2,6 +2,8 @@ package org.booklore.service;
 
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import com.github.junrar.exception.RarException;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.exception.ApiError;
@@ -21,7 +23,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import java.util.zip.ZipFile;
+import java.util.Collections;
 
 @Slf4j
 @Service
@@ -43,10 +45,11 @@ public class ArchiveService {
     }
 
     private Stream<Entry> streamEntriesFromZip(Path path) throws IOException {
-        try (ZipFile file = new ZipFile(path.toFile())) {
-            // Stream to list so we enumerate all of them before the zipfile closes.
-            return file.stream()
-                    .toList()
+        try (ZipFile file = ZipFile.builder()
+                .setPath(path)
+                .get()) {
+
+            return Collections.list(file.getEntries())
                     .stream()
                     .filter(e -> !e.isDirectory())
                     .map(e -> new Entry(e.getName(), e.getSize()));
@@ -102,8 +105,11 @@ public class ArchiveService {
     }
 
     private long transferZipEntryTo(Path path, String entryName, OutputStream outputStream) throws IOException {
-        try (ZipFile zipFile = new ZipFile(path.toFile())) {
-            var entry = zipFile.getEntry(entryName);
+        try (ZipFile zipFile = ZipFile.builder()
+                .setPath(path)
+                .get()) {
+
+            ZipArchiveEntry entry = zipFile.getEntry(entryName);
 
             if (entry == null || entry.isDirectory()) {
                 throw new IOException("Entry not found in archive");

--- a/backend/src/main/java/org/booklore/service/reader/CbxReaderService.java
+++ b/backend/src/main/java/org/booklore/service/reader/CbxReaderService.java
@@ -36,8 +36,8 @@ import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 
 @Slf4j
 @Service
@@ -227,7 +227,7 @@ public class CbxReaderService {
      * Reads image dimensions for all pages using only image headers (a few KB
      * per page) instead of loading the full image.
      * <p>
-     * For ZIP/CBZ archives the fast path uses {@link java.util.zip.ZipFile}
+     * For ZIP/CBZ archives the fast path uses {@link org.apache.commons.compress.archivers.zip.ZipFile}
      * which supports random access, so each entry stream feeds directly into
      * {@link ImageIO}. For non-ZIP archives (RAR, 7z) the first
      * {@value #DIMENSION_PREFIX_BYTES} bytes of each entry are extracted via
@@ -255,20 +255,29 @@ public class CbxReaderService {
      */
     private List<CbxPageDimension> readDimensionsViaZipFile(Path cbxPath, List<String> imageEntries) throws IOException {
         List<CbxPageDimension> dimensions = new ArrayList<>(imageEntries.size());
-        try (ZipFile zip = new ZipFile(cbxPath.toFile())) {
+        try (ZipFile zip = ZipFile.builder()
+                .setPath(cbxPath)
+                .get()) {
+
             for (int i = 0; i < imageEntries.size(); i++) {
                 int pageNumber = i + 1;
                 String entryName = imageEntries.get(i);
-                ZipEntry entry = zip.getEntry(entryName);
+
+                ZipArchiveEntry entry = zip.getEntry(entryName);
+
                 if (entry != null) {
                     try (InputStream is = zip.getInputStream(entry);
                          ImageInputStream iis = ImageIO.createImageInputStream(is)) {
+
                         dimensions.add(readDimensionFromImageStream(iis, pageNumber));
                         continue;
+
                     } catch (Exception e) {
-                        log.warn("Failed to read dimensions for page {} via ZipFile (entry: {}): {}", pageNumber, entryName, e.getMessage());
+                        log.warn("Failed to read dimensions for page {} via ZipFile (entry: {}): {}",
+                                pageNumber, entryName, e.getMessage());
                     }
                 }
+
                 dimensions.add(fallbackDimension(pageNumber));
             }
         }
@@ -357,7 +366,7 @@ public class CbxReaderService {
             ZipFile zip = getZipFile(cbxPath, metadata.lastModified());
             if (zip != null) {
                 String entryName = metadata.imageEntries().get(page - 1);
-                ZipEntry entry = zip.getEntry(entryName);
+                ZipArchiveEntry entry = zip.getEntry(entryName);
                 if (entry != null) {
                     try (InputStream is = zip.getInputStream(entry)) {
                         is.transferTo(outputStream);
@@ -384,10 +393,13 @@ public class CbxReaderService {
 
     private ZipFile getZipFile(Path cbxPath, long lastModified) {
         String cacheKey = cbxPath.toString() + ":" + lastModified;
+
         return zipHandleCache.get(cacheKey, _ -> {
             try {
                 if (isZipPath(cbxPath)) {
-                    return new ZipFile(cbxPath.toFile());
+                    return ZipFile.builder()
+                            .setPath(cbxPath)
+                            .get();
                 }
             } catch (IOException e) {
                 log.warn("Failed to open ZipFile for {}: {}", cbxPath, e.getMessage());

--- a/backend/src/test/java/org/booklore/service/reader/CbxReaderServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/reader/CbxReaderServiceTest.java
@@ -21,7 +21,7 @@ import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Stream;
-import java.util.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
## Description

Replace the use of java.util.zip.ZipFile with Apache Commons Compress in the CBX archive handling and update the related tests.

## Linked Issue

[CBZ "invalid CEN header" #2393](https://github.com/grimmory-tools/grimmory/issues/2393)


## Changes

- Updated `ArchiveService `to use **Apache Commons Compress** for ZIP/CBX archive access.
- Updated `CbxReaderService `to use **Apache Commons Compress** ZipFile.
- Updated `CbxReaderServiceTest` to use the new ZipFile implementation.


## Manual Testing Steps

1. Run the backend test suite with ./gradlew test and verify all tests pass.
2. Open a CBZ/CBX book in the reader and verify that pages are loaded and displayed correctly.
3. Navigate between multiple pages and verify page streaming works without errors.
4. Verify page dimensions and page information are loaded correctly.
5. Re-open the same book/page to verify the archive cache is used correctly.

## Screenshots (Optional)

N/A

## Additional Context (Optional)

This change is an internal archive-handling refactor. The existing CBX/CBZ reader behavior and caching flow are preserved; the main change is replacing java.util.zip.ZipFile with Apache Commons Compress for ZIP archive access.

No changes to the public API or reader behavior are intended.

## AI Disclosure

Codex - helped refactor services; I reviewed all changes.

## Checklist

- [ ] This PR links and implements an accepted issue. <-- Wait for acceptation
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP archive handling for more reliable archive enumeration, extraction, image dimension reading, and page streaming.
  * Enhanced compatibility when processing CBZ/CBX comic book files.

* **Tests**
  * Updated archive-processing tests to validate the improved ZIP handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->