### PR TITLE
feat(api): add guarded physical-to-digital replacement delete

### DIFF
--- a/backend/src/main/java/org/booklore/controller/BookController.java
+++ b/backend/src/main/java/org/booklore/controller/BookController.java
@@ -12,18 +12,21 @@ import org.booklore.model.dto.request.DuplicateDetectionRequest;
 import org.booklore.model.dto.request.PersonalRatingUpdateRequest;
 import org.booklore.model.dto.request.ReadProgressRequest;
 import org.booklore.model.dto.request.ReadStatusUpdateRequest;
+import org.booklore.model.dto.request.ReplacementDeleteGuardRequest;
 import org.booklore.model.dto.request.ShelvesAssignmentRequest;
 import org.booklore.model.dto.response.AttachBookFileResponse;
 import org.booklore.model.dto.response.BookDeletionResponse;
 import org.booklore.model.dto.response.BookStatusUpdateResponse;
 import org.booklore.model.dto.response.DuplicateGroup;
 import org.booklore.model.dto.response.PersonalRatingUpdateResponse;
+import org.booklore.model.dto.response.ReplacementDeleteGuardResponse;
 import org.booklore.model.enums.ResetProgressType;
 import org.booklore.service.book.BookFileAttachmentService;
 import org.booklore.service.book.BookService;
 import org.booklore.service.book.BookUpdateService;
 import org.booklore.service.book.DuplicateDetectionService;
 import org.booklore.service.book.PhysicalBookService;
+import org.booklore.service.book.ReplacementDeleteGuardService;
 import org.booklore.service.browse.BookBrowseService;
 import org.booklore.service.browse.BookFacetService;
 import org.booklore.model.dto.browse.FacetGroupsResponse;
