### PR TITLE
fix(oidc): preserve stored client secret when saved blank

### DIFF
--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -66,6 +66,10 @@ public class AppSettingService {
             val = validateAndNormalizeOidcRedirectUris(val);
         }
 
+        if (key == AppSettingKey.OIDC_PROVIDER_DETAILS) {
+            val = preserveExistingOidcClientSecret(val);
+        }
+
         if (key == AppSettingKey.OIDC_FORCE_ONLY_MODE) {
             validateOidcForceOnlyMode(val);
         }
@@ -84,6 +88,31 @@ public class AppSettingService {
             default -> AuditAction.SETTINGS_UPDATED;
         };
         auditService.log(action, "Updated setting: " + key);
+    }
+
+    /**
+     * The client secret is never sent back to the UI (see {@link #buildPublicSetting()}), so the OIDC
+     * provider form saves with a blank secret whenever the admin edits other fields without re-entering it.
+     * Treat a blank/missing incoming secret as "unchanged" and keep the stored one instead of erasing it.
+     */
+    private Object preserveExistingOidcClientSecret(Object val) {
+        OidcProviderDetails incoming = settingPersistenceHelper.convertOidcProviderDetails(val);
+        if (incoming == null || (incoming.getClientSecret() != null && !incoming.getClientSecret().isBlank())) {
+            return val;
+        }
+
+        AppSettingEntity existing = settingPersistenceHelper.appSettingsRepository.findByName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString());
+        if (existing == null) {
+            return val;
+        }
+
+        OidcProviderDetails stored = settingPersistenceHelper.readOidcProviderDetails(existing.getVal());
+        if (stored == null || stored.getClientSecret() == null || stored.getClientSecret().isBlank()) {
+            return val;
+        }
+
+        incoming.setClientSecret(stored.getClientSecret());
+        return incoming;
     }
 
     private void validateOidcForceOnlyMode(Object val) {

--- a/backend/src/main/java/org/booklore/service/appsettings/SettingPersistenceHelper.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/SettingPersistenceHelper.java
@@ -81,6 +81,25 @@ public class SettingPersistenceHelper {
         return key.isJson() ? objectMapper.writeValueAsString(val) : val.toString();
     }
 
+    public OidcProviderDetails convertOidcProviderDetails(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return objectMapper.convertValue(value, OidcProviderDetails.class);
+    }
+
+    public OidcProviderDetails readOidcProviderDetails(String json) {
+        if (json == null || json.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(json, OidcProviderDetails.class);
+        } catch (JacksonException e) {
+            log.error("Failed to parse stored OIDC provider details. Error: {}", e.getMessage());
+            return null;
+        }
+    }
+
     public MetadataProviderSettings getDefaultMetadataProviderSettings() {
         MetadataProviderSettings defaultMetadataProviderSettings = new MetadataProviderSettings();
 

--- a/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.ObjectMapper;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -86,6 +87,24 @@ class AppSettingServiceTest {
                 AppSettingKey.OIDC_PROVIDER_DETAILS,
                 Map.of("clientId", "grimmory")
         );
+
+        ArgumentCaptor<AppSettingEntity> settingCaptor = ArgumentCaptor.forClass(AppSettingEntity.class);
+        verify(appSettingsRepository).save(settingCaptor.capture());
+        assertThat(settingCaptor.getValue().getVal()).contains("\"clientSecret\":\"super-secret\"");
+    }
+
+    @Test
+    void updateSetting_keepsStoredClientSecretWhenIncomingSecretIsNull() throws Exception {
+        AppSettingEntity stored = new AppSettingEntity();
+        stored.setName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString());
+        stored.setVal("{\"clientId\":\"grimmory\",\"clientSecret\":\"super-secret\"}");
+        when(appSettingsRepository.findByName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString())).thenReturn(stored);
+
+        Map<String, Object> incoming = new HashMap<>();
+        incoming.put("clientId", "grimmory");
+        incoming.put("clientSecret", null);
+
+        appSettingService.updateSetting(AppSettingKey.OIDC_PROVIDER_DETAILS, incoming);
 
         ArgumentCaptor<AppSettingEntity> settingCaptor = ArgumentCaptor.forClass(AppSettingEntity.class);
         verify(appSettingsRepository).save(settingCaptor.capture());

