### PR TITLE
chore(docs): drop booklore migration from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> Grimmory is an independent community fork of Booklore.
-
 <div align="center">
 
 <picture>
@@ -95,15 +92,6 @@ MYSQL_DATABASE=grimmory
 ### Step 2: Docker Compose
 
 Stable images are published from semantic-release tags on `main` as `vX.Y.Z` plus `latest`. Nightly images are built from `develop` and tagged `nightly`.
-
-> [!NOTE]
-> Migrating from an existing Booklore container? You can keep your current service name, `container_name`, database name and user, ports, and mounted volumes the same. Replace only the `image:` line with `grimmory/grimmory:<tag>` or `ghcr.io/grimmory-tools/grimmory:<tag>`.
-
-```yaml
-services:
-  booklore:
-    image: grimmory/grimmory:v2.2.1
-```
 
 Create a `docker-compose.yml` or copy and adapt [`deploy/compose/docker-compose.yml`](deploy/compose/docker-compose.yml):
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
because of a migration change, booklore is no longer directly compatible with Grimmory and will need more in-depth migration instructions

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #2486

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* drop booklore note from README
* drop direct migration instructions from README

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->
N/A

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
the migration introduced in 2.3.1 for OpenLibrary metadata source broke this

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the README notice identifying the project as an independent community fork.
  - Removed the Quick Start guidance for migrating an existing Booklore container by retaining its configuration and changing only the container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->