### PR TITLE
docs: add original authoring NOTICE

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -109,11 +109,15 @@ jobs:
         run:
           pnpm build:prod
 
+      - name: Embed LICENSE information
+        run:
+          cp LICENSE NOTICE frontend/dist/
+
       - name: Upload Frontend Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend
-          path: frontend/dist/grimmory/browser/
+          path: frontend/dist/
           retention-days: 30
 
   build-backend:
@@ -143,7 +147,7 @@ jobs:
         with:
           app-version: ${{ needs.semantic-version.outputs.version }}
           task: bootJar
-          task-extra-params: "-PfrontendDistDir=/tmp/frontend-dist"
+          task-extra-params: "-PfrontendDistDir=/tmp/frontend-dist/grimmory/browser"
 
       - name: Upload Backend Jar Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN chmod +x ./gradlew
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     ./gradlew --no-daemon dependencies
 
+COPY LICENSE NOTICE ./
 COPY backend/ ./
 COPY --from=frontend-build /workspace/frontend/dist/grimmory/browser /tmp/frontend-dist
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Grimmory
+Copyright 2026 The Grimmory Contributors
+
+The Initial Developer of some parts of the software, which are copied from, derived from, or
+inspired by BookLore, is BookLore and its contributors (https://github.com/booklore-app/booklore).
+Copyright 2024 - 2026 BookLore.  All rights reserved.

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -243,6 +243,9 @@ tasks.named<BootRun>("bootRun") {
 
 tasks.named<BootJar>("bootJar") {
     mainClass.set("org.booklore.BookloreApplication")
+    into("/META-INF") {
+        from("../NOTICE", "../LICENSE")
+    }
 }
 
 tasks.register("exportOpenApi") {


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->

## Linked Issue

<!-- Required. Example: Fixes #123 -->
fixes #2569 

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->
* add `NOTICE` to reference licensing information
* embed `NOTICE` and `LICENSE` in builds

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

It's there now, huzzah.

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
N/A

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
While I don't believe anyone has ever authored code as the legal entity `BookLore` it seems to be the pseudonym used to define copyright ownership.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added licensing and attribution notices to distributed application packages.
  * Release artifacts now include the project’s `LICENSE` and `NOTICE` files for easier access to legal and attribution information.

* **Chores**
  * Updated release packaging so frontend and backend deliverables consistently include the required licensing materials.
  * Improved release artifact structure to simplify access to packaged licensing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->