### PR TITLE
fix(api): allow deleting primary book format when other formats exist

### DIFF
--- a/backend/src/main/java/org/booklore/service/file/AdditionalFileService.java
+++ b/backend/src/main/java/org/booklore/service/file/AdditionalFileService.java
@@ -59,7 +59,7 @@ public class AdditionalFileService {
 
         BookFileEntity file = fileOpt.get();
         BookEntity book = file.getBook();
-        validateAdditionalFile(file, book);
+        validateNotLastBookFormat(file, book);
 
         try {
             monitoringRegistrationService.unregisterSpecificPath(file.getFullFilePath().getParent());
@@ -160,6 +160,17 @@ public class AdditionalFileService {
     private void validateAdditionalFile(BookFileEntity file, BookEntity book) {
         if (book != null && book.getPrimaryBookFile() != null && file.getId().equals(book.getPrimaryBookFile().getId())) {
             throw new IllegalArgumentException("Primary book file cannot be processed as an additional file: " + file.getId());
+        }
+    }
+
+    // Deleting the primary format is allowed as long as another book format remains: the
+    // primary is derived (library format priority, then lowest id), so the next format is
+    // promoted automatically. Only the last book format is protected, since removing it
+    // would leave the book without a readable file — delete the book itself instead.
+    private void validateNotLastBookFormat(BookFileEntity file, BookEntity book) {
+        if (file.isBook() && book != null && book.getBookFiles().stream()
+                .noneMatch(bf -> bf.isBook() && !bf.getId().equals(file.getId()))) {
+            throw new IllegalArgumentException("Cannot delete the last book format file: " + file.getId() + ". Delete the book instead.");
         }
     }
 }

--- a/backend/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/AdditionalFileServiceTest.java
@@ -309,7 +309,7 @@ class AdditionalFileServiceTest {
     }
 
     @Test
-    void deleteAdditionalFile_WhenFileIsPrimaryBookFile_ShouldThrowException() {
+    void deleteAdditionalFile_WhenFileIsLastBookFormat_ShouldThrowException() {
         Long bookId = 100L;
         Long fileId = 1L;
         bookEntity.setBookFiles(Set.of(fileEntity));
@@ -320,9 +320,33 @@ class AdditionalFileServiceTest {
                 () -> additionalFileService.deleteAdditionalFile(bookId, fileId)
         );
 
-        assertEquals("Primary book file cannot be processed as an additional file: 1", exception.getMessage());
+        assertEquals("Cannot delete the last book format file: 1. Delete the book instead.", exception.getMessage());
         verify(additionalFileRepository, never()).delete(any());
         verify(monitoringRegistrationService, never()).unregisterSpecificPath(any());
+    }
+
+    @Test
+    void deleteAdditionalFile_WhenFileIsPrimaryButOtherFormatsExist_ShouldDeleteSuccessfully() {
+        Long bookId = 100L;
+        Long fileId = 1L;
+        BookFileEntity alternativeFormat = createBookFile(2L, "alternative.epub");
+        bookEntity.setBookFiles(new HashSet<>(Set.of(fileEntity, alternativeFormat)));
+        assertEquals(fileEntity, bookEntity.getPrimaryBookFile());
+        Path parentPath = fileEntity.getFullFilePath().getParent();
+
+        when(additionalFileRepository.findByIdAndBookIdWithBookAndLibraryPath(fileId, bookId)).thenReturn(Optional.of(fileEntity));
+
+        try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
+            filesMock.when(() -> Files.deleteIfExists(fileEntity.getFullFilePath())).thenReturn(true);
+
+            additionalFileService.deleteAdditionalFile(bookId, fileId);
+
+            verify(monitoringRegistrationService).unregisterSpecificPath(parentPath);
+            filesMock.verify(() -> Files.deleteIfExists(fileEntity.getFullFilePath()));
+            verify(additionalFileRepository).delete(fileEntity);
+        }
+
+        assertEquals(alternativeFormat, bookEntity.getPrimaryBookFile());
     }
 
     @Test


### PR DESCRIPTION
Fixes #2455

## Problem

Deleting a book's primary format via the UI's "Delete format" dropdown fails with HTTP 400:

```
Primary book file cannot be processed as an additional file: <fileId>
```

`AdditionalFileService.deleteAdditionalFile` reuses the primary-file guard introduced in #463. That guard is right for downloads (the primary file has its own download endpoint) but wrong for deletes: the frontend deliberately offers the primary file in the delete dropdown and already handles promoting the next format on success.

## Fix

Since the primary file is derived (`BookEntity.getPrimaryBookFile()`: library format priority, then lowest id), deleting the primary automatically promotes the next book format — no extra promotion logic is needed. The delete path now only refuses to remove the **last remaining book format**, which would leave the book without a readable file (deleting the book itself is the right operation there). Supplementary (non-book) files are unaffected, and the download guard is unchanged.

## Testing

- Updated `deleteAdditionalFile_WhenFileIsPrimaryBookFile_ShouldThrowException` → `deleteAdditionalFile_WhenFileIsLastBookFormat_ShouldThrowException` (new message/behavior).
- Added `deleteAdditionalFile_WhenFileIsPrimaryButOtherFormatsExist_ShouldDeleteSuccessfully`, which also asserts the other format becomes primary afterwards.
- Full backend test suite passes locally (`./gradlew test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuUR58BRNecW8yD5hwRJKy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved book file deletion behavior: primary book formats can now be removed when alternative formats are available.
  - Prevented deletion of the last remaining book format; books with no formats must be deleted instead.
  - Automatically assigns another available format as the primary file after deletion.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->