### PR TITLE
refactor(api): add missing book sorts

### DIFF
--- a/backend/src/main/java/org/booklore/service/browse/BookSortRegistry.java
+++ b/backend/src/main/java/org/booklore/service/browse/BookSortRegistry.java
@@ -39,6 +39,7 @@ public class BookSortRegistry {
                 "title", "seriesName", "seriesNumber", "publisher", "publishedDate",
                 "amazonRating", "amazonReviewCount", "goodreadsRating", "goodreadsReviewCount",
                 "hardcoverRating", "hardcoverReviewCount", "ranobedbRating",
+                "lubimyczytacRating", "audibleRating", "audibleReviewCount",
                 "narrator", "pageCount", "language")) {
             registry.register(field, metadataField(field));
         }


### PR DESCRIPTION
## Description

Adds the three missing sort options (lubimyczytac and audible ratings + audible ratings count) to the book page sort list.
 
## Linked Issue

Fixes #2553 

## Changes

Adds the three missing sorts to the book sort registry

## Manual Testing Steps

N/A

## Screenshots (Optional)

N/A

## Additional Context (Optional)

N/A

## AI Disclosure

None

## Checklist

- [X] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] There are new or updated tests validating this change.
- [X] I ran `just ui check` and `just api check`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sorting books by Lubimyczytac rating, Audible rating, and Audible review count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->