### PR TITLE
fix(magic-shelf): keep rule value on compatible operator change

### DIFF
--- a/frontend/src/app/features/magic-shelf/component/magic-shelf-component.spec.ts
+++ b/frontend/src/app/features/magic-shelf/component/magic-shelf-component.spec.ts
@@ -540,6 +540,13 @@ describe('MagicShelfComponent (Part 3)', () => {
       expect(ruleCtrl.get('value')?.value).toBe('');
     });
 
+    it('should clear the single value when switching to in_between, which edits valueStart/valueEnd', () => {
+      const ruleCtrl = component.buildRuleFromData({field: 'dateFinished', operator: 'equals', value: '2026-07-24'});
+      ruleCtrl.get('operator')?.setValue('in_between');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('');
+    });
+
     it('should preserve a value loaded from saved shelf data when switching to a compatible operator', () => {
       const ruleCtrl = component.buildRuleFromData({field: 'title', operator: 'contains', value: 'Harry Potter'});
       ruleCtrl.get('operator')?.setValue('starts_with');

--- a/frontend/src/app/features/magic-shelf/component/magic-shelf-component.spec.ts
+++ b/frontend/src/app/features/magic-shelf/component/magic-shelf-component.spec.ts
@@ -459,14 +459,92 @@ describe('MagicShelfComponent (Part 3)', () => {
       expect(ruleCtrl.get('value')?.value).toBe('');
     });
 
-    it('should not affect form when called with already-set within_last', () => {
+    it('should preserve a compatible value when re-selecting within_last', () => {
       const ruleCtrl = component.createRule();
       ruleCtrl.get('operator')?.setValue('within_last');
       component.onOperatorChange(ruleCtrl);
       ruleCtrl.get('value')?.setValue('15');
       ruleCtrl.get('operator')?.setValue('within_last');
       component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('15');
+    });
+
+    it('should preserve the value when switching between compatible single-value operators', () => {
+      const ruleCtrl = component.buildRuleFromData({field: 'pageCount', operator: 'equals', value: 42});
+      ruleCtrl.get('operator')?.setValue('greater_than_equal_to');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe(42);
+    });
+
+    it('should preserve a boolean value when switching between equals and not_equals', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('field')?.setValue('abridged');
+      ruleCtrl.get('operator')?.setValue('equals');
+      component.onOperatorChange(ruleCtrl);
+      ruleCtrl.get('value')?.setValue('true');
+      ruleCtrl.get('operator')?.setValue('not_equals');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('true');
+    });
+
+    it('should preserve both amount and unit when switching between within_last and older_than', () => {
+      const ruleCtrl = component.buildRuleFromData({field: 'dateFinished', operator: 'within_last', value: 5, valueEnd: 'weeks'});
+      ruleCtrl.get('operator')?.setValue('older_than');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe(5);
+      expect(ruleCtrl.get('valueEnd')?.value).toBe('weeks');
+    });
+
+    it('should preserve the array when switching between multi-value operators', () => {
+      const ruleCtrl = component.buildRuleFromData({field: 'tags', operator: 'includes_any', value: ['a', 'b']});
+      ruleCtrl.get('operator')?.setValue('includes_all');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toEqual(['a', 'b']);
+    });
+
+    it('should clear the value when switching from a multi-value operator to a single-value operator', () => {
+      const ruleCtrl = component.buildRuleFromData({field: 'tags', operator: 'includes_any', value: ['a', 'b']});
+      ruleCtrl.get('operator')?.setValue('equals');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('');
+    });
+
+    it('should clear the value when switching from a single-value operator to a multi-value operator', () => {
+      const ruleCtrl = component.buildRuleFromData({field: 'tags', operator: 'equals', value: 'foo'});
+      ruleCtrl.get('operator')?.setValue('includes_any');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toEqual([]);
+    });
+
+    it('should clear the value when switching from equals to within_last', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('field')?.setValue('dateFinished');
+      ruleCtrl.get('operator')?.setValue('equals');
+      component.onOperatorChange(ruleCtrl);
+      ruleCtrl.get('value')?.setValue('2026-07-24');
+      ruleCtrl.get('operator')?.setValue('within_last');
+      component.onOperatorChange(ruleCtrl);
       expect(ruleCtrl.get('value')?.value).toBeNull();
+      expect(ruleCtrl.get('valueEnd')?.value).toBe('days');
+    });
+
+    it('should not resurrect a value from before an is_empty round trip', () => {
+      const ruleCtrl = component.createRule();
+      ruleCtrl.get('operator')?.setValue('equals');
+      component.onOperatorChange(ruleCtrl);
+      ruleCtrl.get('value')?.setValue('foo');
+      ruleCtrl.get('operator')?.setValue('is_empty');
+      component.onOperatorChange(ruleCtrl);
+      ruleCtrl.get('operator')?.setValue('equals');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('');
+    });
+
+    it('should preserve a value loaded from saved shelf data when switching to a compatible operator', () => {
+      const ruleCtrl = component.buildRuleFromData({field: 'title', operator: 'contains', value: 'Harry Potter'});
+      ruleCtrl.get('operator')?.setValue('starts_with');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('Harry Potter');
     });
   });
 

