### PR TITLE
fix(archive): handle non-utf8 ZIP headers with apache ZIP library

### DIFF
--- a/backend/src/main/java/org/booklore/service/ArchiveService.java
+++ b/backend/src/main/java/org/booklore/service/ArchiveService.java
@@ -2,6 +2,7 @@ package org.booklore.service;
 
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import com.github.junrar.exception.RarException;
 import lombok.extern.slf4j.Slf4j;
 import org.booklore.exception.ApiError;
@@ -18,10 +19,10 @@ import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import java.util.zip.ZipFile;
 
 @Slf4j
 @Service
@@ -43,13 +44,14 @@ public class ArchiveService {
     }
 
     private Stream<Entry> streamEntriesFromZip(Path path) throws IOException {
-        try (ZipFile file = new ZipFile(path.toFile())) {
-            // Stream to list so we enumerate all of them before the zipfile closes.
+        try (ZipFile file = ZipFile.builder().setPath(path).get()) {
+            // Collect to list then emit a stream so we collect all of the entries before
+            // we close the zip file.
             return file.stream()
-                    .toList()
-                    .stream()
                     .filter(e -> !e.isDirectory())
-                    .map(e -> new Entry(e.getName(), e.getSize()));
+                    .map(e -> new Entry(e.getName(), e.getSize()))
+                    .collect(Collectors.toList())
+                    .stream();
         }
     }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the built-in java ZIP library fails to handle non-UTF8 file headers.  this switches the archive service over to use the Apache commons ZIP library (similar to Komga) which handles these cases more gracefully

## Linked Issue

<!-- Required. Example: Fixes #123 -->
closes #2393 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* update ArchiveService to use `org.apache.commons.compress.archivers.zip.*`

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. create archive with SHIFTJIS encoding
2. add CBZ to library
3. see no crash


## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
[This can be seen in use by Komga here.](https://github.com/gotson/komga/blob/cba53ed3750fcc7b333293e093a6bfaa6afa3a26/komga/src/main/kotlin/org/gotson/komga/infrastructure/mediacontainer/divina/ZipExtractor.kt#L5-L6)

There are other usages of the `java.util.zip` that this doesn't touch - mostly writing archives.  I left the Kobo Span Map Extraction Service alone as it should be switched to the epub reader and refactored.  It's less likely to hit this issue as kepubs should be utf-8 zips, as far as I'm aware?

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ZIP archive handling for more reliable browsing and extraction of archived content.
  - Ensured archive entries remain available after the archive is safely closed, reducing potential access errors during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->