### PR TITLE
fix(book): stop N+1 SELECT on comicMetadata in findAllWithMetadata*

### DIFF
--- a/backend/src/main/java/org/booklore/repository/BookRepository.java
+++ b/backend/src/main/java/org/booklore/repository/BookRepository.java
@@ -80,9 +80,10 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
     @Query("SELECT b.id FROM BookEntity b WHERE b.libraryPath.id IN :libraryPathIds AND (b.deleted IS NULL OR b.deleted = false)")
     List<Long> findAllBookIdsByLibraryPathIdIn(@Param("libraryPathIds") Collection<Long> libraryPathIds);
 
-    // Only ToOne paths in EntityGraph; collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
-    @EntityGraph(attributePaths = {"metadata", "metadata.comicMetadata", "library"})
-    @Query("SELECT b FROM BookEntity b WHERE (b.deleted IS NULL OR b.deleted = false)")
+    // Nested to-one path metadata.comicMetadata is not honoured by @EntityGraph (produces no join,
+    // leaving comicMetadata lazy and causing an N+1 SELECT per book) — fetched explicitly instead.
+    // collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
+    @Query("SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata JOIN FETCH b.library WHERE (b.deleted IS NULL OR b.deleted = false)")
     List<BookEntity> findAllWithMetadata();
 
     // Only ToOne paths in EntityGraph; collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
@@ -116,9 +117,10 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
     @Query("SELECT b FROM BookEntity b WHERE b.library.id = :libraryId AND (b.deleted IS NULL OR b.deleted = false)")
     List<BookEntity> findAllForDuplicateDetection(@Param("libraryId") Long libraryId);
 