@@ -71,6 +74,7 @@ public class BookController {
     private final ReadingProgressService readingProgressService;
     private final PhysicalBookService physicalBookService;
     private final DuplicateDetectionService duplicateDetectionService;
+    private final ReplacementDeleteGuardService replacementDeleteGuardService;
 
     @Operation(summary = "Get all books", description = "Retrieve a list of all books. Optionally include descriptions.")
     @ApiResponse(responseCode = "200", description = "List of books returned successfully")
@@ -170,6 +174,21 @@ public class BookController {
     public ResponseEntity<BookDeletionResponse> deleteBooks(
             @Parameter(description = "Set of book IDs to delete") @RequestParam Set<Long> ids) {
         return bookService.deleteBooks(ids);
+    }
+
+    @Operation(summary = "Create a conditional replacement-delete guard")
+    @PostMapping("/replacement-delete-guards")
+    @PreAuthorize("@securityUtil.canDeleteBook() or @securityUtil.isAdmin()")
+    public ResponseEntity<ReplacementDeleteGuardResponse> createReplacementDeleteGuard(
+            @RequestBody @Valid ReplacementDeleteGuardRequest request) {
+        return ResponseEntity.ok(replacementDeleteGuardService.create(request));
+    }
+
+    @Operation(summary = "Consume a conditional replacement-delete guard")
+    @DeleteMapping("/replacement-delete-guards/{guardId}")
+    @PreAuthorize("@securityUtil.canDeleteBook() or @securityUtil.isAdmin()")
+    public ResponseEntity<?> consumeReplacementDeleteGuard(@PathVariable String guardId) {
+        return ResponseEntity.ok(replacementDeleteGuardService.consume(guardId));
     }
 
     @Operation(summary = "Get books by IDs", description = "Retrieve multiple books by their IDs. Optionally include descriptions.")

--- a/backend/src/main/java/org/booklore/model/dto/request/ReplacementDeleteGuardRequest.java
+++ b/backend/src/main/java/org/booklore/model/dto/request/ReplacementDeleteGuardRequest.java
@@ -1,0 +1,27 @@
+package org.booklore.model.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.booklore.model.enums.ReadStatus;
+
+import java.time.Instant;
+import java.util.Set;
+
+public record ReplacementDeleteGuardRequest(
+        @Positive long predecessorId,
+        @Positive long successorId,
+        @NotBlank String isbn,
+        @NotNull @Valid ReaderState expectedSuccessorState
+) {
+    public record ReaderState(
+            @NotNull ReadStatus status,
+            Instant finishedAt,
+            Integer rating,
+            Set<Long> shelfIds,
+            Float progressPercent,
+            String progress,
+            String progressHref
+    ) {}
+}

--- a/backend/src/main/java/org/booklore/model/dto/response/ReplacementDeleteGuardResponse.java
+++ b/backend/src/main/java/org/booklore/model/dto/response/ReplacementDeleteGuardResponse.java
@@ -1,0 +1,3 @@
+package org.booklore.model.dto.response;
+
+public record ReplacementDeleteGuardResponse(String guardId) {}

--- a/backend/src/main/java/org/booklore/repository/BookRepository.java
+++ b/backend/src/main/java/org/booklore/repository/BookRepository.java
@@ -21,6 +21,10 @@ import java.util.Set;
 
 @Repository
 public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpecificationExecutor<BookEntity> {
+    @Override
+    @EntityGraph(attributePaths = {"metadata", "metadata.comicMetadata", "library", "bookFiles"})
+    List<BookEntity> findAll(org.springframework.data.jpa.domain.Specification<BookEntity> spec);
+
     Optional<BookEntity> findBookByIdAndLibraryId(long id, long libraryId);
 
     @EntityGraph(attributePaths = { "metadata", "metadata.authors", "bookFiles", "libraryPath" })

--- a/backend/src/main/java/org/booklore/repository/UserBookFileProgressRepository.java
+++ b/backend/src/main/java/org/booklore/repository/UserBookFileProgressRepository.java
@@ -15,6 +15,13 @@ import java.util.Optional;
 @Repository
 public interface UserBookFileProgressRepository extends JpaRepository<UserBookFileProgressEntity, Long> {
 
+    @Query("""
+        SELECT CASE WHEN COUNT(ubfp) > 0 THEN true ELSE false END
+        FROM UserBookFileProgressEntity ubfp
+        WHERE ubfp.bookFile.book.id = :bookId
+    """)
+    boolean existsByBookFileBookId(@Param("bookId") Long bookId);
+
     @EntityGraph(attributePaths = {"bookFile", "bookFile.book"})
     Optional<UserBookFileProgressEntity> findByUserIdAndBookFileId(Long userId, Long bookFileId);
 

--- a/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
+++ b/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
@@ -50,13 +50,15 @@ public class ReplacementDeleteGuardService {
         String isbn13 = canonical13(request.isbn());
         if (isbn13 == null || request.predecessorId() == request.successorId()) fail();
         BookLoreUser user = authenticationService.getAuthenticatedUser();
-        List<BookEntity> population = matchingPopulation(visibleBooks(user), isbn13);
+        List<BookEntity> population = matchingPopulation(allCatalogBooks(), isbn13);
+        List<BookEntity> visiblePopulation = matchingPopulation(visibleBooks(user), isbn13);
         BookEntity predecessor = find(population, request.predecessorId());
         BookEntity successor = find(population, request.successorId());
-        if (population.size() != 2 || predecessor == null || successor == null
+        if (population.size() != 2 || find(visiblePopulation, request.predecessorId()) == null
+                || find(visiblePopulation, request.successorId()) == null || predecessor == null || successor == null
                 || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || predecessor.hasFiles() || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !successor.hasFiles() || !consistentIsbn(predecessor, isbn13) || !consistentIsbn(successor, isbn13)) fail();
-        if (!successorFileProgressEmpty(user.getId(), successor.getId())) fail();
+        if (!successorFileProgressEmpty(successor.getId())) fail();
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), successor.getId()).orElse(null);
         if (!stateMatches(state, successor, user.getId(), request.expectedSuccessorState())) fail();
         String id = UUID.randomUUID().toString();
@@ -76,15 +78,18 @@ public class ReplacementDeleteGuardService {
         BookLoreUser user = authenticationService.getAuthenticatedUser();
         if (!Objects.equals(user.getId(), guard.userId())) fail();
         if (!guards.remove(id, guard)) fail();
-        List<BookEntity> population = matchingPopulation(visibleBooks(user), guard.isbn13());
+        List<BookEntity> population = matchingPopulation(allCatalogBooks(), guard.isbn13());
+        List<BookEntity> visiblePopulation = matchingPopulation(visibleBooks(user), guard.isbn13());
         BookEntity predecessor = find(population, guard.predecessorId());
         BookEntity successor = find(population, guard.successorId());
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), guard.successorId()).orElse(null);
-        if (population.size() != 2 || !populationIds(population).equals(guard.populationIds()) || predecessor == null || successor == null
+        if (population.size() != 2 || !populationIds(population).equals(guard.populationIds())
+                || find(visiblePopulation, guard.predecessorId()) == null || find(visiblePopulation, guard.successorId()) == null
+                || predecessor == null || successor == null
                 || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || predecessor.hasFiles() || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !successor.hasFiles() || !consistentIsbn(predecessor, guard.isbn13()) || !consistentIsbn(successor, guard.isbn13())
                 || !stateMatches(state, successor, user.getId(), guard.expectedState())
-                || !successorFileProgressEmpty(user.getId(), guard.successorId())) fail();
+                || !successorFileProgressEmpty(guard.successorId())) fail();
         // The guard is consumed first. If deletion reports an unexpected result, the
         // database transaction rolls back, but filesystem side effects may already exist;
         // report indeterminate rather than claiming that the predecessor survived.
@@ -110,12 +115,15 @@ public class ReplacementDeleteGuardService {
                 .and(inLibraries(libraries))
                 .and(ContentRestrictionSpecification.from(restrictionRepository.findByUserId(user.getId()))));
     }
+    private List<BookEntity> allCatalogBooks() {
+        return bookRepository.findAllFullBooksWithFiles();
+    }
     private static org.springframework.data.jpa.domain.Specification<BookEntity> inLibraries(Set<Long> libraryIds) {
         return (root, query, cb) -> libraryIds.isEmpty()
                 ? cb.disjunction() : root.get("library").get("id").in(libraryIds);
     }
-    private boolean successorFileProgressEmpty(Long userId, Long bookId) {
-        return fileProgressRepository.findByUserIdAndBookFileBookId(userId, bookId).isEmpty();
+    private boolean successorFileProgressEmpty(Long bookId) {
+        return !fileProgressRepository.existsByBookFileBookId(bookId);
     }
     private static BookEntity find(List<BookEntity> books, long id) { return books.stream().filter(b -> b.getId() == id).findFirst().orElse(null); }
     private static Set<Long> populationIds(List<BookEntity> books) { return books.stream().map(BookEntity::getId).collect(Collectors.toSet()); }

--- a/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
+++ b/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
@@ -8,6 +8,7 @@ import org.booklore.model.dto.Library;
 import org.booklore.model.dto.request.ReplacementDeleteGuardRequest;
 import org.booklore.model.dto.response.ReplacementDeleteGuardResponse;
 import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.ShelfEntity;
 import org.booklore.model.entity.UserBookProgressEntity;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserBookProgressRepository;
@@ -31,21 +32,23 @@ public class ReplacementDeleteGuardService {
     private final UserBookProgressRepository progressRepository;
     private final AuthenticationService authenticationService;
     private final BookService bookService;
+    // JVM-local by design: restart or another node invalidates outstanding guards fail-closed; use sticky routing until durable shared storage exists.
     private final Map<String, Guard> guards = new ConcurrentHashMap<>();
 
     @Transactional(readOnly = true)
     public ReplacementDeleteGuardResponse create(ReplacementDeleteGuardRequest request) {
+        purgeExpiredGuards();
         String isbn13 = canonical13(request.isbn());
         if (isbn13 == null || request.predecessorId() == request.successorId()) fail();
         BookLoreUser user = authenticationService.getAuthenticatedUser();
-        List<BookEntity> population = visibleBooks(user).stream().filter(ReplacementDeleteGuardService::hasAnyIsbn).toList();
+        List<BookEntity> population = matchingPopulation(visibleBooks(user), isbn13);
         BookEntity predecessor = find(population, request.predecessorId());
         BookEntity successor = find(population, request.successorId());
         if (population.size() != 2 || predecessor == null || successor == null
                 || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !successor.hasFiles() || !consistentIsbn(predecessor, isbn13) || !consistentIsbn(successor, isbn13)) fail();
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), successor.getId()).orElse(null);
-        if (!stateMatches(state, request.expectedSuccessorState())) fail();
+        if (!stateMatches(state, successor, request.expectedSuccessorState())) fail();
         String id = UUID.randomUUID().toString();
         guards.put(id, new Guard(user.getId(), predecessor.getId(), successor.getId(), population.stream().map(BookEntity::getId).collect(Collectors.toUnmodifiableSet()), isbn13, request.expectedSuccessorState(), Instant.now().plus(TTL)));
         return new ReplacementDeleteGuardResponse(id);
@@ -53,18 +56,19 @@ public class ReplacementDeleteGuardService {
 
     @Transactional
     public Map<String, Object> consume(String id) {
+        purgeExpiredGuards();
         Guard guard = guards.remove(id);
         if (guard == null || guard.expiresAt().isBefore(Instant.now())) fail();
         BookLoreUser user = authenticationService.getAuthenticatedUser();
         if (!Objects.equals(user.getId(), guard.userId())) fail();
-        List<BookEntity> population = visibleBooks(user).stream().filter(ReplacementDeleteGuardService::hasAnyIsbn).toList();
+        List<BookEntity> population = matchingPopulation(visibleBooks(user), guard.isbn13());
         BookEntity predecessor = find(population, guard.predecessorId());
         BookEntity successor = find(population, guard.successorId());
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), guard.successorId()).orElse(null);
         if (population.size() != 2 || !populationIds(population).equals(guard.populationIds()) || predecessor == null || successor == null
                 || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !consistentIsbn(predecessor, guard.isbn13()) || !consistentIsbn(successor, guard.isbn13())
-                || !stateMatches(state, guard.expectedState())) fail();
+                || !stateMatches(state, successor, guard.expectedState())) fail();
         // This is the existing transactional file/sidecar deletion implementation; the guard is consumed first.
         bookService.deleteBooks(Set.of(predecessor.getId()));
         return Map.of("deletedBookId", predecessor.getId(), "guardId", id, "status", "deleted");
@@ -76,14 +80,37 @@ public class ReplacementDeleteGuardService {
     }
     private static BookEntity find(List<BookEntity> books, long id) { return books.stream().filter(b -> b.getId() == id).findFirst().orElse(null); }
     private static Set<Long> populationIds(List<BookEntity> books) { return books.stream().map(BookEntity::getId).collect(Collectors.toSet()); }
-    private static boolean hasAnyIsbn(BookEntity b) { return b.getMetadata() != null && (b.getMetadata().getIsbn13() != null || b.getMetadata().getIsbn10() != null); }
-    private static boolean matchesIsbn(BookEntity b, String isbn13) { return b.getMetadata() != null && (isbn13.equals(b.getMetadata().getIsbn13()) || isbn13.equals(to13(b.getMetadata().getIsbn10()))); }
-    private static boolean consistentIsbn(BookEntity b, String isbn13) { return matchesIsbn(b, isbn13) && (b.getMetadata().getIsbn13() == null || valid13(b.getMetadata().getIsbn13())) && (b.getMetadata().getIsbn10() == null || valid10(b.getMetadata().getIsbn10())); }
-    private static String canonical13(String value) { if (value == null) return null; String v = value.replaceAll("[^0-9Xx]", "").toUpperCase(); if (!ISBN.matcher(v).matches()) return null; return v.length() == 13 && valid13(v) ? v : to13(v); }
+    static List<BookEntity> matchingPopulation(List<BookEntity> books, String isbn13) { return books.stream().filter(book -> mentionsIsbn(book, isbn13)).toList(); }
+    static boolean mentionsIsbn(BookEntity b, String isbn13) {
+        if (b.getMetadata() == null) return false;
+        return isbn13.equals(canonical13(b.getMetadata().getIsbn13())) || isbn13.equals(canonical13(b.getMetadata().getIsbn10()));
+    }
+    static boolean consistentIsbn(BookEntity b, String isbn13) {
+        if (!mentionsIsbn(b, isbn13)) return false;
+        String isbn13Value = b.getMetadata().getIsbn13();
+        String isbn10Value = b.getMetadata().getIsbn10();
+        return (isbn13Value == null || isbn13.equals(canonical13(isbn13Value)))
+                && (isbn10Value == null || isbn13.equals(canonical13(isbn10Value)));
+    }
+    private static String canonical13(String value) { if (value == null) return null; String v = value.trim().replaceAll("[\\s-]", "").toUpperCase(); if (!ISBN.matcher(v).matches()) return null; return v.length() == 13 && valid13(v) ? v : to13(v); }
     private static String to13(String v) { if (v == null || !valid10(v)) return null; String p = "978" + v.substring(0, 9); int sum = 0; for (int i=0;i<12;i++) sum += (p.charAt(i)-'0') * (i%2==0?1:3); return p + ((10-sum%10)%10); }
     private static boolean valid13(String v) { if (v == null || !v.matches("[0-9]{13}")) return false; int s=0; for(int i=0;i<13;i++) s+=(v.charAt(i)-'0')*(i%2==0?1:3); return s%10==0; }
     private static boolean valid10(String v) { if (v == null || !v.matches("[0-9]{9}[0-9X]")) return false; int s=0; for(int i=0;i<10;i++) s+=(v.charAt(i)=='X'?10:v.charAt(i)-'0')*(10-i); return s%11==0; }
-    private static boolean stateMatches(UserBookProgressEntity p, ReplacementDeleteGuardRequest.ReaderState e) { return p != null && p.getReadStatus()==e.status() && Objects.equals(p.getDateFinished(),e.finishedAt()) && Objects.equals(p.getPersonalRating(),e.rating()) && Objects.equals(p.getEpubProgressPercent(),e.progressPercent()) && Objects.equals(p.getEpubProgress(),e.progress()) && Objects.equals(p.getEpubProgressHref(),e.progressHref()); }
+    private static boolean stateMatches(UserBookProgressEntity p, BookEntity successor, ReplacementDeleteGuardRequest.ReaderState e) {
+        return p != null && Objects.equals(shelves(successor), e.shelfIds())
+                && p.getReadStatus() == e.status() && Objects.equals(p.getDateFinished(), e.finishedAt())
+                && Objects.equals(p.getPersonalRating(), e.rating()) && Objects.equals(p.getEpubProgressPercent(), e.progressPercent())
+                && Objects.equals(p.getEpubProgress(), e.progress()) && Objects.equals(p.getEpubProgressHref(), e.progressHref())
+                && supportedProgress(p);
+    }
+    static Set<Long> shelves(BookEntity book) { return book.getShelves() == null ? Set.of() : book.getShelves().stream().map(ShelfEntity::getId).collect(Collectors.toUnmodifiableSet()); }
+    static boolean supportedProgress(UserBookProgressEntity p) {
+        return p.getPdfProgress() == null && p.getPdfProgressPercent() == null && p.getCbxProgress() == null
+                && p.getCbxProgressPercent() == null && p.getKoreaderProgress() == null && p.getKoreaderProgressPercent() == null
+                && p.getKoboProgressPercent() == null && p.getKoboLocation() == null && p.getKoboLocationType() == null
+                && p.getKoboLocationSource() == null;
+    }
+    private void purgeExpiredGuards() { Instant now = Instant.now(); guards.entrySet().removeIf(entry -> entry.getValue().expiresAt().isBefore(now)); }
     private static void fail() { throw new APIException("Replacement delete guard conflict", HttpStatus.CONFLICT); }
     private record Guard(Long userId, Long predecessorId, Long successorId, Set<Long> populationIds, String isbn13, ReplacementDeleteGuardRequest.ReaderState expectedState, Instant expiresAt) {}
 }

--- a/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
+++ b/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
@@ -6,6 +6,7 @@ import org.booklore.exception.APIException;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.dto.Library;
 import org.booklore.model.dto.request.ReplacementDeleteGuardRequest;
+import org.booklore.model.dto.response.BookDeletionResponse;
 import org.booklore.model.dto.response.ReplacementDeleteGuardResponse;
 import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.ShelfEntity;
@@ -13,6 +14,7 @@ import org.booklore.model.entity.UserBookProgressEntity;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserBookProgressRepository;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.annotation.Isolation;
@@ -46,7 +48,7 @@ public class ReplacementDeleteGuardService {
         BookEntity predecessor = find(population, request.predecessorId());
         BookEntity successor = find(population, request.successorId());
         if (population.size() != 2 || predecessor == null || successor == null
-                || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || Boolean.TRUE.equals(successor.getIsPhysical())
+                || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || predecessor.hasFiles() || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !successor.hasFiles() || !consistentIsbn(predecessor, isbn13) || !consistentIsbn(successor, isbn13)) fail();
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), successor.getId()).orElse(null);
         if (!stateMatches(state, successor, request.expectedSuccessorState())) fail();
