### PR TITLE
build: properly include LICENSE information during docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN chmod +x ./gradlew
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     ./gradlew --no-daemon dependencies
 
-COPY LICENSE NOTICE ./
+COPY LICENSE NOTICE /workspace/
 COPY backend/ ./
 COPY --from=frontend-build /workspace/frontend/dist/grimmory/browser /tmp/frontend-dist
 


### PR DESCRIPTION
## Description

<!-- Required. Briefly explain what changed and why. -->
includes the `LICENSE` information where the gradle file expects it

## Linked Issue

<!-- Required. Example: Fixes #123 -->
N/A

## Changes

<!-- Required. List the main changes. Use bullets if helpful. -->

## Manual Testing Steps

<!-- Required. List the exact steps you used to verify behaviour/test against regressions. -->

1. `docker build . -t grimmory:test-license`
2. `docker run -it --entrypoint /bin/sh grimmory:test-license`
3. `unzip /app/app.jar`
4. `ls META-INF` shows the license / notice

## Screenshots (Optional)

<!-- If the UI changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->

## Additional Context (Optional)

<!-- Add anything reviewers should know that does not fit above. -->
Noticed this when testing for the previous PR but during a fight with coderabbit I accidentally merged.

## AI Disclosure

<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped refactor a service and draft tests; I reviewed all changes. -->
None.

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the location of license and notice files in backend build artifacts, placing them at the workspace level instead of inside the backend directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->