-    // Only ToOne paths in EntityGraph; collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
-    @EntityGraph(attributePaths = {"metadata", "metadata.comicMetadata", "library"})
-    @Query("SELECT b FROM BookEntity b WHERE b.library.id IN :libraryIds AND (b.deleted IS NULL OR b.deleted = false)")
+    // Nested to-one path metadata.comicMetadata is not honoured by @EntityGraph (produces no join,
+    // leaving comicMetadata lazy and causing an N+1 SELECT per book) — fetched explicitly instead.
+    // collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
+    @Query("SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata JOIN FETCH b.library WHERE b.library.id IN :libraryIds AND (b.deleted IS NULL OR b.deleted = false)")
     List<BookEntity> findAllWithMetadataByLibraryIds(@Param("libraryIds") Collection<Long> libraryIds);
 
     @EntityGraph(attributePaths = {

--- a/backend/src/main/java/org/booklore/repository/BookRepository.java
+++ b/backend/src/main/java/org/booklore/repository/BookRepository.java
@@ -86,9 +86,10 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
     @Query("SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata JOIN FETCH b.library WHERE (b.deleted IS NULL OR b.deleted = false)")
     List<BookEntity> findAllWithMetadata();
 
-    // Only ToOne paths in EntityGraph; collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
-    @EntityGraph(attributePaths = {"metadata", "metadata.comicMetadata", "libraryPath", "library"})
-    @Query("SELECT b FROM BookEntity b WHERE b.id IN :bookIds AND (b.deleted IS NULL OR b.deleted = false)")
+    // Nested to-one path metadata.comicMetadata is not honoured by @EntityGraph (produces no join,
+    // leaving comicMetadata lazy and causing an N+1 SELECT per book) — fetched explicitly instead.
+    // collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
+    @Query("SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata JOIN FETCH b.libraryPath JOIN FETCH b.library WHERE b.id IN :bookIds AND (b.deleted IS NULL OR b.deleted = false)")
     List<BookEntity> findAllWithMetadataByIds(@Param("bookIds") Set<Long> bookIds);
 
     @EntityGraph(attributePaths = {
@@ -485,8 +486,10 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
      * Only ToOne paths in EntityGraph to avoid Cartesian product with LIMIT;
      * collections (authors, categories, tags, moods, shelves, bookFiles) loaded via @BatchSize.
      */
-    @EntityGraph(attributePaths = {"metadata", "metadata.comicMetadata", "libraryPath", "library"})
-    @Query("SELECT b FROM BookEntity b WHERE (b.deleted IS NULL OR b.deleted = false)")
+    // Nested to-one path metadata.comicMetadata is not honoured by @EntityGraph (produces no join,
+    // leaving comicMetadata lazy and causing an N+1 SELECT per book) — fetched explicitly instead.
+    @Query(value = "SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata JOIN FETCH b.libraryPath JOIN FETCH b.library WHERE (b.deleted IS NULL OR b.deleted = false)",
+           countQuery = "SELECT COUNT(b) FROM BookEntity b WHERE (b.deleted IS NULL OR b.deleted = false)")
     Page<BookEntity> findAllWithMetadataPage(Pageable pageable);
 
     /**

--- a/backend/src/main/java/org/booklore/repository/BookRepository.java
+++ b/backend/src/main/java/org/booklore/repository/BookRepository.java
@@ -89,7 +89,7 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
     // Nested to-one path metadata.comicMetadata is not honoured by @EntityGraph (produces no join,
     // leaving comicMetadata lazy and causing an N+1 SELECT per book) — fetched explicitly instead.
     // collections (authors, categories, moods, tags, shelves, bookFiles) loaded via @BatchSize.
-    @Query("SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata JOIN FETCH b.libraryPath JOIN FETCH b.library WHERE b.id IN :bookIds AND (b.deleted IS NULL OR b.deleted = false)")
+    @Query("SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata LEFT JOIN FETCH b.libraryPath JOIN FETCH b.library WHERE b.id IN :bookIds AND (b.deleted IS NULL OR b.deleted = false)")
     List<BookEntity> findAllWithMetadataByIds(@Param("bookIds") Set<Long> bookIds);
 
     @EntityGraph(attributePaths = {
@@ -488,7 +488,7 @@ public interface BookRepository extends JpaRepository<BookEntity, Long>, JpaSpec
      */
     // Nested to-one path metadata.comicMetadata is not honoured by @EntityGraph (produces no join,
     // leaving comicMetadata lazy and causing an N+1 SELECT per book) — fetched explicitly instead.
-    @Query(value = "SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata JOIN FETCH b.libraryPath JOIN FETCH b.library WHERE (b.deleted IS NULL OR b.deleted = false)",
+    @Query(value = "SELECT b FROM BookEntity b LEFT JOIN FETCH b.metadata m LEFT JOIN FETCH m.comicMetadata LEFT JOIN FETCH b.libraryPath JOIN FETCH b.library WHERE (b.deleted IS NULL OR b.deleted = false)",
            countQuery = "SELECT COUNT(b) FROM BookEntity b WHERE (b.deleted IS NULL OR b.deleted = false)")
     Page<BookEntity> findAllWithMetadataPage(Pageable pageable);
 

--- a/backend/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
+++ b/backend/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
@@ -132,7 +132,10 @@ class BookRepositoryDataJpaTest {
         assertThat(bookEntity.getPrimaryBookFile()).isNotNull();
     }
 
-    private List<Long> persistLibraryWithBooks(int bookCount) {
+    private record LibraryFixture(Long libraryId, List<Long> bookIds) {
+    }
+
+    private LibraryFixture persistLibraryWithBooks(int bookCount) {
         LibraryEntity library = LibraryEntity.builder()
                 .name("Test Library")
                 .icon("book")
@@ -169,7 +172,7 @@ class BookRepositoryDataJpaTest {
         }
         entityManager.flush();
         entityManager.clear();
-        return bookIds;
+        return new LibraryFixture(library.getId(), bookIds);
     }
 
     private org.hibernate.stat.Statistics resetStatistics() {
@@ -182,7 +185,10 @@ class BookRepositoryDataJpaTest {
     }
 
     // No comic_metadata row exists for any book in these fixtures — accessing it is what
-    // previously triggered a per-book SELECT (see #2482).
+    // previously triggered a per-book SELECT (see #2482). Each fetch plan below issues exactly
+    // one SELECT regardless of book count, so the statement count is asserted against a fixed
+    // upper bound rather than one derived from bookCount.
+    private static final long MAX_STATEMENTS_FOR_FIXED_FETCH_PLAN = 2;
 
     @Test
     void findAllWithMetadata_doesNotIssueOneSelectPerBookForComicMetadata() {
@@ -201,16 +207,16 @@ class BookRepositoryDataJpaTest {
         assertThat(books).hasSize(bookCount);
         assertThat(statementCount)
                 .as("statement count must not scale with the number of books")
-                .isLessThan(bookCount);
+                .isLessThanOrEqualTo(MAX_STATEMENTS_FOR_FIXED_FETCH_PLAN);
     }
 
     @Test
     void findAllWithMetadataByIds_doesNotIssueOneSelectPerBookForComicMetadata() {
         int bookCount = 20;
-        List<Long> bookIds = persistLibraryWithBooks(bookCount);
+        LibraryFixture fixture = persistLibraryWithBooks(bookCount);
         org.hibernate.stat.Statistics statistics = resetStatistics();
 
-        List<BookEntity> books = bookRepository.findAllWithMetadataByIds(new java.util.HashSet<>(bookIds));
+        List<BookEntity> books = bookRepository.findAllWithMetadataByIds(new java.util.HashSet<>(fixture.bookIds()));
         for (BookEntity book : books) {
             assertThat(book.getMetadata().getComicMetadata()).isNull();
         }
@@ -221,7 +227,27 @@ class BookRepositoryDataJpaTest {
         assertThat(books).hasSize(bookCount);
         assertThat(statementCount)
                 .as("statement count must not scale with the number of books")
-                .isLessThan(bookCount);
+                .isLessThanOrEqualTo(MAX_STATEMENTS_FOR_FIXED_FETCH_PLAN);
+    }
+
+    @Test
+    void findAllWithMetadataByLibraryIds_doesNotIssueOneSelectPerBookForComicMetadata() {
+        int bookCount = 20;
+        LibraryFixture fixture = persistLibraryWithBooks(bookCount);
+        org.hibernate.stat.Statistics statistics = resetStatistics();
+
+        List<BookEntity> books = bookRepository.findAllWithMetadataByLibraryIds(List.of(fixture.libraryId()));
+        for (BookEntity book : books) {
+            assertThat(book.getMetadata().getComicMetadata()).isNull();
+        }
+
+        long statementCount = statistics.getPrepareStatementCount();
+        TestTransaction.end();
+
+        assertThat(books).hasSize(bookCount);
+        assertThat(statementCount)
+                .as("statement count must not scale with the number of books")
+                .isLessThanOrEqualTo(MAX_STATEMENTS_FOR_FIXED_FETCH_PLAN);
     }
 
     @Test
@@ -242,6 +268,6 @@ class BookRepositoryDataJpaTest {
         assertThat(books).hasSize(bookCount);
         assertThat(statementCount)
                 .as("statement count must not scale with the number of books")
-                .isLessThan(bookCount);
+                .isLessThanOrEqualTo(MAX_STATEMENTS_FOR_FIXED_FETCH_PLAN + 1); // +1 for the paging COUNT query
     }
 }

--- a/backend/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
+++ b/backend/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
@@ -231,6 +231,34 @@ class BookRepositoryDataJpaTest {
     }
 
     @Test
+    void findAllWithMetadataByIds_includesBooksWithNullLibraryPath() {
+        LibraryEntity library = LibraryEntity.builder()
+                .name("Test Library")
+                .icon("book")
+                .watch(false)
+                .formatPriority(List.of(BookFileType.EPUB, BookFileType.PDF))
+                .build();
+        entityManager.persist(library);
+        entityManager.flush();
+
+        BookEntity book = BookEntity.builder()
+                .library(library)
+                .libraryPath(null)
+                .addedOn(Instant.now())
+                .deleted(false)
+                .build();
+        entityManager.persist(book);
+        entityManager.flush();
+        entityManager.clear();
+
+        List<BookEntity> books = bookRepository.findAllWithMetadataByIds(java.util.Set.of(book.getId()));
+        TestTransaction.end();
+
+        assertThat(books).hasSize(1);
+        assertThat(books.get(0).getLibraryPath()).isNull();
+    }
+
+    @Test
     void findAllWithMetadataByLibraryIds_doesNotIssueOneSelectPerBookForComicMetadata() {
         int bookCount = 20;
         LibraryFixture fixture = persistLibraryWithBooks(bookCount);
@@ -269,5 +297,34 @@ class BookRepositoryDataJpaTest {
         assertThat(statementCount)
                 .as("statement count must not scale with the number of books")
                 .isLessThanOrEqualTo(MAX_STATEMENTS_FOR_FIXED_FETCH_PLAN + 1); // +1 for the paging COUNT query
+    }
+
+    @Test
+    void findAllWithMetadataPage_includesBooksWithNullLibraryPath() {
+        LibraryEntity library = LibraryEntity.builder()
+                .name("Test Library")
+                .icon("book")
+                .watch(false)
+                .formatPriority(List.of(BookFileType.EPUB, BookFileType.PDF))
+                .build();
+        entityManager.persist(library);
+        entityManager.flush();
+
+        BookEntity book = BookEntity.builder()
+                .library(library)
+                .libraryPath(null)
+                .addedOn(Instant.now())
+                .deleted(false)
+                .build();
+        entityManager.persist(book);
+        entityManager.flush();
+        entityManager.clear();
+
+        List<BookEntity> books = bookRepository.findAllWithMetadataPage(
+                org.springframework.data.domain.PageRequest.of(0, 10)).getContent();
+        TestTransaction.end();
+
+        assertThat(books).hasSize(1);
+        assertThat(books.get(0).getLibraryPath()).isNull();
     }
 }

--- a/backend/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
+++ b/backend/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
@@ -121,7 +121,7 @@ class BookRepositoryDataJpaTest {
 
         entityManager.clear();
 
-        Optional<BookEntity> result = bookRepository.findByIdForKoboDownload(1L);
+        Optional<BookEntity> result = bookRepository.findByIdForKoboDownload(book.getId());
 
         TestTransaction.end();
 
@@ -132,8 +132,7 @@ class BookRepositoryDataJpaTest {
         assertThat(bookEntity.getPrimaryBookFile()).isNotNull();
     }
 
-    @Test
-    void findAllWithMetadata_doesNotIssueOneSelectPerBookForComicMetadata() {
+    private List<Long> persistLibraryWithBooks(int bookCount) {
         LibraryEntity library = LibraryEntity.builder()
                 .name("Test Library")
                 .icon("book")
@@ -150,7 +149,7 @@ class BookRepositoryDataJpaTest {
         entityManager.persist(libraryPath);
         entityManager.flush();
 
-        int bookCount = 20;
+        List<Long> bookIds = new java.util.ArrayList<>();
         for (int i = 0; i < bookCount; i++) {
             BookEntity book = BookEntity.builder()
                     .library(library)
@@ -166,25 +165,78 @@ class BookRepositoryDataJpaTest {
                     .title("Book " + i)
                     .build();
             entityManager.persist(metadata);
+            bookIds.add(book.getId());
         }
         entityManager.flush();
         entityManager.clear();
+        return bookIds;
+    }
 
+    private org.hibernate.stat.Statistics resetStatistics() {
         org.hibernate.stat.Statistics statistics = entityManager.getEntityManagerFactory()
                 .unwrap(org.hibernate.SessionFactory.class)
                 .getStatistics();
         statistics.setStatisticsEnabled(true);
         statistics.clear();
+        return statistics;
+    }
+
+    // No comic_metadata row exists for any book in these fixtures — accessing it is what
+    // previously triggered a per-book SELECT (see #2482).
+
+    @Test
+    void findAllWithMetadata_doesNotIssueOneSelectPerBookForComicMetadata() {
+        int bookCount = 20;
+        persistLibraryWithBooks(bookCount);
+        org.hibernate.stat.Statistics statistics = resetStatistics();
 
         List<BookEntity> books = bookRepository.findAllWithMetadata();
         for (BookEntity book : books) {
-            // No comic_metadata row exists for any book — accessing it is what previously
-            // triggered a per-book SELECT (see #2482).
             assertThat(book.getMetadata().getComicMetadata()).isNull();
         }
 
         long statementCount = statistics.getPrepareStatementCount();
+        TestTransaction.end();
 
+        assertThat(books).hasSize(bookCount);
+        assertThat(statementCount)
+                .as("statement count must not scale with the number of books")
+                .isLessThan(bookCount);
+    }
+
+    @Test
+    void findAllWithMetadataByIds_doesNotIssueOneSelectPerBookForComicMetadata() {
+        int bookCount = 20;
+        List<Long> bookIds = persistLibraryWithBooks(bookCount);
+        org.hibernate.stat.Statistics statistics = resetStatistics();
+
+        List<BookEntity> books = bookRepository.findAllWithMetadataByIds(new java.util.HashSet<>(bookIds));
+        for (BookEntity book : books) {
+            assertThat(book.getMetadata().getComicMetadata()).isNull();
+        }
+
+        long statementCount = statistics.getPrepareStatementCount();
+        TestTransaction.end();
+
+        assertThat(books).hasSize(bookCount);
+        assertThat(statementCount)
+                .as("statement count must not scale with the number of books")
+                .isLessThan(bookCount);
+    }
+
+    @Test
+    void findAllWithMetadataPage_doesNotIssueOneSelectPerBookForComicMetadata() {
+        int bookCount = 20;
+        persistLibraryWithBooks(bookCount);
+        org.hibernate.stat.Statistics statistics = resetStatistics();
+
+        List<BookEntity> books = bookRepository.findAllWithMetadataPage(
+                org.springframework.data.domain.PageRequest.of(0, bookCount)).getContent();
+        for (BookEntity book : books) {
+            assertThat(book.getMetadata().getComicMetadata()).isNull();
+        }
+
+        long statementCount = statistics.getPrepareStatementCount();
         TestTransaction.end();
 
         assertThat(books).hasSize(bookCount);

--- a/backend/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
+++ b/backend/src/test/java/org/booklore/repository/BookRepositoryDataJpaTest.java
@@ -131,4 +131,65 @@ class BookRepositoryDataJpaTest {
         assertThat(bookEntity.getId()).isEqualTo(book.getId());
         assertThat(bookEntity.getPrimaryBookFile()).isNotNull();
     }
+
+    @Test
+    void findAllWithMetadata_doesNotIssueOneSelectPerBookForComicMetadata() {
+        LibraryEntity library = LibraryEntity.builder()
+                .name("Test Library")
+                .icon("book")
+                .watch(false)
+                .formatPriority(List.of(BookFileType.EPUB, BookFileType.PDF))
+                .build();
+        entityManager.persist(library);
+        entityManager.flush();
+
+        LibraryPathEntity libraryPath = LibraryPathEntity.builder()
+                .library(library)
+                .path("/test/path")
+                .build();
+        entityManager.persist(libraryPath);
+        entityManager.flush();
+
+        int bookCount = 20;
+        for (int i = 0; i < bookCount; i++) {
+            BookEntity book = BookEntity.builder()
+                    .library(library)
+                    .libraryPath(libraryPath)
+                    .addedOn(Instant.now())
+                    .deleted(false)
+                    .build();
+            entityManager.persist(book);
+            entityManager.flush();
+
+            BookMetadataEntity metadata = BookMetadataEntity.builder()
+                    .book(book)
+                    .title("Book " + i)
+                    .build();
+            entityManager.persist(metadata);
+        }
+        entityManager.flush();
+        entityManager.clear();
+
+        org.hibernate.stat.Statistics statistics = entityManager.getEntityManagerFactory()
+                .unwrap(org.hibernate.SessionFactory.class)
+                .getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+
+        List<BookEntity> books = bookRepository.findAllWithMetadata();
+        for (BookEntity book : books) {
+            // No comic_metadata row exists for any book — accessing it is what previously
+            // triggered a per-book SELECT (see #2482).
+            assertThat(book.getMetadata().getComicMetadata()).isNull();
+        }
+
+        long statementCount = statistics.getPrepareStatementCount();
+
+        TestTransaction.end();
+
+        assertThat(books).hasSize(bookCount);
+        assertThat(statementCount)
+                .as("statement count must not scale with the number of books")
+                .isLessThan(bookCount);
+    }
 }


### PR DESCRIPTION
## Description

`@EntityGraph` doesn't honour the nested to-one path `metadata.comicMetadata`, so no join is produced, `comicMetadata` stays lazy, and every caller that reads it (`BookMapperV2.mapMetadata`) fires one extra SELECT per book. Replacing the entity graph with an explicit `LEFT JOIN FETCH` collapses that back to a single statement.

Per the follow-up measurements in the issue, this affects four repository methods, not only the one originally reported:

* `findAllWithMetadata()`, the case in the issue
* `findAllWithMetadataByLibraryIds()`, non-admin `/api/v1/books`
* `findAllWithMetadataByIds()`, the browse path (`sort/facet/query/cursor`), used widely
* `findAllWithMetadataPage()`, legacy admin listing

## Linked Issue

Fixes #2482

## Changes

* `BookRepository`: replaced `@EntityGraph` with explicit `LEFT JOIN FETCH` on the four methods above. `libraryPath` is fetched with `LEFT JOIN FETCH` too, since it is nullable and an inner join would silently drop books without a library path.
* `BookRepositoryDataJpaTest`: added one statement-count regression test per method. Each persists N books with no `comic_metadata` row, runs the query, touches `getComicMetadata()` on every result, and asserts the Hibernate statement count does not scale with N.
* Fixed a pre-existing test (`findAllWithMetadataByIds_executesAgainstJpaMetamodel`) that hardcoded book id `1L` instead of the persisted id. It only passed when it happened to run first in the class, and broke once IDENTITY allocation moved past 1 because of the new tests.

## Manual Testing Steps

1. `just api test-class test_class=org.booklore.repository.BookRepositoryDataJpaTest` on `main` with only the new tests applied: the statement-count assertions fail, showing N+1 on all four methods.
2. Apply the `BookRepository` change and rerun the same class: all tests pass, one statement per query regardless of N.
3. `just api check` on the branch: green.

## AI Disclosure

Claude Code. Used to explore the repository, write the tests and draft the patch. I reviewed and ran everything myself.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [ ] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.