@@ -71,11 +73,24 @@ public class ReplacementDeleteGuardService {
         BookEntity successor = find(population, guard.successorId());
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), guard.successorId()).orElse(null);
         if (population.size() != 2 || !populationIds(population).equals(guard.populationIds()) || predecessor == null || successor == null
-                || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || Boolean.TRUE.equals(successor.getIsPhysical())
+                || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || predecessor.hasFiles() || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !successor.hasFiles() || !consistentIsbn(predecessor, guard.isbn13()) || !consistentIsbn(successor, guard.isbn13())
                 || !stateMatches(state, successor, guard.expectedState())) fail();
-        // This is the existing transactional file/sidecar deletion implementation; the guard is consumed first.
-        bookService.deleteBooks(Set.of(predecessor.getId()));
+        // The guard is consumed first. If deletion reports an unexpected result, the
+        // database transaction rolls back, but filesystem side effects may already exist;
+        // report indeterminate rather than claiming that the predecessor survived.
+        ResponseEntity<BookDeletionResponse> deletionResult;
+        try {
+            deletionResult = bookService.deleteBooks(Set.of(predecessor.getId()));
+        } catch (RuntimeException e) {
+            throw indeterminateDelete();
+        }
+        BookDeletionResponse deletion = deletionResult == null ? null : deletionResult.getBody();
+        if (deletionResult == null || deletionResult.getStatusCode() != HttpStatus.OK || deletion == null
+                || !Set.of(predecessor.getId()).equals(deletion.getDeleted())
+                || deletion.getFailedFileDeletions() == null || !deletion.getFailedFileDeletions().isEmpty()) {
+            throw indeterminateDelete();
+        }
         return Map.of("deletedBookId", predecessor.getId(), "guardId", id, "status", "deleted");
     }
 
@@ -117,5 +132,8 @@ public class ReplacementDeleteGuardService {
     }
     private void purgeExpiredGuards() { Instant now = Instant.now(); guards.entrySet().removeIf(entry -> entry.getValue().expiresAt().isBefore(now)); }
     private static void fail() { throw new APIException("Replacement delete guard conflict", HttpStatus.CONFLICT); }
+    private static APIException indeterminateDelete() {
+        return new APIException("Replacement delete outcome is indeterminate; predecessor state must be re-read", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
     private record Guard(Long userId, Long predecessorId, Long successorId, Set<Long> populationIds, String isbn13, ReplacementDeleteGuardRequest.ReaderState expectedState, Instant expiresAt) {}
 }

--- a/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
+++ b/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
@@ -15,6 +15,7 @@ import org.booklore.repository.UserBookProgressRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Isolation;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -54,7 +55,11 @@ public class ReplacementDeleteGuardService {
         return new ReplacementDeleteGuardResponse(id);
     }
 
-    @Transactional
+    // MariaDB/InnoDB SERIALIZABLE turns the population read into a locking read and
+    // holds its row/gap locks until the joined BookService deletion commits. This is
+    // the database linearization boundary: ISBN population inserts/updates cannot
+    // pass the final validation and deletion as a read-committed race could.
+    @Transactional(isolation = Isolation.SERIALIZABLE)
     public Map<String, Object> consume(String id) {
         purgeExpiredGuards();
         Guard guard = guards.remove(id);
@@ -67,7 +72,7 @@ public class ReplacementDeleteGuardService {
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), guard.successorId()).orElse(null);
         if (population.size() != 2 || !populationIds(population).equals(guard.populationIds()) || predecessor == null || successor == null
                 || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || Boolean.TRUE.equals(successor.getIsPhysical())
-                || !consistentIsbn(predecessor, guard.isbn13()) || !consistentIsbn(successor, guard.isbn13())
+                || !successor.hasFiles() || !consistentIsbn(predecessor, guard.isbn13()) || !consistentIsbn(successor, guard.isbn13())
                 || !stateMatches(state, successor, guard.expectedState())) fail();
         // This is the existing transactional file/sidecar deletion implementation; the guard is consumed first.
         bookService.deleteBooks(Set.of(predecessor.getId()));

--- a/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
+++ b/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
@@ -58,7 +58,7 @@ public class ReplacementDeleteGuardService {
                 || !successor.hasFiles() || !consistentIsbn(predecessor, isbn13) || !consistentIsbn(successor, isbn13)) fail();
         if (!successorFileProgressEmpty(user.getId(), successor.getId())) fail();
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), successor.getId()).orElse(null);
-        if (!stateMatches(state, successor, request.expectedSuccessorState())) fail();
+        if (!stateMatches(state, successor, user.getId(), request.expectedSuccessorState())) fail();
         String id = UUID.randomUUID().toString();
         guards.put(id, new Guard(user.getId(), predecessor.getId(), successor.getId(), population.stream().map(BookEntity::getId).collect(Collectors.toUnmodifiableSet()), isbn13, request.expectedSuccessorState(), Instant.now().plus(TTL)));
         return new ReplacementDeleteGuardResponse(id);
