### PR TITLE
fix(ui): use signals in OIDC test connection

### DIFF
--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -250,14 +250,14 @@
 
       <div class="provider-actions-row">
         <div class="test-results-inline">
-          @if (testConnectionResult) {
+          @if (testConnectionResult()) {
             <div class="test-results-toggle"
-                 [style.border-radius]="showTestDetails ? '6px 6px 0 0' : '6px'"
+                 [style.border-radius]="showTestDetails() ? '6px 6px 0 0' : '6px'"
                  role="button"
                  tabindex="0"
-                 (click)="showTestDetails = !showTestDetails"
-                 (keydown.enter)="showTestDetails = !showTestDetails">
-              @if (testConnectionResult.success) {
+                 (click)="toggleTestDetails()"
+                 (keydown.enter)="toggleTestDetails()">
+              @if (testConnectionResult()?.success) {
                 <i class="pi pi-check-circle text-emerald-700 dark:text-emerald-300"></i>
                 <span>{{ t('testConnection.passed') }}</span>
               } @else {
@@ -265,9 +265,9 @@
                 <span>{{ t('testConnection.failed') }}</span>
               }
               <span style="color: var(--p-text-muted-color); font-size: 0.75rem;">
-                ({{ testConnectionResult.checks.length }} {{ t('testConnection.checks') }})
+                ({{ testConnectionResult()?.checks?.length ?? 0 }} {{ t('testConnection.checks') }})
               </span>
-              <i class="pi pi-chevron-right toggle-chevron" [class.expanded]="showTestDetails"></i>
+              <i class="pi pi-chevron-right toggle-chevron" [class.expanded]="showTestDetails()"></i>
             </div>
           }
         </div>
@@ -275,11 +275,11 @@
           <p-button
             [outlined]="true"
             [label]="t('testConnection.button')"
-            [icon]="isTestingConnection ? 'pi pi-spin pi-spinner' : 'pi pi-bolt'"
+            [icon]="isTestingConnection() ? 'pi pi-spin pi-spinner' : 'pi pi-bolt'"
             severity="info"
             size="small"
             (click)="testConnection()"
-            [disabled]="!oidcProvider.issuerUri || isTestingConnection">
+            [disabled]="!oidcProvider.issuerUri || isTestingConnection()">
           </p-button>
           <p-button
             [outlined]="true"
@@ -292,9 +292,9 @@
           </p-button>
         </div>
       </div>
-      @if (testConnectionResult && showTestDetails) {
+      @if (testConnectionResult() && showTestDetails()) {
         <div class="test-results-details">
-          @for (check of testConnectionResult.checks; track check.name) {
+          @for (check of testConnectionResult()?.checks; track check.name) {
             <div class="test-check-row">
               @switch (check.status) {
                 @case ('PASS') {

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
@@ -495,12 +495,12 @@ describe('AuthenticationSettingsComponent', () => {
 
     component.testConnection();
 
-    expect(component.isTestingConnection).toBe(false);
-    expect(component.testConnectionResult).toEqual({
+    expect(component.isTestingConnection()).toBe(false);
+    expect(component.testConnectionResult()).toEqual({
       success: true,
       checks: [{name: 'issuer', status: 'PASS', message: 'ok'}],
     });
-    expect(component.showTestDetails).toBe(true);
+    expect(component.showTestDetails()).toBe(true);
 
     appSettingsService.testOidcConnection.mockReturnValueOnce(
       throwError(() => new HttpErrorResponse({status: 500}))
@@ -508,7 +508,7 @@ describe('AuthenticationSettingsComponent', () => {
 
     component.testConnection();
 
-    expect(component.isTestingConnection).toBe(false);
+    expect(component.isTestingConnection()).toBe(false);
     expect(messageService.add).toHaveBeenCalledWith(expect.objectContaining({
       severity: 'error',
       detail: 'settingsAuth.testConnection.error',

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -1,5 +1,5 @@
 import {HttpErrorResponse} from '@angular/common/http';
-import {Component, effect, inject, signal} from '@angular/core';
+import {Component, effect, inject, signal, WritableSignal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {InputText} from '@openng/optimus-ui/inputtext';
 import {Button} from '@openng/optimus-ui/button';
@@ -99,9 +99,9 @@ export class AuthenticationSettingsComponent {
   ];
 
   // Test connection
-  isTestingConnection = false;
-  testConnectionResult: OidcTestResult | null = null;
-  showTestDetails = false;
+  readonly isTestingConnection = signal(false);
+  readonly testConnectionResult: WritableSignal<OidcTestResult | null> = signal(null);
+  readonly showTestDetails = signal(false);
 
   // Group mapping
   readonly groupSyncMode = signal('DISABLED');
@@ -450,14 +450,18 @@ export class AuthenticationSettingsComponent {
     return this.allLibraries.find(l => l.id === id)?.name ?? `#${id}`;
   }
 
+  toggleTestDetails(): void {
+    this.showTestDetails.update(s => !s)
+  }
+
   testConnection(): void {
-    this.isTestingConnection = true;
-    this.testConnectionResult = null;
+    this.isTestingConnection.set(true);
+    this.testConnectionResult.set(null);
     this.appSettingsService.testOidcConnection(this.oidcProvider).subscribe({
       next: (result) => {
-        this.testConnectionResult = result;
-        this.showTestDetails = true;
-        this.isTestingConnection = false;
+        this.testConnectionResult.set(result);
+        this.showTestDetails.set(true);
+        this.isTestingConnection.set(false);
       },
       error: () => {
         this.messageService.add({
@@ -465,7 +469,7 @@ export class AuthenticationSettingsComponent {
           summary: this.t.translate('common.error'),
           detail: this.t.translate('settingsAuth.testConnection.error')
         });
-        this.isTestingConnection = false;
+        this.isTestingConnection.set(false);
       }
     });
   }


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the OIDC test connection button is not responsive because it's not using signals.  this PR switches the test connection feature to use the angular signals feature for reactivity

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2416

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* add signals for test connection button
* update tests for new signals

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. click test connection
2. see results immediately

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the OIDC connection test experience by ensuring testing status, results, and detail visibility update reliably.
  * Test results now handle missing details gracefully.
  * Added consistent toggling for viewing connection test details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->