### PR TITLE
fix md resolution wrapping

### DIFF
--- a/frontend/src/app/features/book/components/book-browser/book-browser.component.scss
+++ b/frontend/src/app/features/book/components/book-browser/book-browser.component.scss
@@ -47,6 +47,7 @@
   flex-shrink: 0;
   background-color: var(--color-card);
   border-bottom: 1px solid var(--p-content-border-color);
+  flex-wrap: wrap;
 
   @media (width >= 768px) {
     gap: 0.875rem;


### PR DESCRIPTION
Very small fix of this issue: (ipad, portrait, on libraries/shelves views)

<img width="1792" height="525" alt="image" src="https://github.com/user-attachments/assets/50aa3469-00ef-4a51-840c-0dd997df27b5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the book browser header layout to allow content to wrap onto multiple lines, improving responsiveness on narrower screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->