### PR TITLE
refactor: move OIDC client secret to non public app setting

### DIFF
--- a/backend/src/main/java/org/booklore/config/security/oidc/OidcAuthService.java
+++ b/backend/src/main/java/org/booklore/config/security/oidc/OidcAuthService.java
@@ -71,14 +71,17 @@ public class OidcAuthService {
             throw ApiError.FORBIDDEN.createException("OIDC is not enabled");
         }
 
-        OidcProviderDetails providerDetails = appSettingService.getAppSettings().getOidcProviderDetails();
+        var appSettings = appSettingService.getAppSettings();
+        OidcProviderDetails providerDetails = appSettings.getOidcProviderDetails();
+        String providerClientSecret = appSettings.getOidcProviderClientSecret();
+
         if (providerDetails == null || providerDetails.getIssuerUri() == null) {
             throw ApiError.FORBIDDEN.createException("OIDC is not properly configured");
         }
 
         validateRedirectUri(redirectUri, httpRequest);
 
-        var tokenResponse = oidcTokenClient.exchangeAuthorizationCode(code, codeVerifier, redirectUri, providerDetails);
+        var tokenResponse = oidcTokenClient.exchangeAuthorizationCode(code, codeVerifier, redirectUri, providerDetails, providerClientSecret);
 
         String idToken = tokenResponse.idToken();
         if (idToken == null) {

--- a/backend/src/main/java/org/booklore/config/security/oidc/OidcTokenClient.java
+++ b/backend/src/main/java/org/booklore/config/security/oidc/OidcTokenClient.java
@@ -40,7 +40,7 @@ public class OidcTokenClient {
             Integer expiresIn
     ) {}
 
-    public TokenResponse exchangeAuthorizationCode(String code, String codeVerifier, String redirectUri, OidcProviderDetails providerDetails) {
+    public TokenResponse exchangeAuthorizationCode(String code, String codeVerifier, String redirectUri, OidcProviderDetails providerDetails, String providerClientSecret) {
         var discovery = discoveryService.discover(providerDetails.getIssuerUri());
         String tokenEndpoint = discovery.tokenEndpoint();
 
@@ -51,8 +51,8 @@ public class OidcTokenClient {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", providerDetails.getClientId());
-        if (providerDetails.getClientSecret() != null && !providerDetails.getClientSecret().isBlank()) {
-            body.add("client_secret", providerDetails.getClientSecret());
+        if (providerClientSecret != null && !providerClientSecret.isBlank()) {
+            body.add("client_secret", providerClientSecret);
         }
         body.add("code", code);
         body.add("redirect_uri", redirectUri);

--- a/backend/src/main/java/org/booklore/model/dto/settings/AppSettingKey.java
+++ b/backend/src/main/java/org/booklore/model/dto/settings/AppSettingKey.java
@@ -10,6 +10,7 @@ public enum AppSettingKey {
     // @formatter:off
     // ADMIN only (public settings)
     OIDC_PROVIDER_DETAILS               ("oidc_provider_details",                true,  true,  List.of(PermissionType.ADMIN)),
+    OIDC_PROVIDER_CLIENT_SECRET         ("oidc_provider_client_secret",          false, false, List.of(PermissionType.ADMIN)),
     OIDC_REDIRECT_URIS                  ("oidc_redirect_uris",                   true,  false, List.of(PermissionType.ADMIN)),
     OIDC_ENABLED                        ("oidc_enabled",                         false, true,  List.of(PermissionType.ADMIN)),
     OIDC_AUTO_PROVISION_DETAILS         ("oidc_auto_provision_details",          true,  false, List.of(PermissionType.ADMIN)),

--- a/backend/src/main/java/org/booklore/model/dto/settings/AppSettings.java
+++ b/backend/src/main/java/org/booklore/model/dto/settings/AppSettings.java
@@ -27,6 +27,7 @@ public class AppSettings {
     private boolean metadataDownloadOnBookdrop;
     private boolean oidcEnabled;
     private OidcProviderDetails oidcProviderDetails;
+    private String oidcProviderClientSecret;
     private List<String> oidcRedirectUris;
     private OidcAutoProvisionDetails oidcAutoProvisionDetails;
     private MetadataProviderSettings metadataProviderSettings;

--- a/backend/src/main/java/org/booklore/model/dto/settings/OidcProviderDetails.java
+++ b/backend/src/main/java/org/booklore/model/dto/settings/OidcProviderDetails.java
@@ -6,7 +6,6 @@ import lombok.Data;
 public class OidcProviderDetails {
     private String providerName;
     private String clientId;
-    private String clientSecret;
     private String issuerUri;
     private String scopes;
     private ClaimMapping claimMapping;

--- a/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
+++ b/backend/src/main/java/org/booklore/service/appsettings/AppSettingService.java
@@ -252,9 +252,6 @@ public class AppSettingService {
 
         builder.remoteAuthEnabled(appProperties.getRemoteAuth().isEnabled());
         OidcProviderDetails details = getJsonSetting(settingsMap, AppSettingKey.OIDC_PROVIDER_DETAILS, OidcProviderDetails.class, null);
-        if (details != null) {
-            details.setClientSecret(null);
-        }
 
         boolean oidcEnabled = Boolean.parseBoolean(settingsMap.getOrDefault(AppSettingKey.OIDC_ENABLED, "false"));
         boolean oidcForceOnlyMode = Boolean.parseBoolean(settingsMap.getOrDefault(AppSettingKey.OIDC_FORCE_ONLY_MODE, "false"));
@@ -299,6 +296,7 @@ public class AppSettingService {
         builder.pdfCacheSizeInMb(Integer.parseInt(settingsMap.getOrDefault(AppSettingKey.PDF_CACHE_SIZE_IN_MB, "5120")));
         builder.maxFileUploadSizeInMb(Integer.parseInt(settingsMap.getOrDefault(AppSettingKey.MAX_FILE_UPLOAD_SIZE_IN_MB, "100")));
         builder.metadataDownloadOnBookdrop(Boolean.parseBoolean(settingsMap.getOrDefault(AppSettingKey.METADATA_DOWNLOAD_ON_BOOKDROP, "true")));
+        builder.oidcProviderClientSecret(settingsMap.getOrDefault(AppSettingKey.OIDC_PROVIDER_CLIENT_SECRET, ""));
 
         String sessionDurationStr = settingsMap.get(AppSettingKey.OIDC_SESSION_DURATION_HOURS);
         if (sessionDurationStr != null && !sessionDurationStr.isBlank()) {

--- a/backend/src/main/java/org/booklore/service/migration/AppMigrationStartup.java
+++ b/backend/src/main/java/org/booklore/service/migration/AppMigrationStartup.java
@@ -20,6 +20,7 @@ public class AppMigrationStartup {
     private final MigrateProgressToFileProgressMigration migrateProgressToFileProgressMigration;
     private final PopulateAuthorSortNameMigration populateAuthorSortNameMigration;
     private final RemoveBundledCustomSvgIconsMigration removeBundledCustomSvgIconsMigration;
+    private final OIDCClientSecretSeparateKey oidcClientSecretSeparateKey;
 
     @EventListener(ApplicationReadyEvent.class)
     public void runMigrationsOnce() {
@@ -32,5 +33,6 @@ public class AppMigrationStartup {
         appMigrationService.executeMigration(migrateProgressToFileProgressMigration);
         appMigrationService.executeMigration(populateAuthorSortNameMigration);
         appMigrationService.executeMigration(removeBundledCustomSvgIconsMigration);
+        appMigrationService.executeMigration(oidcClientSecretSeparateKey);
     }
 }

--- a/backend/src/main/java/org/booklore/service/migration/migrations/OIDCClientSecretSeparateKey.java
+++ b/backend/src/main/java/org/booklore/service/migration/migrations/OIDCClientSecretSeparateKey.java
@@ -1,0 +1,79 @@
+package org.booklore.service.migration.migrations;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.booklore.model.dto.settings.AppSettingKey;
+import org.booklore.model.entity.AppSettingEntity;
+import org.booklore.repository.AppSettingsRepository;
+import org.booklore.service.migration.Migration;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OIDCClientSecretSeparateKey implements Migration {
+    private static final String KEY_CLIENT_SECRET = "clientSecret";
+    private final AppSettingsRepository appSettingsRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String getKey() {
+        return "oidcClientSecretSeparateKey";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate existing OIDC Provider Client Secret from Provider Details to a dedicated key";
+    }
+
+    @Override
+    public void execute() {
+        log.info("Executing migration: {}", getKey());
+
+        AppSettingEntity providerDetailsSetting = appSettingsRepository.findByName(AppSettingKey.OIDC_PROVIDER_DETAILS.getDbKey());
+        AppSettingEntity providerClientSecretSetting = appSettingsRepository.findByName(AppSettingKey.OIDC_PROVIDER_CLIENT_SECRET.getDbKey());
+
+        if (providerDetailsSetting == null) {
+            log.debug("Setting does not exist, skipping");
+            log.info("Completed migration: {}", getKey());
+            return;
+        }
+
+        if (providerClientSecretSetting == null) {
+            providerClientSecretSetting = new AppSettingEntity();
+            providerClientSecretSetting.setName(AppSettingKey.OIDC_PROVIDER_CLIENT_SECRET.getDbKey());
+        }
+
+        try {
+            var node = objectMapper.readTree(providerDetailsSetting.getVal());
+
+            if (node instanceof ObjectNode objectNode) {
+                if (providerClientSecretSetting.getVal() != null) {
+                    log.info("Skipping persisting client secret to new field: already exists");
+                } else if (objectNode.has(KEY_CLIENT_SECRET) && objectNode.get(KEY_CLIENT_SECRET).isString()) {
+                    log.debug("Migrated client secret to separate key");
+                    providerClientSecretSetting.setVal(objectNode.get(KEY_CLIENT_SECRET).asString());
+                }
+
+                log.debug("Removing client secret from public settings");
+                objectNode.remove(KEY_CLIENT_SECRET);
+
+                providerDetailsSetting.setVal(objectMapper.writeValueAsString(objectNode));
+            } else {
+                log.info("Unable to read OIDC Provider Details JSON, purging value");
+                providerDetailsSetting.setVal(null);
+            }
+        } catch (Exception e) {
+            log.info("Unable to read OIDC Provider Details JSON, purging value");
+            providerDetailsSetting.setVal(null);
+        }
+
+        appSettingsRepository.save(providerDetailsSetting);
+        appSettingsRepository.save(providerClientSecretSetting);
+
+        log.info("Completed migration: {}", getKey());
+    }
+}
+

--- a/backend/src/test/java/org/booklore/config/security/oidc/OidcAuthServiceTest.java
+++ b/backend/src/test/java/org/booklore/config/security/oidc/OidcAuthServiceTest.java
@@ -78,7 +78,7 @@ class OidcAuthServiceTest {
         var expectedResponse = ResponseEntity.ok(AccessTokenDto.builder().accessToken("jwt").build());
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -138,7 +138,7 @@ class OidcAuthServiceTest {
         var tokenResponse = tokenResponse("access-token", null);
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
 
         assertThatThrownBy(() -> oidcAuthService.exchangeCodeForTokens(CODE, CODE_VERIFIER, REDIRECT_URI, NONCE, mockRequest()))
@@ -155,7 +155,7 @@ class OidcAuthServiceTest {
         var user = existingOidcUser("jdoe", "sub-123");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, null))
                 .thenReturn(claims);
@@ -178,7 +178,7 @@ class OidcAuthServiceTest {
         var user = existingOidcUser("jdoe", "sub-123");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -203,7 +203,7 @@ class OidcAuthServiceTest {
         var user = existingOidcUser("jdoe", "sub-123");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -227,7 +227,7 @@ class OidcAuthServiceTest {
         var user = existingOidcUser("jdoe", "sub-123");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -296,7 +296,7 @@ class OidcAuthServiceTest {
         user.setEmail("old@example.com");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -325,7 +325,7 @@ class OidcAuthServiceTest {
                 .build();
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -353,7 +353,7 @@ class OidcAuthServiceTest {
                 .id(1L).username("jdoe").provisioningMethod(ProvisioningMethod.LOCAL).build();
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -379,7 +379,7 @@ class OidcAuthServiceTest {
                 .oidcSubject("sub-new").oidcIssuer(ISSUER_URI).build();
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -409,7 +409,7 @@ class OidcAuthServiceTest {
         var userClaims = userClaims("unknown", "sub-unknown");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -437,7 +437,7 @@ class OidcAuthServiceTest {
         user.setAvatarUrl("old-url");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -467,7 +467,7 @@ class OidcAuthServiceTest {
                 .build();
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -496,7 +496,7 @@ class OidcAuthServiceTest {
                 .build();
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails()))
+        when(oidcTokenClient.exchangeAuthorizationCode(CODE, CODE_VERIFIER, REDIRECT_URI, settings.getOidcProviderDetails(), null))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, "access-token"))
                 .thenReturn(claims);
@@ -525,7 +525,7 @@ class OidcAuthServiceTest {
         var user = existingOidcUser("jdoe", "sub-123");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(eq(CODE), eq(CODE_VERIFIER), eq("https://example.com/oauth2-callback"), any()))
+        when(oidcTokenClient.exchangeAuthorizationCode(eq(CODE), eq(CODE_VERIFIER), eq("https://example.com/oauth2-callback"), any(), any()))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, null))
                 .thenReturn(claims);
@@ -548,7 +548,7 @@ class OidcAuthServiceTest {
         var user = existingOidcUser("jdoe", "sub-123");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(eq(CODE), eq(CODE_VERIFIER), eq("booklore://oauth2-callback"), any()))
+        when(oidcTokenClient.exchangeAuthorizationCode(eq(CODE), eq(CODE_VERIFIER), eq("booklore://oauth2-callback"), any(), any()))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, null))
                 .thenReturn(claims);
@@ -572,7 +572,7 @@ class OidcAuthServiceTest {
         var user = existingOidcUser("jdoe", "sub-123");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(eq(CODE), eq(CODE_VERIFIER), eq("booklore://oauth2-callback"), any()))
+        when(oidcTokenClient.exchangeAuthorizationCode(eq(CODE), eq(CODE_VERIFIER), eq("booklore://oauth2-callback"), any(), any()))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, null))
                 .thenReturn(claims);
@@ -606,7 +606,7 @@ class OidcAuthServiceTest {
         var user = existingOidcUser("jdoe", "sub-123");
 
         when(appSettingService.getAppSettings()).thenReturn(settings);
-        when(oidcTokenClient.exchangeAuthorizationCode(eq(CODE), eq(CODE_VERIFIER), eq("grimmory://some-other-path"), any()))
+        when(oidcTokenClient.exchangeAuthorizationCode(eq(CODE), eq(CODE_VERIFIER), eq("grimmory://some-other-path"), any(), any()))
                 .thenReturn(tokenResponse);
         when(oidcTokenValidator.validateIdToken("id-token", ISSUER_URI, CLIENT_ID, NONCE, null))
                 .thenReturn(claims);

--- a/backend/src/test/java/org/booklore/config/security/oidc/OidcTokenClientTest.java
+++ b/backend/src/test/java/org/booklore/config/security/oidc/OidcTokenClientTest.java
@@ -40,11 +40,10 @@ class OidcTokenClientTest {
     private static final String USERINFO_ENDPOINT = "https://issuer.example.com/userinfo";
     private static final String ISSUER_URI = "https://issuer.example.com";
 
-    private OidcProviderDetails createProviderDetails(String clientSecret) {
+    private OidcProviderDetails createProviderDetails() {
         var details = new OidcProviderDetails();
         details.setProviderName("test-provider");
         details.setClientId("test-client-id");
-        details.setClientSecret(clientSecret);
         details.setIssuerUri(ISSUER_URI);
         return details;
     }
@@ -67,7 +66,7 @@ class OidcTokenClientTest {
     @Test
     void exchangeAuthorizationCode_success_returnsTokenResponse() {
         var discovery = createDiscoveryDocument(TOKEN_ENDPOINT, USERINFO_ENDPOINT);
-        var providerDetails = createProviderDetails("test-secret");
+        var providerDetails = createProviderDetails();
 
         Map<String, Object> responseMap = new LinkedHashMap<>();
         responseMap.put("access_token", "access-123");
@@ -80,7 +79,7 @@ class OidcTokenClientTest {
         when(oidcRestTemplate.postForObject(eq(TOKEN_ENDPOINT), any(HttpEntity.class), eq(Map.class)))
                 .thenReturn(responseMap);
 
-        var result = oidcTokenClient.exchangeAuthorizationCode("auth-code", "verifier", "https://app/callback", providerDetails);
+        var result = oidcTokenClient.exchangeAuthorizationCode("auth-code", "verifier", "https://app/callback", providerDetails, "test-secret");
 
         assertThat(result.accessToken()).isEqualTo("access-123");
         assertThat(result.idToken()).isEqualTo("id-456");
@@ -92,7 +91,7 @@ class OidcTokenClientTest {
     @Test
     void exchangeAuthorizationCode_publicClient_omitsClientSecret() {
         var discovery = createDiscoveryDocument(TOKEN_ENDPOINT, USERINFO_ENDPOINT);
-        var providerDetails = createProviderDetails(null);
+        var providerDetails = createProviderDetails();
 
         Map<String, Object> responseMap = new LinkedHashMap<>();
         responseMap.put("access_token", "access-123");
@@ -103,7 +102,7 @@ class OidcTokenClientTest {
         when(oidcRestTemplate.postForObject(eq(TOKEN_ENDPOINT), any(HttpEntity.class), eq(Map.class)))
                 .thenReturn(responseMap);
 
-        var result = oidcTokenClient.exchangeAuthorizationCode("auth-code", "verifier", "https://app/callback", providerDetails);
+        var result = oidcTokenClient.exchangeAuthorizationCode("auth-code", "verifier", "https://app/callback", providerDetails, null);
 
         assertThat(result.accessToken()).isEqualTo("access-123");
         assertThat(result.idToken()).isEqualTo("id-456");
@@ -114,13 +113,13 @@ class OidcTokenClientTest {
     @Test
     void exchangeAuthorizationCode_nullResponse_throwsTokenExchangeFailed() {
         var discovery = createDiscoveryDocument(TOKEN_ENDPOINT, USERINFO_ENDPOINT);
-        var providerDetails = createProviderDetails("secret");
+        var providerDetails = createProviderDetails();
 
         when(discoveryService.discover(ISSUER_URI)).thenReturn(discovery);
         when(oidcRestTemplate.postForObject(eq(TOKEN_ENDPOINT), any(HttpEntity.class), eq(Map.class)))
                 .thenReturn(null);
 
-        assertThatThrownBy(() -> oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails))
+        assertThatThrownBy(() -> oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails, "secret"))
                 .isInstanceOf(APIException.class)
                 .hasMessageContaining("Empty response from token endpoint");
     }
@@ -128,7 +127,7 @@ class OidcTokenClientTest {
     @Test
     void exchangeAuthorizationCode_errorInResponse_throwsTokenExchangeFailed() {
         var discovery = createDiscoveryDocument(TOKEN_ENDPOINT, USERINFO_ENDPOINT);
-        var providerDetails = createProviderDetails("secret");
+        var providerDetails = createProviderDetails();
 
         Map<String, Object> responseMap = new LinkedHashMap<>();
         responseMap.put("error", "invalid_grant");
@@ -138,7 +137,7 @@ class OidcTokenClientTest {
         when(oidcRestTemplate.postForObject(eq(TOKEN_ENDPOINT), any(HttpEntity.class), eq(Map.class)))
                 .thenReturn(responseMap);
 
-        assertThatThrownBy(() -> oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails))
+        assertThatThrownBy(() -> oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails, "secret"))
                 .isInstanceOf(APIException.class)
                 .hasMessageContaining("invalid_grant");
     }
@@ -146,13 +145,13 @@ class OidcTokenClientTest {
     @Test
     void exchangeAuthorizationCode_restClientException_throwsProviderUnreachable() {
         var discovery = createDiscoveryDocument(TOKEN_ENDPOINT, USERINFO_ENDPOINT);
-        var providerDetails = createProviderDetails("secret");
+        var providerDetails = createProviderDetails();
 
         when(discoveryService.discover(ISSUER_URI)).thenReturn(discovery);
         when(oidcRestTemplate.postForObject(eq(TOKEN_ENDPOINT), any(HttpEntity.class), eq(Map.class)))
                 .thenThrow(new RestClientException("Connection refused"));
 
-        assertThatThrownBy(() -> oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails))
+        assertThatThrownBy(() -> oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails, "secret"))
                 .isInstanceOf(APIException.class)
                 .hasMessageContaining("Connection refused");
     }
@@ -160,11 +159,11 @@ class OidcTokenClientTest {
     @Test
     void exchangeAuthorizationCode_blankTokenEndpoint_throwsProviderUnreachable() {
         var discovery = createDiscoveryDocument("  ", USERINFO_ENDPOINT);
-        var providerDetails = createProviderDetails("secret");
+        var providerDetails = createProviderDetails();
 
         when(discoveryService.discover(ISSUER_URI)).thenReturn(discovery);
 
-        assertThatThrownBy(() -> oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails))
+        assertThatThrownBy(() -> oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails, "secret"))
                 .isInstanceOf(APIException.class)
                 .hasMessageContaining("Token endpoint not found");
     }
@@ -223,7 +222,7 @@ class OidcTokenClientTest {
     @Test
     void exchangeAuthorizationCode_expiresInAsNumber_parsedCorrectly() {
         var discovery = createDiscoveryDocument(TOKEN_ENDPOINT, USERINFO_ENDPOINT);
-        var providerDetails = createProviderDetails("secret");
+        var providerDetails = createProviderDetails();
 
         Map<String, Object> responseMap = new LinkedHashMap<>();
         responseMap.put("access_token", "access-123");
@@ -235,7 +234,7 @@ class OidcTokenClientTest {
         when(oidcRestTemplate.postForObject(eq(TOKEN_ENDPOINT), any(HttpEntity.class), eq(Map.class)))
                 .thenReturn(responseMap);
 
-        var result = oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails);
+        var result = oidcTokenClient.exchangeAuthorizationCode("code", "verifier", "https://app/callback", providerDetails, "secret");
 
         assertThat(result.expiresIn()).isEqualTo(7200);
     }

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.html
@@ -118,7 +118,7 @@
             pSize="small"
             id="clientSecret"
             type="password"
-            [(ngModel)]="oidcProvider.clientSecret"
+            [(ngModel)]="oidcProviderClientSecret"
             [placeholder]="t('providerConfig.clientSecretPlaceholder')"/>
           <span class="field-hint">{{ t('providerConfig.clientSecretHint') }}</span>
         </div>

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.spec.ts
@@ -30,7 +30,6 @@ function completeProvider(overrides: Partial<OidcProviderDetails> = {}): OidcPro
   return {
     providerName: 'Example IdP',
     clientId: 'client-id',
-    clientSecret: 'secret',
     issuerUri: 'https://issuer.example',
     scopes: 'openid profile email',
     claimMapping: {
@@ -280,7 +279,11 @@ describe('AuthenticationSettingsComponent', () => {
       {
         key: AppSettingKey.OIDC_REDIRECT_URIS,
         newValue: ['grimmory://oauth2-callback', 'grimmory://auth/return'],
-      }
+      },
+      {
+        key: AppSettingKey.OIDC_PROVIDER_CLIENT_SECRET,
+        newValue: "",
+      },
     ]);
 
     component.oidcEnabled = true;
@@ -296,9 +299,13 @@ describe('AuthenticationSettingsComponent', () => {
         newValue: ['grimmory://oauth2-callback', 'grimmory://auth/return'],
       },
       {
+        key: AppSettingKey.OIDC_PROVIDER_CLIENT_SECRET,
+        newValue: "",
+      },
+      {
         key: AppSettingKey.OIDC_SESSION_DURATION_HOURS,
         newValue: 24,
-      }
+      },
     ]);
   });
 

--- a/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
+++ b/frontend/src/app/core/security/oauth2-management/authentication-settings.component.ts
@@ -113,10 +113,11 @@ export class AuthenticationSettingsComponent {
   readonly groupMappings = signal<OidcGroupMapping[]>([]);
   readonly groupMappingDraft = signal<OidcGroupMapping | null>(null);
 
+  oidcProviderClientSecret: string = '';
+
   oidcProvider: OidcProviderDetails = {
     providerName: '',
     clientId: '',
-    clientSecret: '',
     issuerUri: '',
     scopes: '',
     claimMapping: {
@@ -172,8 +173,9 @@ export class AuthenticationSettingsComponent {
       issuerUri: settings.oidcProviderDetails?.issuerUri || '',
       scopes: settings.oidcProviderDetails?.scopes || '',
       claimMapping: settings.oidcProviderDetails?.claimMapping || defaultClaimMapping,
-      clientSecret: settings.oidcProviderDetails?.clientSecret || '',
     };
+
+    this.oidcProviderClientSecret = settings.oidcProviderClientSecret || '';
 
     this.availablePermissions.forEach(perm => {
       perm.selected = this.selectedPermissions.includes(perm.value);
@@ -216,6 +218,10 @@ export class AuthenticationSettingsComponent {
       {
         key: AppSettingKey.OIDC_REDIRECT_URIS,
         newValue: this.mobileRedirectUris
+      },
+      {
+        key: AppSettingKey.OIDC_PROVIDER_CLIENT_SECRET,
+        newValue: this.oidcProviderClientSecret
       }
     ];
     if (this.oidcEnabled) {

--- a/frontend/src/app/shared/model/app-settings.model.ts
+++ b/frontend/src/app/shared/model/app-settings.model.ts
@@ -33,7 +33,6 @@ export interface MetadataMatchWeights {
 export interface OidcProviderDetails {
   providerName: string;
   clientId: string;
-  clientSecret?: string;
   issuerUri: string;
   scopes?: string;
   claimMapping: {
@@ -185,6 +184,7 @@ export interface AppSettings {
   remoteAuthEnabled: boolean;
   oidcEnabled: boolean;
   oidcProviderDetails: OidcProviderDetails;
+  oidcProviderClientSecret: string | null;
   oidcRedirectUris: string[];
   oidcAutoProvisionDetails: OidcAutoProvisionDetails;
   maxFileUploadSizeInMb: number;
@@ -235,6 +235,7 @@ export enum AppSettingKey {
   KOMGA_GROUP_UNKNOWN = 'KOMGA_GROUP_UNKNOWN',
   OIDC_ENABLED = 'OIDC_ENABLED',
   OIDC_PROVIDER_DETAILS = 'OIDC_PROVIDER_DETAILS',
+  OIDC_PROVIDER_CLIENT_SECRET = 'OIDC_PROVIDER_CLIENT_SECRET',
   OIDC_REDIRECT_URIS = 'OIDC_REDIRECT_URIS',
   OIDC_AUTO_PROVISION_DETAILS = 'OIDC_AUTO_PROVISION_DETAILS',
   MAX_FILE_UPLOAD_SIZE_IN_MB = 'MAX_FILE_UPLOAD_SIZE_IN_MB',

--- a/frontend/src/app/shared/service/app-settings.service.spec.ts
+++ b/frontend/src/app/shared/service/app-settings.service.spec.ts
@@ -43,6 +43,7 @@ function buildAppSettings(overrides: Partial<AppSettings> = {}): AppSettings {
     remoteAuthEnabled: publicSettings.remoteAuthEnabled,
     oidcEnabled: publicSettings.oidcEnabled,
     oidcProviderDetails: publicSettings.oidcProviderDetails,
+    oidcProviderClientSecret: null,
     oidcRedirectUris: ['grimmory://oauth2-callback'],
     oidcAutoProvisionDetails: {
       enableAutoProvisioning: false,


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
the current OIDC client secret is embedded in the "public" OIDC provider details - which puts us in the precarious situation of having to mask the value deep in JSON.  however, we can instead migrate this to its own setting key, which has the proper `public` setting & permissions making everything a little bit safer

## Linked Issue

<!-- Required. Example: Fixes #123 -->
related to #1996

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* adds migration to extract `clientSecret` from provider details if it exists
* adds client secret key to settings
* removes the deep masking needed in the public settings (as it's no longer in the value)
* updates the UI to use the new setting

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. curl `settings` and see after migration that the details no longer have the secret
2. curl the public settings to confirm no secret there
3. open OIDC settings page
4. update value to confirm OIDC secret is embedded in expected key
5. set up and use OIDC config with private key confirming login and logout

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
this technically fixes #1996 but seems a bit more involved than #2557

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - OIDC client secrets are now stored separately from provider configuration details and managed through dedicated administrator settings.
  - Existing OIDC configurations are automatically migrated to the updated storage format.

- **Bug Fixes**
  - OIDC authorization-code exchanges now consistently use the configured client secret.
  - OIDC authentication settings correctly load and save the separate client-secret value.
  - OIDC provider configuration no longer includes the client secret in its provider details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->