--- a/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/appsettings/AppSettingServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -55,6 +56,57 @@ class AppSettingServiceTest {
                 .build();
 
         when(authenticationService.getAuthenticatedUser()).thenReturn(user);
+    }
+
+    @Test
+    void updateSetting_keepsStoredClientSecretWhenIncomingSecretIsBlank() throws Exception {
+        AppSettingEntity stored = new AppSettingEntity();
+        stored.setName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString());
+        stored.setVal("{\"clientId\":\"grimmory\",\"clientSecret\":\"super-secret\"}");
+        when(appSettingsRepository.findByName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString())).thenReturn(stored);
+
+        appSettingService.updateSetting(
+                AppSettingKey.OIDC_PROVIDER_DETAILS,
+                Map.of("clientId", "grimmory", "clientSecret", "")
+        );
+
+        ArgumentCaptor<AppSettingEntity> settingCaptor = ArgumentCaptor.forClass(AppSettingEntity.class);
+        verify(appSettingsRepository).save(settingCaptor.capture());
+        assertThat(settingCaptor.getValue().getVal()).contains("\"clientSecret\":\"super-secret\"");
+    }
+
+    @Test
+    void updateSetting_keepsStoredClientSecretWhenIncomingSecretIsMissing() throws Exception {
+        AppSettingEntity stored = new AppSettingEntity();
+        stored.setName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString());
+        stored.setVal("{\"clientId\":\"grimmory\",\"clientSecret\":\"super-secret\"}");
+        when(appSettingsRepository.findByName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString())).thenReturn(stored);
+
+        appSettingService.updateSetting(
+                AppSettingKey.OIDC_PROVIDER_DETAILS,
+                Map.of("clientId", "grimmory")
+        );
+
+        ArgumentCaptor<AppSettingEntity> settingCaptor = ArgumentCaptor.forClass(AppSettingEntity.class);
+        verify(appSettingsRepository).save(settingCaptor.capture());
+        assertThat(settingCaptor.getValue().getVal()).contains("\"clientSecret\":\"super-secret\"");
+    }
+
+    @Test
+    void updateSetting_updatesClientSecretWhenNewSecretProvided() throws Exception {
+        AppSettingEntity stored = new AppSettingEntity();
+        stored.setName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString());
+        stored.setVal("{\"clientId\":\"grimmory\",\"clientSecret\":\"old-secret\"}");
+        when(appSettingsRepository.findByName(AppSettingKey.OIDC_PROVIDER_DETAILS.toString())).thenReturn(stored);
+
+        appSettingService.updateSetting(
+                AppSettingKey.OIDC_PROVIDER_DETAILS,
+                Map.of("clientId", "grimmory", "clientSecret", "new-secret")
+        );
+
+        ArgumentCaptor<AppSettingEntity> settingCaptor = ArgumentCaptor.forClass(AppSettingEntity.class);
+        verify(appSettingsRepository).save(settingCaptor.capture());
+        assertThat(settingCaptor.getValue().getVal()).contains("\"clientSecret\":\"new-secret\"");
     }
 
     @Test


### PR DESCRIPTION
## Description

Saving the OIDC provider settings form erased the stored client secret whenever an admin re-saved without re-typing the secret, breaking OIDC login. The secret is intentionally never sent back to the browser, so the form almost always submits a blank secret. The backend then persisted that blank value verbatim, wiping the real secret.

This treats a blank or missing incoming `clientSecret` as "unchanged" and keeps the stored value, while a newly entered secret still updates as before.

Scope of this PR is the data-loss bug (secret erased on save). The purely visual aspect of the original discussion (showing a masked `***` placeholder so admins can see a secret is set after a page refresh) is a separate frontend change and is not included here. I'm happy to work on this change as well, but I think we'll want to open a new issue to track the improvement, is that correct?

## Linked Issue

Fixes #1996

## Changes

- `AppSettingService.updateSetting`: for `OIDC_PROVIDER_DETAILS`, preserve the existing stored client secret when the incoming secret is blank or missing.
- `SettingPersistenceHelper`: add `convertOidcProviderDetails` / `readOidcProviderDetails` helpers reusing the existing `ObjectMapper`.
- Handling this in the service (rather than the web form) covers every client, including the mobile app and direct API calls.
- Added unit tests for the three cases: blank secret preserved, missing secret preserved, and new secret applied.

## Manual Testing Steps

1. Configure OIDC with a real client secret and confirm login works.
2. Re-open the authentication settings, edit an unrelated field (e.g. scopes) without touching the secret, and save.
3. Confirm OIDC login still works (secret was not erased).
4. Enter a new client secret and save; confirm the new value takes effect.
5. Backend unit tests: `AppSettingServiceTest` (12 tests, including the 3 new ones) pass via `./gradlew test --tests 'org.booklore.service.appsettings.AppSettingServiceTest'`.

## AI Disclosure

Claude Code (Claude Opus) investigated the bug, implemented the backend fix and unit tests. All changes reviewed by the maintainer.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`. (Ran the backend `AppSettingServiceTest` suite; no frontend changes in this PR.)
- [ ] I have added screenshots if there were any UI changes. (No UI changes.)
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Updating OIDC provider settings without entering a new client secret now preserves the existing secret.
- Existing secrets remain unchanged when the secret field is blank, omitted, or null.
- Entering a new client secret continues to replace the previously stored value.
- OIDC provider settings are handled more reliably when saved data is incomplete or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->