@@ -82,7 +82,7 @@ public class ReplacementDeleteGuardService {
         if (population.size() != 2 || !populationIds(population).equals(guard.populationIds()) || predecessor == null || successor == null
                 || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || predecessor.hasFiles() || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !successor.hasFiles() || !consistentIsbn(predecessor, guard.isbn13()) || !consistentIsbn(successor, guard.isbn13())
-                || !stateMatches(state, successor, guard.expectedState())
+                || !stateMatches(state, successor, user.getId(), guard.expectedState())
                 || !successorFileProgressEmpty(user.getId(), guard.successorId())) fail();
         // The guard is consumed first. If deletion reports an unexpected result, the
         // database transaction rolls back, but filesystem side effects may already exist;
@@ -134,14 +134,20 @@ public class ReplacementDeleteGuardService {
     private static String to13(String v) { if (v == null || !valid10(v)) return null; String p = "978" + v.substring(0, 9); int sum = 0; for (int i=0;i<12;i++) sum += (p.charAt(i)-'0') * (i%2==0?1:3); return p + ((10-sum%10)%10); }
     private static boolean valid13(String v) { if (v == null || !v.matches("[0-9]{13}")) return false; int s=0; for(int i=0;i<13;i++) s+=(v.charAt(i)-'0')*(i%2==0?1:3); return s%10==0; }
     private static boolean valid10(String v) { if (v == null || !v.matches("[0-9]{9}[0-9X]")) return false; int s=0; for(int i=0;i<10;i++) s+=(v.charAt(i)=='X'?10:v.charAt(i)-'0')*(10-i); return s%11==0; }
-    private static boolean stateMatches(UserBookProgressEntity p, BookEntity successor, ReplacementDeleteGuardRequest.ReaderState e) {
-        return p != null && Objects.equals(shelves(successor), e.shelfIds())
+    private static boolean stateMatches(UserBookProgressEntity p, BookEntity successor, Long authenticatedUserId,
+                                        ReplacementDeleteGuardRequest.ReaderState e) {
+        return p != null && Objects.equals(shelves(successor, authenticatedUserId), e.shelfIds())
                 && p.getReadStatus() == e.status() && Objects.equals(p.getDateFinished(), e.finishedAt())
                 && Objects.equals(p.getPersonalRating(), e.rating()) && Objects.equals(p.getEpubProgressPercent(), e.progressPercent())
                 && Objects.equals(p.getEpubProgress(), e.progress()) && Objects.equals(p.getEpubProgressHref(), e.progressHref())
                 && supportedProgress(p);
     }
-    static Set<Long> shelves(BookEntity book) { return book.getShelves() == null ? Set.of() : book.getShelves().stream().map(ShelfEntity::getId).collect(Collectors.toUnmodifiableSet()); }
+    static Set<Long> shelves(BookEntity book, Long authenticatedUserId) {
+        return book.getShelves() == null ? Set.of() : book.getShelves().stream()
+                .filter(shelf -> shelf.isPublic() || (shelf.getUser() != null && authenticatedUserId.equals(shelf.getUser().getId())))
+                .map(ShelfEntity::getId)
+                .collect(Collectors.toUnmodifiableSet());
+    }
     static boolean supportedProgress(UserBookProgressEntity p) {
         return p.getPdfProgress() == null && p.getPdfProgressPercent() == null && p.getCbxProgress() == null
                 && p.getCbxProgressPercent() == null && p.getKoreaderProgress() == null && p.getKoreaderProgressPercent() == null

--- a/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
+++ b/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
@@ -71,10 +71,11 @@ public class ReplacementDeleteGuardService {
     @Transactional(isolation = Isolation.SERIALIZABLE)
     public Map<String, Object> consume(String id) {
         purgeExpiredGuards();
-        Guard guard = guards.remove(id);
+        Guard guard = guards.get(id);
         if (guard == null || guard.expiresAt().isBefore(Instant.now())) fail();
         BookLoreUser user = authenticationService.getAuthenticatedUser();
         if (!Objects.equals(user.getId(), guard.userId())) fail();
+        if (!guards.remove(id, guard)) fail();
         List<BookEntity> population = matchingPopulation(visibleBooks(user), guard.isbn13());
         BookEntity predecessor = find(population, guard.predecessorId());
         BookEntity successor = find(population, guard.successorId());

--- a/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
+++ b/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
@@ -13,6 +13,10 @@ import org.booklore.model.entity.ShelfEntity;
 import org.booklore.model.entity.UserBookProgressEntity;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserBookProgressRepository;
+import org.booklore.repository.UserBookFileProgressRepository;
+import org.booklore.repository.UserContentRestrictionRepository;
+import org.booklore.security.policy.ContentRestrictionSpecification;
+import org.booklore.app.specification.AppBookSpecification;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -33,6 +37,8 @@ public class ReplacementDeleteGuardService {
     private static final Pattern ISBN = Pattern.compile("[0-9]{9}[0-9X]|[0-9]{13}");
     private final BookRepository bookRepository;
     private final UserBookProgressRepository progressRepository;
+    private final UserBookFileProgressRepository fileProgressRepository;
+    private final UserContentRestrictionRepository restrictionRepository;
     private final AuthenticationService authenticationService;
     private final BookService bookService;
     // JVM-local by design: restart or another node invalidates outstanding guards fail-closed; use sticky routing until durable shared storage exists.
@@ -50,6 +56,7 @@ public class ReplacementDeleteGuardService {
         if (population.size() != 2 || predecessor == null || successor == null
                 || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || predecessor.hasFiles() || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !successor.hasFiles() || !consistentIsbn(predecessor, isbn13) || !consistentIsbn(successor, isbn13)) fail();
+        if (!successorFileProgressEmpty(user.getId(), successor.getId())) fail();
         UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), successor.getId()).orElse(null);
         if (!stateMatches(state, successor, request.expectedSuccessorState())) fail();
         String id = UUID.randomUUID().toString();
@@ -75,7 +82,8 @@ public class ReplacementDeleteGuardService {
         if (population.size() != 2 || !populationIds(population).equals(guard.populationIds()) || predecessor == null || successor == null
                 || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || predecessor.hasFiles() || Boolean.TRUE.equals(successor.getIsPhysical())
                 || !successor.hasFiles() || !consistentIsbn(predecessor, guard.isbn13()) || !consistentIsbn(successor, guard.isbn13())
-                || !stateMatches(state, successor, guard.expectedState())) fail();
+                || !stateMatches(state, successor, guard.expectedState())
+                || !successorFileProgressEmpty(user.getId(), guard.successorId())) fail();
         // The guard is consumed first. If deletion reports an unexpected result, the
         // database transaction rolls back, but filesystem side effects may already exist;
         // report indeterminate rather than claiming that the predecessor survived.
@@ -96,7 +104,17 @@ public class ReplacementDeleteGuardService {
 
     private List<BookEntity> visibleBooks(BookLoreUser user) {
         Set<Long> libraries = user.getAssignedLibraries().stream().map(Library::getId).collect(Collectors.toSet());
-        return bookRepository.findAllFullBooksWithFiles().stream().filter(b -> user.getPermissions().isAdmin() || libraries.contains(b.getLibrary().getId())).toList();
+        if (user.getPermissions().isAdmin()) return bookRepository.findAllFullBooksWithFiles();
+        return bookRepository.findAll(AppBookSpecification.notDeleted()
+                .and(inLibraries(libraries))
+                .and(ContentRestrictionSpecification.from(restrictionRepository.findByUserId(user.getId()))));
+    }
+    private static org.springframework.data.jpa.domain.Specification<BookEntity> inLibraries(Set<Long> libraryIds) {
+        return (root, query, cb) -> libraryIds.isEmpty()
+                ? cb.disjunction() : root.get("library").get("id").in(libraryIds);
+    }
+    private boolean successorFileProgressEmpty(Long userId, Long bookId) {
+        return fileProgressRepository.findByUserIdAndBookFileBookId(userId, bookId).isEmpty();
     }
     private static BookEntity find(List<BookEntity> books, long id) { return books.stream().filter(b -> b.getId() == id).findFirst().orElse(null); }
     private static Set<Long> populationIds(List<BookEntity> books) { return books.stream().map(BookEntity::getId).collect(Collectors.toSet()); }

--- a/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
+++ b/backend/src/main/java/org/booklore/service/book/ReplacementDeleteGuardService.java
@@ -1,0 +1,89 @@
+package org.booklore.service.book;
+
+import lombok.AllArgsConstructor;
+import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.exception.APIException;
+import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.dto.Library;
+import org.booklore.model.dto.request.ReplacementDeleteGuardRequest;
+import org.booklore.model.dto.response.ReplacementDeleteGuardResponse;
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.UserBookProgressEntity;
+import org.booklore.repository.BookRepository;
+import org.booklore.repository.UserBookProgressRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class ReplacementDeleteGuardService {
+    private static final Duration TTL = Duration.ofMinutes(5);
+    private static final Pattern ISBN = Pattern.compile("[0-9]{9}[0-9X]|[0-9]{13}");
+    private final BookRepository bookRepository;
+    private final UserBookProgressRepository progressRepository;
+    private final AuthenticationService authenticationService;
+    private final BookService bookService;
+    private final Map<String, Guard> guards = new ConcurrentHashMap<>();
+
+    @Transactional(readOnly = true)
+    public ReplacementDeleteGuardResponse create(ReplacementDeleteGuardRequest request) {
+        String isbn13 = canonical13(request.isbn());
+        if (isbn13 == null || request.predecessorId() == request.successorId()) fail();
+        BookLoreUser user = authenticationService.getAuthenticatedUser();
+        List<BookEntity> population = visibleBooks(user).stream().filter(ReplacementDeleteGuardService::hasAnyIsbn).toList();
+        BookEntity predecessor = find(population, request.predecessorId());
+        BookEntity successor = find(population, request.successorId());
+        if (population.size() != 2 || predecessor == null || successor == null
+                || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || Boolean.TRUE.equals(successor.getIsPhysical())
+                || !successor.hasFiles() || !consistentIsbn(predecessor, isbn13) || !consistentIsbn(successor, isbn13)) fail();
+        UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), successor.getId()).orElse(null);
+        if (!stateMatches(state, request.expectedSuccessorState())) fail();
+        String id = UUID.randomUUID().toString();
+        guards.put(id, new Guard(user.getId(), predecessor.getId(), successor.getId(), population.stream().map(BookEntity::getId).collect(Collectors.toUnmodifiableSet()), isbn13, request.expectedSuccessorState(), Instant.now().plus(TTL)));
+        return new ReplacementDeleteGuardResponse(id);
+    }
+
+    @Transactional
+    public Map<String, Object> consume(String id) {
+        Guard guard = guards.remove(id);
+        if (guard == null || guard.expiresAt().isBefore(Instant.now())) fail();
+        BookLoreUser user = authenticationService.getAuthenticatedUser();
+        if (!Objects.equals(user.getId(), guard.userId())) fail();
+        List<BookEntity> population = visibleBooks(user).stream().filter(ReplacementDeleteGuardService::hasAnyIsbn).toList();
+        BookEntity predecessor = find(population, guard.predecessorId());
+        BookEntity successor = find(population, guard.successorId());
+        UserBookProgressEntity state = progressRepository.findByUserIdAndBookId(user.getId(), guard.successorId()).orElse(null);
+        if (population.size() != 2 || !populationIds(population).equals(guard.populationIds()) || predecessor == null || successor == null
+                || !Boolean.TRUE.equals(predecessor.getIsPhysical()) || Boolean.TRUE.equals(successor.getIsPhysical())
+                || !consistentIsbn(predecessor, guard.isbn13()) || !consistentIsbn(successor, guard.isbn13())
+                || !stateMatches(state, guard.expectedState())) fail();
+        // This is the existing transactional file/sidecar deletion implementation; the guard is consumed first.
+        bookService.deleteBooks(Set.of(predecessor.getId()));
+        return Map.of("deletedBookId", predecessor.getId(), "guardId", id, "status", "deleted");
+    }
+
+    private List<BookEntity> visibleBooks(BookLoreUser user) {
+        Set<Long> libraries = user.getAssignedLibraries().stream().map(Library::getId).collect(Collectors.toSet());
+        return bookRepository.findAllFullBooksWithFiles().stream().filter(b -> user.getPermissions().isAdmin() || libraries.contains(b.getLibrary().getId())).toList();
+    }
+    private static BookEntity find(List<BookEntity> books, long id) { return books.stream().filter(b -> b.getId() == id).findFirst().orElse(null); }
+    private static Set<Long> populationIds(List<BookEntity> books) { return books.stream().map(BookEntity::getId).collect(Collectors.toSet()); }
+    private static boolean hasAnyIsbn(BookEntity b) { return b.getMetadata() != null && (b.getMetadata().getIsbn13() != null || b.getMetadata().getIsbn10() != null); }
+    private static boolean matchesIsbn(BookEntity b, String isbn13) { return b.getMetadata() != null && (isbn13.equals(b.getMetadata().getIsbn13()) || isbn13.equals(to13(b.getMetadata().getIsbn10()))); }
+    private static boolean consistentIsbn(BookEntity b, String isbn13) { return matchesIsbn(b, isbn13) && (b.getMetadata().getIsbn13() == null || valid13(b.getMetadata().getIsbn13())) && (b.getMetadata().getIsbn10() == null || valid10(b.getMetadata().getIsbn10())); }
+    private static String canonical13(String value) { if (value == null) return null; String v = value.replaceAll("[^0-9Xx]", "").toUpperCase(); if (!ISBN.matcher(v).matches()) return null; return v.length() == 13 && valid13(v) ? v : to13(v); }
+    private static String to13(String v) { if (v == null || !valid10(v)) return null; String p = "978" + v.substring(0, 9); int sum = 0; for (int i=0;i<12;i++) sum += (p.charAt(i)-'0') * (i%2==0?1:3); return p + ((10-sum%10)%10); }
+    private static boolean valid13(String v) { if (v == null || !v.matches("[0-9]{13}")) return false; int s=0; for(int i=0;i<13;i++) s+=(v.charAt(i)-'0')*(i%2==0?1:3); return s%10==0; }
+    private static boolean valid10(String v) { if (v == null || !v.matches("[0-9]{9}[0-9X]")) return false; int s=0; for(int i=0;i<10;i++) s+=(v.charAt(i)=='X'?10:v.charAt(i)-'0')*(10-i); return s%11==0; }
+    private static boolean stateMatches(UserBookProgressEntity p, ReplacementDeleteGuardRequest.ReaderState e) { return p != null && p.getReadStatus()==e.status() && Objects.equals(p.getDateFinished(),e.finishedAt()) && Objects.equals(p.getPersonalRating(),e.rating()) && Objects.equals(p.getEpubProgressPercent(),e.progressPercent()) && Objects.equals(p.getEpubProgress(),e.progress()) && Objects.equals(p.getEpubProgressHref(),e.progressHref()); }
+    private static void fail() { throw new APIException("Replacement delete guard conflict", HttpStatus.CONFLICT); }
+    private record Guard(Long userId, Long predecessorId, Long successorId, Set<Long> populationIds, String isbn13, ReplacementDeleteGuardRequest.ReaderState expectedState, Instant expiresAt) {}
+}

--- a/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
@@ -4,16 +4,40 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.entity.ShelfEntity;
 import org.booklore.model.entity.UserBookProgressEntity;
+import org.booklore.model.dto.BookLoreUser;
+import org.booklore.model.entity.BookFileEntity;
+import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.dto.Library;
+import org.booklore.model.dto.request.ReplacementDeleteGuardRequest;
+import org.booklore.model.enums.BookFileType;
+import org.booklore.model.enums.ReadStatus;
+import org.booklore.config.security.service.AuthenticationService;
+import org.booklore.repository.BookRepository;
+import org.booklore.repository.UserBookProgressRepository;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpStatus;
+import org.booklore.exception.APIException;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class ReplacementDeleteGuardServiceTest {
     private static final String ISBN13 = "9780306406157";
     private static final String ISBN10 = "0306406152";
     private static final String OTHER_ISBN10 = "0140328726";
+
+    @Mock private BookRepository bookRepository;
+    @Mock private UserBookProgressRepository progressRepository;
+    @Mock private AuthenticationService authenticationService;
+    @Mock private BookService bookService;
 
     @Test
     void unrelatedIsbnBookDoesNotJoinPopulation() {
@@ -67,6 +91,36 @@ class ReplacementDeleteGuardServiceTest {
         UserBookProgressEntity progress = UserBookProgressEntity.builder().koboProgressPercent(42f).build();
 
         assertFalse(ReplacementDeleteGuardService.supportedProgress(progress));
+    }
+
+    @Test
+    void consumeRejectsSuccessorThatLostItsLastFileWithoutDeletingPredecessor() {
+        BookEntity predecessor = book(1, ISBN13, null);
+        predecessor.setIsPhysical(true);
+        BookEntity successor = book(2, ISBN13, ISBN10);
+        successor.setLibrary(LibraryEntity.builder().id(7L).build());
+        successor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build())));
+        predecessor.setLibrary(successor.getLibrary());
+        BookLoreUser user = BookLoreUser.builder().id(42L).assignedLibraries(List.of()).permissions(adminPermissions()).build();
+        UserBookProgressEntity progress = UserBookProgressEntity.builder().readStatus(ReadStatus.UNREAD).build();
+        ReplacementDeleteGuardRequest.ReaderState expected = new ReplacementDeleteGuardRequest.ReaderState(ReadStatus.UNREAD, null, null, Set.of(), null, null, null);
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository, authenticationService, bookService);
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+        when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
+        when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress));
+
+        String guardId = service.create(new ReplacementDeleteGuardRequest(1L, 2L, ISBN13, expected)).guardId();
+        successor.getBookFiles().clear();
+
+        APIException error = assertThrows(APIException.class, () -> service.consume(guardId));
+        assertEquals(HttpStatus.CONFLICT, error.getStatus());
+        verifyNoInteractions(bookService);
+    }
+
+    private static BookLoreUser.UserPermissions adminPermissions() {
+        BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();
+        permissions.setAdmin(true);
+        return permissions;
     }
 
     private static BookEntity book(long id, String isbn13, String isbn10) {

--- a/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
@@ -9,6 +9,7 @@ import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.LibraryEntity;
 import org.booklore.model.dto.Library;
 import org.booklore.model.dto.request.ReplacementDeleteGuardRequest;
+import org.booklore.model.dto.response.BookDeletionResponse;
 import org.booklore.model.enums.BookFileType;
 import org.booklore.model.enums.ReadStatus;
 import org.booklore.config.security.service.AuthenticationService;
@@ -18,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.booklore.exception.APIException;
 import java.util.Optional;
 import java.util.Set;
@@ -116,6 +118,89 @@ class ReplacementDeleteGuardServiceTest {
         assertEquals(HttpStatus.CONFLICT, error.getStatus());
         verifyNoInteractions(bookService);
     }
+
+    @Test
+    void filelessPhysicalPredecessorRequiresAndAcceptsExactOrdinaryDeleteResponse() {
+        Prepared prepared = prepared(false);
+        when(bookService.deleteBooks(Set.of(1L))).thenReturn(ResponseEntity.ok(
+                new BookDeletionResponse(Set.of(1L), List.of())));
+
+        assertEquals("deleted", prepared.service().consume(prepared.guardId()).get("status"));
+        verify(bookService).deleteBooks(Set.of(1L));
+    }
+
+    @Test
+    void physicalPredecessorWithFileIsRejectedAtCreate() {
+        BookEntity predecessor = book(1, ISBN13, null);
+        predecessor.setIsPhysical(true);
+        predecessor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(predecessor).bookType(BookFileType.EPUB).build())));
+        BookEntity successor = book(2, ISBN13, ISBN10);
+        successor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build())));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user());
+        when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
+
+        assertThrows(APIException.class, () -> new ReplacementDeleteGuardService(bookRepository, progressRepository, authenticationService, bookService)
+                .create(request()));
+        verifyNoInteractions(bookService);
+    }
+
+    @Test
+    void unexpectedOrdinaryDeleteResultsAreIndeterminateAndGuardCannotReplay() {
+        List<ResponseEntity<BookDeletionResponse>> results = List.of(
+                ResponseEntity.status(HttpStatus.MULTI_STATUS).body(new BookDeletionResponse(Set.of(1L), List.of(1L))),
+                ResponseEntity.ok(null),
+                ResponseEntity.ok(new BookDeletionResponse(Set.of(2L), List.of())),
+                ResponseEntity.ok(new BookDeletionResponse(Set.of(1L), List.of(1L))));
+        for (ResponseEntity<BookDeletionResponse> result : results) {
+            Prepared prepared = prepared(false);
+            when(bookService.deleteBooks(Set.of(1L))).thenReturn(result);
+
+            APIException error = assertThrows(APIException.class, () -> prepared.service().consume(prepared.guardId()));
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, error.getStatus());
+            assertTrue(error.getMessage().contains("indeterminate"));
+            assertThrows(APIException.class, () -> prepared.service().consume(prepared.guardId()));
+            reset(bookService);
+        }
+    }
+
+    @Test
+    void deletionExceptionIsIndeterminateAndConsumedGuardCannotBeReplayed() {
+        Prepared prepared = prepared(false);
+        when(bookService.deleteBooks(Set.of(1L))).thenThrow(new RuntimeException("response lost"));
+
+        APIException error = assertThrows(APIException.class, () -> prepared.service().consume(prepared.guardId()));
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, error.getStatus());
+        assertTrue(error.getMessage().contains("indeterminate"));
+        assertThrows(APIException.class, () -> prepared.service().consume(prepared.guardId()));
+    }
+
+    private Prepared prepared(boolean predecessorHasFiles) {
+        BookEntity predecessor = book(1, ISBN13, null);
+        predecessor.setIsPhysical(true);
+        if (predecessorHasFiles) predecessor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(predecessor).bookType(BookFileType.EPUB).build())));
+        BookEntity successor = book(2, ISBN13, ISBN10);
+        successor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build())));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user());
+        when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
+        when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository, authenticationService, bookService);
+        return new Prepared(service, service.create(request()).guardId());
+    }
+
+    private ReplacementDeleteGuardRequest request() {
+        return new ReplacementDeleteGuardRequest(1L, 2L, ISBN13,
+                new ReplacementDeleteGuardRequest.ReaderState(ReadStatus.UNREAD, null, null, Set.of(), null, null, null));
+    }
+
+    private BookLoreUser user() {
+        return BookLoreUser.builder().id(42L).assignedLibraries(List.of()).permissions(adminPermissions()).build();
+    }
+
+    private UserBookProgressEntity progress() {
+        return UserBookProgressEntity.builder().readStatus(ReadStatus.UNREAD).build();
+    }
+
+    private record Prepared(ReplacementDeleteGuardService service, String guardId) {}
 
     private static BookLoreUser.UserPermissions adminPermissions() {
         BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();

--- a/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
@@ -4,6 +4,7 @@ import org.booklore.model.entity.BookEntity;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.booklore.model.entity.ShelfEntity;
 import org.booklore.model.entity.UserBookProgressEntity;
+import org.booklore.model.entity.UserBookFileProgressEntity;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.LibraryEntity;
@@ -15,6 +16,8 @@ import org.booklore.model.enums.ReadStatus;
 import org.booklore.config.security.service.AuthenticationService;
 import org.booklore.repository.BookRepository;
 import org.booklore.repository.UserBookProgressRepository;
+import org.booklore.repository.UserBookFileProgressRepository;
+import org.booklore.repository.UserContentRestrictionRepository;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +41,8 @@ class ReplacementDeleteGuardServiceTest {
 
     @Mock private BookRepository bookRepository;
     @Mock private UserBookProgressRepository progressRepository;
+    @Mock private UserBookFileProgressRepository fileProgressRepository;
+    @Mock private UserContentRestrictionRepository restrictionRepository;
     @Mock private AuthenticationService authenticationService;
     @Mock private BookService bookService;
 
@@ -106,7 +111,7 @@ class ReplacementDeleteGuardServiceTest {
         BookLoreUser user = BookLoreUser.builder().id(42L).assignedLibraries(List.of()).permissions(adminPermissions()).build();
         UserBookProgressEntity progress = UserBookProgressEntity.builder().readStatus(ReadStatus.UNREAD).build();
         ReplacementDeleteGuardRequest.ReaderState expected = new ReplacementDeleteGuardRequest.ReaderState(ReadStatus.UNREAD, null, null, Set.of(), null, null, null);
-        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository, authenticationService, bookService);
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository, fileProgressRepository, restrictionRepository, authenticationService, bookService);
         when(authenticationService.getAuthenticatedUser()).thenReturn(user);
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
         when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress));
