### PR TITLE
fix(api): include filename in books page search

### DIFF
--- a/backend/src/main/java/org/booklore/service/browse/BookSearchSpecification.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookSearchSpecification.java
@@ -8,6 +8,7 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
 import org.booklore.model.entity.BookEntity;
+import org.booklore.model.entity.BookFileEntity;
 import org.booklore.model.entity.BookMetadataEntity;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -31,9 +32,20 @@ public final class BookSearchSpecification {
                     cb.like(cb.lower(metadata.get("asin")), pattern),
                     collectionMatches(root, criteriaQuery, cb, "authors", pattern),
                     collectionMatches(root, criteriaQuery, cb, "categories", pattern),
-                    collectionMatches(root, criteriaQuery, cb, "tags", pattern)
+                    collectionMatches(root, criteriaQuery, cb, "tags", pattern),
+                    fileNameMatches(root, criteriaQuery, cb, pattern)
             );
         };
+    }
+
+    private static Predicate fileNameMatches(Root<BookEntity> root, CriteriaQuery<?> query, CriteriaBuilder cb,
+                                             String pattern) {
+        Subquery<Long> sub = query.subquery(Long.class);
+        Root<BookFileEntity> file = sub.from(BookFileEntity.class);
+        sub.select(cb.literal(1L)).where(
+                cb.equal(file.get("book").get("id"), root.get("id")),
+                cb.like(cb.lower(file.get("fileName")), pattern));
+        return cb.exists(sub);
     }
 
     private static Predicate collectionMatches(Root<BookEntity> root, CriteriaQuery<?> query, CriteriaBuilder cb,

--- a/backend/src/test/java/org/booklore/service/browse/BookSearchSpecificationTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookSearchSpecificationTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -111,6 +112,21 @@ class BookSearchSpecificationTest {
         List<BookEntity> results = bookRepository.findAll(BookSearchSpecification.matching("nonexistent"));
 
         assertThat(results).isEmpty();
+    }
+
+    @Test
+    void matching_returnsAllBooks_whenQueryIsNullEmptyOrBlank() {
+        LibraryEntity library = persistLibrary();
+        BookEntity book = persistBook(library, "Some Title", "some-file.epub");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // A null/blank query short-circuits to cb.conjunction(); every persisted book must match.
+        for (String blank : Arrays.asList(null, "", "   ")) {
+            List<BookEntity> results = bookRepository.findAll(BookSearchSpecification.matching(blank));
+            assertThat(results).extracting(BookEntity::getId).contains(book.getId());
+        }
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/browse/BookSearchSpecificationTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookSearchSpecificationTest.java
@@ -117,15 +117,18 @@ class BookSearchSpecificationTest {
     @Test
     void matching_returnsAllBooks_whenQueryIsNullEmptyOrBlank() {
         LibraryEntity library = persistLibrary();
-        BookEntity book = persistBook(library, "Some Title", "some-file.epub");
+        BookEntity first = persistBook(library, "Some Title", "some-file.epub");
+        BookEntity second = persistBook(library, "Another Title", "another-file.pdf");
 
         entityManager.flush();
         entityManager.clear();
 
-        // A null/blank query short-circuits to cb.conjunction(); every persisted book must match.
+        // A null/blank query short-circuits to cb.conjunction(); every persisted book must match,
+        // not just one, so assert the full set is returned.
         for (String blank : Arrays.asList(null, "", "   ")) {
             List<BookEntity> results = bookRepository.findAll(BookSearchSpecification.matching(blank));
-            assertThat(results).extracting(BookEntity::getId).contains(book.getId());
+            assertThat(results).extracting(BookEntity::getId)
+                    .containsExactlyInAnyOrder(first.getId(), second.getId());
         }
     }
 

--- a/backend/src/test/java/org/booklore/service/browse/BookSearchSpecificationTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookSearchSpecificationTest.java
@@ -1,0 +1,181 @@
+package org.booklore.service.browse;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.booklore.BookloreApplication;
+import org.booklore.model.entity.*;
+import org.booklore.model.enums.BookFileType;
+import org.booklore.repository.BookRepository;
+import org.booklore.service.task.TaskCronService;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies {@link BookSearchSpecification#matching(String)} against H2, exercising the real
+ * JPA criteria query. This is the spec behind the {@code query} parameter of
+ * {@code GET /api/v1/books/page} (the command-palette search), which must match on filename
+ * (see issue #2293).
+ */
+@SpringBootTest(classes = BookloreApplication.class)
+@Transactional
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "app.path-config=build/tmp/test-config",
+        "app.bookdrop-folder=build/tmp/test-bookdrop",
+        "spring.main.allow-bean-definition-overriding=true",
+        "spring.task.scheduling.enabled=false",
+        "app.task.scan-library-cron=*/1 * * * * *",
+        "app.task.process-bookdrop-cron=*/1 * * * * *",
+        "app.features.oidc-enabled=false",
+        "spring.jpa.properties.hibernate.connection.provider_disables_autocommit=false"
+})
+@Import(BookSearchSpecificationTest.TestConfig.class)
+class BookSearchSpecificationTest {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @TestConfiguration
+    public static class TestConfig {
+        @Bean("flyway")
+        @Primary
+        public Flyway flyway() {
+            return mock(Flyway.class);
+        }
+
+        @Bean
+        @Primary
+        public TaskCronService taskCronService() {
+            return mock(TaskCronService.class);
+        }
+    }
+
+    @Test
+    void matching_findsBookByFilename_whenTitleAndAuthorDoNotMatch() {
+        LibraryEntity library = persistLibrary();
+        BookEntity book = persistBook(library, "Unrelated Title", "The Fellowship of the Ring.epub");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<BookEntity> results = bookRepository.findAll(BookSearchSpecification.matching("fellowship"));
+
+        assertThat(results).extracting(BookEntity::getId).containsExactly(book.getId());
+    }
+
+    @Test
+    void matching_isCaseInsensitiveOnFilename() {
+        LibraryEntity library = persistLibrary();
+        BookEntity book = persistBook(library, "Unrelated Title", "Dune-Messiah.pdf");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<BookEntity> results = bookRepository.findAll(BookSearchSpecification.matching("DUNE"));
+
+        assertThat(results).extracting(BookEntity::getId).containsExactly(book.getId());
+    }
+
+    @Test
+    void matching_doesNotMatch_whenQueryIsAbsentFromAllFields() {
+        LibraryEntity library = persistLibrary();
+        persistBook(library, "Unrelated Title", "some-file.epub");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<BookEntity> results = bookRepository.findAll(BookSearchSpecification.matching("nonexistent"));
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void matching_returnsBookOnce_whenMultipleFilesShareTheQuery() {
+        LibraryEntity library = persistLibrary();
+        BookEntity book = persistBook(library, "Unrelated Title", "The Hobbit.epub");
+        addFile(book, "The Hobbit.pdf", BookFileType.PDF);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<BookEntity> results = bookRepository.findAll(BookSearchSpecification.matching("hobbit"));
+
+        assertThat(results).extracting(BookEntity::getId).containsExactly(book.getId());
+    }
+
+    private LibraryEntity persistLibrary() {
+        LibraryEntity library = LibraryEntity.builder()
+                .name("Search Library " + System.nanoTime())
+                .icon("book")
+                .watch(false)
+                .formatPriority(List.of(BookFileType.EPUB, BookFileType.PDF))
+                .build();
+        entityManager.persist(library);
+
+        LibraryPathEntity libraryPath = LibraryPathEntity.builder()
+                .library(library)
+                .path("/search/" + System.nanoTime())
+                .build();
+        entityManager.persist(libraryPath);
+        library.getLibraryPaths().add(libraryPath);
+        return library;
+    }
+
+    private BookEntity persistBook(LibraryEntity library, String title, String fileName) {
+        BookEntity book = BookEntity.builder()
+                .library(library)
+                .libraryPath(library.getLibraryPaths().getFirst())
+                .addedOn(Instant.now())
+                .deleted(false)
+                .build();
+        entityManager.persist(book);
+
+        BookMetadataEntity metadata = BookMetadataEntity.builder()
+                .book(book)
+                .title(title)
+                .build();
+        book.setMetadata(metadata);
+        entityManager.persist(metadata);
+
+        addFile(book, fileName, BookFileType.EPUB);
+        return book;
+    }
+
+    private void addFile(BookEntity book, String fileName, BookFileType type) {
+        BookFileEntity file = BookFileEntity.builder()
+                .book(book)
+                .fileName(fileName)
+                .fileSubPath(".")
+                .isBookFormat(true)
+                .bookType(type)
+                .fileSizeKb(256L)
+                .currentHash("hash-" + System.nanoTime())
+                .build();
+        book.getBookFiles().add(file);
+        entityManager.persist(file);
+    }
+}


### PR DESCRIPTION
## Description

The command-palette search on `GET /api/v1/books/page` (its `query` parameter) no longer matched a book's filename, a regression from the previous client-side search. The spec behind that endpoint, `BookSearchSpecification.matching`, searched title, series name, ISBN, ASIN, authors, categories, and tags, but never the filename. This restores filename matching.

## Linked Issue

Fixes #2293

## Changes

- Add a correlated `EXISTS` subquery over `BookFileEntity` to `BookSearchSpecification.matching`, matching when any of a book's file names contain the query (case-insensitive). Mirrors the existing `collectionMatches` helper; `EXISTS` avoids returning a multi-file book more than once.
- Add `BookSearchSpecificationTest` (H2 integration test): filename match when title/author/series don't match, case-insensitivity, no false positives, and multi-file dedup.

## Manual Testing Steps

1. Ran the backend (dev profile) against MariaDB; created the admin user and a library.
2. Placed a PDF whose filename token `zqxwvtoken` does **not** appear in its embedded title (`Printable 4-page SVG (Letter)`), then rescanned the library.
3. `GET /api/v1/books/page?query=zqxwvtoken` returns the book. Because the token exists only in the filename, this confirms the filename match.
4. `GET /api/v1/books/page?query=printable` (title) returns the book; `?query=notpresentxyz` returns nothing. Confirms existing search still works and there are no false positives.

## AI Disclosure

Claude (Claude Code) - investigated the regression and traced the real endpoint code path, wrote the spec change and the H2 integration test, and ran the backend checks and a live end-to-end verification. I reviewed and understand all changes.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just api check` (`just ui check` is N/A: backend-only change).
- [ ] I have added screenshots if there were any UI changes. (N/A: no UI change.)
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Book search now includes tags and associated file names.
  * File-name matching is case-insensitive, making it easier to find books when the query differs from the title or author.
  * Searches return each book only once, even when multiple associated files match.
  * Empty or blank searches continue to return all available books.

* **Bug Fixes**
  * Improved search accuracy for queries matching associated file names or tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->