### PR TITLE
fix(ui): use OIDC client secret if included in settings

### DIFF
--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -171,7 +171,8 @@ export class AuthenticationSettingsComponent {
       clientId: settings.oidcProviderDetails?.clientId || '',
       issuerUri: settings.oidcProviderDetails?.issuerUri || '',
       scopes: settings.oidcProviderDetails?.scopes || '',
-      claimMapping: settings.oidcProviderDetails?.claimMapping || defaultClaimMapping
+      claimMapping: settings.oidcProviderDetails?.claimMapping || defaultClaimMapping,
+      clientSecret: settings.oidcProviderDetails?.clientSecret || '',
     };
 
     this.availablePermissions.forEach(perm => {


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the API exposes the client secret through the `settings` endpoint but the UI never actually does anything with it, leading to users accidentally erasing the value when they hit save

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #1996 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* read `clientSecret` from API response for usage in UI

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. open OIDC settings
2. see value in field
3. hit save
4. see value persisted still

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
This seems to have been an oversight?  As it was always in the response but never read.  If it's there, we should read it.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Saved OpenID Connect client secrets are now correctly restored when authentication settings are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->