@@ -139,7 +144,7 @@ class ReplacementDeleteGuardServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(user());
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
 
-        assertThrows(APIException.class, () -> new ReplacementDeleteGuardService(bookRepository, progressRepository, authenticationService, bookService)
+        assertThrows(APIException.class, () -> new ReplacementDeleteGuardService(bookRepository, progressRepository, fileProgressRepository, restrictionRepository, authenticationService, bookService)
                 .create(request()));
         verifyNoInteractions(bookService);
     }
@@ -174,6 +179,49 @@ class ReplacementDeleteGuardServiceTest {
         assertThrows(APIException.class, () -> prepared.service().consume(prepared.guardId()));
     }
 
+    @Test
+    void restrictedPairIsNotVisibleToNonAdminGuard() {
+        BookLoreUser regular = BookLoreUser.builder().id(42L).assignedLibraries(List.of(Library.builder().id(7L).build()))
+                .permissions(new BookLoreUser.UserPermissions()).build();
+        when(authenticationService.getAuthenticatedUser()).thenReturn(regular);
+        when(restrictionRepository.findByUserId(42L)).thenReturn(List.of(mock(org.booklore.model.entity.UserContentRestrictionEntity.class)));
+        when(bookRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class))).thenReturn(List.of());
+
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository,
+                fileProgressRepository, restrictionRepository, authenticationService, bookService);
+        assertThrows(APIException.class, () -> service.create(request()));
+        verifyNoInteractions(bookService);
+    }
+
+    @Test
+    void successorFileProgressAddedAfterIssuanceRejectsConsume() {
+        Prepared prepared = prepared(false);
+        // create used the empty default result; this replacement represents a row added after issuance.
+        UserBookFileProgressEntity fileProgress = mock(UserBookFileProgressEntity.class);
+        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L))
+                .thenReturn(List.of(fileProgress));
+
+        APIException error = assertThrows(APIException.class, () -> prepared.service().consume(prepared.guardId()));
+        assertEquals(HttpStatus.CONFLICT, error.getStatus());
+        verifyNoInteractions(bookService);
+    }
+
+    @Test
+    void successorFileProgressRejectsCreate() {
+        BookEntity predecessor = book(1, ISBN13, null);
+        predecessor.setIsPhysical(true);
+        BookEntity successor = book(2, ISBN13, ISBN10);
+        successor.setBookFiles(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build()));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user());
+        when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
+        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of(mock(UserBookFileProgressEntity.class)));
+
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository,
+                fileProgressRepository, restrictionRepository, authenticationService, bookService);
+        assertThrows(APIException.class, () -> service.create(request()));
+        verifyNoInteractions(bookService);
+    }
+
     private Prepared prepared(boolean predecessorHasFiles) {
         BookEntity predecessor = book(1, ISBN13, null);
         predecessor.setIsPhysical(true);
@@ -183,7 +231,8 @@ class ReplacementDeleteGuardServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(user());
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
         when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
-        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository, authenticationService, bookService);
+        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of());
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository, fileProgressRepository, restrictionRepository, authenticationService, bookService);
         return new Prepared(service, service.create(request()).guardId());
     }
 

