### PR TITLE
fix: make notebook bookmarks clickable to open reader

### DIFF
--- a/backend/src/main/java/org/booklore/model/dto/NotebookEntry.java
+++ b/backend/src/main/java/org/booklore/model/dto/NotebookEntry.java
@@ -22,6 +22,8 @@ public class NotebookEntry {
     private String style;
     private String chapterTitle;
     private String primaryBookType;
+    private String cfi;
+    private Integer pageNumber;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/org/booklore/model/entity/NotebookEntryView.java
+++ b/backend/src/main/java/org/booklore/model/entity/NotebookEntryView.java
@@ -26,6 +26,8 @@ import java.time.LocalDateTime;
            a.chapter_title,
            (SELECT bf.book_type FROM book_file bf WHERE bf.book_id = a.book_id ORDER BY bf.id LIMIT 1) AS primary_book_type,
            bm.cover_updated_on,
+           a.cfi,
+           NULL AS page_number,
            a.created_at,
            a.updated_at
     FROM annotations a
@@ -44,6 +46,8 @@ import java.time.LocalDateTime;
            n.chapter_title,
            (SELECT bf.book_type FROM book_file bf WHERE bf.book_id = n.book_id ORDER BY bf.id LIMIT 1),
            bm.cover_updated_on,
+           n.cfi,
+           NULL AS page_number,
            n.created_at,
            n.updated_at
     FROM book_notes_v2 n
@@ -62,6 +66,8 @@ import java.time.LocalDateTime;
            NULL,
            (SELECT bf.book_type FROM book_file bf WHERE bf.book_id = b.book_id ORDER BY bf.id LIMIT 1),
            bm.cover_updated_on,
+           b.cfi,
+           b.page_number,
            b.created_at,
            b.updated_at
     FROM book_marks b
@@ -108,6 +114,12 @@ public class NotebookEntryView {
 
     @Column(name = "cover_updated_on")
     private Instant coverUpdatedOn;
+
+    @Column(name = "cfi")
+    private String cfi;
+
+    @Column(name = "page_number")
+    private Integer pageNumber;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/backend/src/main/java/org/booklore/repository/NotebookEntryRepository.java
+++ b/backend/src/main/java/org/booklore/repository/NotebookEntryRepository.java
@@ -25,6 +25,8 @@ public interface NotebookEntryRepository extends Repository<NotebookEntryView, L
         String getStyle();
         String getChapterTitle();
         String getPrimaryBookType();
+        String getCfi();
+        Integer getPageNumber();
         LocalDateTime getCreatedAt();
         LocalDateTime getUpdatedAt();
     }
@@ -52,6 +54,8 @@ public interface NotebookEntryRepository extends Repository<NotebookEntryView, L
                    ne.style as style,
                    ne.chapterTitle as chapterTitle,
                    ne.primaryBookType as primaryBookType,
+                   ne.cfi as cfi,
+                   ne.pageNumber as pageNumber,
                    ne.createdAt as createdAt,
                    ne.updatedAt as updatedAt
             FROM NotebookEntryView ne

--- a/backend/src/main/java/org/booklore/service/book/NotebookService.java
+++ b/backend/src/main/java/org/booklore/service/book/NotebookService.java
@@ -80,6 +80,8 @@ public class NotebookService {
                 .style(p.getStyle())
                 .chapterTitle(p.getChapterTitle())
                 .primaryBookType(p.getPrimaryBookType())
+                .cfi(p.getCfi())
+                .pageNumber(p.getPageNumber())
                 .createdAt(p.getCreatedAt())
                 .updatedAt(p.getUpdatedAt())
                 .build();

--- a/frontend/src/app/features/notebook/components/notebook/notebook.component.html
+++ b/frontend/src/app/features/notebook/components/notebook/notebook.component.html
@@ -160,6 +160,9 @@
                   <div
                     class="entry-item"
                     [style.border-left-color]="entry.color || 'var(--p-primary-color)'"
+                    [class.clickable]="entry.type === 'BOOKMARK'"
+                    [class.cursor-pointer]="entry.type === 'BOOKMARK'"
+                    (click)="entry.type === 'BOOKMARK' && navigateToBookmark(entry)"
                   >
                     <div class="entry-top-row">
                       <div class="entry-type-badge" [class]="'type-' + entry.type.toLowerCase()">

--- a/frontend/src/app/features/notebook/components/notebook/notebook.component.scss
+++ b/frontend/src/app/features/notebook/components/notebook/notebook.component.scss
@@ -259,6 +259,19 @@
   &:hover {
     background: color-mix(in srgb, var(--color-card) 92%, var(--color-text) 8%);
   }
+
+  &.clickable {
+    cursor: pointer;
+    user-select: none;
+
+    &:hover {
+      background: color-mix(in srgb, var(--p-primary-color) 8%, var(--color-card));
+    }
+
+    &:active {
+      background: color-mix(in srgb, var(--p-primary-color) 12%, var(--color-card));
+    }
+  }
 }
 
 .entry-top-row {

--- a/frontend/src/app/features/notebook/components/notebook/notebook.component.ts
+++ b/frontend/src/app/features/notebook/components/notebook/notebook.component.ts
@@ -3,6 +3,7 @@ import {FormsModule} from '@angular/forms';
 import {of, Subject} from 'rxjs';
 import {debounceTime, switchMap} from 'rxjs/operators';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {Router} from '@angular/router';
 import {InputText} from '@openng/optimus-ui/inputtext';
 import {Select} from '@openng/optimus-ui/select';
 import {Button} from '@openng/optimus-ui/button';
@@ -57,6 +58,7 @@ export class NotebookComponent implements OnInit {
   private readonly bookFilterSubject = new Subject<string>();
   private readonly notebookService = inject(NotebookService);
   private readonly urlHelper = inject(UrlHelperService);
+  private readonly router = inject(Router);
   private readonly pageTitle = inject(PageTitleService);
   private readonly t = inject(TranslocoService);
 
@@ -227,6 +229,44 @@ export class NotebookComponent implements OnInit {
       case 'BOOKMARK': return this.t.translate('notebook.bookmark');
       default: return type;
     }
+  }
+
+  navigateToBookmark(entry: NotebookEntry): void {
+    if (entry.type !== 'BOOKMARK') {
+      return;
+    }
+
+    const bookType = entry.primaryBookType;
+    let readerPath: string;
+
+    switch (bookType) {
+      case 'PDF':
+        readerPath = 'pdf-reader';
+        break;
+      case 'EPUB':
+      case 'FB2':
+      case 'MOBI':
+      case 'AZW3':
+        readerPath = 'ebook-reader';
+        break;
+      case 'AUDIOBOOK':
+        readerPath = 'audiobook-player';
+        break;
+      default:
+        return;
+    }
+
+    const queryParams: any = {};
+    if (entry.cfi) {
+      queryParams.cfi = entry.cfi;
+    } else if (entry.pageNumber !== undefined && entry.pageNumber !== null) {
+      queryParams.page = entry.pageNumber;
+    }
+
+    this.router.navigate(
+      [`/${readerPath}/book/${entry.bookId}`],
+      { queryParams: Object.keys(queryParams).length > 0 ? queryParams : undefined }
+    );
   }
 
   exportMarkdown(): void {

--- a/frontend/src/app/features/notebook/model/notebook.model.ts
+++ b/frontend/src/app/features/notebook/model/notebook.model.ts
@@ -9,6 +9,8 @@ export interface NotebookEntry {
   style?: string;
   chapterTitle?: string;
   primaryBookType?: string;
+  cfi?: string;
+  pageNumber?: number;
   createdAt: string;
   updatedAt?: string;
 }

--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
@@ -395,6 +395,21 @@ export class EbookReaderComponent implements OnInit {
   private restoreSavedPosition(book: Book): Observable<void> {
     this.pendingInitialChapterRestore = null;
 
+    // Check for CFI or page query parameter first (for deep linking from bookmarks)
+    const cfiParam = this.route.snapshot.queryParamMap.get('cfi');
+    if (cfiParam) {
+      return this.viewManager.goTo(cfiParam);
+    }
+
+    const pageParam = this.route.snapshot.queryParamMap.get('page');
+    if (pageParam) {
+      const pageNumber = parseInt(pageParam, 10);
+      if (!isNaN(pageNumber)) {
+        return this.viewManager.goTo(pageNumber - 1); // Convert to 0-based index
+      }
+    }
+
+    // Fall back to saved progress
     const progress = book.epubProgress;
 
     if (progress?.cfi) {


### PR DESCRIPTION
I made the bookmarks on the notebook clickable. When clicked, it goes right in the reader to the bookmark.


## Changes
- Backend: Added cfi and pageNumber to NotebookEntry DTO
- Frontend: Made bookmark entries clickable with navigation
- Added query param handling for deep linking to bookmark locations

## Testing
- Navigate to /notebook
- Click on a bookmark → reader opens at exact location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notebook bookmarks are now clickable and open directly in the appropriate reader.
  * Bookmarks preserve and use saved locations, including ebook positions and page numbers.
  * Ebook readers can open directly to a specified location from bookmark links.
* **Style**
  * Clickable notebook entries now show pointer, hover, and active-state feedback for clearer interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->