### PR TITLE
fix(ui): add show/hide toggle to admin change-password dialog

### DIFF
--- a/frontend/src/app/features/settings/user-management/user-management.component.html
+++ b/frontend/src/app/features/settings/user-management/user-management.component.html
@@ -447,6 +447,7 @@
           [(ngModel)]="newPassword"
           [placeholder]="t('passwordDialog.enterNew')"
           [feedback]="false"
+          [toggleMask]="true"
           fluid>
         </p-password>
       </div>
@@ -457,6 +458,7 @@
           [(ngModel)]="confirmNewPassword"
           [placeholder]="t('passwordDialog.confirmNew')"
           [feedback]="false"
+          [toggleMask]="true"
           fluid>
         </p-password>
       </div>


### PR DESCRIPTION
## Description

The admin "Change Password" dialog uses PrimeNG's
`p-password` component without `toggleMask` enabled, so admins have no
way to verify what they typed before submitting, only masked dots.

## Linked Issue

Fixes #2600

## Changes

- Added `[toggleMask]="true"` to the "New Password" and "Confirm Password"
  `p-password` fields in the admin per-user change-password dialog
  (`user-management.component.html`), matching the pattern already used
  in the self-service change-password form.

## Manual Testing Steps

1. Tested locally:

## Screenshots

<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/cc8014f0-667e-4027-bdf7-d06c05258ad9" />

## AI Disclosure

None

## Checklist

- [x] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] There are new or updated tests validating this change.
- [ ] I ran `just ui check` and `just api check`.
- [x] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added show/hide visibility toggles to both password fields in the password change dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->