### PR TITLE
fix: bookmarks created via API don't show reader ribbon

### DIFF
--- a/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
+++ b/frontend/src/app/features/readers/ebook-reader/ebook-reader.component.ts
@@ -520,9 +520,26 @@ export class EbookReaderComponent implements OnInit {
   private updateBookmarkIndicator(): void {
     const currentCfi = this.progressService.currentCfi;
     const isBookmarked = currentCfi
-      ? this.sidebarService.bookmarks().some(bookmark => bookmark.cfi === currentCfi)
+      ? this.sidebarService.bookmarks().some(bookmark => this.cfiMatches(bookmark.cfi, currentCfi))
       : false;
     this.headerService.setCurrentCfiBookmarked(isBookmarked);
+  }
+
+  /**
+   * Compare bookmarks by the section part of the CFI (everything before the
+   * indirection step `!`). Bookmark CFIs vary in structure depending on how
+   * they were created: the reader emits point CFIs with idrefs (e.g.
+   * epubcfi(/6/122!/4/2[chapter-56],,/2/22/1:394)) while API-created
+   * bookmarks may store range CFIs without idrefs (e.g.
+   * epubcfi(/6/122!/4/2/2/22,/1:0,/1:10)). The section part is the only
+   * stable common denominator, and matching it makes the ribbon show for the
+   * bookmarked section regardless of creation path.
+   */
+  private cfiMatches(bookmarkCfi: string | undefined | null, currentCfi: string): boolean {
+    if (!bookmarkCfi) return false;
+    const section = (cfi: string): string =>
+      cfi.replace(/^epubcfi\(/, '').replace(/\)$/, '').split('!')[0];
+    return section(bookmarkCfi) === section(currentCfi);
   }
 
   private applyStyles(): void {

--- a/frontend/src/app/features/readers/ebook-reader/layout/sidebar/sidebar.service.ts
+++ b/frontend/src/app/features/readers/ebook-reader/layout/sidebar/sidebar.service.ts
@@ -246,12 +246,29 @@ export class ReaderSidebarService {
     const currentCfi = this.progressService.currentCfi;
     if (!currentCfi) return;
 
-    const existingBookmark = this._bookmarks().find(bookmark => bookmark.cfi === currentCfi);
+    const existingBookmark = this._bookmarks().find(bookmark => this.cfiMatches(bookmark.cfi, currentCfi));
     if (existingBookmark) {
       this.deleteBookmark(existingBookmark.id!);
     } else {
       this.createBookmark();
     }
+  }
+
+  /**
+   * Compare bookmarks by the section part of the CFI (everything before the
+   * indirection step `!`). Bookmark CFIs vary in structure depending on how
+   * they were created: the reader emits point CFIs with idrefs (e.g.
+   * epubcfi(/6/122!/4/2[chapter-56],,/2/22/1:394)) while API-created
+   * bookmarks may store range CFIs without idrefs (e.g.
+   * epubcfi(/6/122!/4/2/2/22,/1:0,/1:10)). The section part is the only
+   * stable common denominator, and matching it makes the ribbon show for the
+   * bookmarked section regardless of creation path.
+   */
+  private cfiMatches(bookmarkCfi: string | undefined | null, currentCfi: string): boolean {
+    if (!bookmarkCfi) return false;
+    const section = (cfi: string): string =>
+      cfi.replace(/^epubcfi\(/, '').replace(/\)$/, '').split('!')[0];
+    return section(bookmarkCfi) === section(currentCfi);
   }
 
   deleteBookmark(bookmarkId: number): void {


### PR DESCRIPTION
## The issue:
Bookmarks created outside the reader (via POST /api/v1/bookmarks) never
triggered the bookmark ribbon in the ebook reader, while bookmarks made
inside the reader did.

## Root cause: 
the reader compared the current CFI against each bookmark's
CFI with strict string equality. Bookmarks created in the reader store
the exact point CFI the reader emits, so they matched. Bookmarks created
from a selection (which is what some API clients send) store a range CFI
without the idrefs the reader uses on its own CFIs, e.g.

  reader position: epubcfi(/6/122!/4/2[chapter-56],,/2/22/1:394)
  api-created:     epubcfi(/6/122!/4/2/2/22,/1:0,/1:10)

Same section, structurally different strings, so equality failed.

## Fix: 
compare bookmarks by the section part of the CFI (everything before
the `!` indirection step) instead of the full string. That part is stable
across both formats. Changed updateBookmarkIndicator() and toggleBookmark().

Noticed while testing crosspoint-bookmark-sync against the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bookmark detection when navigating within an ebook.
  - Bookmark indicators now remain accurate across equivalent CFI formats.
  - Toggling a bookmark correctly recognizes existing bookmarks created through different navigation or API flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->