--- a/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
@@ -121,6 +121,30 @@ class ReplacementDeleteGuardServiceTest {
     }
 
     @Test
+    void nonOwnerCannotConsumeOrInvalidateGuard() {
+        BookLoreUser owner = user();
+        BookLoreUser otherUser = BookLoreUser.builder().id(99L).assignedLibraries(List.of()).permissions(adminPermissions()).build();
+        when(authenticationService.getAuthenticatedUser()).thenReturn(owner, otherUser, owner);
+        BookEntity predecessor = book(1, ISBN13, null);
+        predecessor.setIsPhysical(true);
+        BookEntity successor = book(2, ISBN13, ISBN10);
+        successor.setBookFiles(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build()));
+        when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
+        when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
+        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of());
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository,
+                fileProgressRepository, restrictionRepository, authenticationService, bookService);
+        String guardId = service.create(request()).guardId();
+        when(bookService.deleteBooks(Set.of(1L))).thenReturn(ResponseEntity.ok(new BookDeletionResponse(Set.of(1L), List.of())));
+
+        APIException error = assertThrows(APIException.class, () -> service.consume(guardId));
+        assertEquals(HttpStatus.CONFLICT, error.getStatus());
+        verifyNoInteractions(bookService);
+        assertEquals("deleted", service.consume(guardId).get("status"));
+        verify(bookService).deleteBooks(Set.of(1L));
+    }
+
+    @Test
     void visibleShelfChangeAfterIssuanceRejectsConsume() {
         Prepared prepared = prepared(false);
         BookLoreUserEntity owner = BookLoreUserEntity.builder().id(42L).build();

--- a/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
@@ -110,7 +110,7 @@ class ReplacementDeleteGuardServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(user());
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
         when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
-        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of());
+        when(fileProgressRepository.existsByBookFileBookId(2L)).thenReturn(false);
         ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository,
                 fileProgressRepository, restrictionRepository, authenticationService, bookService);
 
