### PR TITLE
fix(cbx): use natural compare that handles numbers larger than int

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/extractor/CbxMetadataExtractor.java
+++ b/backend/src/main/java/org/booklore/service/metadata/extractor/CbxMetadataExtractor.java
@@ -651,33 +651,100 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
         return n.startsWith("cover") || "folder".equals(n) || n.startsWith("front");
     }
 
+    /**
+     * Check if the character is an ISO-LATIN-1 digit.  This is
+     * different from the `Character.isDigit` which checks multiple
+     * types of digits.
+     *
+     * @param c char to check
+     * @return boolean Whether this is a ISO-LATIN-1 digit
+     */
+    private boolean isLatinDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private int getNextMeaningfulDigit(String target, int start) {
+      for (int i = start; i < target.length(); i++) {
+          char c = target.charAt(i);
+          // If we don't have any more digits we need to bail out.
+          if (!isLatinDigit(c)) {
+              return i;
+          }
+
+          // If it's a meaningful number we can stop. (eg, not '0')
+          if (Character.digit(c, 10) > 0) {
+            return i;
+          }
+      }
+
+      return target.length() - 1;
+    }
+
+    private int getEndOfDigits(String target, int start) {
+        int end = start;
+        while (end < target.length() && isLatinDigit(target.charAt(end))) {
+            end++;
+        }
+        return end;
+    }
+
     private int naturalCompare(String a, String b) {
-        if (a == null) return b == null ? 0 : -1;
-        if (b == null) return 1;
-        String s1 = a.toLowerCase();
-        String s2 = b.toLowerCase();
-        int i = 0, j = 0, n1 = s1.length(), n2 = s2.length();
-        while (i < n1 && j < n2) {
-            char c1 = s1.charAt(i);
-            char c2 = s2.charAt(j);
-            if (Character.isDigit(c1) && Character.isDigit(c2)) {
-                int i1 = i;
-                while (i1 < n1 && Character.isDigit(s1.charAt(i1))) i1++;
-                int j1 = j;
-                while (j1 < n2 && Character.isDigit(s2.charAt(j1))) j1++;
-                String num1 = LEADING_ZEROS_PATTERN.matcher(s1.substring(i, i1)).replaceFirst("");
-                String num2 = LEADING_ZEROS_PATTERN.matcher(s2.substring(j, j1)).replaceFirst("");
-                int cmp = Integer.compare(num1.isEmpty() ? 0 : Integer.parseInt(num1), num2.isEmpty() ? 0 : Integer.parseInt(num2));
-                if (cmp != 0) return cmp;
-                i = i1;
-                j = j1;
+        if (a == null && b == null ) {
+            return 0;
+        } else if (a == null) {
+            return -1;
+        } else if (b == null) {
+            return 1;
+        }
+
+        a = a.toLowerCase();
+        b = b.toLowerCase();
+
+        int aPointer = 0, bPointer = 0, aLength = a.length(), bLength = b.length();
+        while (aPointer < aLength && bPointer < bLength) {
+            char aChar = a.charAt(aPointer);
+            char bChar = b.charAt(bPointer);
+            if (isLatinDigit(aChar) && isLatinDigit(bChar)) {
+                aPointer = getNextMeaningfulDigit(a, aPointer);
+                int aPointerEnd = getEndOfDigits(a, aPointer);
+
+                bPointer = getNextMeaningfulDigit(b, bPointer);
+                int bPointerEnd = getEndOfDigits(b, bPointer);
+
+                // If they aren't the same length, we can know which number is bigger without
+                // comparing them directly.
+                int lengthCmp = Integer.compare(aPointerEnd - aPointer, bPointerEnd - bPointer);
+                if (lengthCmp != 0) {
+                    return lengthCmp;
+                }
+
+                int length = aPointerEnd - aPointer;
+
+                // Since we know they're the same length, and they're comprised of digits
+                // we can operate on both at the same time.
+                for (int i = 0; i < length; i++) {
+                    int cmp = Integer.compare(
+                            Character.digit(a.charAt(aPointer + i), 10),
+                            Character.digit(b.charAt(bPointer + i), 10)
+                    );
+
+                    if (cmp != 0) {
+                        return cmp;
+                    }
+                }
+
+                // If no comparison was made, we push the pointer to the end.
+                aPointer = aPointerEnd;
+                bPointer = bPointerEnd;
+            } else if (aChar != bChar) {
+                return Character.compare(aChar, bChar);
             } else {
-                if (c1 != c2) return Character.compare(c1, c2);
-                i++;
-                j++;
+                aPointer++;
+                bPointer++;
             }
         }
-        return Integer.compare(n1 - i, n2 - j);
+
+        return Integer.compare(aLength - aPointer, bLength - bPointer);
     }
 
     private static boolean isComicInfoName(String name) {

--- a/backend/src/test/java/org/booklore/service/metadata/extractor/CbxMetadataExtractorTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/extractor/CbxMetadataExtractorTest.java
@@ -1037,6 +1037,36 @@ class CbxMetadataExtractorTest {
 
             assertThat(cover).isNull();
         }
+
+        @Test
+        void extractsCoverWithNaturalNumberComparisons() throws IOException {
+            byte[] expected = createMinimalJpeg(1);
+
+            Path cbzPath = mockArchiveContents(Map.of(
+                    "img_000002.jpg", createMinimalJpeg(2),
+                    "img_0001.jpg", expected,
+                    "img_003.jpg", createMinimalJpeg(3)
+            ));
+
+            byte[] actual = extractor.extractCover(cbzPath);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        void extractsCoverWithBigIntegerNumbers() throws IOException {
+            byte[] expected = createMinimalJpeg(1);
+
+            Path cbzPath = mockArchiveContents(Map.of(
+                    "9789031433940_002.jpg", createMinimalJpeg(3),
+                    "9789031433940_000.jpg", expected,
+                    "9789031433940_001.jpg", createMinimalJpeg(2)
+            ));
+
+            byte[] actual = extractor.extractCover(cbzPath);
+
+            assertThat(actual).isEqualTo(expected);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
for some reason, some CBX files have filenames with big numbers that overflow java's integer.  this causes a `NumberFormatException` and leads to failures during the natural compare process.  intead, we can look at these as if they are individual digits, assuming that they can only be larger if there's a difference in length

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2535

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
refactored the natural compare function to make it easier to read
switched the behavior to instead only need to do `char` comparisons
added new test to validate this fixes the behavior and avoids regression

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. craft CBZ with images with long strings of numbers
2. upload to Grimmory
3. see no error on extracting metadata / cover

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
the existing tests seem to handle the natural compare verification but I added one more just in case

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved natural filename ordering for embedded numbers, including very large numeric values and filenames with leading zeros.
  * Cover image selection now consistently chooses the alphabetically first image when filenames contain numeric sequences.
  * Improved reliability when comparing image filenames with long numbers, helping ensure the intended cover image is selected across a wider range of naming formats.
  * Image ordering now correctly distinguishes filenames such as `img_0001.jpg`, `img_000002.jpg`, and `img_003.jpg`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->