### PR TITLE
ci: pin angular table to v8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,8 @@ updates:
         versions: [">=22.0.0"]
       - dependency-name: "@angular/service-worker"
         versions: [">=22.0.0"]
+      - dependency-name: "@tanstack/angular-table"
+        versions: [">=9.0.0"]
       - dependency-name: "angular-eslint"
         versions: [">=22.0.0"]
       - dependency-name: "ngx-infinite-scroll"


### PR DESCRIPTION
## Description

Avoids dependabot updating to v9 until the book browser table work is merged. 

## Linked Issue

Related to #2419 

## Changes

Pinned `@tanstack/angular-table` to avoid the major v9 bump

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

N/A

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to skip major-version updates for the Angular table package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->