@@ -131,7 +131,7 @@ class ReplacementDeleteGuardServiceTest {
         successor.setBookFiles(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build()));
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
         when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
-        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of());
+        when(fileProgressRepository.existsByBookFileBookId(2L)).thenReturn(false);
         ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository,
                 fileProgressRepository, restrictionRepository, authenticationService, bookService);
         String guardId = service.create(request()).guardId();
@@ -264,9 +264,7 @@ class ReplacementDeleteGuardServiceTest {
     void successorFileProgressAddedAfterIssuanceRejectsConsume() {
         Prepared prepared = prepared(false);
         // create used the empty default result; this replacement represents a row added after issuance.
-        UserBookFileProgressEntity fileProgress = mock(UserBookFileProgressEntity.class);
-        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L))
-                .thenReturn(List.of(fileProgress));
+        when(fileProgressRepository.existsByBookFileBookId(2L)).thenReturn(true);
 
         APIException error = assertThrows(APIException.class, () -> prepared.service().consume(prepared.guardId()));
         assertEquals(HttpStatus.CONFLICT, error.getStatus());
@@ -281,11 +279,66 @@ class ReplacementDeleteGuardServiceTest {
         successor.setBookFiles(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build()));
         when(authenticationService.getAuthenticatedUser()).thenReturn(user());
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
-        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of(mock(UserBookFileProgressEntity.class)));
+        when(fileProgressRepository.existsByBookFileBookId(2L)).thenReturn(true);
 
         ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository,
                 fileProgressRepository, restrictionRepository, authenticationService, bookService);
         assertThrows(APIException.class, () -> service.create(request()));
+        verifyNoInteractions(bookService);
+    }
+
+    @Test
+    void hiddenCatalogCollisionRejectsCreateBeforeDeletion() {
+        BookEntity predecessor = physicalPredecessor();
+        BookEntity successor = digitalSuccessor();
+        BookEntity collision = book(3, ISBN13, OTHER_ISBN10);
+        BookLoreUser regular = BookLoreUser.builder().id(42L)
+                .assignedLibraries(List.of(Library.builder().id(7L).build()))
+                .permissions(new BookLoreUser.UserPermissions()).build();
+        when(authenticationService.getAuthenticatedUser()).thenReturn(regular);
+        when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor, collision));
+        when(restrictionRepository.findByUserId(42L)).thenReturn(List.of());
+        when(bookRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class)))
+                .thenReturn(List.of(predecessor, successor));
+
+        assertThrows(APIException.class, () -> new ReplacementDeleteGuardService(bookRepository, progressRepository,
+                fileProgressRepository, restrictionRepository, authenticationService, bookService).create(request()));
+        verifyNoInteractions(bookService);
+    }
+
+    @Test
+    void collisionAddedAfterIssuanceRejectsConsumeBeforeDeletion() {
+        BookEntity predecessor = physicalPredecessor();
+        BookEntity successor = digitalSuccessor();
+        List<BookEntity> catalog = new java.util.ArrayList<>(List.of(predecessor, successor));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user());
+        when(bookRepository.findAllFullBooksWithFiles()).thenAnswer(invocation -> catalog);
+        when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
+        when(fileProgressRepository.existsByBookFileBookId(2L)).thenReturn(false);
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository,
+                fileProgressRepository, restrictionRepository, authenticationService, bookService);
+
+        String guardId = service.create(request()).guardId();
+        catalog.add(book(3, ISBN13, OTHER_ISBN10));
+
+        assertThrows(APIException.class, () -> service.consume(guardId));
+        verifyNoInteractions(bookService);
+    }
+
+    @Test
+    void exactCatalogPairStillRejectsWhenPairIsHiddenFromViewer() {
+        BookEntity predecessor = physicalPredecessor();
+        BookEntity successor = digitalSuccessor();
+        BookLoreUser regular = BookLoreUser.builder().id(42L)
+                .assignedLibraries(List.of(Library.builder().id(7L).build()))
+                .permissions(new BookLoreUser.UserPermissions()).build();
+        when(authenticationService.getAuthenticatedUser()).thenReturn(regular);
+        when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
+        when(restrictionRepository.findByUserId(42L)).thenReturn(List.of());
+        when(bookRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class))).thenReturn(List.of());
+
+        assertThrows(APIException.class, () -> new ReplacementDeleteGuardService(bookRepository, progressRepository,
+                fileProgressRepository, restrictionRepository, authenticationService, bookService).create(request()));
         verifyNoInteractions(bookService);
     }
 
@@ -298,9 +351,23 @@ class ReplacementDeleteGuardServiceTest {
         when(authenticationService.getAuthenticatedUser()).thenReturn(user());
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
         when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
-        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of());
+        when(fileProgressRepository.existsByBookFileBookId(2L)).thenReturn(false);
         ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository, fileProgressRepository, restrictionRepository, authenticationService, bookService);
         return new Prepared(service, service.create(request()).guardId(), successor);
