### PR TITLE
fix(epub): handle duplicate zip entries when extracting epubs

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
+++ b/backend/src/main/java/org/booklore/service/metadata/writer/EpubMetadataWriter.java
@@ -538,6 +538,12 @@ public class EpubMetadataWriter implements MetadataWriter {
             if (!entryPath.startsWith(targetDir)) {
                 throw new IOException("ZIP entry outside target directory: " + name);
             }
+
+            if (Files.exists(entryPath)) {
+                log.warn("EPUB Entry already exists, skipping: {}", entryPath);
+                continue;
+            }
+
             Files.createDirectories(entryPath.getParent());
             archiveService.extractEntryToPath(zipPath, name, entryPath);
         }

--- a/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/writer/EpubMetadataWriterTest.java
@@ -1,5 +1,7 @@
 package org.booklore.service.metadata.writer;
 
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.booklore.model.MetadataClearFlags;
 import org.booklore.model.dto.settings.AppSettings;
 import org.booklore.model.dto.settings.MetadataPersistenceSettings;
@@ -343,8 +345,74 @@ class EpubMetadataWriterTest {
     }
 
     @Nested
-    @DisplayName("Mimetype ZIP Entry Tests")
+    @DisplayName("ZIP Entry Tests")
     class MimetypeZipTests {
+
+        @Test
+        @DisplayName("Should handle duplicate entries in zip")
+        void saveMetadata_handlesDuplicateCovers() throws Exception {
+            String opfContent = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                            <dc:title>Original Title</dc:title>
+                            <meta name="cover" content="cover-image"/>
+                        </metadata>
+                        <manifest>
+                            <item id="cover-image" href="cover.png" media-type="image/png" properties="cover-image"/>
+                        </manifest>
+                    </package>""";
+
+            byte[] coverImageA = new byte[]{0x0A};
+            byte[] coverImageB = new byte[]{0x0B};
+            byte[] coverImageC = new byte[]{0x0C};
+
+            File coverImageFile = tempDir.resolve("new-cover-" + System.nanoTime() + ".png").toFile();
+            Files.write(coverImageFile.toPath(), coverImageC);
+
+            File epubFile = tempDir.resolve("test-duplicate-" + System.nanoTime() + ".epub").toFile();
+
+            try (var zos = new ZipArchiveOutputStream(new FileOutputStream(epubFile))) {
+                String containerXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                    <rootfiles>
+                        <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+                    </rootfiles>
+                </container>
+                """;
+
+                zos.putArchiveEntry(new ZipArchiveEntry("mimetype"));
+                zos.write("application/epub+zip".getBytes(StandardCharsets.UTF_8));
+                zos.closeArchiveEntry();
+
+                zos.putArchiveEntry(new ZipArchiveEntry("META-INF/container.xml"));
+                zos.write(containerXml.getBytes(StandardCharsets.UTF_8));
+                zos.closeArchiveEntry();
+
+                zos.putArchiveEntry(new ZipArchiveEntry("content.opf"));
+                zos.write(opfContent.getBytes(StandardCharsets.UTF_8));
+                zos.closeArchiveEntry();
+
+                zos.putArchiveEntry(new ZipArchiveEntry("cover.png"));
+                zos.write(coverImageA);
+                zos.closeArchiveEntry();
+
+                zos.putArchiveEntry(new ZipArchiveEntry("cover.png"));
+                zos.write(coverImageB);
+                zos.closeArchiveEntry();
+            }
+
+            writer.saveMetadataToFile(epubFile, metadata, coverImageFile.toString(), new MetadataClearFlags());
+
+            try (ZipFile zf = new ZipFile(epubFile)) {
+                var entry = zf.getEntry("cover.png");
+
+                try (InputStream is = zf.getInputStream(entry)) {
+                    assertThat(is.readAllBytes()).isEqualTo(coverImageC);
+                }
+            }
+        }
 
         @Test
         @DisplayName("Should store mimetype as first uncompressed entry in ZIP")


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
when extracting an epub, we currently don't handle the sitaution where a file may exist multiple times in the epub zip file.  while uncommon, this would lead to us being stuck in a situation where users cannot directly replace a cover (with duplicate zip entries) with a different valid cover

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2524

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* updates epub writer to ignore duplicate files on extraction
* add test for new epub writer behavior

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. manually craft an epub that has two `/cover.jpg` files
2. attempt to switch the cover
3. see new cover in epub zip

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
this is a pretty uncommon edge case but is technically possible. this only fixes the ability to replace the cover, not to properly read the cover from an invalid epub

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB metadata and cover-image updates when duplicate ZIP entries are present.
  * Prevented duplicate archive entries from overwriting previously extracted content during editing.
* **Tests**
  * Added coverage for updating cover images in EPUBs containing duplicate cover entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->