### PR TITLE
fix(library): refresh file size and hash for in-place modified files

### DIFF
--- a/backend/src/main/java/org/booklore/service/library/LibraryProcessingService.java
+++ b/backend/src/main/java/org/booklore/service/library/LibraryProcessingService.java
@@ -117,6 +117,10 @@ public class LibraryProcessingService {
                 .orElseThrow(() -> ApiError.LIBRARY_NOT_FOUND.createException(libraryId));
         books = bookRepository.findAllByLibraryIdForRescan(libraryId);
 
+        // Refresh stored size/hash for files modified in place (same path, changed content),
+        // which detectNewBookPaths would otherwise skip because the path already exists.
+        syncModifiedBookFiles(books);
+
         List<LibraryFile> newFiles = libraryFileHelper.detectNewBookPaths(filteredFiles, books, allAdditionalFiles);
 
         // Use BookGroupingService to determine what to attach vs create new
@@ -137,6 +141,58 @@ public class LibraryProcessingService {
 
     public void processLibraryFiles(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity) {
         fileAsBookProcessor.processLibraryFiles(libraryFiles, libraryEntity);
+    }
+
+    private void syncModifiedBookFiles(List<BookEntity> books) {
+        for (BookEntity book : books) {
+            if (book.getBookFiles() == null) {
+                continue;
+            }
+            for (BookFileEntity bookFile : book.getBookFiles()) {
+                syncBookFileIfModified(bookFile);
+            }
+        }
+    }
+
+    /**
+     * Detect a file that was modified in place (same path, different content) by comparing the
+     * stored size against the current on-disk size, and refresh the stored size and content hash
+     * when they differ. Files that are missing or unreadable are left untouched here; removals are
+     * handled separately by the deletion detection above.
+     */
+    private void syncBookFileIfModified(BookFileEntity bookFile) {
+        Path fullPath;
+        try {
+            fullPath = bookFile.getFullFilePath();
+        } catch (IllegalStateException e) {
+            // Fileless or incomplete record: nothing on disk to sync.
+            return;
+        }
+
+        Long actualSizeKb = bookFile.isFolderBased()
+                ? FileUtils.getFolderSizeInKb(fullPath)
+                : FileUtils.getFileSizeInKb(fullPath);
+        if (actualSizeKb == null) {
+            return;
+        }
+
+        Long storedSizeKb = bookFile.getFileSizeKb();
+        if (storedSizeKb != null && storedSizeKb.equals(actualSizeKb)) {
+            return;
+        }
+
+        try {
+            String newHash = bookFile.isFolderBased()
+                    ? FileFingerprint.generateFolderHash(fullPath)
+                    : FileFingerprint.generateHash(fullPath);
+            bookFile.setFileSizeKb(actualSizeKb);
+            bookFile.setCurrentHash(newHash);
+            bookAdditionalFileRepository.save(bookFile);
+            log.info("Refreshed metadata for modified file '{}' (size {} KB -> {} KB)",
+                    bookFile.getFileName(), storedSizeKb, actualSizeKb);
+        } catch (Exception e) {
+            log.error("Failed to refresh metadata for modified file '{}': {}", bookFile.getFileName(), e.getMessage());
+        }
     }
 
     private void validateLibraryPathsAccessible(LibraryEntity libraryEntity) {

--- a/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
@@ -633,6 +633,110 @@ class LibraryProcessingServiceTest {
     }
 
     @Test
+    void rescanLibrary_shouldBackfillSizeAndHashWhenStoredSizeIsNull(@TempDir Path tempDir) throws IOException {
+        long libraryId = 1L;
+        Path accessiblePath = tempDir.resolve("accessible");
+        Files.createDirectory(accessiblePath);
+        Path bookFileOnDisk = accessiblePath.resolve("book1.epub");
+        Files.write(bookFileOnDisk, new byte[5000]); // 5000 bytes -> 4 KB
+
+        LibraryEntity libraryEntity = new LibraryEntity();
+        libraryEntity.setId(libraryId);
+        libraryEntity.setName("Test Library");
+
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(10L);
+        pathEntity.setPath(accessiblePath.toString());
+        libraryEntity.setLibraryPaths(List.of(pathEntity));
+
+        BookEntity existingBook = new BookEntity();
+        existingBook.setId(1L);
+        existingBook.setLibraryPath(pathEntity);
+        BookFileEntity existingBookFile = new BookFileEntity();
+        existingBookFile.setBook(existingBook);
+        existingBookFile.setFileSubPath("");
+        existingBookFile.setFileName("book1.epub");
+        existingBookFile.setFileSizeKb(null); // never recorded (legacy row)
+        existingBook.setBookFiles(Set.of(existingBookFile));
+        libraryEntity.setBookEntities(List.of(existingBook));
+
+        LibraryFile fileOnDisk = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("")
+                .fileName("book1.epub")
+                .build();
+
+        when(libraryRepository.findByIdWithPaths(libraryId)).thenReturn(Optional.of(libraryEntity));
+        when(bookRepository.findAllByLibraryIdForRescan(libraryId)).thenReturn(List.of(existingBook));
+        when(libraryFileHelper.getAllLibraryFiles(libraryEntity)).thenReturn(List.of(fileOnDisk));
+        when(libraryFileHelper.filterByAllowedFormats(anyList(), any())).thenAnswer(inv -> inv.getArgument(0));
+        when(bookAdditionalFileRepository.findByLibraryId(libraryId)).thenReturn(Collections.emptyList());
+        when(bookGroupingService.groupForRescan(anyList(), any(LibraryEntity.class)))
+                .thenReturn(new BookGroupingService.GroupingResult(Collections.emptyMap(), Collections.emptyMap()));
+
+        libraryProcessingService.rescanLibrary(RescanLibraryContext.builder().libraryId(libraryId).build());
+
+        assertThat(existingBookFile.getFileSizeKb()).isEqualTo(4L);
+        assertThat(existingBookFile.getCurrentHash()).isNotBlank();
+        verify(bookAdditionalFileRepository).save(existingBookFile);
+    }
+
+    @Test
+    void rescanLibrary_shouldRefreshSizeAndHashForModifiedFolderBasedAudiobook(@TempDir Path tempDir) throws IOException {
+        long libraryId = 1L;
+        Path accessiblePath = tempDir.resolve("accessible");
+        Files.createDirectory(accessiblePath);
+        Path audiobookFolder = accessiblePath.resolve("audiobook");
+        Files.createDirectory(audiobookFolder);
+        Files.write(audiobookFolder.resolve("01.mp3"), new byte[3000]);
+        Files.write(audiobookFolder.resolve("02.mp3"), new byte[3000]); // 6000 bytes total -> 5 KB
+
+        LibraryEntity libraryEntity = new LibraryEntity();
+        libraryEntity.setId(libraryId);
+        libraryEntity.setName("Test Library");
+
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(10L);
+        pathEntity.setPath(accessiblePath.toString());
+        libraryEntity.setLibraryPaths(List.of(pathEntity));
+
+        BookEntity existingBook = new BookEntity();
+        existingBook.setId(1L);
+        existingBook.setLibraryPath(pathEntity);
+        BookFileEntity existingBookFile = new BookFileEntity();
+        existingBookFile.setBook(existingBook);
+        existingBookFile.setFileSubPath("");
+        existingBookFile.setFileName("audiobook");
+        existingBookFile.setFolderBased(true);
+        existingBookFile.setFileSizeKb(1L); // stale size before the in-place edit
+        existingBook.setBookFiles(Set.of(existingBookFile));
+        libraryEntity.setBookEntities(List.of(existingBook));
+
+        LibraryFile fileOnDisk = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("")
+                .fileName("audiobook")
+                .folderBased(true)
+                .build();
+
+        when(libraryRepository.findByIdWithPaths(libraryId)).thenReturn(Optional.of(libraryEntity));
+        when(bookRepository.findAllByLibraryIdForRescan(libraryId)).thenReturn(List.of(existingBook));
+        when(libraryFileHelper.getAllLibraryFiles(libraryEntity)).thenReturn(List.of(fileOnDisk));
+        when(libraryFileHelper.filterByAllowedFormats(anyList(), any())).thenAnswer(inv -> inv.getArgument(0));
+        when(bookAdditionalFileRepository.findByLibraryId(libraryId)).thenReturn(Collections.emptyList());
+        when(bookGroupingService.groupForRescan(anyList(), any(LibraryEntity.class)))
+                .thenReturn(new BookGroupingService.GroupingResult(Collections.emptyMap(), Collections.emptyMap()));
+
+        libraryProcessingService.rescanLibrary(RescanLibraryContext.builder().libraryId(libraryId).build());
+
+        assertThat(existingBookFile.getFileSizeKb()).isEqualTo(5L);
+        assertThat(existingBookFile.getCurrentHash()).isNotBlank();
+        verify(bookAdditionalFileRepository).save(existingBookFile);
+    }
+
+    @Test
     void rescanLibrary_shouldRefetchLibraryAfterEntityManagerClear(@TempDir Path tempDir) throws IOException {
 
         long libraryId = 1L;

--- a/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
@@ -556,6 +556,7 @@ class LibraryProcessingServiceTest {
         existingBookFile.setFileSubPath("");
         existingBookFile.setFileName("book1.epub");
         existingBookFile.setFileSizeKb(1L); // stale size before the in-place edit
+        existingBookFile.setCurrentHash("stale-hash"); // stale hash to be replaced
         existingBook.setBookFiles(Set.of(existingBookFile));
         libraryEntity.setBookEntities(List.of(existingBook));
 
@@ -577,7 +578,7 @@ class LibraryProcessingServiceTest {
         libraryProcessingService.rescanLibrary(RescanLibraryContext.builder().libraryId(libraryId).build());
 
         assertThat(existingBookFile.getFileSizeKb()).isEqualTo(4L);
-        assertThat(existingBookFile.getCurrentHash()).isNotBlank();
+        assertThat(existingBookFile.getCurrentHash()).isNotBlank().isNotEqualTo("stale-hash");
         verify(bookAdditionalFileRepository).save(existingBookFile);
     }
 
@@ -657,6 +658,7 @@ class LibraryProcessingServiceTest {
         existingBookFile.setFileSubPath("");
         existingBookFile.setFileName("book1.epub");
         existingBookFile.setFileSizeKb(null); // never recorded (legacy row)
+        existingBookFile.setCurrentHash("stale-hash"); // stale hash to be replaced
         existingBook.setBookFiles(Set.of(existingBookFile));
         libraryEntity.setBookEntities(List.of(existingBook));
 
@@ -678,7 +680,7 @@ class LibraryProcessingServiceTest {
         libraryProcessingService.rescanLibrary(RescanLibraryContext.builder().libraryId(libraryId).build());
 
         assertThat(existingBookFile.getFileSizeKb()).isEqualTo(4L);
-        assertThat(existingBookFile.getCurrentHash()).isNotBlank();
+        assertThat(existingBookFile.getCurrentHash()).isNotBlank().isNotEqualTo("stale-hash");
         verify(bookAdditionalFileRepository).save(existingBookFile);
     }
 
@@ -710,6 +712,7 @@ class LibraryProcessingServiceTest {
         existingBookFile.setFileName("audiobook");
         existingBookFile.setFolderBased(true);
         existingBookFile.setFileSizeKb(1L); // stale size before the in-place edit
+        existingBookFile.setCurrentHash("stale-hash"); // stale hash to be replaced
         existingBook.setBookFiles(Set.of(existingBookFile));
         libraryEntity.setBookEntities(List.of(existingBook));
 
@@ -732,7 +735,56 @@ class LibraryProcessingServiceTest {
         libraryProcessingService.rescanLibrary(RescanLibraryContext.builder().libraryId(libraryId).build());
 
         assertThat(existingBookFile.getFileSizeKb()).isEqualTo(5L);
-        assertThat(existingBookFile.getCurrentHash()).isNotBlank();
+        assertThat(existingBookFile.getCurrentHash()).isNotBlank().isNotEqualTo("stale-hash");
+        verify(bookAdditionalFileRepository).save(existingBookFile);
+    }
+
+    @Test
+    void rescanLibrary_shouldConvertExactKilobyteSize(@TempDir Path tempDir) throws IOException {
+        long libraryId = 1L;
+        Path accessiblePath = tempDir.resolve("accessible");
+        Files.createDirectory(accessiblePath);
+        Path bookFileOnDisk = accessiblePath.resolve("book1.epub");
+        Files.write(bookFileOnDisk, new byte[1024]); // exactly 1 KiB -> 1 KB
+
+        LibraryEntity libraryEntity = new LibraryEntity();
+        libraryEntity.setId(libraryId);
+        libraryEntity.setName("Test Library");
+
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(10L);
+        pathEntity.setPath(accessiblePath.toString());
+        libraryEntity.setLibraryPaths(List.of(pathEntity));
+
+        BookEntity existingBook = new BookEntity();
+        existingBook.setId(1L);
+        existingBook.setLibraryPath(pathEntity);
+        BookFileEntity existingBookFile = new BookFileEntity();
+        existingBookFile.setBook(existingBook);
+        existingBookFile.setFileSubPath("");
+        existingBookFile.setFileName("book1.epub");
+        existingBookFile.setFileSizeKb(5L); // stale size before the in-place edit
+        existingBook.setBookFiles(Set.of(existingBookFile));
+        libraryEntity.setBookEntities(List.of(existingBook));
+
+        LibraryFile fileOnDisk = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("")
+                .fileName("book1.epub")
+                .build();
+
+        when(libraryRepository.findByIdWithPaths(libraryId)).thenReturn(Optional.of(libraryEntity));
+        when(bookRepository.findAllByLibraryIdForRescan(libraryId)).thenReturn(List.of(existingBook));
+        when(libraryFileHelper.getAllLibraryFiles(libraryEntity)).thenReturn(List.of(fileOnDisk));
+        when(libraryFileHelper.filterByAllowedFormats(anyList(), any())).thenAnswer(inv -> inv.getArgument(0));
+        when(bookAdditionalFileRepository.findByLibraryId(libraryId)).thenReturn(Collections.emptyList());
+        when(bookGroupingService.groupForRescan(anyList(), any(LibraryEntity.class)))
+                .thenReturn(new BookGroupingService.GroupingResult(Collections.emptyMap(), Collections.emptyMap()));
+
+        libraryProcessingService.rescanLibrary(RescanLibraryContext.builder().libraryId(libraryId).build());
+
+        assertThat(existingBookFile.getFileSizeKb()).isEqualTo(1L);
         verify(bookAdditionalFileRepository).save(existingBookFile);
     }
 

--- a/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/library/LibraryProcessingServiceTest.java
@@ -532,6 +532,107 @@ class LibraryProcessingServiceTest {
     }
 
     @Test
+    void rescanLibrary_shouldRefreshSizeAndHashForInPlaceModifiedFile(@TempDir Path tempDir) throws IOException {
+        long libraryId = 1L;
+        Path accessiblePath = tempDir.resolve("accessible");
+        Files.createDirectory(accessiblePath);
+        Path bookFileOnDisk = accessiblePath.resolve("book1.epub");
+        Files.write(bookFileOnDisk, new byte[5000]); // 5000 bytes -> 4 KB
+
+        LibraryEntity libraryEntity = new LibraryEntity();
+        libraryEntity.setId(libraryId);
+        libraryEntity.setName("Test Library");
+
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(10L);
+        pathEntity.setPath(accessiblePath.toString());
+        libraryEntity.setLibraryPaths(List.of(pathEntity));
+
+        BookEntity existingBook = new BookEntity();
+        existingBook.setId(1L);
+        existingBook.setLibraryPath(pathEntity);
+        BookFileEntity existingBookFile = new BookFileEntity();
+        existingBookFile.setBook(existingBook);
+        existingBookFile.setFileSubPath("");
+        existingBookFile.setFileName("book1.epub");
+        existingBookFile.setFileSizeKb(1L); // stale size before the in-place edit
+        existingBook.setBookFiles(Set.of(existingBookFile));
+        libraryEntity.setBookEntities(List.of(existingBook));
+
+        LibraryFile fileOnDisk = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("")
+                .fileName("book1.epub")
+                .build();
+
+        when(libraryRepository.findByIdWithPaths(libraryId)).thenReturn(Optional.of(libraryEntity));
+        when(bookRepository.findAllByLibraryIdForRescan(libraryId)).thenReturn(List.of(existingBook));
+        when(libraryFileHelper.getAllLibraryFiles(libraryEntity)).thenReturn(List.of(fileOnDisk));
+        when(libraryFileHelper.filterByAllowedFormats(anyList(), any())).thenAnswer(inv -> inv.getArgument(0));
+        when(bookAdditionalFileRepository.findByLibraryId(libraryId)).thenReturn(Collections.emptyList());
+        when(bookGroupingService.groupForRescan(anyList(), any(LibraryEntity.class)))
+                .thenReturn(new BookGroupingService.GroupingResult(Collections.emptyMap(), Collections.emptyMap()));
+
+        libraryProcessingService.rescanLibrary(RescanLibraryContext.builder().libraryId(libraryId).build());
+
+        assertThat(existingBookFile.getFileSizeKb()).isEqualTo(4L);
+        assertThat(existingBookFile.getCurrentHash()).isNotBlank();
+        verify(bookAdditionalFileRepository).save(existingBookFile);
+    }
+
+    @Test
+    void rescanLibrary_shouldNotRewriteUnchangedFile(@TempDir Path tempDir) throws IOException {
+        long libraryId = 1L;
+        Path accessiblePath = tempDir.resolve("accessible");
+        Files.createDirectory(accessiblePath);
+        Path bookFileOnDisk = accessiblePath.resolve("book1.epub");
+        Files.write(bookFileOnDisk, new byte[5000]); // 5000 bytes -> 4 KB
+
+        LibraryEntity libraryEntity = new LibraryEntity();
+        libraryEntity.setId(libraryId);
+        libraryEntity.setName("Test Library");
+
+        LibraryPathEntity pathEntity = new LibraryPathEntity();
+        pathEntity.setId(10L);
+        pathEntity.setPath(accessiblePath.toString());
+        libraryEntity.setLibraryPaths(List.of(pathEntity));
+
+        BookEntity existingBook = new BookEntity();
+        existingBook.setId(1L);
+        existingBook.setLibraryPath(pathEntity);
+        BookFileEntity existingBookFile = new BookFileEntity();
+        existingBookFile.setBook(existingBook);
+        existingBookFile.setFileSubPath("");
+        existingBookFile.setFileName("book1.epub");
+        existingBookFile.setFileSizeKb(4L); // already matches on-disk size
+        existingBookFile.setCurrentHash("unchanged-hash");
+        existingBook.setBookFiles(Set.of(existingBookFile));
+        libraryEntity.setBookEntities(List.of(existingBook));
+
+        LibraryFile fileOnDisk = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(pathEntity)
+                .fileSubPath("")
+                .fileName("book1.epub")
+                .build();
+
+        when(libraryRepository.findByIdWithPaths(libraryId)).thenReturn(Optional.of(libraryEntity));
+        when(bookRepository.findAllByLibraryIdForRescan(libraryId)).thenReturn(List.of(existingBook));
+        when(libraryFileHelper.getAllLibraryFiles(libraryEntity)).thenReturn(List.of(fileOnDisk));
+        when(libraryFileHelper.filterByAllowedFormats(anyList(), any())).thenAnswer(inv -> inv.getArgument(0));
+        when(bookAdditionalFileRepository.findByLibraryId(libraryId)).thenReturn(Collections.emptyList());
+        when(bookGroupingService.groupForRescan(anyList(), any(LibraryEntity.class)))
+                .thenReturn(new BookGroupingService.GroupingResult(Collections.emptyMap(), Collections.emptyMap()));
+
+        libraryProcessingService.rescanLibrary(RescanLibraryContext.builder().libraryId(libraryId).build());
+
+        assertThat(existingBookFile.getFileSizeKb()).isEqualTo(4L);
+        assertThat(existingBookFile.getCurrentHash()).isEqualTo("unchanged-hash");
+        verify(bookAdditionalFileRepository, never()).save(any());
+    }
+
+    @Test
     void rescanLibrary_shouldRefetchLibraryAfterEntityManagerClear(@TempDir Path tempDir) throws IOException {
 
         long libraryId = 1L;


### PR DESCRIPTION
## Description

Library rescan ("Sync library files") never refreshed the stored size of a book that was modified in place. When a file is edited but keeps the same path, `detectNewBookPaths` matches it by path key and skips it, so its `fileSizeKb` (and content hash) are never updated and the UI keeps showing the old size.

This adds a sync pass during rescan that detects a size change on an existing file and refreshes the stored size and hash.

## Linked Issue

Fixes #2368

## Changes

- `LibraryProcessingService.rescanLibrary`: after the post-`entityManager.clear()` re-fetch and before `detectNewBookPaths`, run a new `syncModifiedBookFiles(books)` pass.
- For each existing book file still present on disk, compare the stored `fileSizeKb` against the current on-disk size (file size, or folder size for folder-based audiobooks). On mismatch, update the size and recompute `currentHash`.
- The (partial MD5) hash is recomputed only when the size changed, so a normal rescan stays cheap (one stat per file). Missing/unreadable files are left untouched — removals remain owned by the existing deletion detection.

## Manual Testing Steps

1. Add a book to a library and let it scan; note the file size shown in the UI.
2. Replace/edit that file in place on disk so its size changes, keeping the same path and filename.
3. Run "Sync library files" (library rescan).
4. The book's displayed file size updates to the new size (previously it stayed stale).

Automated: added unit tests in `LibraryProcessingServiceTest` covering the modified-file and unchanged-file paths; ran `./gradlew test --tests 'org.booklore.service.library.LibraryProcessingServiceTest'` — 13 passed, 0 failures.

## Additional Context

There is no persisted mtime column, so change detection is size-based. Because size is stored in KB (`bytes / 1024`), a sub-kilobyte in-place edit that doesn't cross a KB boundary won't be detected; real content edits almost always move the size by more than 1 KB. Byte-exact or mtime-based detection would require a schema change and is out of scope here.

## AI Disclosure

Claude Code (Opus) investigated the issue, implemented the fix, and wrote the unit tests. I reviewed all changes.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`. (Backend-only change; ran the targeted `LibraryProcessingServiceTest` locally, leaving the full check suite to CI.)
- [x] I have added screenshots if there were any UI changes. (No UI changes.)
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Library rescans now detect books modified in place and refresh their stored file size and content hash.
  - Folder-based audiobooks receive updated size and hash metadata when their contents change.
  - Missing legacy size metadata is restored during rescans.
  - Unchanged files are left untouched, avoiding unnecessary updates.
  - A problem processing one book no longer prevents other books from being synchronized.
  - Updated books now trigger refresh notifications.

- **Tests**
  - Added coverage for modified, unchanged, legacy, and folder-based book metadata scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->