+    }
+
+    private BookEntity physicalPredecessor() {
+        BookEntity predecessor = book(1, ISBN13, null);
+        predecessor.setIsPhysical(true);
+        predecessor.setLibrary(LibraryEntity.builder().id(7L).build());
+        return predecessor;
+    }
+
+    private BookEntity digitalSuccessor() {
+        BookEntity successor = book(2, ISBN13, ISBN10);
+        successor.setBookFiles(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build()));
+        successor.setLibrary(LibraryEntity.builder().id(7L).build());
+        return successor;
     }
 
     private ReplacementDeleteGuardRequest request() {

--- a/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
@@ -1,0 +1,77 @@
+package org.booklore.service.book;
+
+import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookMetadataEntity;
+import org.booklore.model.entity.ShelfEntity;
+import org.booklore.model.entity.UserBookProgressEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReplacementDeleteGuardServiceTest {
+    private static final String ISBN13 = "9780306406157";
+    private static final String ISBN10 = "0306406152";
+    private static final String OTHER_ISBN10 = "0140328726";
+
+    @Test
+    void unrelatedIsbnBookDoesNotJoinPopulation() {
+        List<BookEntity> population = ReplacementDeleteGuardService.matchingPopulation(
+                List.of(book(1, ISBN13, null), book(2, null, ISBN10), book(3, null, OTHER_ISBN10)), ISBN13);
+
+        assertEquals(List.of(1L, 2L), population.stream().map(BookEntity::getId).toList());
+    }
+
+    @Test
+    void matchingIsbn13WithDifferentValidIsbn10IsCollision() {
+        BookEntity collision = book(1, ISBN13, OTHER_ISBN10);
+
+        assertTrue(ReplacementDeleteGuardService.mentionsIsbn(collision, ISBN13));
+        assertFalse(ReplacementDeleteGuardService.consistentIsbn(collision, ISBN13));
+    }
+
+    @Test
+    void extraCollisionRecordRemainsInPopulationAndBlocksExactPair() {
+        List<BookEntity> population = ReplacementDeleteGuardService.matchingPopulation(
+                List.of(book(1, ISBN13, null), book(2, null, ISBN10), book(3, ISBN13, OTHER_ISBN10)), ISBN13);
+
+        assertEquals(3, population.size());
+        assertFalse(ReplacementDeleteGuardService.consistentIsbn(population.get(2), ISBN13));
+    }
+
+    @Test
+    void canonicalValidIsbn10AndIsbn13PairIsStrictlyConsistent() {
+        BookEntity pair = book(1, ISBN13, ISBN10);
+
+        assertTrue(ReplacementDeleteGuardService.mentionsIsbn(pair, ISBN13));
+        assertTrue(ReplacementDeleteGuardService.consistentIsbn(pair, ISBN13));
+    }
+
+    @Test
+    void invalidOrBlankSiblingIsFailClosed() {
+        assertFalse(ReplacementDeleteGuardService.consistentIsbn(book(1, ISBN13, " "), ISBN13));
+        assertFalse(ReplacementDeleteGuardService.consistentIsbn(book(1, ISBN13, "not-an-isbn"), ISBN13));
+    }
+
+    @Test
+    void shelfWitnessUsesCurrentSuccessorShelfIds() {
+        BookEntity successor = book(2, ISBN13, ISBN10);
+        successor.setShelves(java.util.Set.of(ShelfEntity.builder().id(7L).build(), ShelfEntity.builder().id(9L).build()));
+
+        assertEquals(java.util.Set.of(7L, 9L), ReplacementDeleteGuardService.shelves(successor));
+    }
+
+    @Test
+    void unsupportedProgressRepresentationIsRejectedFailClosed() {
+        UserBookProgressEntity progress = UserBookProgressEntity.builder().koboProgressPercent(42f).build();
+
+        assertFalse(ReplacementDeleteGuardService.supportedProgress(progress));
+    }
+
+    private static BookEntity book(long id, String isbn13, String isbn10) {
+        return BookEntity.builder().id(id)
+                .metadata(BookMetadataEntity.builder().isbn13(isbn13).isbn10(isbn10).build())
+                .build();
+    }
+}

--- a/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
@@ -8,6 +8,7 @@ import org.booklore.model.entity.UserBookFileProgressEntity;
 import org.booklore.model.dto.BookLoreUser;
 import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.LibraryEntity;
+import org.booklore.model.entity.BookLoreUserEntity;
 import org.booklore.model.dto.Library;
 import org.booklore.model.dto.request.ReplacementDeleteGuardRequest;
 import org.booklore.model.dto.response.BookDeletionResponse;
@@ -86,11 +87,53 @@ class ReplacementDeleteGuardServiceTest {
     }
 
     @Test
-    void shelfWitnessUsesCurrentSuccessorShelfIds() {
+    void shelfWitnessUsesOnlyShelvesVisibleToAuthenticatedUser() {
         BookEntity successor = book(2, ISBN13, ISBN10);
-        successor.setShelves(java.util.Set.of(ShelfEntity.builder().id(7L).build(), ShelfEntity.builder().id(9L).build()));
+        BookLoreUserEntity owner = BookLoreUserEntity.builder().id(42L).build();
+        BookLoreUserEntity otherUser = BookLoreUserEntity.builder().id(99L).build();
+        successor.setShelves(java.util.Set.of(
+                ShelfEntity.builder().id(7L).user(owner).build(),
+                ShelfEntity.builder().id(8L).user(otherUser).build(),
+                ShelfEntity.builder().id(9L).isPublic(true).user(otherUser).build()));
 
-        assertEquals(java.util.Set.of(7L, 9L), ReplacementDeleteGuardService.shelves(successor));
+        assertEquals(java.util.Set.of(7L, 9L), ReplacementDeleteGuardService.shelves(successor, 42L));
+    }
+
+    @Test
+    void privateOtherUserShelfDoesNotBlockCreateAndConsume() {
+        BookEntity predecessor = book(1, ISBN13, null);
+        predecessor.setIsPhysical(true);
+        BookEntity successor = book(2, ISBN13, ISBN10);
+        successor.setBookFiles(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build()));
+        successor.setShelves(Set.of(ShelfEntity.builder().id(8L)
+                .user(BookLoreUserEntity.builder().id(99L).build()).build()));
+        when(authenticationService.getAuthenticatedUser()).thenReturn(user());
+        when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
+        when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
+        when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of());
+        ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository,
+                fileProgressRepository, restrictionRepository, authenticationService, bookService);
+
+        String guardId = service.create(request()).guardId();
+        when(bookService.deleteBooks(Set.of(1L))).thenReturn(ResponseEntity.ok(new BookDeletionResponse(Set.of(1L), List.of())));
+
+        assertEquals("deleted", service.consume(guardId).get("status"));
+    }
+
+    @Test
+    void visibleShelfChangeAfterIssuanceRejectsConsume() {
+        Prepared prepared = prepared(false);
+        BookLoreUserEntity owner = BookLoreUserEntity.builder().id(42L).build();
+        prepared.successor().setShelves(Set.of(ShelfEntity.builder().id(7L).user(owner).build()));
+        ReplacementDeleteGuardRequest expected = new ReplacementDeleteGuardRequest(1L, 2L, ISBN13,
+                new ReplacementDeleteGuardRequest.ReaderState(ReadStatus.UNREAD, null, null, Set.of(7L), null, null, null));
+        // Re-issue with the visible shelf as the witnessed state, then mutate that visible shelf.
+        String guardId = prepared.service().create(expected).guardId();
+        prepared.successor().setShelves(Set.of(ShelfEntity.builder().id(8L).user(owner).build()));
+
+        APIException error = assertThrows(APIException.class, () -> prepared.service().consume(guardId));
+        assertEquals(HttpStatus.CONFLICT, error.getStatus());
+        verifyNoInteractions(bookService);
     }
 
     @Test
@@ -233,7 +276,7 @@ class ReplacementDeleteGuardServiceTest {
         when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));
         when(fileProgressRepository.findByUserIdAndBookFileBookId(42L, 2L)).thenReturn(List.of());
         ReplacementDeleteGuardService service = new ReplacementDeleteGuardService(bookRepository, progressRepository, fileProgressRepository, restrictionRepository, authenticationService, bookService);
-        return new Prepared(service, service.create(request()).guardId());
+        return new Prepared(service, service.create(request()).guardId(), successor);
     }
 
     private ReplacementDeleteGuardRequest request() {
@@ -249,7 +292,7 @@ class ReplacementDeleteGuardServiceTest {
         return UserBookProgressEntity.builder().readStatus(ReadStatus.UNREAD).build();
     }
 
-    private record Prepared(ReplacementDeleteGuardService service, String guardId) {}
+    private record Prepared(ReplacementDeleteGuardService service, String guardId, BookEntity successor) {}
 
     private static BookLoreUser.UserPermissions adminPermissions() {
         BookLoreUser.UserPermissions permissions = new BookLoreUser.UserPermissions();

--- a/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/book/ReplacementDeleteGuardServiceTest.java
@@ -101,7 +101,7 @@ class ReplacementDeleteGuardServiceTest {
         predecessor.setIsPhysical(true);
         BookEntity successor = book(2, ISBN13, ISBN10);
         successor.setLibrary(LibraryEntity.builder().id(7L).build());
-        successor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build())));
+        successor.setBookFiles(new java.util.HashSet<>(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build())));
         predecessor.setLibrary(successor.getLibrary());
         BookLoreUser user = BookLoreUser.builder().id(42L).assignedLibraries(List.of()).permissions(adminPermissions()).build();
         UserBookProgressEntity progress = UserBookProgressEntity.builder().readStatus(ReadStatus.UNREAD).build();
@@ -133,9 +133,9 @@ class ReplacementDeleteGuardServiceTest {
     void physicalPredecessorWithFileIsRejectedAtCreate() {
         BookEntity predecessor = book(1, ISBN13, null);
         predecessor.setIsPhysical(true);
-        predecessor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(predecessor).bookType(BookFileType.EPUB).build())));
+        predecessor.setBookFiles(Set.of(BookFileEntity.builder().book(predecessor).bookType(BookFileType.EPUB).build()));
         BookEntity successor = book(2, ISBN13, ISBN10);
-        successor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build())));
+        successor.setBookFiles(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build()));
         when(authenticationService.getAuthenticatedUser()).thenReturn(user());
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
 
@@ -177,9 +177,9 @@ class ReplacementDeleteGuardServiceTest {
     private Prepared prepared(boolean predecessorHasFiles) {
         BookEntity predecessor = book(1, ISBN13, null);
         predecessor.setIsPhysical(true);
-        if (predecessorHasFiles) predecessor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(predecessor).bookType(BookFileType.EPUB).build())));
+        if (predecessorHasFiles) predecessor.setBookFiles(Set.of(BookFileEntity.builder().book(predecessor).bookType(BookFileType.EPUB).build()));
         BookEntity successor = book(2, ISBN13, ISBN10);
-        successor.setBookFiles(new java.util.ArrayList<>(List.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build())));
+        successor.setBookFiles(Set.of(BookFileEntity.builder().book(successor).bookType(BookFileType.EPUB).build()));
         when(authenticationService.getAuthenticatedUser()).thenReturn(user());
         when(bookRepository.findAllFullBooksWithFiles()).thenReturn(List.of(predecessor, successor));
         when(progressRepository.findByUserIdAndBookId(42L, 2L)).thenReturn(Optional.of(progress()));


### PR DESCRIPTION
## What
Adds an authenticated, fail-closed replacement-delete guard endpoint for a fileless physical predecessor and a file-bearing digital successor.

## Safety properties
- canonical ISBN-10/13 identity with full non-deleted catalog collision closure
- separate viewer visibility check for the requested pair
- user-bound, expiring, replay-safe conditional consume
- SERIALIZABLE final revalidation before the existing delete path
- EPUB reader-state and viewer-visible shelf witness; any file-progress row fails closed
- delete only reports success for the exact normal deletion response

## Verification
- `./gradlew --rerun-tasks test --tests org.booklore.service.book.ReplacementDeleteGuardServiceTest`
- `./gradlew --rerun-tasks compileJava compileTestJava`
- `git diff --check origin/develop..HEAD`

No production data or files were changed by this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secured endpoints for safely replacing and deleting duplicate book entries.
  * Added validation for ISBN consistency, ownership, visibility, files, reader progress, and expected reading state.
  * Added short-lived, single-use safeguards to prevent accidental or repeated deletions.

* **Bug Fixes**
  * Improved book loading and progress checks to support reliable replacement operations.

* **Tests**
  * Added comprehensive coverage for validation, conflict handling, replay prevention, and successful replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->