### PR TITLE
feat(api): add book sorts for author name / author sort name

### DIFF
--- a/backend/src/main/java/org/booklore/service/book/BookQueryService.java
+++ b/backend/src/main/java/org/booklore/service/book/BookQueryService.java
@@ -55,8 +55,21 @@ public class BookQueryService {
         return findBooksPaged(visibleBooks(libraryIds, userId), pageable, userId);
     }
 
+    private Specification<BookEntity> distinct(Specification<BookEntity> filter) {
+        return (root, query, cb) -> {
+            // We need to query distinct because otherwise the `JOIN` + `LIMIT` cause the page sizes to be wrong.
+            //
+            // I've tried a few ways to just get only what we need - distinct IDs from the repository.
+            // With Projections, we ran into issues with the order by not getting applied.  I'm sure
+            // there's a better way but right now this works well enough, even though it over-fetches.
+
+            query.distinct(true);
+            return filter.toPredicate(root, query, cb);
+        };
+    }
+
     public Page<Book> findBooksPaged(Specification<BookEntity> spec, Pageable pageable, Long userId) {
-        Page<BookEntity> page = bookRepository.findAll(spec, pageable);
+        Page<BookEntity> page = bookRepository.findAll(distinct(spec), pageable);
         Map<Long, BookEntity> booksById = bookRepository
                 .findAllWithMetadataByIds(page.getContent().stream().map(BookEntity::getId).collect(Collectors.toSet()))
                 .stream()

--- a/backend/src/main/java/org/booklore/service/browse/BookSortRegistry.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookSortRegistry.java
@@ -2,6 +2,7 @@ package org.booklore.service.browse;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Order;
@@ -45,6 +46,10 @@ public class BookSortRegistry {
         for (String field : List.of("personalRating", "lastReadTime", "readStatus", "dateFinished")) {
             registry.register(field, progressField(field));
         }
+
+        registry.register("authorName", authorField("name"));
+        registry.register("authorSortName", authorField("sortName"));
+
         registry.register("readingProgress", readingProgress());
         registry.register("random", random());
 
@@ -56,17 +61,21 @@ public class BookSortRegistry {
     }
 
     private static SortOrderBuilder<BookEntity> metadataField(String field) {
-        return ctx -> List.of(order(ctx, metadataJoin(ctx.root()).get(field)));
+        return ctx -> List.of(order(ctx, metadataJoin(ctx).get(field)));
     }
 
     private static SortOrderBuilder<BookEntity> progressField(String field) {
         return ctx -> List.of(order(ctx, progressJoin(ctx).get(field)));
     }
 
+    private static SortOrderBuilder<BookEntity> authorField(String field) {
+        return ctx -> List.of(order(ctx, authorJoin(ctx).get(field)));
+    }
+
     private static SortOrderBuilder<BookEntity> readingProgress() {
         return ctx -> {
             CriteriaBuilder cb = ctx.cb();
-            Join<BookEntity, ?> progress = progressJoin(ctx);
+            var progress = progressJoin(ctx);
             Expression<Float> greatest = null;
             for (String field : PROGRESS_PERCENT_FIELDS) {
                 Expression<Float> value = cb.coalesce(progress.get(field), cb.literal(0f));
@@ -112,28 +121,49 @@ public class BookSortRegistry {
         return ctx.descending() ? ctx.cb().desc(expression) : ctx.cb().asc(expression);
     }
 
-    @SuppressWarnings("unchecked")
-    private static <Y> Join<BookEntity, Y> metadataJoin(Root<BookEntity> root) {
-        for (Join<BookEntity, ?> join : root.getJoins()) {
-            if (join.getAttribute().getName().equals("metadata") && join.getJoinType() == JoinType.LEFT) {
-                return (Join<BookEntity, Y>) join;
+    private static Join<?, ?> getSortJoin(From<?, ?> root, String name) {
+        String alias = "sort_" + name;
+        for (var join : root.getJoins()) {
+            if (!alias.equals(join.getAlias())) {
+                continue;
             }
+
+            if (!name.equals(join.getAttribute().getName())) {
+                continue;
+            }
+
+            if (!JoinType.LEFT.equals(join.getJoinType())) {
+                continue;
+            }
+
+            return join;
         }
-        return root.join("metadata", JoinType.LEFT);
+
+        Join<?, ?> join = root.join(name, JoinType.LEFT);
+        join.alias(alias);
+        return join;
     }
 
-    @SuppressWarnings("unchecked")
-    private static Join<BookEntity, ?> progressJoin(SortContext<BookEntity> ctx) {
+    private static Join<?, ?> metadataJoin(SortContext<BookEntity> ctx) {
         Root<BookEntity> root = ctx.root();
-        for (Join<BookEntity, ?> join : root.getJoins()) {
-            if (join.getAttribute().getName().equals("userBookProgress")) {
-                return join;
-            }
-        }
-        Join<BookEntity, ?> join = root.join("userBookProgress", JoinType.LEFT);
+        return getSortJoin(root, "metadata");
+    }
+
+    private static Join<?, ?> progressJoin(SortContext<BookEntity> ctx) {
+        Root<BookEntity> root = ctx.root();
+
+        var join = getSortJoin(root, "userBookProgress");
+
         CriteriaBuilder cb = ctx.cb();
-        Path<Object> joinUserId = ((Join<BookEntity, Object>) join).get("user").get("id");
+        Path<?> joinUserId = join.get("user").get("id");
         join.on(ctx.userId() != null ? cb.equal(joinUserId, ctx.userId()) : cb.disjunction());
+
         return join;
+    }
+
+    private static Join<?, ?> authorJoin(SortContext<BookEntity> ctx) {
+        var parent = metadataJoin(ctx);
+
+        return getSortJoin(parent, "authors");
     }
 }

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseRegistryTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseRegistryTest.java
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.jpa.hibernate.ddl-auto=create-drop",
         "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
         "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
-        "spring.datasource.url=jdbc:h2:mem:browsetest;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE",
+        "spring.datasource.url=jdbc:h2:mem:browsetest;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE;MODE=MYSQL",
         "spring.datasource.driver-class-name=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.datasource.password=",
@@ -144,6 +144,7 @@ class BookBrowseRegistryTest {
     private AuthorEntity author(String name) {
         return authors.computeIfAbsent(name, n -> {
             AuthorEntity e = AuthorEntity.builder().name(n).build();
+            e.computeSortName();
             em.persist(e);
             return e;
         });
@@ -173,6 +174,49 @@ class BookBrowseRegistryTest {
         em.flush();
         assertThat(sortedIds("title", user.getId())).containsExactly(a, b, c);
         assertThat(sortedIds("-title", user.getId())).containsExactly(c, b, a);
+    }
+
+    @Test
+    void authorAscendingAndDescending() {
+        Long a = book("Alpha", null, null, Instant.now(), List.of(), List.of("Ned McDodd"), null).getId();
+        Long b = book("Bravo", null, null, Instant.now(), List.of(), List.of("Sally O'Malley"), null).getId();
+        Long c = book("Charlie", null, null, Instant.now(), List.of(), List.of("Haily Yelp"), null).getId();
+        em.flush();
+        assertThat(sortedIds("authorName", user.getId())).containsExactly(c, a, b);
+        assertThat(sortedIds("-authorName", user.getId())).containsExactly(b, a, c);
+    }
+
+    @Test
+    void emptyAuthorAscendingAndDescending() {
+        Long a = book("Alpha", null, null, Instant.now(), List.of(), List.of(), null).getId();
+        Long b = book("Bravo", null, null, Instant.now(), List.of(), List.of("Sally O'Malley"), null).getId();
+        Long c = book("Charlie", null, null, Instant.now(), List.of(), List.of("Haily Yelp"), null).getId();
+        em.flush();
+        assertThat(sortedIds("authorName", user.getId())).containsExactly(a, c, b);
+        assertThat(sortedIds("-authorName", user.getId())).containsExactly(b, c, a);
+    }
+
+    @Test
+    void multiAuthorAscendingAndDescending() {
+        Long a = book("Alpha", null, null, Instant.now(), List.of(), List.of("Ned McDodd", "Euchariah Who"), null).getId();
+        Long b = book("Bravo", null, null, Instant.now(), List.of(), List.of("Sally O'Malley", "Axl"), null).getId();
+        Long c = book("Charlie", null, null, Instant.now(), List.of(), List.of("Haily Yelp"), null).getId();
+        em.flush();
+
+        // These are the same because of how the sorting works with multiple authors.
+        // `b` has both the highest and lowest.
+        assertThat(sortedIds("authorName", user.getId())).containsExactly(b, a, c);
+        assertThat(sortedIds("-authorName", user.getId())).containsExactly(b, a, c);
+    }
+
+    @Test
+    void authorSortNameAscendingAndDescending() {
+        Long a = book("Alpha", null, null, Instant.now(), List.of(), List.of("Red McDodd"), null).getId();
+        Long b = book("Bravo", null, null, Instant.now(), List.of(), List.of("Sally O'Malley"), null).getId();
+        Long c = book("Charlie", null, null, Instant.now(), List.of(), List.of("Haily Yelp"), null).getId();
+        em.flush();
+        assertThat(sortedIds("authorSortName", user.getId())).containsExactly(a, b, c);
+        assertThat(sortedIds("-authorSortName", user.getId())).containsExactly(c, b, a);
     }
 
     @Test

--- a/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/browse/BookBrowseServiceTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
         "spring.jpa.hibernate.ddl-auto=create-drop",
         "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
         "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
-        "spring.datasource.url=jdbc:h2:mem:browseservicetest;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE",
+        "spring.datasource.url=jdbc:h2:mem:browseservicetest;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE;MODE=MYSQL",
         "spring.datasource.driver-class-name=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.datasource.password=",


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
adds sorts for author name / author sort name.  this is done by adding `BookSortRegistry` entries and adding a `distinct` flag to the `BookQueryService` to avoid issues with joins.

When we add the join from `BookEntity` to `BookMetadataEntity` to `Author` this can lead to multiple rows being in the result SQL.  When the limit is applied, it's applied to the rows returned, not the entities these might be mapped to.  so, if we have 3 books, a page size of 5, but the books have 2, 3, and many authors?  We only get 2 books on the first page.

In this example, the rows are sent flat from SQL as such:

| Book ID | Title | Author ID | Author Name |
| --- | --- | --- | --- |
| 1 | The Magic School Bus at the Waterworks | 1 | Joanna Cole |
| 1 | The Magic School Bus at the Waterworks | 2 | Bruce Degen |
| 2 |  Satellite Space Mission (The Magic School Bus Rides Again) | 3 | AnnMarie Anderson |
| 2 |  Satellite Space Mission (The Magic School Bus Rides Again) | 4 | Chrissie Boehm |
| 2 |  Satellite Space Mission (The Magic School Bus Rides Again) | 5 | Hannah Boehm |
| 3 | The Cardboard Kingdom | 6 | Chad Sell |
| 3 | The Cardboard Kingdom | 7 | Jay Fuller |
| 3 | The Cardboard Kingdom | 8 | David DeMeo |
| 3 | The Cardboard Kingdom | 9 | Katie Schenkel |
| 3 | The Cardboard Kingdom | 10 | Kris Moore |
| 3 | The Cardboard Kingdom | 11 | Molly Muldoon |
| 3 | The Cardboard Kingdom | 11 | Vid Alliger |
| 3 | The Cardboard Kingdom | 12 | Manuel Betancourt |
| 3 | The Cardboard Kingdom | 13 | Michael Cole |
| 3 | The Cardboard Kingdom | 14 | Cloud Jacobs |
| 3 | The Cardboard Kingdom | 15 | Barbara Perez Marquez |

In extreme cases, you could get the same book across multiple pages - eg, if a book has 45 authors, then the first and second page will have only one book - both the same book.

To correct this, I've updated the `BookBrowseService` to inject a `distinct` when fetching the records.  Since we only use the `id` column this doesn't cause issues.  If there were a way to modify the repository / query to only retrieve the IDs I'd suggest that, but after multiple attempts, none I tried actually worked without severe drawbacks.

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2438 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* adds `authorName` / `authorSortName` to `BookSortRegistry`
* add `distinct` to the `BookQueryService`
* add tests for new features
* add `MODE=MYSQL` because otherwise h2 doesn't support it


## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. ran `curl` against `http://localhost:6060/api/v1/books/page?sort=authorName`
2. checked authors are sorted
3. curl against `http://localhost:6060/api/v1/books/page?sort=-authorName`
4. checked authors are inverted

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added sorting options by author name and author sort name.
  - Author-based sorting now works consistently with other book sorting options, including multiple and unnamed authors.

- **Bug Fixes**
  - Corrected paginated book results so page sizes remain accurate when related metadata is included.
  - Prevented duplicate books from appearing in results caused by joined data.
  - Improved ordering consistency when display names differ from sort names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->