### PR TITLE
refactor(googbooks): move google books key to HTTP header

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 @Service
 public class GoogleParser implements BookParser {
 
+    private static final String HEADER_API_KEY = "X-Goog-Api-Key"; // From https://docs.cloud.google.com/apis/docs/system-parameters
     private static final Pattern FOUR_DIGIT_YEAR_PATTERN = Pattern.compile("^(\\d{4})$");
     private static final Pattern YEAR_MONTH_PATTERN = Pattern.compile("^(\\d{4})-(\\d{2})$");
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
@@ -141,6 +142,9 @@ public class GoogleParser implements BookParser {
     }
 
     private List<BookMetadata> fetchFromApi(String query, boolean isIsbnSearch) {
+        var googleSettings = getSettings();
+        String apiKey = googleSettings.getApiKey();
+
         try {
             waitForRateLimit();
 
@@ -154,12 +158,17 @@ public class GoogleParser implements BookParser {
             
             URI uri = uriBuilder.build().toUri();
 
-            log.info("Google Books API URL: {}", uri);
+            log.debug("Google Books API URL: {}", uri);
 
-            HttpRequest request = HttpRequest.newBuilder()
+            var requestBuilder = HttpRequest.newBuilder()
                     .uri(uri)
-                    .GET()
-                    .build();
+                    .GET();
+
+            if (apiKey != null) {
+                requestBuilder.setHeader(HEADER_API_KEY, apiKey);
+            }
+
+            HttpRequest request = requestBuilder.build();
 
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
@@ -571,21 +580,29 @@ public class GoogleParser implements BookParser {
         }
     }
 
+    private MetadataProviderSettings.Google getSettings() {
+        var appSettings = appSettingService.getAppSettings();
+
+        if (
+                appSettings == null ||
+                appSettings.getMetadataProviderSettings() == null ||
+                appSettings.getMetadataProviderSettings().getGoogle() == null
+        ) {
+            return new MetadataProviderSettings.Google();
+        }
+
+        return appSettings.getMetadataProviderSettings().getGoogle();
+    }
+
     private String getApiUrl() {
-        MetadataProviderSettings.Google googleSettings = appSettingService.getAppSettings()
-                .getMetadataProviderSettings().getGoogle();
+        var googleSettings = getSettings();
 
         String language = googleSettings.getLanguage();
-        String apiKey = googleSettings.getApiKey();
 
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(GOOGLE_BOOKS_API_URL);
 
         if (language != null && !language.isEmpty()) {
             builder.queryParam("langRestrict", language);
-        }
-
-        if (apiKey != null && !apiKey.isBlank()) {
-            builder.queryParam("key", apiKey);
         }
 
         return builder.build().toUri().toString();

--- a/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
+++ b/backend/src/main/java/org/booklore/service/metadata/parser/GoogleParser.java
@@ -164,7 +164,7 @@ public class GoogleParser implements BookParser {
                     .uri(uri)
                     .GET();
 
-            if (apiKey != null) {
+            if (apiKey != null && !apiKey.isBlank()) {
                 requestBuilder.setHeader(HEADER_API_KEY, apiKey);
             }
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
this change makes it less likely for us to be writing the cloud key - which is of some secrecy - from various log files / debugging etc.  this is pulled from the google API docs

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2531

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* cleans up google settings loading
* moves Google API key from URL param `key` to header `X-Goog-Api-Key`
* moves a log message from info to debug

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. enable google books provider
2. enable debug logs
3. make search with Google key
4. check logs, see no key
5. check results, see results

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
Pulled from https://docs.cloud.google.com/apis/docs/system-parameters

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Google Books API requests now transmit API keys through a request header instead of the URL.
  * API keys are no longer included in generated API URLs.
* **Logging**
  * API request URLs are logged at a less prominent level to reduce exposure of request details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->