### PR TITLE
ci: update groupings for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,6 @@ updates:
       - "backend"
     commit-message:
       prefix: "chore(deps)"
-    groups:
-      gradle-dependencies:
-        patterns:
-          - "*"
 
   # JavaScript – pnpm workspace (frontend + release tooling)
   - package-ecosystem: "npm"
@@ -41,9 +37,9 @@ updates:
           - "semantic-release"
           - "@semantic-release/*"
           - "conventional-changelog*"
-      frontend:
+      angular:
         patterns:
-          - "*"
+          - "@angular/*"
     ignore:
       - dependency-name: "typescript"
       - dependency-name: "@types/node"


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
drops the "frontend" group and "gradle-dependencies" group, adding the "angular" group instead

this allows us to more easily see what is being updated in the commit log

## Linked Issue

<!-- Required. Example: Fixes #123 -->
N/A

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* drops `frontend` dependabot group
* drops `gradle-dependencies` dependabot group
* adds `angular` dependabot group

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

N/A

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency update grouping for frontend packages.
  - Removed the broad backend dependency grouping configuration.
  - Preserved the existing release tooling dependency group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->