### PR TITLE
refactor(oidc): use similar rest client config across OIDC

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/oidc/OidcDiscoveryService.java
+++ b/backend/src/main/java/org/booklore/config/security/oidc/OidcDiscoveryService.java
@@ -1,9 +1,9 @@
 package org.booklore.config.security.oidc;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
 import java.time.Instant;
@@ -15,14 +15,14 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Service
+@AllArgsConstructor
 public class OidcDiscoveryService {
 
     private static final Pattern TRAILING_SLASH = Pattern.compile("/+$");
     private static final long CACHE_TTL_MS = 3_600_000; // 1 hour
-    private static final int CONNECT_TIMEOUT_MS = 10_000;
-    private static final int READ_TIMEOUT_MS = 10_000;
 
     private final ConcurrentMap<String, CachedDiscovery> cache = new ConcurrentHashMap<>();
+    private final RestTemplate oidcRestTemplate;
 
     public record DiscoveryDocument(
             String issuer,
@@ -63,16 +63,10 @@ public class OidcDiscoveryService {
         String discoveryUrl = issuerUri + "/.well-known/openid-configuration";
         log.info("Fetching OIDC discovery document from {}", discoveryUrl);
 
-        var factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
-        factory.setReadTimeout(READ_TIMEOUT_MS);
-
-        var restClient = RestClient.builder().requestFactory(factory).build();
-
-        Map<String, Object> doc = restClient.get()
-                .uri(discoveryUrl)
-                .retrieve()
-                .body(Map.class);
+        Map<String, Object> doc = oidcRestTemplate.getForObject(
+                    discoveryUrl,
+                    Map.class
+                );
 
         if (doc == null) {
             throw new IllegalStateException("Failed to fetch OIDC discovery document from " + discoveryUrl);

--- a/backend/src/main/java/org/booklore/service/oidc/OidcDiagnosticService.java
+++ b/backend/src/main/java/org/booklore/service/oidc/OidcDiagnosticService.java
@@ -4,15 +4,14 @@ import com.nimbusds.jose.jwk.JWKSet;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.model.dto.settings.OidcProviderDetails;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.booklore.util.FileUtils;
+import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
@@ -28,6 +27,8 @@ public class OidcDiagnosticService {
     private static final int CONNECT_TIMEOUT_MS = 10_000;
     private static final int READ_TIMEOUT_MS = 10_000;
 
+    private final RestTemplate oidcRestTemplate;
+
     @SuppressWarnings("unchecked")
     public OidcTestResult testConnection(OidcProviderDetails providerDetails) {
         List<OidcTestCheck> checks = new ArrayList<>();
@@ -39,12 +40,7 @@ public class OidcDiagnosticService {
             String issuerUri = FileUtils.trimTrailingSlashes(providerDetails.getIssuerUri());
             String discoveryUrl = issuerUri + "/.well-known/openid-configuration";
 
-            var factory = new SimpleClientHttpRequestFactory();
-            factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
-            factory.setReadTimeout(READ_TIMEOUT_MS);
-
-            var restClient = RestClient.builder().requestFactory(factory).build();
-            doc = restClient.get().uri(discoveryUrl).retrieve().body(Map.class);
+            doc = oidcRestTemplate.getForObject(discoveryUrl, Map.class);
 
             if (doc == null) {
                 checks.add(new OidcTestCheck("Discovery Document", CheckStatus.FAIL, "Empty response from discovery endpoint"));


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
OIDC uses multiple different rest configurations, which leads to differences between testing, running, etc.  this forces all of the OIDC configurations to use the `oidcRestTemplate`

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2407

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* updates OIDC Discovery service to use rest config rest template
* updates OIDC Diagnostic service to use rest config rest template

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

* ran normal OIDC flow happy path
* confirmed host filtering now also applies on "test connection"

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved OIDC discovery and diagnostic request handling through shared HTTP configuration.
  * Preserved existing discovery validation, caching, timeout behavior, and error handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->