--- a/frontend/src/app/features/magic-shelf/component/magic-shelf-component.spec.ts
+++ b/frontend/src/app/features/magic-shelf/component/magic-shelf-component.spec.ts
@@ -469,6 +469,17 @@ describe('MagicShelfComponent (Part 3)', () => {
       expect(ruleCtrl.get('value')?.value).toBe('15');
     });
 
+    it('should preserve a valid period and clear valueStart/valueEnd when re-selecting this_period', () => {
+      const ruleCtrl = component.buildRuleFromData({field: 'addedOn', operator: 'this_period', value: 'month'});
+      ruleCtrl.get('valueStart')?.setValue('stale-start');
+      ruleCtrl.get('valueEnd')?.setValue('stale-end');
+      ruleCtrl.get('operator')?.setValue('this_period');
+      component.onOperatorChange(ruleCtrl);
+      expect(ruleCtrl.get('value')?.value).toBe('month');
+      expect(ruleCtrl.get('valueStart')?.value).toBeNull();
+      expect(ruleCtrl.get('valueEnd')?.value).toBeNull();
+    });
+
     it('should preserve the value when switching between compatible single-value operators', () => {
       const ruleCtrl = component.buildRuleFromData({field: 'pageCount', operator: 'equals', value: 42});
       ruleCtrl.get('operator')?.setValue('greater_than_equal_to');

--- a/frontend/src/app/features/magic-shelf/component/magic-shelf-component.ts
+++ b/frontend/src/app/features/magic-shelf/component/magic-shelf-component.ts
@@ -13,7 +13,7 @@ import {MessageService} from '@openng/optimus-ui/api';
 import {DynamicDialogConfig, DynamicDialogRef} from '@openng/optimus-ui/dynamicdialog';
 import {MultiSelect} from '@openng/optimus-ui/multiselect';
 import {AutoComplete} from '@openng/optimus-ui/autocomplete';
-import {DATE_UNIT_VALUES, EMPTY_CHECK_OPERATORS, getOperatorValueKind, MULTI_VALUE_OPERATORS, RELATIVE_DATE_OPERATORS, parseValue, removeNulls, serializeDateRules} from '../service/magic-shelf-utils';
+import {EMPTY_CHECK_OPERATORS, MULTI_VALUE_OPERATORS, RELATIVE_DATE_OPERATORS, parseValue, removeNulls, serializeDateRules} from '../service/magic-shelf-utils';
 import {IconPickerService} from '../../../shared/service/icon-picker.service';
 import {CheckboxChangeEvent, Checkbox} from "@openng/optimus-ui/checkbox";
 import {UserService} from "../../settings/user-management/user.service";
@@ -211,6 +211,14 @@ const FIELD_GROUPS: FieldGroup[] = [
   { translationKey: 'fileIdentifiers', fields: ['fileType', 'fileSize', 'isbn13', 'isbn10', 'isPhysical'] }
 ];
 
+const DATE_UNITS = ['days', 'weeks', 'months', 'years'];
+const DATE_PERIODS = ['week', 'month', 'year'];
+
+function isRelativeAmount(value: unknown): boolean {
+  if (typeof value !== 'number' && typeof value !== 'string') return false;
+  return String(value).trim() !== '' && Number.isFinite(Number(value));
+}
+
 const READ_STATUS_KEYS: Record<string, string> = {
   UNREAD: 'unread',
   READING: 'reading',
@@ -252,7 +260,6 @@ export class MagicShelfComponent implements OnInit {
   private readonly injector = inject(Injector);
   private readonly controlIds = new WeakMap<AbstractControl, string>();
   private controlIdCounter = 0;
-  private readonly previousOperators = new WeakMap<AbstractControl, RuleOperator | ''>();
 
   numericFieldConfigMap = new Map<RuleField, FieldConfig>(
     Object.entries(FIELD_CONFIGS)
@@ -425,20 +432,11 @@ export class MagicShelfComponent implements OnInit {
   }
 
   get dateUnitOptions() {
-    return [
-      {label: this.t.translate('magicShelf.dateUnits.days'), value: 'days'},
-      {label: this.t.translate('magicShelf.dateUnits.weeks'), value: 'weeks'},
-      {label: this.t.translate('magicShelf.dateUnits.months'), value: 'months'},
-      {label: this.t.translate('magicShelf.dateUnits.years'), value: 'years'},
-    ];
+    return DATE_UNITS.map(unit => ({label: this.t.translate(`magicShelf.dateUnits.${unit}`), value: unit}));
   }
 
   get datePeriodOptions() {
-    return [
-      {label: this.t.translate('magicShelf.datePeriods.week'), value: 'week'},
-      {label: this.t.translate('magicShelf.datePeriods.month'), value: 'month'},
-      {label: this.t.translate('magicShelf.datePeriods.year'), value: 'year'},
-    ];
+    return DATE_PERIODS.map(period => ({label: this.t.translate(`magicShelf.datePeriods.${period}`), value: period}));
   }
 
   libraryOptions = computed(() =>
@@ -585,16 +583,13 @@ export class MagicShelfComponent implements OnInit {
       valueEnd = parseValue(data.valueEnd, type);
     }
 
-    const ruleFormGroup = new FormGroup({
+    return new FormGroup({
       field: new FormControl<RuleField>(data.field),
       operator: new FormControl<RuleOperator>(data.operator),
       value: new FormControl(value),
       valueStart: new FormControl(valueStart),
       valueEnd: new FormControl(valueEnd),
     }) as RuleFormGroup;
-
-    this.previousOperators.set(ruleFormGroup, data.operator);
-    return ruleFormGroup;
   }
 
   get group(): GroupFormGroup {
@@ -679,16 +674,13 @@ export class MagicShelfComponent implements OnInit {
   }
 
   createRule(): RuleFormGroup {
-    const ruleFormGroup = new FormGroup({
+    return new FormGroup({
       field: new FormControl<RuleField | ''>(''),
       operator: new FormControl<RuleOperator | ''>(''),
       value: new FormControl<string | null>(null),
       valueStart: new FormControl<string | null>(null),
       valueEnd: new FormControl<string | null>(null),
     }) as RuleFormGroup;
-
-    this.previousOperators.set(ruleFormGroup, '');
-    return ruleFormGroup;
   }
 
   createGroup(): GroupFormGroup {
@@ -730,45 +722,41 @@ export class MagicShelfComponent implements OnInit {
 
   onOperatorChange(ruleCtrl: FormGroup) {
     const operator = ruleCtrl.get('operator')?.value as RuleOperator;
-    const previousOperator = this.previousOperators.get(ruleCtrl) ?? '';
-    this.previousOperators.set(ruleCtrl, operator);
 
     const valueCtrl = ruleCtrl.get('value');
     const valueStartCtrl = ruleCtrl.get('valueStart');
     const valueEndCtrl = ruleCtrl.get('valueEnd');
-    const sameKind = getOperatorValueKind(operator) === getOperatorValueKind(previousOperator);
+    const value = valueCtrl?.value;
 
     if (operator === 'within_last' || operator === 'older_than') {
+      if (!isRelativeAmount(value)) valueCtrl?.setValue(null);
       valueStartCtrl?.setValue(null);
-      if (!sameKind) {
-        valueCtrl?.setValue(null);
-        valueEndCtrl?.setValue('days');
-      } else if (!DATE_UNIT_VALUES.includes(valueEndCtrl?.value)) {
-        valueEndCtrl?.setValue('days');
-      }
+      if (!DATE_UNITS.includes(valueEndCtrl?.value)) valueEndCtrl?.setValue('days');
     } else if (operator === 'this_period') {
+      if (!DATE_PERIODS.includes(value)) valueCtrl?.setValue(null);
       valueStartCtrl?.setValue(null);
       valueEndCtrl?.setValue(null);
-      if (!sameKind) {
-        valueCtrl?.setValue(null);
-      }
     } else if (MULTI_VALUE_OPERATORS.includes(operator)) {
+      if (!Array.isArray(value)) valueCtrl?.setValue([]);
       valueStartCtrl?.setValue(null);
       valueEndCtrl?.setValue(null);
-      if (!sameKind || !Array.isArray(valueCtrl?.value)) {
-        valueCtrl?.setValue([]);
-      }
     } else if (EMPTY_CHECK_OPERATORS.includes(operator)) {
       valueCtrl?.setValue(null);
       valueStartCtrl?.setValue(null);
       valueEndCtrl?.setValue(null);
     } else {
+      // in_between edits valueStart/valueEnd, so it never keeps the single value
+      if (operator === 'in_between' || !this.isSingleValue(ruleCtrl, value)) valueCtrl?.setValue('');
       valueStartCtrl?.setValue(null);
       valueEndCtrl?.setValue(null);
-      if (!sameKind) {
-        valueCtrl?.setValue('');
-      }
     }
+  }
+
+  /** A value survives an operator change only when the input the new operator renders can still edit it. */
+  private isSingleValue(ruleCtrl: FormGroup, value: unknown): boolean {
+    if (value == null || value === '' || Array.isArray(value)) return false;
+    const type = FIELD_CONFIGS[ruleCtrl.get('field')?.value as RuleField]?.type;
+    return type !== 'date' || value instanceof Date;
   }
 
   onFieldChange(ruleCtrl: RuleFormGroup) {
@@ -776,7 +764,6 @@ export class MagicShelfComponent implements OnInit {
     ruleCtrl.get('value')?.setValue(null);
     ruleCtrl.get('valueStart')?.setValue(null);
     ruleCtrl.get('valueEnd')?.setValue(null);
-    this.previousOperators.set(ruleCtrl, '');
   }
 
   openIconPicker() {

--- a/frontend/src/app/features/magic-shelf/component/magic-shelf-component.ts
+++ b/frontend/src/app/features/magic-shelf/component/magic-shelf-component.ts
@@ -13,7 +13,7 @@ import {MessageService} from '@openng/optimus-ui/api';
 import {DynamicDialogConfig, DynamicDialogRef} from '@openng/optimus-ui/dynamicdialog';
 import {MultiSelect} from '@openng/optimus-ui/multiselect';
 import {AutoComplete} from '@openng/optimus-ui/autocomplete';
-import {EMPTY_CHECK_OPERATORS, MULTI_VALUE_OPERATORS, RELATIVE_DATE_OPERATORS, parseValue, removeNulls, serializeDateRules} from '../service/magic-shelf-utils';
+import {DATE_UNIT_VALUES, EMPTY_CHECK_OPERATORS, getOperatorValueKind, MULTI_VALUE_OPERATORS, RELATIVE_DATE_OPERATORS, parseValue, removeNulls, serializeDateRules} from '../service/magic-shelf-utils';
 import {IconPickerService} from '../../../shared/service/icon-picker.service';
 import {CheckboxChangeEvent, Checkbox} from "@openng/optimus-ui/checkbox";
 import {UserService} from "../../settings/user-management/user.service";
@@ -252,6 +252,7 @@ export class MagicShelfComponent implements OnInit {
   private readonly injector = inject(Injector);
   private readonly controlIds = new WeakMap<AbstractControl, string>();
   private controlIdCounter = 0;
+  private readonly previousOperators = new WeakMap<AbstractControl, RuleOperator | ''>();
 
   numericFieldConfigMap = new Map<RuleField, FieldConfig>(
     Object.entries(FIELD_CONFIGS)
@@ -584,13 +585,16 @@ export class MagicShelfComponent implements OnInit {
       valueEnd = parseValue(data.valueEnd, type);
     }
 
-    return new FormGroup({
+    const ruleFormGroup = new FormGroup({
       field: new FormControl<RuleField>(data.field),
       operator: new FormControl<RuleOperator>(data.operator),
       value: new FormControl(value),
       valueStart: new FormControl(valueStart),
       valueEnd: new FormControl(valueEnd),
     }) as RuleFormGroup;
+
+    this.previousOperators.set(ruleFormGroup, data.operator);
+    return ruleFormGroup;
   }
 
   get group(): GroupFormGroup {
@@ -675,13 +679,16 @@ export class MagicShelfComponent implements OnInit {
   }
 
   createRule(): RuleFormGroup {
-    return new FormGroup({
+    const ruleFormGroup = new FormGroup({
       field: new FormControl<RuleField | ''>(''),
       operator: new FormControl<RuleOperator | ''>(''),
       value: new FormControl<string | null>(null),
       valueStart: new FormControl<string | null>(null),
       valueEnd: new FormControl<string | null>(null),
     }) as RuleFormGroup;
+
+    this.previousOperators.set(ruleFormGroup, '');
+    return ruleFormGroup;
   }
 
   createGroup(): GroupFormGroup {
@@ -723,31 +730,44 @@ export class MagicShelfComponent implements OnInit {
 
   onOperatorChange(ruleCtrl: FormGroup) {
     const operator = ruleCtrl.get('operator')?.value as RuleOperator;
+    const previousOperator = this.previousOperators.get(ruleCtrl) ?? '';
+    this.previousOperators.set(ruleCtrl, operator);
 
     const valueCtrl = ruleCtrl.get('value');
     const valueStartCtrl = ruleCtrl.get('valueStart');
     const valueEndCtrl = ruleCtrl.get('valueEnd');
+    const sameKind = getOperatorValueKind(operator) === getOperatorValueKind(previousOperator);
 
     if (operator === 'within_last' || operator === 'older_than') {
-      valueCtrl?.setValue(null);
       valueStartCtrl?.setValue(null);
-      valueEndCtrl?.setValue('days');
+      if (!sameKind) {
+        valueCtrl?.setValue(null);
+        valueEndCtrl?.setValue('days');
+      } else if (!DATE_UNIT_VALUES.includes(valueEndCtrl?.value)) {
+        valueEndCtrl?.setValue('days');
+      }
     } else if (operator === 'this_period') {
-      valueCtrl?.setValue(null);
       valueStartCtrl?.setValue(null);
       valueEndCtrl?.setValue(null);
+      if (!sameKind) {
+        valueCtrl?.setValue(null);
+      }
     } else if (MULTI_VALUE_OPERATORS.includes(operator)) {
-      valueCtrl?.setValue([]);
       valueStartCtrl?.setValue(null);
       valueEndCtrl?.setValue(null);
+      if (!sameKind || !Array.isArray(valueCtrl?.value)) {
+        valueCtrl?.setValue([]);
+      }
     } else if (EMPTY_CHECK_OPERATORS.includes(operator)) {
       valueCtrl?.setValue(null);
       valueStartCtrl?.setValue(null);
       valueEndCtrl?.setValue(null);
     } else {
-      valueCtrl?.setValue('');
       valueStartCtrl?.setValue(null);
       valueEndCtrl?.setValue(null);
+      if (!sameKind) {
+        valueCtrl?.setValue('');
+      }
     }
   }
 
@@ -756,6 +776,7 @@ export class MagicShelfComponent implements OnInit {
     ruleCtrl.get('value')?.setValue(null);
     ruleCtrl.get('valueStart')?.setValue(null);
     ruleCtrl.get('valueEnd')?.setValue(null);
+    this.previousOperators.set(ruleCtrl, '');
   }
 
   openIconPicker() {

--- a/frontend/src/app/features/magic-shelf/service/magic-shelf-utils.ts
+++ b/frontend/src/app/features/magic-shelf/service/magic-shelf-utils.ts
@@ -17,6 +17,19 @@ export const RELATIVE_DATE_OPERATORS: RuleOperator[] = [
   'this_period'
 ];
 
+export const DATE_UNIT_VALUES = ['days', 'weeks', 'months', 'years'];
+
+export type OperatorValueKind = 'unset' | 'none' | 'amountUnit' | 'period' | 'multi' | 'default';
+
+export function getOperatorValueKind(operator: RuleOperator | '' | null | undefined): OperatorValueKind {
+  if (!operator) return 'unset';
+  if (EMPTY_CHECK_OPERATORS.includes(operator)) return 'none';
+  if (operator === 'within_last' || operator === 'older_than') return 'amountUnit';
+  if (operator === 'this_period') return 'period';
+  if (MULTI_VALUE_OPERATORS.includes(operator)) return 'multi';
+  return 'default';
+}
+
 function parseDate(val: unknown): Date | null {
   if (typeof val === "string") {
     if (val.match("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) {

--- a/frontend/src/app/features/magic-shelf/service/magic-shelf-utils.ts
+++ b/frontend/src/app/features/magic-shelf/service/magic-shelf-utils.ts
@@ -17,19 +17,6 @@ export const RELATIVE_DATE_OPERATORS: RuleOperator[] = [
   'this_period'
 ];
 
-export const DATE_UNIT_VALUES = ['days', 'weeks', 'months', 'years'];
-
-export type OperatorValueKind = 'unset' | 'none' | 'amountUnit' | 'period' | 'multi' | 'default';
-
-export function getOperatorValueKind(operator: RuleOperator | '' | null | undefined): OperatorValueKind {
-  if (!operator) return 'unset';
-  if (EMPTY_CHECK_OPERATORS.includes(operator)) return 'none';
-  if (operator === 'within_last' || operator === 'older_than') return 'amountUnit';
-  if (operator === 'this_period') return 'period';
-  if (MULTI_VALUE_OPERATORS.includes(operator)) return 'multi';
-  return 'default';
-}
-
 function parseDate(val: unknown): Date | null {
   if (typeof val === "string") {
     if (val.match("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) {


### PR DESCRIPTION
## Description

Changing a Magic Shelf filter rule's comparator always cleared the rule's value, even when the new comparator could still use it (e.g. Equals to Greater or Equal). Now the value is only reset when the newly selected operator actually needs a different shape of input than what's already there (e.g. switching to Within Last, which needs an amount and unit instead of a date).

## Linked Issue

Fixes #2335

## Changes

- `magic-shelf-component.ts`: `onOperatorChange()` now keeps `value`/`valueEnd` when the new operator's input can still edit what's already in the control (single value, multi-value array, relative-date amount+unit, or relative-date period, checked via a new `isSingleValue` helper plus the existing multi/relative-date/empty-check logic), instead of unconditionally clearing on every operator change. `in_between` always clears the single value since it edits `valueStart`/`valueEnd` instead.
- `magic-shelf-component.spec.ts`: added regression tests covering compatible and incompatible operator switches across single-value, multi-value, and relative-date operators.

## Manual Testing Steps

1. `node node_modules/typescript/bin/tsc --noEmit` (app and spec configs), full ESLint + Stylelint, build, and all tests pass.
2. Tested the real Magic Shelf Builder in a browser, recorded on attached video:

## Screenshots (Optional)


https://github.com/user-attachments/assets/02d5c654-adbd-4916-93e7-9363ad75682d



## AI Disclosure

Claude Code was used to map out how each comparator should/should not reset:

```
   - Date Finished: Equals → Greater or Equal → Not Equal (value kept) → Within Last (clears, since it needs a different shape) → set amount/unit → Older Than (kept) → This Period (clears again) → back to Equals (stays cleared, doesn't resurrect the old date).
   - Page Count: Equals → Less or Equal → Greater or Equal (kept) → Empty → back to Equals (stays cleared).
   - Title: Contains → Starts With (kept) → Includes Any (clears to an empty list) → add two values → Includes All (list kept) → back to Equals (clears).
   - Abridged (boolean): Equals Yes → Not Equal (kept) → Empty (value input disappears).
```

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [x] There are new or updated tests validating this change.
- [x] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rule values are now preserved when switching between compatible operators, reducing unnecessary re-entry.
  - Incompatible operator changes clear values appropriately to prevent invalid configurations.
  - Relative-date values are retained when valid, including existing amounts such as “15”.
  - Multi-value and saved-rule selections remain available when supported by the new operator.
  - Range-based operators continue to retain their start and end values while editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->