### PR TITLE
Feat/book info bookmarks tab

### DIFF
--- a/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.html
+++ b/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.html
@@ -1,0 +1,60 @@
+<div class="book-bookmarks-container">
+  <div class="bookmarks-content">
+    @if (loading()) {
+      <div class="loading-state">
+        <p-progressSpinner/>
+        <span class="loading-text">Loading bookmarks...</span>
+      </div>
+    } @else if (bookmarks.length === 0) {
+      <div class="empty-state">
+        <p class="empty-state-title">No bookmarks yet for this book</p>
+        <p class="empty-state-subtitle">
+          Add bookmarks while reading to quick-jump back to your favorite spots.
+        </p>
+        <div class="empty-state-decoration"></div>
+      </div>
+    } @else {
+      <div class="bookmarks-scroll-container">
+        <div class="bookmarks-horizontal-list">
+          @for (bookmark of bookmarks; track bookmark.id) {
+            <div class="bookmark-card">
+              <div class="bookmark-header">
+                <div class="bookmark-header-inner">
+                  <div class="bookmark-title-group">
+                    <h4 class="bookmark-title">{{ bookmark.title || 'Bookmark' }}</h4>
+                    <div class="bookmark-meta">
+                      <i class="pi pi-bookmark bookmark-meta-icon"></i>
+                      <span class="bookmark-location">{{ getLocationLabel(bookmark) }}</span>
+                      <span class="meta-separator">•</span>
+                      <i class="pi pi-clock bookmark-meta-icon"></i>
+                      <span class="bookmark-meta-text">{{ bookmark.createdAt | date:'mediumDate' }}</span>
+                    </div>
+                  </div>
+
+                  <div class="bookmark-actions">
+                    <p-button
+                      icon="pi pi-trash"
+                      size="small"
+                      severity="danger"
+                      text
+                      (onClick)="deleteBookmark(bookmark)"
+                      pTooltip="Delete bookmark"
+                      tooltipPosition="top"
+                      class="action-btn-hover">
+                    </p-button>
+                  </div>
+                </div>
+              </div>
+
+              @if (bookmark.notes) {
+                <div class="bookmark-content-area">
+                  <div class="bookmark-body">{{ bookmark.notes }}</div>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.html
+++ b/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.html
@@ -17,7 +17,7 @@
       <div class="bookmarks-scroll-container">
         <div class="bookmarks-horizontal-list">
           @for (bookmark of bookmarks; track bookmark.id) {
-            <div class="bookmark-card">
+            <div class="bookmark-card" (click)="navigateToBookmark(bookmark)">
               <div class="bookmark-header">
                 <div class="bookmark-header-inner">
                   <div class="bookmark-title-group">
@@ -37,7 +37,7 @@
                       size="small"
                       severity="danger"
                       text
-                      (onClick)="deleteBookmark(bookmark)"
+                      (onClick)="deleteBookmark($event, bookmark)"
                       pTooltip="Delete bookmark"
                       tooltipPosition="top"
                       class="action-btn-hover">

--- a/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.scss
+++ b/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.scss
@@ -1,0 +1,151 @@
+.book-bookmarks-container {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  min-height: 250px;
+
+  .bookmarks-content {
+    flex: 1;
+    height: 100%;
+    overflow: hidden;
+  }
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.75rem;
+  gap: 0.875rem;
+
+  .loading-text {
+    color: var(--color-text-secondary);
+  }
+}
+
+.empty-state {
+  position: relative;
+  padding: 2.625rem !important;
+  text-align: center;
+  color: var(--color-text-secondary);
+
+  .empty-state-title {
+    font-size: 1.0938rem;
+    font-weight: 600;
+    margin-top: 0.875rem;
+    margin-bottom: 0.4375rem;
+    color: var(--color-text);
+  }
+
+  .empty-state-subtitle {
+    max-width: 400px;
+    margin: 0.4375rem auto 0;
+    line-height: 1.6;
+    font-size: var(--app-text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .empty-state-decoration {
+    position: absolute;
+    top: 20%;
+    right: 15%;
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    filter: blur(40px);
+    animation: float 4s ease-in-out infinite;
+  }
+}
+
+.bookmarks-scroll-container {
+  overflow: auto hidden;
+  height: 100%;
+}
+
+.bookmarks-horizontal-list {
+  display: flex;
+  gap: 1.3125rem;
+  padding: 0.4375rem;
+}
+
+.bookmark-card {
+  width: 400px;
+  height: 200px;
+  flex-shrink: 0;
+  padding: 0;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+  border: 1px solid var(--p-content-border-color);
+  background: var(--p-content-background);
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+
+  @media (width <= 768px) {
+    width: 320px;
+    height: 180px;
+  }
+
+  &:hover {
+    border-color: var(--p-primary-color);
+  }
+}
+
+.bookmark-header {
+  padding: 1rem 1.25rem 0.75rem;
+  border-bottom: 1px solid var(--p-content-border-color);
+
+  .bookmark-header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .bookmark-title-group {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .bookmark-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.35rem 0;
+    color: var(--p-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .bookmark-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--p-text-muted-color);
+
+    .bookmark-meta-icon {
+      font-size: 0.75rem;
+    }
+
+    .meta-separator {
+      margin: 0 0.2rem;
+    }
+  }
+}
+
+.bookmark-content-area {
+  padding: 0.875rem 1.25rem;
+  flex: 1;
+  overflow-y: auto;
+
+  .bookmark-body {
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: var(--p-text-color);
+    white-space: pre-wrap;
+  }
+}

--- a/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.scss
+++ b/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.scss
@@ -83,6 +83,8 @@
   border: 1px solid var(--p-content-border-color);
   background: var(--p-content-background);
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: pointer;
+  user-select: none;
 
   @media (width <= 768px) {
     width: 320px;
@@ -91,6 +93,14 @@
 
   &:hover {
     border-color: var(--p-primary-color);
+    background: color-mix(in srgb, var(--p-primary-color) 4%, var(--p-content-background));
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px color-mix(in srgb, var(--p-primary-color) 20%, transparent);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: none;
   }
 }
 

--- a/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.ts
+++ b/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.ts
@@ -1,5 +1,6 @@
 import {Component, DestroyRef, inject, Input, OnChanges, OnInit, signal, SimpleChanges} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {Router} from '@angular/router';
 import {Button} from '@openng/optimus-ui/button';
 import {ProgressSpinner} from '@openng/optimus-ui/progressspinner';
 import {Tooltip} from '@openng/optimus-ui/tooltip';
@@ -22,9 +23,11 @@ import {DatePipe} from '@angular/common';
 })
 export class BookBookmarksComponent implements OnInit, OnChanges {
   @Input() bookId!: number;
+  @Input() primaryBookType?: string;
 
   private bookMarkService = inject(BookMarkService);
   private messageService = inject(MessageService);
+  private router = inject(Router);
   private destroyRef = inject(DestroyRef);
   private readonly t = inject(TranslocoService);
 
@@ -68,7 +71,53 @@ export class BookBookmarksComponent implements OnInit, OnChanges {
       });
   }
 
-  deleteBookmark(bookmark: BookMark): void {
+  navigateToBookmark(bookmark: BookMark): void {
+    const bookType = this.primaryBookType;
+    let readerPath: string;
+
+    switch (bookType) {
+      case 'PDF':
+        readerPath = 'pdf-reader';
+        break;
+      case 'EPUB':
+      case 'FB2':
+      case 'MOBI':
+      case 'AZW3':
+        readerPath = 'ebook-reader';
+        break;
+      case 'AUDIOBOOK':
+        readerPath = 'audiobook-player';
+        break;
+      default:
+        // If we don't know the book type, try to infer from bookmark fields
+        if (bookmark.pageNumber !== undefined && bookmark.pageNumber !== null) {
+          readerPath = 'pdf-reader';
+        } else if (bookmark.cfi) {
+          readerPath = 'ebook-reader';
+        } else if (bookmark.positionMs !== undefined) {
+          readerPath = 'audiobook-player';
+        } else {
+          return; // Can't determine reader type
+        }
+    }
+
+    const queryParams: any = {};
+    if (bookmark.cfi) {
+      queryParams.cfi = bookmark.cfi;
+    } else if (bookmark.pageNumber !== undefined && bookmark.pageNumber !== null) {
+      queryParams.page = bookmark.pageNumber;
+    } else if (bookmark.positionMs !== undefined) {
+      queryParams.position = bookmark.positionMs;
+    }
+
+    this.router.navigate(
+      [`/${readerPath}/book/${this.bookId}`],
+      { queryParams: Object.keys(queryParams).length > 0 ? queryParams : undefined }
+    );
+  }
+
+  deleteBookmark(event: MouseEvent, bookmark: BookMark): void {
+    event.stopPropagation(); // Prevent navigation when clicking delete
     this.bookMarkService.deleteBookmark(bookmark.id)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
@@ -96,7 +145,16 @@ export class BookBookmarksComponent implements OnInit, OnChanges {
       return `Page ${bookmark.pageNumber}`;
     }
     if (bookmark.cfi) {
-      return `CFI: ${bookmark.cfi}`;
+      return 'EPUB Location';
+    }
+    if (bookmark.positionMs !== undefined) {
+      const seconds = Math.floor(bookmark.positionMs / 1000);
+      const minutes = Math.floor(seconds / 60);
+      const hrs = Math.floor(minutes / 60);
+      if (hrs > 0) {
+        return `${hrs}h ${minutes % 60}m`;
+      }
+      return `${minutes}m ${seconds % 60}s`;
     }
     return 'Saved Position';
   }

--- a/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.ts
+++ b/frontend/src/app/features/book/components/book-bookmarks/book-bookmarks.component.ts
@@ -1,0 +1,103 @@
+import {Component, DestroyRef, inject, Input, OnChanges, OnInit, signal, SimpleChanges} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {Button} from '@openng/optimus-ui/button';
+import {ProgressSpinner} from '@openng/optimus-ui/progressspinner';
+import {Tooltip} from '@openng/optimus-ui/tooltip';
+import {MessageService} from '@openng/optimus-ui/api';
+import {TranslocoService} from '@jsverse/transloco';
+import {BookMark, BookMarkService} from '../../../../shared/service/book-mark.service';
+import {DatePipe} from '@angular/common';
+
+@Component({
+  selector: 'app-book-bookmarks',
+  standalone: true,
+  imports: [
+    DatePipe,
+    Button,
+    ProgressSpinner,
+    Tooltip
+  ],
+  templateUrl: './book-bookmarks.component.html',
+  styleUrl: './book-bookmarks.component.scss'
+})
+export class BookBookmarksComponent implements OnInit, OnChanges {
+  @Input() bookId!: number;
+
+  private bookMarkService = inject(BookMarkService);
+  private messageService = inject(MessageService);
+  private destroyRef = inject(DestroyRef);
+  private readonly t = inject(TranslocoService);
+
+  bookmarks: BookMark[] = [];
+  loading = signal(false);
+
+  ngOnInit(): void {
+    if (this.bookId) {
+      this.loadBookmarks();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['bookId'] && changes['bookId'].currentValue) {
+      this.loadBookmarks();
+    }
+  }
+
+  loadBookmarks(): void {
+    if (!this.bookId) return;
+
+    this.loading.set(true);
+    this.bookMarkService.getBookmarksForBook(this.bookId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (bookmarks) => {
+          this.bookmarks = bookmarks.sort((a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          );
+          this.loading.set(false);
+        },
+        error: (error) => {
+          console.error('Failed to load bookmarks:', error);
+          this.loading.set(false);
+          this.messageService.add({
+            severity: 'error',
+            summary: this.t.translate('common.error'),
+            detail: 'Failed to load bookmarks'
+          });
+        }
+      });
+  }
+
+  deleteBookmark(bookmark: BookMark): void {
+    this.bookMarkService.deleteBookmark(bookmark.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.bookmarks = this.bookmarks.filter(b => b.id !== bookmark.id);
+          this.messageService.add({
+            severity: 'success',
+            summary: this.t.translate('common.success'),
+            detail: 'Bookmark deleted'
+          });
+        },
+        error: (error) => {
+          console.error('Failed to delete bookmark:', error);
+          this.messageService.add({
+            severity: 'error',
+            summary: this.t.translate('common.error'),
+            detail: 'Failed to delete bookmark'
+          });
+        }
+      });
+  }
+
+  getLocationLabel(bookmark: BookMark): string {
+    if (bookmark.pageNumber !== undefined && bookmark.pageNumber !== null) {
+      return `Page ${bookmark.pageNumber}`;
+    }
+    if (bookmark.cfi) {
+      return `CFI: ${bookmark.cfi}`;
+    }
+    return 'Saved Position';
+  }
+}

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.html
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.html
@@ -85,6 +85,11 @@
         <app-book-notes-component [bookId]="currentBook.id"></app-book-notes-component>
       </ng-template>
     </p-tabpanel>
+    <p-tabpanel value="bookmarks">
+      <ng-template #content>
+        <app-book-bookmarks [bookId]="currentBook.id"></app-book-bookmarks>
+      </ng-template>
+    </p-tabpanel>
     <p-tabpanel value="sessions">
       <ng-template #content>
         <app-book-reading-sessions [bookId]="currentBook.id"></app-book-reading-sessions>

--- a/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.ts
+++ b/frontend/src/app/features/metadata/component/book-metadata-center/metadata-viewer/metadata-tabs/metadata-tabs.component.ts
@@ -7,6 +7,7 @@ import {InfiniteScrollDirective} from 'ngx-infinite-scroll';
 import {BookCardLiteComponent} from '../../../../../book/components/book-card-lite/book-card-lite-component';
 import {BookReviewsComponent} from '../../../../../book/components/book-reviews/book-reviews.component';
 import {BookNotesComponent} from '../../../../../book/components/book-notes/book-notes-component';
+import {BookBookmarksComponent} from '../../../../../book/components/book-bookmarks/book-bookmarks.component';
 import {BookReadingSessionsComponent} from '../../book-reading-sessions/book-reading-sessions.component';
 import {Button} from '@openng/optimus-ui/button';
 import {Tooltip} from '@openng/optimus-ui/tooltip';
@@ -57,7 +58,7 @@ export interface DetachBookFileEvent {
   fileName: string;
 }
 
-type MetadataTabValue = 'series' | 'similar' | 'covers' | 'chapters' | 'files' | 'notes' | 'sessions' | 'reviews';
+type MetadataTabValue = 'series' | 'similar' | 'covers' | 'chapters' | 'files' | 'notes' | 'bookmarks' | 'sessions' | 'reviews';
 interface MetadataTab {
   value: MetadataTabValue;
   icon: string;
@@ -80,6 +81,7 @@ const metadataTab = (value: MetadataTabValue, icon: string, labelKey: string): M
     BookCardLiteComponent,
     BookReviewsComponent,
     BookNotesComponent,
+    BookBookmarksComponent,
     BookReadingSessionsComponent,
     Button,
     Tooltip,
@@ -140,6 +142,7 @@ export class MetadataTabsComponent {
     ...(this.fileState().hasAudiobookFormat ? [metadataTab('chapters', 'pi pi-headphones', 'chapters')] : []),
     metadataTab('files', 'pi pi-folder-open', 'files'),
     metadataTab('notes', 'pi pi-pen-to-square', 'notes'),
+    metadataTab('bookmarks', 'pi pi-bookmark', 'bookmarks'),
     metadataTab('sessions', 'pi pi-clock', 'readingSessions'),
     metadataTab('reviews', 'pi pi-comments', 'reviews'),
   ]);

--- a/frontend/src/i18n/en/metadata.json
+++ b/frontend/src/i18n/en/metadata.json
@@ -207,6 +207,7 @@
     "covers": "Covers",
     "files": "Files",
     "notes": "Notes",
+    "bookmarks": "Bookmarks",
     "readingSessions": "Reading Sessions",
     "reviews": "Reviews",
     "ebookCover": "Ebook Cover",


### PR DESCRIPTION
Adds a bookmark tab to the book-info page. 
This is a simple, yet really usefull feature for people to manager their bookmarks, could be extended to highlights aswell.

<img width="847" height="299" alt="image" src="https://github.com/user-attachments/assets/29cd83c9-e40e-4b05-8caa-b2c1fa8fb257" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Bookmarks tab to book details.
  * View saved bookmarks with titles, locations, dates, and notes.
  * Open bookmarks directly in the appropriate reader or player.
  * Delete bookmarks from the list.
  * Added loading, empty, responsive, and interactive bookmark card states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->