### PR TITLE
fix: sidecar files are not written when only cover changes 

### DIFF
--- a/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
@@ -121,7 +121,7 @@ public class BookCoverService {
         updateBookCoverMetadata(bookEntity);
         bookRepository.save(bookEntity);
         notifyBookCoverUpdate(bookEntity);
-        writeSidecarAfterCoverChange(bookEntity);
+        writeSidecarMetadata(bookEntity);
     }
 
     /**
@@ -140,7 +140,7 @@ public class BookCoverService {
         updateBookCoverMetadata(bookEntity);
         bookRepository.save(bookEntity);
         notifyBookCoverUpdate(bookEntity);
-        writeSidecarAfterCoverChange(bookEntity);
+        writeSidecarMetadata(bookEntity);
     }
 
     // =========================
@@ -163,7 +163,7 @@ public class BookCoverService {
         updateAudiobookCoverMetadata(bookEntity);
         bookRepository.save(bookEntity);
         notifyBookCoverUpdate(bookEntity);
-        writeSidecarAfterCoverChange(bookEntity);
+        writeSidecarMetadata(bookEntity);
     }
 
     /**
@@ -182,7 +182,7 @@ public class BookCoverService {
         updateAudiobookCoverMetadata(bookEntity);
         bookRepository.save(bookEntity);
         notifyBookCoverUpdate(bookEntity);
-        writeSidecarAfterCoverChange(bookEntity);
+        writeSidecarMetadata(bookEntity);
     }
 
     /**
@@ -647,18 +647,14 @@ public class BookCoverService {
         bookEntity.setAudiobookCoverHash(BookCoverUtils.generateCoverHash());
     }
 
-    // A cover-only change never went through the metadata updater, so nothing refreshed the
-    // sidecar files external tools watch to notice edits made here. Written after the cover
-    // caches so the sidecar's cover copy picks up the new image.
-    private void writeSidecarAfterCoverChange(BookEntity bookEntity) {
+    private void writeSidecarMetadata(BookEntity bookEntity) {
         if (!sidecarMetadataWriter.isWriteOnUpdateEnabled()) {
             return;
         }
-
         try {
             sidecarMetadataWriter.writeSidecarMetadata(bookEntity);
         } catch (Exception e) {
-            log.warn("Failed to write sidecar after cover change for book ID {}: {}", bookEntity.getId(), e.getMessage());
+            log.warn("Failed to write sidecar metadata for book ID {}: {}", bookEntity.getId(), e.getMessage());
         }
     }
 

--- a/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
@@ -647,6 +647,9 @@ public class BookCoverService {
         bookEntity.setAudiobookCoverHash(BookCoverUtils.generateCoverHash());
     }
 
+    /**
+     * Refresh the sidecar files for a book when sidecar write-on-update is enabled.
+     */
     private void writeSidecarMetadata(BookEntity bookEntity) {
         if (!sidecarMetadataWriter.isWriteOnUpdateEnabled()) {
             return;

--- a/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
+++ b/backend/src/main/java/org/booklore/service/metadata/BookCoverService.java
@@ -19,6 +19,7 @@ import org.booklore.service.book.BookQueryService;
 import org.booklore.service.file.FileFingerprint;
 import org.booklore.service.fileprocessor.BookFileProcessor;
 import org.booklore.service.fileprocessor.BookFileProcessorRegistry;
+import org.booklore.service.metadata.sidecar.SidecarMetadataWriter;
 import org.booklore.service.metadata.writer.MetadataWriter;
 import org.booklore.service.metadata.writer.MetadataWriterFactory;
 import org.booklore.util.BookCoverUtils;
@@ -58,6 +59,7 @@ public class BookCoverService {
     private final BookQueryService bookQueryService;
     private final CoverImageGenerator coverImageGenerator;
     private final MetadataWriterFactory metadataWriterFactory;
+    private final SidecarMetadataWriter sidecarMetadataWriter;
     private final Executor taskExecutor;
     private final TransactionTemplate transactionTemplate;
     private final AuthenticationService authenticationService;
@@ -119,6 +121,7 @@ public class BookCoverService {
         updateBookCoverMetadata(bookEntity);
         bookRepository.save(bookEntity);
         notifyBookCoverUpdate(bookEntity);
+        writeSidecarAfterCoverChange(bookEntity);
     }
 
     /**
@@ -137,6 +140,7 @@ public class BookCoverService {
         updateBookCoverMetadata(bookEntity);
         bookRepository.save(bookEntity);
         notifyBookCoverUpdate(bookEntity);
+        writeSidecarAfterCoverChange(bookEntity);
     }
 
     // =========================
@@ -159,6 +163,7 @@ public class BookCoverService {
         updateAudiobookCoverMetadata(bookEntity);
         bookRepository.save(bookEntity);
         notifyBookCoverUpdate(bookEntity);
+        writeSidecarAfterCoverChange(bookEntity);
     }
 
     /**
@@ -177,6 +182,7 @@ public class BookCoverService {
         updateAudiobookCoverMetadata(bookEntity);
         bookRepository.save(bookEntity);
         notifyBookCoverUpdate(bookEntity);
+        writeSidecarAfterCoverChange(bookEntity);
     }
 
     /**
@@ -639,6 +645,21 @@ public class BookCoverService {
         bookEntity.setMetadataUpdatedAt(now);
         bookEntity.getMetadata().setAudiobookCoverUpdatedOn(now);
         bookEntity.setAudiobookCoverHash(BookCoverUtils.generateCoverHash());
+    }
+
+    // A cover-only change never went through the metadata updater, so nothing refreshed the
+    // sidecar files external tools watch to notice edits made here. Written after the cover
+    // caches so the sidecar's cover copy picks up the new image.
+    private void writeSidecarAfterCoverChange(BookEntity bookEntity) {
+        if (!sidecarMetadataWriter.isWriteOnUpdateEnabled()) {
+            return;
+        }
+
+        try {
+            sidecarMetadataWriter.writeSidecarMetadata(bookEntity);
+        } catch (Exception e) {
+            log.warn("Failed to write sidecar after cover change for book ID {}: {}", bookEntity.getId(), e.getMessage());
+        }
     }
 
     private void notifyBookCoverUpdate(BookEntity bookEntity) {

--- a/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
+++ b/backend/src/test/java/org/booklore/service/metadata/BookCoverServiceTest.java
@@ -13,6 +13,7 @@ import org.booklore.service.appsettings.AppSettingService;
 import org.booklore.service.book.BookQueryService;
 import org.booklore.service.fileprocessor.BookFileProcessor;
 import org.booklore.service.fileprocessor.BookFileProcessorRegistry;
+import org.booklore.service.metadata.sidecar.SidecarMetadataWriter;
 import org.booklore.service.metadata.writer.MetadataWriter;
 import org.booklore.service.metadata.writer.MetadataWriterFactory;
 import org.booklore.service.file.FileFingerprint;
@@ -56,6 +57,7 @@ class BookCoverServiceTest {
     @Mock private BookQueryService bookQueryService;
     @Mock private CoverImageGenerator coverImageGenerator;
     @Mock private MetadataWriterFactory metadataWriterFactory;
+    @Mock private SidecarMetadataWriter sidecarMetadataWriter;
     @Mock private TransactionTemplate transactionTemplate;
     @Mock private Executor taskExecutor;
     @Mock private AuthenticationService authenticationService;
@@ -1168,6 +1170,60 @@ class BookCoverServiceTest {
 
             verify(metadataWriterFactory, never()).getWriter(any());
             verify(bookRepository).save(book);
+        }
+    }
+
+    @Nested
+    class SidecarWriteOnCoverUpdate {
+
+        @Test
+        void writesSidecarWhenWriteOnUpdateEnabled() {
+            BookEntity book = buildBook(1L, false);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
+            when(sidecarMetadataWriter.isWriteOnUpdateEnabled()).thenReturn(true);
+
+            service.updateCoverFromUrl(1L, "https://example.com/cover.jpg");
+
+            verify(sidecarMetadataWriter).writeSidecarMetadata(book);
+        }
+
+        @Test
+        void writesSidecarForAudiobookCoverWhenWriteOnUpdateEnabled() {
+            BookEntity book = buildBookWithAudiobookLock(1L, false);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
+            when(sidecarMetadataWriter.isWriteOnUpdateEnabled()).thenReturn(true);
+
+            service.updateAudiobookCoverFromUrl(1L, "https://example.com/audiobook-cover.jpg");
+
+            verify(sidecarMetadataWriter).writeSidecarMetadata(book);
+        }
+
+        @Test
+        void skipsSidecarWhenWriteOnUpdateDisabled() {
+            BookEntity book = buildBook(1L, false);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
+            when(sidecarMetadataWriter.isWriteOnUpdateEnabled()).thenReturn(false);
+
+            service.updateCoverFromUrl(1L, "https://example.com/cover.jpg");
+
+            verify(sidecarMetadataWriter, never()).writeSidecarMetadata(any());
+        }
+
+        @Test
+        void coverUpdateSucceedsWhenSidecarWriteFails() {
+            BookEntity book = buildBook(1L, false);
+            when(bookRepository.findByIdWithBookFiles(1L)).thenReturn(Optional.of(book));
+            when(bookRepository.findCoverUpdateInfoByIds(any())).thenReturn(List.of());
+            when(sidecarMetadataWriter.isWriteOnUpdateEnabled()).thenReturn(true);
+            doThrow(new RuntimeException("sidecar unavailable")).when(sidecarMetadataWriter).writeSidecarMetadata(book);
+
+            service.updateCoverFromUrl(1L, "https://example.com/cover.jpg");
+
+            verify(bookRepository).save(book);
+            assertThat(book.getMetadata().getCoverUpdatedOn()).isNotNull();
         }
     }
 }


### PR DESCRIPTION
## Description
With **Enable Sidecar JSON**, **Write on Metadata Update** and **Include Cover Image File** all enabled,
editing a book's metadata rewrites `BookName.metadata.json` and `BookName.cover.jpg`, but changing only the
cover does not touch either file.

`BookMetadataUpdater.setBookMetadata(...)` is the only caller of
`SidecarMetadataWriter.writeSidecarMetadata(...)` behind `isWriteOnUpdateEnabled()`. The cover endpoints on
`BookCoverController` go through `BookCoverService`, which had no `SidecarMetadataWriter` dependency at all,
so a cover-only edit updated the database and the thumbnail cache and then stopped.

That matters because sidecar files are how anything outside Grimmory learns a book changed — the
`.metadata.json` / `.cover.jpg` pair is what external tooling watches, with `generatedAt` and the file mtime
as the change signal. A cover-only edit produced no filesystem write at all, so a downstream watcher had no
way to notice and the book stayed out of sync until an unrelated metadata edit happened to rewrite the
sidecar. It also weakened the sidecar as a portable backup: restoring from sidecars after a cover-only edit
silently reverted the cover.

The setting reads "Automatically update the sidecar JSON file whenever book metadata is edited", and the
cover is presented as metadata throughout the UI — it lives on the metadata tab and has its own
`coverLocked` / `coverUpdatedOn` fields — so the previous behaviour did not match what the setting promises.

## Linked Issue
Bug 2566 - [Sidecar files are not written when only the cover changes ("Write on Metadata Update" is ignored by cover endpoints)](https://github.com/grimmory-tools/grimmory/issues/2566)

## Changes
- `BookCoverService` now takes `SidecarMetadataWriter` and writes the sidecar after the cover is stored and
  the entity saved, on the four endpoints that set a cover explicitly:

  | Endpoint | Method |
  | --- | --- |
  | `POST /{bookId}/metadata/cover/upload` | `updateCoverFromFile` |
  | `POST /{bookId}/metadata/cover/from-url` | `updateCoverFromUrl` |
  | `POST /{bookId}/metadata/audiobook-cover/upload` | `updateAudiobookCoverFromFile` |
  | `POST /{bookId}/metadata/audiobook-cover/from-url` | `updateAudiobookCoverFromUrl` |

- The write is guarded by `isWriteOnUpdateEnabled()` and wrapped so a sidecar failure is logged and cannot
  fail the cover update — the same call shape and the same warn message `BookMetadataUpdater` already uses.
- It is called last in each method, after the thumbnail cache has been refreshed, because
  `SidecarMetadataWriter.writeCoverFile(...)` copies from `fileService.getCoverFile(bookId)` and would
  otherwise capture the previous image.
- `BookCoverServiceTest` gains four cases: sidecar written on a book cover update, sidecar written on an
  audiobook cover update, write skipped when `writeOnUpdate` is disabled, and a cover update still
  succeeding when the sidecar write throws.
- `SidecarMetadataWriter` is registered as a `@Mock` in that fixture. Without it, `@InjectMocks` left the new
  dependency null and ten existing cover tests failed with `NullPointerException`.


## Manual Testing Steps

1. Settings -> Metadata -> Metadata Persistence -> Sidecar JSON Files. Enable **Enable Sidecar JSON**,
   **Write on Metadata Update** and **Include Cover Image File**.
2. Add a book to a local-storage library, e.g. `/books/Some Book.epub`.
3. Edit any metadata field (e.g. title) and save. Confirm `Some Book.metadata.json` and `Some Book.cover.jpg`
   appear next to the file, and note their modification times.
4. Change only the cover — upload a new image via `POST /{bookId}/metadata/cover/upload`, or set one from a
   URL. Touch no other field.
5. Check the two sidecar files again. Both are rewritten, and `Some Book.cover.jpg` holds the new image.
   (Before this change, neither file was modified: times and contents were unchanged from step 3.)
6. Repeat steps 4-5 for an audiobook cover to exercise the audiobook endpoints.
7. Turn **Write on Metadata Update** off, change a cover again, and confirm no sidecar file is written.


## Additional Context (Optional)

Scope — these paths also change a cover but do not route through the four methods above, so they are
deliberately left out of this PR and each deserves its own look:

- `regenerateCover`, `regenerateAudiobookCover`, `regenerateCovers`, `regenerateCoversForBooks`
- `generateCustomCover`, `generateCustomAudiobookCover`, `generateCustomCoversForBooks`
- the bulk cover endpoints (`updateCoverFromFileForBooks` and friends, which go through
  `processBulkCoverUpdate`)

Separately, `SidecarMetadataWriter.writeCoverFile(...)` only ever reads `fileService.getCoverFile(bookId)`,
never `getAudiobookCoverFile(bookId)`. So for an audiobook-cover-only change the `.metadata.json` is
refreshed — a new `generatedAt`, so the change signal does fire — but the sidecar `.cover.jpg` still holds
the ebook cover. That looks like a pre-existing gap in the writer rather than something to fix in
`BookCoverService`, so it is untouched here. Happy to open a follow-up issue for it if you'd like.

## AI Disclosure

`None` 

## Checklist

Note: Not an accepted issue yet but I did make one. I already did this work for my own needs while writing a connector for Grimmory in Chaptarr. If you don't want it no worries :)

- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cover updates for books and audiobooks can now automatically write sidecar metadata when the write-on-update setting is enabled.
  * This applies to covers updated from files or URLs.
  * Sidecar metadata writing is skipped when the setting is disabled.

* **Bug Fixes**
  * Cover updates continue successfully even when sidecar metadata writing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->